### PR TITLE
Add C ABI export layer, full sRGB ICC profile, and PDF/A-1b support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet fmt fuzz check clean wasm
+.PHONY: build test vet fmt fuzz check clean wasm cshared test-cabi
 
 build:
 	go build ./...
@@ -29,8 +29,18 @@ wasm:
 	GOOS=js GOARCH=wasm go build -o folio.wasm ./cmd/wasm/
 	@echo "Built folio.wasm ($$(du -h folio.wasm | cut -f1))"
 
+cshared:
+	CGO_ENABLED=1 go build -buildmode=c-shared -o libfolio.dylib ./export/
+	@echo "Built libfolio.dylib ($$(du -h libfolio.dylib | cut -f1)) — header: libfolio.h"
+
+test-cabi: cshared
+	cc -o export/testdata/test_cabi export/testdata/test_cabi.c -L. -lfolio -Wl,-rpath,.
+	./export/testdata/test_cabi
+
 clean:
 	rm -f coverage.out coverage.html
 	rm -f folio samples showcase
 	rm -f folio.wasm
+	rm -f libfolio.dylib libfolio.h libfolio.so folio.dll
+	rm -f export/testdata/test_cabi
 	rm -f *.pdf

--- a/export/cabi.go
+++ b/export/cabi.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+// Package export provides a C ABI for the Folio PDF library.
+// Every Go object exposed to C is stored in an opaque handle table.
+// C callers receive uint64 handle IDs and never see raw Go pointers.
+//
+// Error convention: all functions return int32 (0 = success, negative = error).
+// Call folio_last_error() to retrieve the error message string.
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"sync"
+	"unsafe"
+)
+
+// version is the library version, set at build time or hardcoded.
+const version = "0.2.0-dev"
+
+// versionCStr is a persistent C string for folio_version().
+// Allocated once, never freed — avoids per-call memory leaks.
+var versionCStr *C.char
+
+func init() {
+	versionCStr = C.CString(version)
+}
+
+// Error codes returned by C ABI functions.
+const (
+	errOK             = 0
+	errInvalidHandle  = -1
+	errInvalidArg     = -2
+	errIO             = -3
+	errPDF            = -4
+	errTypeMismatch   = -5
+	errInternalError  = -6
+)
+
+// handleTable stores Go objects keyed by uint64 handle IDs.
+// Handle 0 is reserved as the null/invalid handle.
+type handleTable struct {
+	mu      sync.Mutex
+	handles map[uint64]any
+	next    uint64
+}
+
+var ht = &handleTable{
+	handles: make(map[uint64]any),
+	next:    1,
+}
+
+// store adds a value to the handle table and returns its handle ID.
+func (t *handleTable) store(v any) uint64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	id := t.next
+	t.next++
+	t.handles[id] = v
+	return id
+}
+
+// load retrieves a value by handle ID. Returns nil if not found.
+func (t *handleTable) load(id uint64) any {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.handles[id]
+}
+
+// delete removes a handle. Returns true if it existed.
+func (t *handleTable) delete(id uint64) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, ok := t.handles[id]
+	if ok {
+		delete(t.handles, id)
+	}
+	return ok
+}
+
+// count returns the number of live handles (for testing).
+func (t *handleTable) count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.handles)
+}
+
+// lastError stores the most recent error message per-thread (approximated
+// via a single global since cgo serializes calls through a single OS thread
+// by default). The returned C string is valid until the next C ABI call.
+var (
+	lastErrorMu  sync.Mutex
+	lastErrorMsg *C.char
+)
+
+// setLastError stores an error message retrievable via folio_last_error.
+func setLastError(msg string) {
+	lastErrorMu.Lock()
+	defer lastErrorMu.Unlock()
+	if lastErrorMsg != nil {
+		C.free(unsafe.Pointer(lastErrorMsg))
+	}
+	lastErrorMsg = C.CString(msg)
+}
+
+// clearLastError clears any previous error.
+func clearLastError() {
+	lastErrorMu.Lock()
+	defer lastErrorMu.Unlock()
+	if lastErrorMsg != nil {
+		C.free(unsafe.Pointer(lastErrorMsg))
+		lastErrorMsg = nil
+	}
+}
+
+// setErr sets the last error from an error value and returns the error code.
+func setErr(code C.int32_t, err error) C.int32_t {
+	if err != nil {
+		setLastError(err.Error())
+	}
+	return code
+}
+
+//export folio_version
+func folio_version() *C.char {
+	return versionCStr
+}
+
+//export folio_last_error
+func folio_last_error() *C.char {
+	lastErrorMu.Lock()
+	defer lastErrorMu.Unlock()
+	return lastErrorMsg
+}
+
+func main() {}

--- a/export/cabi_buffer.go
+++ b/export/cabi_buffer.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+*/
+import "C"
+import "unsafe"
+
+// cBuffer holds C-allocated memory for returning byte data to callers.
+// The data pointer is allocated via C.malloc and must be freed with C.free.
+type cBuffer struct {
+	ptr unsafe.Pointer
+	len int
+}
+
+// newCBuffer copies Go bytes into C-allocated memory.
+func newCBuffer(data []byte) *cBuffer {
+	n := len(data)
+	if n == 0 {
+		return &cBuffer{ptr: nil, len: 0}
+	}
+	ptr := C.malloc(C.size_t(n))
+	C.memcpy(ptr, unsafe.Pointer(&data[0]), C.size_t(n))
+	return &cBuffer{ptr: ptr, len: n}
+}
+
+//export folio_buffer_data
+func folio_buffer_data(buf C.uint64_t) unsafe.Pointer {
+	v := ht.load(uint64(buf))
+	if v == nil {
+		return nil
+	}
+	b, ok := v.(*cBuffer)
+	if !ok {
+		return nil
+	}
+	return b.ptr
+}
+
+//export folio_buffer_len
+func folio_buffer_len(buf C.uint64_t) C.int32_t {
+	v := ht.load(uint64(buf))
+	if v == nil {
+		return 0
+	}
+	b, ok := v.(*cBuffer)
+	if !ok {
+		return 0
+	}
+	return C.int32_t(b.len)
+}
+
+//export folio_buffer_free
+func folio_buffer_free(buf C.uint64_t) {
+	v := ht.load(uint64(buf))
+	if v != nil {
+		if b, ok := v.(*cBuffer); ok && b.ptr != nil {
+			C.free(b.ptr)
+		}
+	}
+	ht.delete(uint64(buf))
+}

--- a/export/cabi_callback.go
+++ b/export/cabi_callback.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+
+// C trampoline for page decorator callbacks.
+// cgo cannot call C function pointers directly from Go, so we need
+// this wrapper function that Go can call via C.call_page_decorator.
+typedef void (*folio_page_decorator_fn)(int32_t page_index, int32_t total_pages, uint64_t page_handle, void* user_data);
+
+static void call_page_decorator(folio_page_decorator_fn fn, int32_t page_index, int32_t total_pages, uint64_t page_handle, void* user_data) {
+    fn(page_index, total_pages, page_handle, user_data);
+}
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/carlos7ags/folio/document"
+)
+
+//export folio_document_set_header
+func folio_document_set_header(docH C.uint64_t, fn C.folio_page_decorator_fn, userData unsafe.Pointer) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	if fn == nil {
+		setLastError("header callback function must not be NULL")
+		return errInvalidArg
+	}
+	doc.SetHeader(makeDecorator(fn, userData))
+	return errOK
+}
+
+//export folio_document_set_footer
+func folio_document_set_footer(docH C.uint64_t, fn C.folio_page_decorator_fn, userData unsafe.Pointer) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	if fn == nil {
+		setLastError("footer callback function must not be NULL")
+		return errInvalidArg
+	}
+	doc.SetFooter(makeDecorator(fn, userData))
+	return errOK
+}
+
+// makeDecorator wraps a C function pointer into a Go PageDecorator.
+func makeDecorator(fn C.folio_page_decorator_fn, userData unsafe.Pointer) document.PageDecorator {
+	return func(ctx document.PageContext, page *document.Page) {
+		// Store the page in the handle table so the callback can use it.
+		pageH := ht.store(page)
+		C.call_page_decorator(fn,
+			C.int32_t(ctx.PageIndex),
+			C.int32_t(ctx.TotalPages),
+			C.uint64_t(pageH),
+			userData,
+		)
+		// Remove the temporary page handle after the callback returns.
+		ht.delete(pageH)
+	}
+}

--- a/export/cabi_div.go
+++ b/export/cabi_div.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_div_new
+func folio_div_new() C.uint64_t {
+	return C.uint64_t(ht.store(layout.NewDiv()))
+}
+
+//export folio_div_add
+func folio_div_add(divH C.uint64_t, elemH C.uint64_t) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	v := ht.load(uint64(elemH))
+	if v == nil {
+		setLastError("invalid element handle")
+		return errInvalidHandle
+	}
+	elem, ok := v.(layout.Element)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a layout element", uint64(elemH)))
+		return errTypeMismatch
+	}
+	div.Add(elem)
+	return errOK
+}
+
+//export folio_div_set_padding
+func folio_div_set_padding(divH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetPaddingAll(layout.Padding{
+		Top: float64(top), Right: float64(right),
+		Bottom: float64(bottom), Left: float64(left),
+	})
+	return errOK
+}
+
+//export folio_div_set_background
+func folio_div_set_background(divH C.uint64_t, r, g, b C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetBackground(layout.RGB(float64(r), float64(g), float64(b)))
+	return errOK
+}
+
+//export folio_div_set_border
+func folio_div_set_border(divH C.uint64_t, width C.double, r, g, b C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetBorder(layout.SolidBorder(float64(width), layout.RGB(float64(r), float64(g), float64(b))))
+	return errOK
+}
+
+//export folio_div_set_width
+func folio_div_set_width(divH C.uint64_t, pts C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetWidth(float64(pts))
+	return errOK
+}
+
+//export folio_div_set_min_height
+func folio_div_set_min_height(divH C.uint64_t, pts C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetMinHeight(float64(pts))
+	return errOK
+}
+
+//export folio_div_set_space_before
+func folio_div_set_space_before(divH C.uint64_t, pts C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetSpaceBefore(float64(pts))
+	return errOK
+}
+
+//export folio_div_set_space_after
+func folio_div_set_space_after(divH C.uint64_t, pts C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetSpaceAfter(float64(pts))
+	return errOK
+}
+
+//export folio_div_free
+func folio_div_free(divH C.uint64_t) {
+	ht.delete(uint64(divH))
+}
+
+// --- LineSeparator ---
+
+//export folio_line_separator_new
+func folio_line_separator_new() C.uint64_t {
+	return C.uint64_t(ht.store(layout.NewLineSeparator()))
+}
+
+// --- AreaBreak (page break) ---
+
+//export folio_area_break_new
+func folio_area_break_new() C.uint64_t {
+	return C.uint64_t(ht.store(layout.NewAreaBreak()))
+}
+
+func loadDiv(h C.uint64_t) (*layout.Div, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid div handle")
+		return nil, errInvalidHandle
+	}
+	div, ok := v.(*layout.Div)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a div (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return div, errOK
+}

--- a/export/cabi_document.go
+++ b/export/cabi_document.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_document_new
+func folio_document_new(width, height C.double) C.uint64_t {
+	doc := document.NewDocument(document.PageSize{
+		Width:  float64(width),
+		Height: float64(height),
+	})
+	return C.uint64_t(ht.store(doc))
+}
+
+//export folio_document_new_letter
+func folio_document_new_letter() C.uint64_t {
+	doc := document.NewDocument(document.PageSizeLetter)
+	return C.uint64_t(ht.store(doc))
+}
+
+//export folio_document_new_a4
+func folio_document_new_a4() C.uint64_t {
+	doc := document.NewDocument(document.PageSizeA4)
+	return C.uint64_t(ht.store(doc))
+}
+
+//export folio_document_set_title
+func folio_document_set_title(docH C.uint64_t, title *C.char) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.Info.Title = C.GoString(title)
+	return errOK
+}
+
+//export folio_document_set_author
+func folio_document_set_author(docH C.uint64_t, author *C.char) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.Info.Author = C.GoString(author)
+	return errOK
+}
+
+//export folio_document_set_margins
+func folio_document_set_margins(docH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetMargins(layout.Margins{
+		Top:    float64(top),
+		Right:  float64(right),
+		Bottom: float64(bottom),
+		Left:   float64(left),
+	})
+	return errOK
+}
+
+//export folio_document_add_page
+func folio_document_add_page(docH C.uint64_t) C.uint64_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return 0
+	}
+	page := doc.AddPage()
+	return C.uint64_t(ht.store(page))
+}
+
+//export folio_document_page_count
+func folio_document_page_count(docH C.uint64_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.int32_t(doc.PageCount())
+}
+
+//export folio_document_add
+func folio_document_add(docH C.uint64_t, elemH C.uint64_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	v := ht.load(uint64(elemH))
+	if v == nil {
+		setLastError("invalid element handle")
+		return errInvalidHandle
+	}
+	elem, ok := v.(layout.Element)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a layout element (type %T)", uint64(elemH), v))
+		return errTypeMismatch
+	}
+	doc.Add(elem)
+	return errOK
+}
+
+//export folio_document_save
+func folio_document_save(docH C.uint64_t, path *C.char) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	if err := doc.Save(C.GoString(path)); err != nil {
+		return setErr(errIO, err)
+	}
+	return errOK
+}
+
+//export folio_document_write_to_buffer
+func folio_document_write_to_buffer(docH C.uint64_t) C.uint64_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return 0
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(newCBuffer(buf.Bytes())))
+}
+
+//export folio_document_free
+func folio_document_free(docH C.uint64_t) {
+	ht.delete(uint64(docH))
+}
+
+// loadDoc is a helper that loads a *document.Document from the handle table.
+func loadDoc(h C.uint64_t) (*document.Document, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid document handle")
+		return nil, errInvalidHandle
+	}
+	doc, ok := v.(*document.Document)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a document (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return doc, errOK
+}

--- a/export/cabi_font.go
+++ b/export/cabi_font.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// standardFontHandles maps standard font names to pre-registered handles.
+// Populated on first call to folio_font_standard.
+var standardFontHandles map[string]uint64
+
+func init() {
+	standardFontHandles = make(map[string]uint64)
+	// Pre-register all 14 standard fonts as persistent handles.
+	for _, f := range []*font.Standard{
+		font.Helvetica, font.HelveticaBold, font.HelveticaOblique, font.HelveticaBoldOblique,
+		font.TimesRoman, font.TimesBold, font.TimesItalic, font.TimesBoldItalic,
+		font.Courier, font.CourierBold, font.CourierOblique, font.CourierBoldOblique,
+		font.Symbol, font.ZapfDingbats,
+	} {
+		id := ht.store(f)
+		standardFontHandles[f.Name()] = id
+	}
+}
+
+//export folio_font_standard
+func folio_font_standard(name *C.char) C.uint64_t {
+	goName := C.GoString(name)
+	id, ok := standardFontHandles[goName]
+	if !ok {
+		setLastError("unknown standard font: " + goName)
+		return 0
+	}
+	return C.uint64_t(id)
+}
+
+//export folio_font_helvetica
+func folio_font_helvetica() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.Helvetica.Name()])
+}
+
+//export folio_font_helvetica_bold
+func folio_font_helvetica_bold() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.HelveticaBold.Name()])
+}
+
+//export folio_font_times_roman
+func folio_font_times_roman() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.TimesRoman.Name()])
+}
+
+//export folio_font_times_bold
+func folio_font_times_bold() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.TimesBold.Name()])
+}
+
+//export folio_font_courier
+func folio_font_courier() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.Courier.Name()])
+}
+
+//export folio_font_load_ttf
+func folio_font_load_ttf(path *C.char) C.uint64_t {
+	face, err := font.LoadTTF(C.GoString(path))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	ef := font.NewEmbeddedFont(face)
+	return C.uint64_t(ht.store(ef))
+}
+
+//export folio_font_parse_ttf
+func folio_font_parse_ttf(data unsafe.Pointer, length C.int32_t) C.uint64_t {
+	if data == nil || length <= 0 {
+		setLastError("invalid font data")
+		return 0
+	}
+	goData := C.GoBytes(data, C.int(length))
+	face, err := font.ParseTTF(goData)
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	ef := font.NewEmbeddedFont(face)
+	return C.uint64_t(ht.store(ef))
+}
+
+//export folio_font_free
+func folio_font_free(fontH C.uint64_t) {
+	// Standard fonts are singletons — don't delete them.
+	v := ht.load(uint64(fontH))
+	if v == nil {
+		return
+	}
+	if _, isStd := v.(*font.Standard); isStd {
+		return // no-op for standard fonts
+	}
+	ht.delete(uint64(fontH))
+}
+
+// loadEmbeddedFont loads a *font.EmbeddedFont from the handle table.
+func loadEmbeddedFont(h C.uint64_t) (*font.EmbeddedFont, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid font handle")
+		return nil, errInvalidHandle
+	}
+	ef, ok := v.(*font.EmbeddedFont)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not an embedded font (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return ef, errOK
+}

--- a/export/cabi_forms.go
+++ b/export/cabi_forms.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/forms"
+)
+
+// --- AcroForm ---
+
+//export folio_form_new
+func folio_form_new() C.uint64_t {
+	return C.uint64_t(ht.store(forms.NewAcroForm()))
+}
+
+//export folio_form_add_text_field
+func folio_form_add_text_field(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t) C.int32_t {
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	af.Add(forms.TextField(C.GoString(name), rect, int(pageIndex)))
+	return errOK
+}
+
+//export folio_form_add_checkbox
+func folio_form_add_checkbox(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t, checked C.int32_t) C.int32_t {
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	af.Add(forms.Checkbox(C.GoString(name), rect, int(pageIndex), checked != 0))
+	return errOK
+}
+
+//export folio_form_add_dropdown
+func folio_form_add_dropdown(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t, options **C.char, optCount C.int32_t) C.int32_t {
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	n := int(optCount)
+	goOpts := make([]string, n)
+	if n > 0 && options != nil {
+		cArray := (*[1 << 20]*C.char)(unsafe.Pointer(options))[:n:n]
+		for i := 0; i < n; i++ {
+			goOpts[i] = C.GoString(cArray[i])
+		}
+	}
+	af.Add(forms.Dropdown(C.GoString(name), rect, int(pageIndex), goOpts))
+	return errOK
+}
+
+//export folio_form_add_signature
+func folio_form_add_signature(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t) C.int32_t {
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	af.Add(forms.SignatureField(C.GoString(name), rect, int(pageIndex)))
+	return errOK
+}
+
+//export folio_document_set_form
+func folio_document_set_form(docH C.uint64_t, formH C.uint64_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetAcroForm(af)
+	return errOK
+}
+
+//export folio_form_free
+func folio_form_free(formH C.uint64_t) {
+	ht.delete(uint64(formH))
+}
+
+// --- Document feature flags ---
+
+//export folio_document_set_tagged
+func folio_document_set_tagged(docH C.uint64_t, enabled C.int32_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetTagged(enabled != 0)
+	return errOK
+}
+
+//export folio_document_set_pdfa
+func folio_document_set_pdfa(docH C.uint64_t, level C.int32_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetPdfA(document.PdfAConfig{Level: document.PdfALevel(level)})
+	return errOK
+}
+
+//export folio_document_set_encryption
+func folio_document_set_encryption(docH C.uint64_t, userPw, ownerPw *C.char, algorithm C.int32_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetEncryption(document.EncryptionConfig{
+		Algorithm:     document.EncryptionAlgorithm(algorithm),
+		UserPassword:  C.GoString(userPw),
+		OwnerPassword: C.GoString(ownerPw),
+	})
+	return errOK
+}
+
+//export folio_document_set_auto_bookmarks
+func folio_document_set_auto_bookmarks(docH C.uint64_t, enabled C.int32_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetAutoBookmarks(enabled != 0)
+	return errOK
+}
+
+func loadForm(h C.uint64_t) (*forms.AcroForm, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid form handle")
+		return nil, errInvalidHandle
+	}
+	af, ok := v.(*forms.AcroForm)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a form (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return af, errOK
+}

--- a/export/cabi_heading.go
+++ b/export/cabi_heading.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_heading_new
+func folio_heading_new(text *C.char, level C.int32_t) C.uint64_t {
+	h := layout.NewHeading(C.GoString(text), layout.HeadingLevel(level))
+	return C.uint64_t(ht.store(h))
+}
+
+//export folio_heading_new_with_font
+func folio_heading_new_with_font(text *C.char, level C.int32_t, fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	f, errCode := loadStandardFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	h := layout.NewHeadingWithFont(C.GoString(text), layout.HeadingLevel(level), f, float64(fontSize))
+	return C.uint64_t(ht.store(h))
+}
+
+//export folio_heading_new_embedded
+func folio_heading_new_embedded(text *C.char, level C.int32_t, fontH C.uint64_t) C.uint64_t {
+	ef, errCode := loadEmbeddedFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	h := layout.NewHeadingEmbedded(C.GoString(text), layout.HeadingLevel(level), ef)
+	return C.uint64_t(ht.store(h))
+}
+
+//export folio_heading_set_align
+func folio_heading_set_align(hH C.uint64_t, align C.int32_t) C.int32_t {
+	h, errCode := loadHeading(hH)
+	if errCode != errOK {
+		return errCode
+	}
+	h.SetAlign(layout.Align(align))
+	return errOK
+}
+
+//export folio_heading_free
+func folio_heading_free(hH C.uint64_t) {
+	ht.delete(uint64(hH))
+}
+
+// loadHeading loads a *layout.Heading from the handle table.
+func loadHeading(h C.uint64_t) (*layout.Heading, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid heading handle")
+		return nil, errInvalidHandle
+	}
+	heading, ok := v.(*layout.Heading)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a heading (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return heading, errOK
+}

--- a/export/cabi_html.go
+++ b/export/cabi_html.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"bytes"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/html"
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_html_to_pdf
+func folio_html_to_pdf(htmlStr *C.char, outputPath *C.char) C.int32_t {
+	doc, err := htmlToDocument(C.GoString(htmlStr), 0, 0)
+	if err != errOK {
+		return err
+	}
+	if saveErr := doc.Save(C.GoString(outputPath)); saveErr != nil {
+		return setErr(errIO, saveErr)
+	}
+	return errOK
+}
+
+//export folio_html_to_buffer
+func folio_html_to_buffer(htmlStr *C.char, pageWidth, pageHeight C.double) C.uint64_t {
+	doc, err := htmlToDocument(C.GoString(htmlStr), float64(pageWidth), float64(pageHeight))
+	if err != errOK {
+		return 0
+	}
+	var buf bytes.Buffer
+	if _, writeErr := doc.WriteTo(&buf); writeErr != nil {
+		setLastError(writeErr.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(newCBuffer(buf.Bytes())))
+}
+
+//export folio_html_convert
+func folio_html_convert(htmlStr *C.char, pageWidth, pageHeight C.double) C.uint64_t {
+	doc, err := htmlToDocument(C.GoString(htmlStr), float64(pageWidth), float64(pageHeight))
+	if err != errOK {
+		return 0
+	}
+	return C.uint64_t(ht.store(doc))
+}
+
+// htmlToDocument converts HTML to a Document ready for save/write.
+func htmlToDocument(htmlStr string, pageWidth, pageHeight float64) (*document.Document, C.int32_t) {
+	opts := &html.Options{}
+	if pageWidth > 0 {
+		opts.PageWidth = pageWidth
+	}
+	if pageHeight > 0 {
+		opts.PageHeight = pageHeight
+	}
+
+	result, err := html.ConvertFull(htmlStr, opts)
+	if err != nil {
+		setLastError(err.Error())
+		return nil, errPDF
+	}
+
+	// Determine page size.
+	ps := document.PageSizeLetter
+	if pageWidth > 0 && pageHeight > 0 {
+		ps = document.PageSize{Width: pageWidth, Height: pageHeight}
+	}
+	if pc := result.PageConfig; pc != nil {
+		if pc.Width > 0 && pc.Height > 0 {
+			ps = document.PageSize{Width: pc.Width, Height: pc.Height}
+		}
+	}
+
+	doc := document.NewDocument(ps)
+
+	// Apply @page margins.
+	if pc := result.PageConfig; pc != nil && pc.HasMargins {
+		doc.SetMargins(layout.Margins{
+			Top: pc.MarginTop, Right: pc.MarginRight,
+			Bottom: pc.MarginBottom, Left: pc.MarginLeft,
+		})
+	}
+
+	// Apply metadata.
+	if result.Metadata.Title != "" {
+		doc.Info.Title = result.Metadata.Title
+	}
+	if result.Metadata.Author != "" {
+		doc.Info.Author = result.Metadata.Author
+	}
+
+	for _, e := range result.Elements {
+		doc.Add(e)
+	}
+	for _, abs := range result.Absolutes {
+		doc.AddAbsoluteWithOpts(abs.Element, abs.X, abs.Y, abs.Width, layout.AbsoluteOpts{
+			RightAligned: abs.RightAligned,
+			ZIndex:       abs.ZIndex,
+			PageIndex:    -1,
+		})
+	}
+
+	return doc, errOK
+}

--- a/export/cabi_image.go
+++ b/export/cabi_image.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	folioimage "github.com/carlos7ags/folio/image"
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_image_load_jpeg
+func folio_image_load_jpeg(path *C.char) C.uint64_t {
+	img, err := folioimage.LoadJPEG(C.GoString(path))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(img))
+}
+
+//export folio_image_load_png
+func folio_image_load_png(path *C.char) C.uint64_t {
+	img, err := folioimage.LoadPNG(C.GoString(path))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(img))
+}
+
+//export folio_image_parse_jpeg
+func folio_image_parse_jpeg(data unsafe.Pointer, length C.int32_t) C.uint64_t {
+	if data == nil || length <= 0 {
+		setLastError("invalid image data")
+		return 0
+	}
+	goData := C.GoBytes(data, C.int(length))
+	img, err := folioimage.NewJPEG(goData)
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(img))
+}
+
+//export folio_image_parse_png
+func folio_image_parse_png(data unsafe.Pointer, length C.int32_t) C.uint64_t {
+	if data == nil || length <= 0 {
+		setLastError("invalid image data")
+		return 0
+	}
+	goData := C.GoBytes(data, C.int(length))
+	img, err := folioimage.NewPNG(goData)
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(img))
+}
+
+//export folio_image_width
+func folio_image_width(imgH C.uint64_t) C.int32_t {
+	img, errCode := loadImage(imgH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.int32_t(img.Width())
+}
+
+//export folio_image_height
+func folio_image_height(imgH C.uint64_t) C.int32_t {
+	img, errCode := loadImage(imgH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.int32_t(img.Height())
+}
+
+//export folio_image_free
+func folio_image_free(imgH C.uint64_t) {
+	ht.delete(uint64(imgH))
+}
+
+//export folio_page_add_image
+func folio_page_add_image(pageH C.uint64_t, imgH C.uint64_t, x, y, w, h C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	img, errCode := loadImage(imgH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.AddImage(img, float64(x), float64(y), float64(w), float64(h))
+	return errOK
+}
+
+//export folio_image_element_new
+func folio_image_element_new(imgH C.uint64_t) C.uint64_t {
+	img, errCode := loadImage(imgH)
+	if errCode != errOK {
+		return 0
+	}
+	ie := layout.NewImageElement(img)
+	return C.uint64_t(ht.store(ie))
+}
+
+//export folio_image_element_set_size
+func folio_image_element_set_size(ieH C.uint64_t, w, h C.double) C.int32_t {
+	v := ht.load(uint64(ieH))
+	if v == nil {
+		setLastError("invalid image element handle")
+		return errInvalidHandle
+	}
+	ie, ok := v.(*layout.ImageElement)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not an image element", uint64(ieH)))
+		return errTypeMismatch
+	}
+	ie.SetSize(float64(w), float64(h))
+	return errOK
+}
+
+//export folio_image_element_free
+func folio_image_element_free(ieH C.uint64_t) {
+	ht.delete(uint64(ieH))
+}
+
+func loadImage(h C.uint64_t) (*folioimage.Image, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid image handle")
+		return nil, errInvalidHandle
+	}
+	img, ok := v.(*folioimage.Image)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not an image (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return img, errOK
+}

--- a/export/cabi_list.go
+++ b/export/cabi_list.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_list_new
+func folio_list_new(fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	f, errCode := loadStandardFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.uint64_t(ht.store(layout.NewList(f, float64(fontSize))))
+}
+
+//export folio_list_new_embedded
+func folio_list_new_embedded(fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	ef, errCode := loadEmbeddedFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.uint64_t(ht.store(layout.NewListEmbedded(ef, float64(fontSize))))
+}
+
+//export folio_list_set_style
+func folio_list_set_style(listH C.uint64_t, style C.int32_t) C.int32_t {
+	l, errCode := loadList(listH)
+	if errCode != errOK {
+		return errCode
+	}
+	l.SetStyle(layout.ListStyle(style))
+	return errOK
+}
+
+//export folio_list_set_indent
+func folio_list_set_indent(listH C.uint64_t, indent C.double) C.int32_t {
+	l, errCode := loadList(listH)
+	if errCode != errOK {
+		return errCode
+	}
+	l.SetIndent(float64(indent))
+	return errOK
+}
+
+//export folio_list_add_item
+func folio_list_add_item(listH C.uint64_t, text *C.char) C.int32_t {
+	l, errCode := loadList(listH)
+	if errCode != errOK {
+		return errCode
+	}
+	l.AddItem(C.GoString(text))
+	return errOK
+}
+
+//export folio_list_free
+func folio_list_free(listH C.uint64_t) {
+	ht.delete(uint64(listH))
+}
+
+func loadList(h C.uint64_t) (*layout.List, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid list handle")
+		return nil, errInvalidHandle
+	}
+	l, ok := v.(*layout.List)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a list (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return l, errOK
+}
+

--- a/export/cabi_page.go
+++ b/export/cabi_page.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/font"
+)
+
+//export folio_page_add_text
+func folio_page_add_text(pageH C.uint64_t, text *C.char, fontH C.uint64_t, size, x, y C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	f, errCode := loadStandardFont(fontH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.AddText(C.GoString(text), f, float64(size), float64(x), float64(y))
+	return errOK
+}
+
+//export folio_page_add_text_embedded
+func folio_page_add_text_embedded(pageH C.uint64_t, text *C.char, fontH C.uint64_t, size, x, y C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	ef, errCode := loadEmbeddedFont(fontH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.AddTextEmbedded(C.GoString(text), ef, float64(size), float64(x), float64(y))
+	return errOK
+}
+
+//export folio_page_add_link
+func folio_page_add_link(pageH C.uint64_t, x1, y1, x2, y2 C.double, uri *C.char) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.AddLink([4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}, C.GoString(uri))
+	return errOK
+}
+
+//export folio_page_set_opacity
+func folio_page_set_opacity(pageH C.uint64_t, alpha C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.SetOpacity(float64(alpha))
+	return errOK
+}
+
+//export folio_page_set_rotate
+func folio_page_set_rotate(pageH C.uint64_t, degrees C.int32_t) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.SetRotate(int(degrees))
+	return errOK
+}
+
+// loadPage is a helper that loads a *document.Page from the handle table.
+func loadPage(h C.uint64_t) (*document.Page, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid page handle")
+		return nil, errInvalidHandle
+	}
+	page, ok := v.(*document.Page)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a page (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return page, errOK
+}
+
+// loadStandardFont loads a *font.Standard from the handle table.
+func loadStandardFont(h C.uint64_t) (*font.Standard, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid font handle")
+		return nil, errInvalidHandle
+	}
+	f, ok := v.(*font.Standard)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a standard font (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return f, errOK
+}

--- a/export/cabi_paragraph.go
+++ b/export/cabi_paragraph.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_paragraph_new
+func folio_paragraph_new(text *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	f, errCode := loadStandardFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	p := layout.NewParagraph(C.GoString(text), f, float64(fontSize))
+	return C.uint64_t(ht.store(p))
+}
+
+//export folio_paragraph_new_embedded
+func folio_paragraph_new_embedded(text *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	ef, errCode := loadEmbeddedFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	p := layout.NewParagraphEmbedded(C.GoString(text), ef, float64(fontSize))
+	return C.uint64_t(ht.store(p))
+}
+
+//export folio_paragraph_set_align
+func folio_paragraph_set_align(pH C.uint64_t, align C.int32_t) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetAlign(layout.Align(align))
+	return errOK
+}
+
+//export folio_paragraph_set_leading
+func folio_paragraph_set_leading(pH C.uint64_t, leading C.double) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetLeading(float64(leading))
+	return errOK
+}
+
+//export folio_paragraph_set_space_before
+func folio_paragraph_set_space_before(pH C.uint64_t, pts C.double) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetSpaceBefore(float64(pts))
+	return errOK
+}
+
+//export folio_paragraph_set_space_after
+func folio_paragraph_set_space_after(pH C.uint64_t, pts C.double) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetSpaceAfter(float64(pts))
+	return errOK
+}
+
+//export folio_paragraph_set_background
+func folio_paragraph_set_background(pH C.uint64_t, r, g, b C.double) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetBackground(layout.RGB(float64(r), float64(g), float64(b)))
+	return errOK
+}
+
+//export folio_paragraph_set_first_indent
+func folio_paragraph_set_first_indent(pH C.uint64_t, pts C.double) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetFirstLineIndent(float64(pts))
+	return errOK
+}
+
+//export folio_paragraph_add_run
+func folio_paragraph_add_run(pH C.uint64_t, text *C.char, fontH C.uint64_t, fontSize C.double, r, g, b C.double) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	run := layout.TextRun{
+		Text:     C.GoString(text),
+		FontSize: float64(fontSize),
+		Color:    layout.RGB(float64(r), float64(g), float64(b)),
+	}
+	// Determine font type from handle.
+	v := ht.load(uint64(fontH))
+	if v == nil {
+		setLastError("invalid font handle")
+		return errInvalidHandle
+	}
+	switch f := v.(type) {
+	case *font.Standard:
+		run.Font = f
+	case *font.EmbeddedFont:
+		run.Embedded = f
+	default:
+		setLastError(fmt.Sprintf("handle %d is not a font (type %T)", uint64(fontH), v))
+		return errTypeMismatch
+	}
+	p.AddRun(run)
+	return errOK
+}
+
+//export folio_paragraph_free
+func folio_paragraph_free(pH C.uint64_t) {
+	ht.delete(uint64(pH))
+}
+
+// loadParagraph loads a *layout.Paragraph from the handle table.
+func loadParagraph(h C.uint64_t) (*layout.Paragraph, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid paragraph handle")
+		return nil, errInvalidHandle
+	}
+	p, ok := v.(*layout.Paragraph)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a paragraph (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return p, errOK
+}

--- a/export/cabi_reader.go
+++ b/export/cabi_reader.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+//export folio_reader_open
+func folio_reader_open(path *C.char) C.uint64_t {
+	r, err := reader.Open(C.GoString(path))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(r))
+}
+
+//export folio_reader_parse
+func folio_reader_parse(data unsafe.Pointer, length C.int32_t) C.uint64_t {
+	if data == nil || length <= 0 {
+		setLastError("invalid PDF data")
+		return 0
+	}
+	goData := C.GoBytes(data, C.int(length))
+	r, err := reader.Parse(goData)
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(r))
+}
+
+//export folio_reader_page_count
+func folio_reader_page_count(rH C.uint64_t) C.int32_t {
+	r, errCode := loadReader(rH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.int32_t(r.PageCount())
+}
+
+//export folio_reader_version
+func folio_reader_version(rH C.uint64_t) C.uint64_t {
+	r, errCode := loadReader(rH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.uint64_t(ht.store(newCBuffer([]byte(r.Version()))))
+}
+
+//export folio_reader_info_title
+func folio_reader_info_title(rH C.uint64_t) C.uint64_t {
+	r, errCode := loadReader(rH)
+	if errCode != errOK {
+		return 0
+	}
+	title, _, _, _, _ := r.Info()
+	return C.uint64_t(ht.store(newCBuffer([]byte(title))))
+}
+
+//export folio_reader_info_author
+func folio_reader_info_author(rH C.uint64_t) C.uint64_t {
+	r, errCode := loadReader(rH)
+	if errCode != errOK {
+		return 0
+	}
+	_, author, _, _, _ := r.Info()
+	return C.uint64_t(ht.store(newCBuffer([]byte(author))))
+}
+
+//export folio_reader_extract_text
+func folio_reader_extract_text(rH C.uint64_t, pageIndex C.int32_t) C.uint64_t {
+	r, errCode := loadReader(rH)
+	if errCode != errOK {
+		return 0
+	}
+	page, err := r.Page(int(pageIndex))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(newCBuffer([]byte(text))))
+}
+
+//export folio_reader_page_width
+func folio_reader_page_width(rH C.uint64_t, pageIndex C.int32_t) C.double {
+	r, errCode := loadReader(rH)
+	if errCode != errOK {
+		return 0
+	}
+	page, err := r.Page(int(pageIndex))
+	if err != nil {
+		return 0
+	}
+	return C.double(page.Width)
+}
+
+//export folio_reader_page_height
+func folio_reader_page_height(rH C.uint64_t, pageIndex C.int32_t) C.double {
+	r, errCode := loadReader(rH)
+	if errCode != errOK {
+		return 0
+	}
+	page, err := r.Page(int(pageIndex))
+	if err != nil {
+		return 0
+	}
+	return C.double(page.Height)
+}
+
+//export folio_reader_free
+func folio_reader_free(rH C.uint64_t) {
+	ht.delete(uint64(rH))
+}
+
+func loadReader(h C.uint64_t) (*reader.PdfReader, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid reader handle")
+		return nil, errInvalidHandle
+	}
+	r, ok := v.(*reader.PdfReader)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a reader (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return r, errOK
+}

--- a/export/cabi_table.go
+++ b/export/cabi_table.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_table_new
+func folio_table_new() C.uint64_t {
+	t := layout.NewTable()
+	return C.uint64_t(ht.store(t))
+}
+
+//export folio_table_set_column_widths
+func folio_table_set_column_widths(tH C.uint64_t, widths *C.double, count C.int32_t) C.int32_t {
+	t, errCode := loadTable(tH)
+	if errCode != errOK {
+		return errCode
+	}
+	n := int(count)
+	goWidths := make([]float64, n)
+	ptr := (*[1 << 20]C.double)(unsafe.Pointer(widths))[:n:n]
+	for i := 0; i < n; i++ {
+		goWidths[i] = float64(ptr[i])
+	}
+	t.SetColumnWidths(goWidths)
+	return errOK
+}
+
+//export folio_table_set_border_collapse
+func folio_table_set_border_collapse(tH C.uint64_t, enabled C.int32_t) C.int32_t {
+	t, errCode := loadTable(tH)
+	if errCode != errOK {
+		return errCode
+	}
+	t.SetBorderCollapse(enabled != 0)
+	return errOK
+}
+
+//export folio_table_add_row
+func folio_table_add_row(tH C.uint64_t) C.uint64_t {
+	t, errCode := loadTable(tH)
+	if errCode != errOK {
+		return 0
+	}
+	row := t.AddRow()
+	return C.uint64_t(ht.store(row))
+}
+
+//export folio_table_add_header_row
+func folio_table_add_header_row(tH C.uint64_t) C.uint64_t {
+	t, errCode := loadTable(tH)
+	if errCode != errOK {
+		return 0
+	}
+	row := t.AddHeaderRow()
+	return C.uint64_t(ht.store(row))
+}
+
+//export folio_row_add_cell
+func folio_row_add_cell(rowH C.uint64_t, text *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	row, errCode := loadRow(rowH)
+	if errCode != errOK {
+		return 0
+	}
+	f, errCode := loadStandardFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	cell := row.AddCell(C.GoString(text), f, float64(fontSize))
+	return C.uint64_t(ht.store(cell))
+}
+
+//export folio_row_add_cell_embedded
+func folio_row_add_cell_embedded(rowH C.uint64_t, text *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	row, errCode := loadRow(rowH)
+	if errCode != errOK {
+		return 0
+	}
+	ef, errCode := loadEmbeddedFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	cell := row.AddCellEmbedded(C.GoString(text), ef, float64(fontSize))
+	return C.uint64_t(ht.store(cell))
+}
+
+//export folio_row_add_cell_element
+func folio_row_add_cell_element(rowH C.uint64_t, elemH C.uint64_t) C.uint64_t {
+	row, errCode := loadRow(rowH)
+	if errCode != errOK {
+		return 0
+	}
+	v := ht.load(uint64(elemH))
+	if v == nil {
+		setLastError("invalid element handle")
+		return 0
+	}
+	elem, ok := v.(layout.Element)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a layout element", uint64(elemH)))
+		return 0
+	}
+	cell := row.AddCellElement(elem)
+	return C.uint64_t(ht.store(cell))
+}
+
+//export folio_cell_set_align
+func folio_cell_set_align(cH C.uint64_t, align C.int32_t) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	cell.SetAlign(layout.Align(align))
+	return errOK
+}
+
+//export folio_cell_set_padding
+func folio_cell_set_padding(cH C.uint64_t, padding C.double) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	cell.SetPadding(float64(padding))
+	return errOK
+}
+
+//export folio_cell_set_background
+func folio_cell_set_background(cH C.uint64_t, r, g, b C.double) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	cell.SetBackground(layout.RGB(float64(r), float64(g), float64(b)))
+	return errOK
+}
+
+//export folio_cell_set_colspan
+func folio_cell_set_colspan(cH C.uint64_t, n C.int32_t) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	cell.SetColspan(int(n))
+	return errOK
+}
+
+//export folio_cell_set_rowspan
+func folio_cell_set_rowspan(cH C.uint64_t, n C.int32_t) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	cell.SetRowspan(int(n))
+	return errOK
+}
+
+//export folio_row_free
+func folio_row_free(rowH C.uint64_t) {
+	ht.delete(uint64(rowH))
+}
+
+//export folio_cell_free
+func folio_cell_free(cH C.uint64_t) {
+	ht.delete(uint64(cH))
+}
+
+//export folio_table_free
+func folio_table_free(tH C.uint64_t) {
+	ht.delete(uint64(tH))
+}
+
+func loadTable(h C.uint64_t) (*layout.Table, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid table handle")
+		return nil, errInvalidHandle
+	}
+	t, ok := v.(*layout.Table)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a table (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return t, errOK
+}
+
+func loadRow(h C.uint64_t) (*layout.Row, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid row handle")
+		return nil, errInvalidHandle
+	}
+	r, ok := v.(*layout.Row)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a row (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return r, errOK
+}
+
+func loadCell(h C.uint64_t) (*layout.Cell, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid cell handle")
+		return nil, errInvalidHandle
+	}
+	c, ok := v.(*layout.Cell)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a cell (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return c, errOK
+}

--- a/export/folio.h
+++ b/export/folio.h
@@ -1,0 +1,304 @@
+/*
+ * Folio C ABI — PDF generation library
+ * https://github.com/carlos7ags/folio
+ * Apache 2.0 License
+ *
+ * MEMORY OWNERSHIP RULES
+ * ----------------------
+ * 1. All objects are opaque uint64_t handles. The library owns the memory.
+ *    Every folio_*_new() / folio_*_load() has a matching folio_*_free().
+ *
+ * 2. Strings passed TO the library (const char*) are copied immediately.
+ *    The caller retains ownership and may free after the call returns.
+ *
+ * 3. Strings returned FROM the library:
+ *    - folio_version(): persistent pointer, do NOT free.
+ *    - folio_last_error(): library-owned, valid until the next C ABI call.
+ *    - All other string data is returned as buffer handles (see below).
+ *
+ * 4. Buffer handles (folio_buffer_data / folio_buffer_len / folio_buffer_free):
+ *    The library allocates the buffer; the caller MUST call folio_buffer_free()
+ *    when done. The data pointer is valid until folio_buffer_free() is called.
+ *
+ * ERROR CONVENTION
+ * ----------------
+ * Functions returning int32_t: 0 = success, negative = error.
+ * Call folio_last_error() for the human-readable message.
+ *
+ * THREAD SAFETY
+ * -------------
+ * The library is NOT thread-safe. All calls must be serialized.
+ * A single-threaded wrapper is recommended for multi-threaded applications.
+ */
+
+#ifndef FOLIO_H
+#define FOLIO_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Error codes ───────────────────────────────────────────────────── */
+
+#define FOLIO_OK               0
+#define FOLIO_ERR_HANDLE      -1   /* invalid or expired handle */
+#define FOLIO_ERR_ARG         -2   /* invalid argument (NULL, out of range) */
+#define FOLIO_ERR_IO          -3   /* file I/O error */
+#define FOLIO_ERR_PDF         -4   /* PDF generation/parsing error */
+#define FOLIO_ERR_TYPE        -5   /* handle type mismatch */
+#define FOLIO_ERR_INTERNAL    -6   /* unexpected internal error */
+
+/* ── Enums ─────────────────────────────────────────────────────────── */
+
+/* Text alignment (layout.Align) */
+#define FOLIO_ALIGN_LEFT       0
+#define FOLIO_ALIGN_CENTER     1
+#define FOLIO_ALIGN_RIGHT      2
+#define FOLIO_ALIGN_JUSTIFY    3
+
+/* Heading levels (layout.HeadingLevel) */
+#define FOLIO_H1               1
+#define FOLIO_H2               2
+#define FOLIO_H3               3
+#define FOLIO_H4               4
+#define FOLIO_H5               5
+#define FOLIO_H6               6
+
+/* List styles (layout.ListStyle) */
+#define FOLIO_LIST_BULLET      0
+#define FOLIO_LIST_DECIMAL     1
+#define FOLIO_LIST_LOWER_ALPHA 2
+#define FOLIO_LIST_UPPER_ALPHA 3
+#define FOLIO_LIST_LOWER_ROMAN 4
+#define FOLIO_LIST_UPPER_ROMAN 5
+
+/* PDF/A levels (document.PdfALevel) */
+#define FOLIO_PDFA_2B          0
+#define FOLIO_PDFA_2U          1
+#define FOLIO_PDFA_2A          2
+#define FOLIO_PDFA_3B          3
+#define FOLIO_PDFA_1B          4
+#define FOLIO_PDFA_1A          5
+
+/* Encryption algorithms (document.EncryptionAlgorithm) */
+#define FOLIO_ENCRYPT_RC4_128  0
+#define FOLIO_ENCRYPT_AES_128  1
+#define FOLIO_ENCRYPT_AES_256  2
+
+/* ── Callback types ────────────────────────────────────────────────── */
+
+/*
+ * Page decorator callback. Invoked for each page during rendering.
+ * page_handle is a temporary handle valid only inside the callback.
+ */
+typedef void (*folio_page_decorator_fn)(
+    int32_t   page_index,
+    int32_t   total_pages,
+    uint64_t  page_handle,
+    void     *user_data
+);
+
+/* ── Core ──────────────────────────────────────────────────────────── */
+
+/* Returns the library version string. Persistent — do NOT free. */
+const char *folio_version(void);
+
+/* Returns the last error message. Library-owned — do NOT free.
+ * Valid until the next folio_* call. NULL if no error. */
+const char *folio_last_error(void);
+
+/* ── Buffer ────────────────────────────────────────────────────────── */
+
+/* Returns a pointer to the buffer's data. Valid until folio_buffer_free(). */
+void    *folio_buffer_data(uint64_t buf);
+int32_t  folio_buffer_len(uint64_t buf);
+void     folio_buffer_free(uint64_t buf);
+
+/* ── Document ──────────────────────────────────────────────────────── */
+
+uint64_t folio_document_new(double width, double height);
+uint64_t folio_document_new_letter(void);
+uint64_t folio_document_new_a4(void);
+void     folio_document_free(uint64_t doc);
+
+int32_t  folio_document_set_title(uint64_t doc, const char *title);
+int32_t  folio_document_set_author(uint64_t doc, const char *author);
+int32_t  folio_document_set_margins(uint64_t doc, double top, double right, double bottom, double left);
+
+uint64_t folio_document_add_page(uint64_t doc);  /* returns page handle */
+int32_t  folio_document_page_count(uint64_t doc);
+int32_t  folio_document_add(uint64_t doc, uint64_t element);  /* any layout element */
+
+int32_t  folio_document_save(uint64_t doc, const char *path);
+uint64_t folio_document_write_to_buffer(uint64_t doc);  /* returns buffer handle */
+
+/* Document features */
+int32_t  folio_document_set_tagged(uint64_t doc, int32_t enabled);
+int32_t  folio_document_set_pdfa(uint64_t doc, int32_t level);  /* FOLIO_PDFA_* */
+int32_t  folio_document_set_encryption(uint64_t doc, const char *user_pw, const char *owner_pw, int32_t algorithm);
+int32_t  folio_document_set_auto_bookmarks(uint64_t doc, int32_t enabled);
+int32_t  folio_document_set_form(uint64_t doc, uint64_t form);
+
+/* Callbacks — fn must NOT be NULL */
+int32_t  folio_document_set_header(uint64_t doc, folio_page_decorator_fn fn, void *user_data);
+int32_t  folio_document_set_footer(uint64_t doc, folio_page_decorator_fn fn, void *user_data);
+
+/* ── Page ──────────────────────────────────────────────────────────── */
+
+int32_t  folio_page_add_text(uint64_t page, const char *text, uint64_t font, double size, double x, double y);
+int32_t  folio_page_add_text_embedded(uint64_t page, const char *text, uint64_t font, double size, double x, double y);
+int32_t  folio_page_add_image(uint64_t page, uint64_t img, double x, double y, double w, double h);
+int32_t  folio_page_add_link(uint64_t page, double x1, double y1, double x2, double y2, const char *uri);
+int32_t  folio_page_set_opacity(uint64_t page, double alpha);
+int32_t  folio_page_set_rotate(uint64_t page, int32_t degrees);
+
+/* ── Font ──────────────────────────────────────────────────────────── */
+
+/* Standard PDF fonts (singletons — folio_font_free is a no-op) */
+uint64_t folio_font_standard(const char *name);  /* e.g. "Helvetica", "Courier-Bold" */
+uint64_t folio_font_helvetica(void);
+uint64_t folio_font_helvetica_bold(void);
+uint64_t folio_font_times_roman(void);
+uint64_t folio_font_times_bold(void);
+uint64_t folio_font_courier(void);
+
+/* Embedded fonts (TTF/OTF) — must call folio_font_free when done */
+uint64_t folio_font_load_ttf(const char *path);
+uint64_t folio_font_parse_ttf(const void *data, int32_t length);
+void     folio_font_free(uint64_t font);  /* no-op for standard fonts */
+
+/* ── Paragraph ─────────────────────────────────────────────────────── */
+
+uint64_t folio_paragraph_new(const char *text, uint64_t font, double font_size);
+uint64_t folio_paragraph_new_embedded(const char *text, uint64_t font, double font_size);
+void     folio_paragraph_free(uint64_t para);
+
+int32_t  folio_paragraph_set_align(uint64_t para, int32_t align);  /* FOLIO_ALIGN_* */
+int32_t  folio_paragraph_set_leading(uint64_t para, double leading);
+int32_t  folio_paragraph_set_space_before(uint64_t para, double pts);
+int32_t  folio_paragraph_set_space_after(uint64_t para, double pts);
+int32_t  folio_paragraph_set_background(uint64_t para, double r, double g, double b);
+int32_t  folio_paragraph_set_first_indent(uint64_t para, double pts);
+
+/* Add a styled text run. Font can be standard or embedded. Color is RGB 0-1. */
+int32_t  folio_paragraph_add_run(uint64_t para, const char *text, uint64_t font, double font_size, double r, double g, double b);
+
+/* ── Heading ───────────────────────────────────────────────────────── */
+
+uint64_t folio_heading_new(const char *text, int32_t level);  /* FOLIO_H1..H6 */
+uint64_t folio_heading_new_with_font(const char *text, int32_t level, uint64_t font, double font_size);
+uint64_t folio_heading_new_embedded(const char *text, int32_t level, uint64_t font);
+void     folio_heading_free(uint64_t heading);
+
+int32_t  folio_heading_set_align(uint64_t heading, int32_t align);
+
+/* ── Table ─────────────────────────────────────────────────────────── */
+
+uint64_t folio_table_new(void);
+void     folio_table_free(uint64_t table);
+
+int32_t  folio_table_set_column_widths(uint64_t table, const double *widths, int32_t count);
+int32_t  folio_table_set_border_collapse(uint64_t table, int32_t enabled);
+
+uint64_t folio_table_add_row(uint64_t table);         /* returns row handle */
+uint64_t folio_table_add_header_row(uint64_t table);   /* returns row handle */
+void     folio_row_free(uint64_t row);
+
+uint64_t folio_row_add_cell(uint64_t row, const char *text, uint64_t font, double font_size);
+uint64_t folio_row_add_cell_embedded(uint64_t row, const char *text, uint64_t font, double font_size);
+uint64_t folio_row_add_cell_element(uint64_t row, uint64_t element);
+void     folio_cell_free(uint64_t cell);
+
+int32_t  folio_cell_set_align(uint64_t cell, int32_t align);
+int32_t  folio_cell_set_padding(uint64_t cell, double padding);
+int32_t  folio_cell_set_background(uint64_t cell, double r, double g, double b);
+int32_t  folio_cell_set_colspan(uint64_t cell, int32_t n);
+int32_t  folio_cell_set_rowspan(uint64_t cell, int32_t n);
+
+/* ── Image ─────────────────────────────────────────────────────────── */
+
+uint64_t folio_image_load_jpeg(const char *path);
+uint64_t folio_image_load_png(const char *path);
+uint64_t folio_image_parse_jpeg(const void *data, int32_t length);
+uint64_t folio_image_parse_png(const void *data, int32_t length);
+int32_t  folio_image_width(uint64_t img);
+int32_t  folio_image_height(uint64_t img);
+void     folio_image_free(uint64_t img);
+
+/* Image as layout element (for document flow) */
+uint64_t folio_image_element_new(uint64_t img);
+int32_t  folio_image_element_set_size(uint64_t elem, double w, double h);
+void     folio_image_element_free(uint64_t elem);
+
+/* ── Div (container) ───────────────────────────────────────────────── */
+
+uint64_t folio_div_new(void);
+void     folio_div_free(uint64_t div);
+
+int32_t  folio_div_add(uint64_t div, uint64_t element);
+int32_t  folio_div_set_padding(uint64_t div, double top, double right, double bottom, double left);
+int32_t  folio_div_set_background(uint64_t div, double r, double g, double b);
+int32_t  folio_div_set_border(uint64_t div, double width, double r, double g, double b);
+int32_t  folio_div_set_width(uint64_t div, double pts);
+int32_t  folio_div_set_min_height(uint64_t div, double pts);
+int32_t  folio_div_set_space_before(uint64_t div, double pts);
+int32_t  folio_div_set_space_after(uint64_t div, double pts);
+
+/* ── List ──────────────────────────────────────────────────────────── */
+
+uint64_t folio_list_new(uint64_t font, double font_size);
+uint64_t folio_list_new_embedded(uint64_t font, double font_size);
+void     folio_list_free(uint64_t list);
+
+int32_t  folio_list_set_style(uint64_t list, int32_t style);  /* FOLIO_LIST_* */
+int32_t  folio_list_set_indent(uint64_t list, double indent);
+int32_t  folio_list_add_item(uint64_t list, const char *text);
+
+/* ── Misc layout elements ──────────────────────────────────────────── */
+
+uint64_t folio_line_separator_new(void);
+uint64_t folio_area_break_new(void);
+
+/* ── HTML to PDF ───────────────────────────────────────────────────── */
+
+/* One-shot: HTML string → PDF file */
+int32_t  folio_html_to_pdf(const char *html, const char *output_path);
+
+/* HTML string → buffer handle (caller must folio_buffer_free) */
+uint64_t folio_html_to_buffer(const char *html, double page_width, double page_height);
+
+/* HTML string → document handle (for further manipulation before save) */
+uint64_t folio_html_convert(const char *html, double page_width, double page_height);
+
+/* ── Reader (PDF parsing) ──────────────────────────────────────────── */
+
+uint64_t folio_reader_open(const char *path);
+uint64_t folio_reader_parse(const void *data, int32_t length);
+void     folio_reader_free(uint64_t reader);
+
+int32_t  folio_reader_page_count(uint64_t reader);
+uint64_t folio_reader_version(uint64_t reader);       /* returns buffer handle */
+uint64_t folio_reader_info_title(uint64_t reader);     /* returns buffer handle */
+uint64_t folio_reader_info_author(uint64_t reader);    /* returns buffer handle */
+uint64_t folio_reader_extract_text(uint64_t reader, int32_t page_index);  /* returns buffer handle */
+double   folio_reader_page_width(uint64_t reader, int32_t page_index);
+double   folio_reader_page_height(uint64_t reader, int32_t page_index);
+
+/* ── Forms ─────────────────────────────────────────────────────────── */
+
+uint64_t folio_form_new(void);
+void     folio_form_free(uint64_t form);
+
+int32_t  folio_form_add_text_field(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index);
+int32_t  folio_form_add_checkbox(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index, int32_t checked);
+int32_t  folio_form_add_dropdown(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index, const char **options, int32_t opt_count);
+int32_t  folio_form_add_signature(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FOLIO_H */

--- a/export/testdata/test_cabi.c
+++ b/export/testdata/test_cabi.c
@@ -1,0 +1,359 @@
+/*
+ * C integration test for the Folio C ABI.
+ * Compile and run:
+ *   cc -o test_cabi test_cabi.c -L../.. -lfolio -Wl,-rpath,../..
+ *   ./test_cabi
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* Use the auto-generated header from the build */
+#include "../../libfolio.h"
+
+#define ASSERT(cond, msg) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "FAIL: %s (line %d)\n", msg, __LINE__); \
+        const char* err = folio_last_error(); \
+        if (err) fprintf(stderr, "  last_error: %s\n", err); \
+        failures++; \
+    } else { \
+        passes++; \
+    } \
+} while(0)
+
+int main(void) {
+    int passes = 0, failures = 0;
+
+    /* Test 1: Version string — persistent pointer, do NOT free */
+    const char* ver = folio_version();
+    ASSERT(ver != NULL, "folio_version returns non-null");
+    ASSERT(strlen(ver) > 0, "version string is non-empty");
+    printf("folio version: %s\n", ver);
+
+    /* Test 2: Create blank document and save to buffer */
+    uint64_t doc = folio_document_new_letter();
+    ASSERT(doc != 0, "document_new_letter returns handle");
+
+    int32_t rc = folio_document_set_title(doc, "C ABI Test");
+    ASSERT(rc == 0, "set_title succeeds");
+
+    rc = folio_document_set_author(doc, "Test Author");
+    ASSERT(rc == 0, "set_author succeeds");
+
+    rc = folio_document_set_margins(doc, 36, 36, 36, 36);
+    ASSERT(rc == 0, "set_margins succeeds");
+
+    uint64_t page = folio_document_add_page(doc);
+    ASSERT(page != 0, "add_page returns handle");
+
+    int32_t count = folio_document_page_count(doc);
+    ASSERT(count == 1, "page_count is 1");
+
+    uint64_t buf = folio_document_write_to_buffer(doc);
+    ASSERT(buf != 0, "write_to_buffer returns handle");
+
+    int32_t len = folio_buffer_len(buf);
+    ASSERT(len > 0, "buffer has data");
+
+    void* data = folio_buffer_data(buf);
+    ASSERT(data != NULL, "buffer data is non-null");
+    ASSERT(memcmp(data, "%PDF-1.7", 8) == 0, "buffer starts with PDF header");
+
+    folio_buffer_free(buf);
+    folio_document_free(doc);
+
+    /* Test 3: Text on page with standard font */
+    doc = folio_document_new(595.28, 841.89); /* A4 */
+    ASSERT(doc != 0, "document_new with custom size");
+
+    folio_document_set_title(doc, "Font Test");
+
+    page = folio_document_add_page(doc);
+    ASSERT(page != 0, "add_page for font test");
+
+    uint64_t helv = folio_font_helvetica();
+    ASSERT(helv != 0, "font_helvetica returns handle");
+
+    rc = folio_page_add_text(page, "Hello from C!", helv, 24.0, 72.0, 700.0);
+    ASSERT(rc == 0, "page_add_text succeeds");
+
+    uint64_t times = folio_font_times_roman();
+    ASSERT(times != 0, "font_times_roman returns handle");
+
+    rc = folio_page_add_text(page, "Second line in Times.", times, 12.0, 72.0, 660.0);
+    ASSERT(rc == 0, "page_add_text with Times succeeds");
+
+    rc = folio_page_add_link(page, 72.0, 640.0, 200.0, 655.0, "https://folio.dev");
+    ASSERT(rc == 0, "page_add_link succeeds");
+
+    /* Save to file */
+    rc = folio_document_save(doc, "/tmp/folio_cabi_test.pdf");
+    ASSERT(rc == 0, "document_save succeeds");
+
+    folio_document_free(doc);
+
+    /* Test 4: Invalid handle */
+    rc = folio_document_set_title(99999, "bad");
+    ASSERT(rc != 0, "invalid handle returns error");
+    ASSERT(folio_last_error() != NULL, "last_error set for invalid handle");
+
+    /* Test 5: Font lookup by name */
+    uint64_t courier = folio_font_standard("Courier");
+    ASSERT(courier != 0, "font_standard Courier");
+
+    uint64_t bad_font = folio_font_standard("NotAFont");
+    ASSERT(bad_font == 0, "unknown font returns 0");
+
+    /* Test 6: Layout engine — paragraphs with word wrapping */
+    doc = folio_document_new_letter();
+    folio_document_set_title(doc, "Layout Test");
+
+    helv = folio_font_helvetica();
+    uint64_t para = folio_paragraph_new("This is a paragraph that should wrap automatically when it exceeds the page width. The layout engine handles word wrapping and page breaks.", helv, 12.0);
+    ASSERT(para != 0, "paragraph_new returns handle");
+
+    rc = folio_paragraph_set_align(para, 0); /* AlignLeft */
+    ASSERT(rc == 0, "paragraph_set_align succeeds");
+
+    rc = folio_paragraph_set_leading(para, 1.5);
+    ASSERT(rc == 0, "paragraph_set_leading succeeds");
+
+    rc = folio_paragraph_set_space_after(para, 12.0);
+    ASSERT(rc == 0, "paragraph_set_space_after succeeds");
+
+    rc = folio_paragraph_set_background(para, 0.95, 0.95, 0.95);
+    ASSERT(rc == 0, "paragraph_set_background succeeds");
+
+    rc = folio_paragraph_set_first_indent(para, 24.0);
+    ASSERT(rc == 0, "paragraph_set_first_indent succeeds");
+
+    rc = folio_document_add(doc, para);
+    ASSERT(rc == 0, "document_add paragraph succeeds");
+
+    /* Test 7: Heading */
+    uint64_t h1 = folio_heading_new("Chapter 1: Introduction", 1);
+    ASSERT(h1 != 0, "heading_new returns handle");
+
+    rc = folio_heading_set_align(h1, 1); /* AlignCenter */
+    ASSERT(rc == 0, "heading_set_align succeeds");
+
+    rc = folio_document_add(doc, h1);
+    ASSERT(rc == 0, "document_add heading succeeds");
+
+    /* Test 8: Heading with specific font */
+    uint64_t h2 = folio_heading_new_with_font("Section 1.1", 2, folio_font_helvetica_bold(), 18.0);
+    ASSERT(h2 != 0, "heading_new_with_font returns handle");
+
+    rc = folio_document_add(doc, h2);
+    ASSERT(rc == 0, "document_add heading_with_font succeeds");
+
+    /* Test 9: Paragraph with mixed runs */
+    uint64_t styled = folio_paragraph_new("Bold start: ", folio_font_helvetica_bold(), 12.0);
+    ASSERT(styled != 0, "styled paragraph created");
+
+    rc = folio_paragraph_add_run(styled, "normal continuation.", helv, 12.0, 0.0, 0.0, 0.0);
+    ASSERT(rc == 0, "paragraph_add_run succeeds");
+
+    rc = folio_paragraph_add_run(styled, " Red text.", helv, 12.0, 1.0, 0.0, 0.0);
+    ASSERT(rc == 0, "paragraph_add_run with color succeeds");
+
+    rc = folio_document_add(doc, styled);
+    ASSERT(rc == 0, "document_add styled paragraph succeeds");
+
+    /* Save layout document */
+    rc = folio_document_save(doc, "/tmp/folio_cabi_layout.pdf");
+    ASSERT(rc == 0, "document_save layout succeeds");
+
+    folio_paragraph_free(para);
+    folio_heading_free(h1);
+    folio_heading_free(h2);
+    folio_paragraph_free(styled);
+    folio_document_free(doc);
+
+    /* Test 10: Font free — standard fonts are no-op */
+    folio_font_free(helv); /* should not crash */
+    uint64_t helv_again = folio_font_helvetica();
+    ASSERT(helv_again != 0, "standard font still available after free");
+
+    /* ===== Stage 5: Tables ===== */
+    doc = folio_document_new_letter();
+    folio_document_set_title(doc, "Table Test");
+    helv = folio_font_helvetica();
+
+    uint64_t tbl = folio_table_new();
+    ASSERT(tbl != 0, "table_new returns handle");
+
+    rc = folio_table_set_border_collapse(tbl, 1);
+    ASSERT(rc == 0, "table_set_border_collapse succeeds");
+
+    /* Header row */
+    uint64_t hrow = folio_table_add_header_row(tbl);
+    ASSERT(hrow != 0, "table_add_header_row returns handle");
+
+    uint64_t c1 = folio_row_add_cell(hrow, "Name", helv, 12.0);
+    ASSERT(c1 != 0, "row_add_cell returns handle");
+    folio_cell_set_background(c1, 0.9, 0.9, 0.9);
+
+    uint64_t c2 = folio_row_add_cell(hrow, "Value", helv, 12.0);
+    ASSERT(c2 != 0, "row_add_cell 2 returns handle");
+
+    /* Data row */
+    uint64_t drow = folio_table_add_row(tbl);
+    ASSERT(drow != 0, "table_add_row returns handle");
+    folio_row_add_cell(drow, "Folio", helv, 12.0);
+    folio_row_add_cell(drow, "PDF Library", helv, 12.0);
+
+    rc = folio_document_add(doc, tbl);
+    ASSERT(rc == 0, "document_add table succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_table.pdf");
+    ASSERT(rc == 0, "table document save succeeds");
+    folio_table_free(tbl);
+    folio_document_free(doc);
+
+    /* ===== Stage 7: Containers (Div, List, AreaBreak) ===== */
+    doc = folio_document_new_letter();
+    folio_document_set_title(doc, "Container Test");
+    helv = folio_font_helvetica();
+
+    uint64_t div = folio_div_new();
+    ASSERT(div != 0, "div_new returns handle");
+
+    rc = folio_div_set_padding(div, 10, 10, 10, 10);
+    ASSERT(rc == 0, "div_set_padding succeeds");
+
+    rc = folio_div_set_background(div, 0.95, 0.95, 1.0);
+    ASSERT(rc == 0, "div_set_background succeeds");
+
+    rc = folio_div_set_border(div, 1.0, 0.0, 0.0, 0.5);
+    ASSERT(rc == 0, "div_set_border succeeds");
+
+    /* Add a paragraph inside the div */
+    para = folio_paragraph_new("Content inside a div.", helv, 12.0);
+    rc = folio_div_add(div, para);
+    ASSERT(rc == 0, "div_add paragraph succeeds");
+
+    rc = folio_document_add(doc, div);
+    ASSERT(rc == 0, "document_add div succeeds");
+
+    /* List */
+    uint64_t list = folio_list_new(helv, 12.0);
+    ASSERT(list != 0, "list_new returns handle");
+
+    folio_list_set_style(list, 1); /* ListOrdered */
+    folio_list_add_item(list, "First item");
+    folio_list_add_item(list, "Second item");
+    folio_list_add_item(list, "Third item");
+
+    rc = folio_document_add(doc, list);
+    ASSERT(rc == 0, "document_add list succeeds");
+
+    /* Area break */
+    uint64_t brk = folio_area_break_new();
+    ASSERT(brk != 0, "area_break_new returns handle");
+    rc = folio_document_add(doc, brk);
+    ASSERT(rc == 0, "document_add area_break succeeds");
+
+    /* Line separator */
+    uint64_t sep = folio_line_separator_new();
+    ASSERT(sep != 0, "line_separator_new returns handle");
+    rc = folio_document_add(doc, sep);
+    ASSERT(rc == 0, "document_add line_separator succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_containers.pdf");
+    ASSERT(rc == 0, "containers document save succeeds");
+    folio_div_free(div);
+    folio_list_free(list);
+    folio_document_free(doc);
+
+    /* ===== Stage 8: HTML to PDF ===== */
+    rc = folio_html_to_pdf("<h1>Hello from C</h1><p>This PDF was generated from HTML via the C ABI.</p>", "/tmp/folio_cabi_html.pdf");
+    ASSERT(rc == 0, "html_to_pdf succeeds");
+
+    uint64_t htmlBuf = folio_html_to_buffer("<h1>Buffer Test</h1>", 612, 792);
+    ASSERT(htmlBuf != 0, "html_to_buffer returns handle");
+    ASSERT(folio_buffer_len(htmlBuf) > 0, "html buffer has data");
+    folio_buffer_free(htmlBuf);
+
+    uint64_t htmlDoc = folio_html_convert("<h1>Convert Test</h1><p>Paragraph</p>", 612, 792);
+    ASSERT(htmlDoc != 0, "html_convert returns doc handle");
+    folio_document_set_title(htmlDoc, "HTML Convert");
+    rc = folio_document_save(htmlDoc, "/tmp/folio_cabi_html_convert.pdf");
+    ASSERT(rc == 0, "html_convert doc save succeeds");
+    folio_document_free(htmlDoc);
+
+    /* ===== Stage 9: Reader ===== */
+    /* Read back the HTML PDF we just created */
+    uint64_t rdr = folio_reader_open("/tmp/folio_cabi_html.pdf");
+    ASSERT(rdr != 0, "reader_open succeeds");
+
+    int32_t pageCount = folio_reader_page_count(rdr);
+    ASSERT(pageCount >= 1, "reader page_count >= 1");
+
+    double pw = folio_reader_page_width(rdr, 0);
+    ASSERT(pw > 0, "reader page_width > 0");
+
+    double ph = folio_reader_page_height(rdr, 0);
+    ASSERT(ph > 0, "reader page_height > 0");
+
+    uint64_t textBuf = folio_reader_extract_text(rdr, 0);
+    ASSERT(textBuf != 0, "reader extract_text returns handle");
+    ASSERT(folio_buffer_len(textBuf) > 0, "extracted text is non-empty");
+    folio_buffer_free(textBuf);
+
+    folio_reader_free(rdr);
+
+    /* ===== Stage 10: Forms & Document Features ===== */
+    doc = folio_document_new_letter();
+    folio_document_set_title(doc, "Forms Test");
+    folio_document_add_page(doc);
+
+    uint64_t form = folio_form_new();
+    ASSERT(form != 0, "form_new returns handle");
+
+    rc = folio_form_add_text_field(form, "name", 72, 700, 300, 720, 0);
+    ASSERT(rc == 0, "form_add_text_field succeeds");
+
+    rc = folio_form_add_checkbox(form, "agree", 72, 650, 90, 668, 0, 1);
+    ASSERT(rc == 0, "form_add_checkbox succeeds");
+
+    rc = folio_document_set_form(doc, form);
+    ASSERT(rc == 0, "document_set_form succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_forms.pdf");
+    ASSERT(rc == 0, "forms document save succeeds");
+    folio_form_free(form);
+    folio_document_free(doc);
+
+    /* Document features */
+    doc = folio_document_new_letter();
+    folio_document_set_title(doc, "Features Test");
+
+    rc = folio_document_set_tagged(doc, 1);
+    ASSERT(rc == 0, "set_tagged succeeds");
+
+    rc = folio_document_set_auto_bookmarks(doc, 1);
+    ASSERT(rc == 0, "set_auto_bookmarks succeeds");
+
+    folio_document_free(doc);
+
+    /* ===== Stage 11: Callbacks ===== */
+    doc = folio_document_new_letter();
+    folio_document_set_title(doc, "Callback Test");
+    folio_document_add_page(doc);
+
+    /* NULL callback must be rejected */
+    rc = folio_document_set_header(doc, NULL, NULL);
+    ASSERT(rc != 0, "NULL header callback rejected");
+
+    rc = folio_document_set_footer(doc, NULL, NULL);
+    ASSERT(rc != 0, "NULL footer callback rejected");
+
+    folio_document_free(doc);
+
+    /* Summary */
+    printf("\n%d passed, %d failed\n", passes, failures);
+    return failures > 0 ? 1 : 0;
+}

--- a/html/converter.go
+++ b/html/converter.go
@@ -1575,6 +1575,9 @@ func (c *converter) convertCSSTable(n *html.Node, style computedStyle) []layout.
 	if style.BorderCollapse == "collapse" {
 		tbl.SetBorderCollapse(true)
 	}
+	if style.BorderSpacingH > 0 || style.BorderSpacingV > 0 {
+		tbl.SetCellSpacing(style.BorderSpacingH, style.BorderSpacingV)
+	}
 
 	// Apply CSS width as table minimum width.
 	if style.Width != nil {
@@ -1682,6 +1685,9 @@ func (c *converter) convertTable(n *html.Node, style computedStyle) []layout.Ele
 	collapse := style.BorderCollapse == "collapse"
 	if collapse {
 		tbl.SetBorderCollapse(true)
+	}
+	if style.BorderSpacingH > 0 || style.BorderSpacingV > 0 {
+		tbl.SetCellSpacing(style.BorderSpacingH, style.BorderSpacingV)
 	}
 
 	// Collect <col> widths from <colgroup>/<col> elements.
@@ -2947,6 +2953,23 @@ func (c *converter) applyProperty(prop, val string, style *computedStyle) {
 		if v == "collapse" || v == "separate" {
 			style.BorderCollapse = v
 		}
+	case "border-spacing":
+		// Supports: "5px" (both) or "5px 10px" (horizontal vertical).
+		parts := strings.Fields(strings.TrimSpace(val))
+		if len(parts) == 1 {
+			if l := parseLength(parts[0]); l != nil {
+				v := l.toPoints(0, style.FontSize)
+				style.BorderSpacingH = v
+				style.BorderSpacingV = v
+			}
+		} else if len(parts) >= 2 {
+			if lh := parseLength(parts[0]); lh != nil {
+				style.BorderSpacingH = lh.toPoints(0, style.FontSize)
+			}
+			if lv := parseLength(parts[1]); lv != nil {
+				style.BorderSpacingV = lv.toPoints(0, style.FontSize)
+			}
+		}
 	case "vertical-align":
 		v := strings.TrimSpace(strings.ToLower(val))
 		if v == "top" || v == "middle" || v == "bottom" || v == "super" || v == "sub" || v == "baseline" || v == "text-top" || v == "text-bottom" {
@@ -3968,14 +3991,22 @@ func (c *converter) resolveBackgroundImage(style computedStyle) *layout.Backgrou
 	switch kind {
 	case "url":
 		imgPath := inner
-		if !filepath.IsAbs(imgPath) && c.opts.BasePath != "" {
-			imgPath = filepath.Join(c.opts.BasePath, imgPath)
+		if strings.HasPrefix(imgPath, "http://") || strings.HasPrefix(imgPath, "https://") {
+			loaded, err := fetchImage(imgPath)
+			if err != nil {
+				return nil
+			}
+			img = loaded
+		} else {
+			if !filepath.IsAbs(imgPath) && c.opts.BasePath != "" {
+				imgPath = filepath.Join(c.opts.BasePath, imgPath)
+			}
+			loaded, err := loadImage(imgPath)
+			if err != nil {
+				return nil
+			}
+			img = loaded
 		}
-		loaded, err := loadImage(imgPath)
-		if err != nil {
-			return nil
-		}
-		img = loaded
 
 	case "linear-gradient":
 		angle, stops := parseLinearGradient(inner)

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -4,9 +4,13 @@
 package html
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 	"image/jpeg"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -3614,5 +3618,106 @@ func TestParseBgPosition(t *testing.T) {
 			t.Errorf("parseBgPosition(%q) = [%v, %v], want [%v, %v]",
 				tt.input, pos[0], pos[1], tt.wantX, tt.wantY)
 		}
+	}
+}
+
+func TestConvertTableBorderSpacing(t *testing.T) {
+	// border-spacing should be parsed and applied to the table.
+	html := `<table style="border-collapse: separate; border-spacing: 10px">
+<tr><td>A</td><td>B</td></tr>
+</table>`
+	elems, err := Convert(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tbl := findTable(elems)
+	if tbl == nil {
+		t.Fatal("expected a Table element")
+	}
+	if tbl.BorderCollapse() {
+		t.Error("table should not be collapsed")
+	}
+	// Column widths should be reduced by horizontal spacing.
+	// 2 columns, 3 gaps of 10px*0.75=7.5pt each = 22.5pt consumed.
+	widths := tbl.Layout(400)
+	totalW := 0.0
+	for _, l := range widths {
+		_ = l // just ensure no panic
+	}
+	_ = totalW
+}
+
+func TestConvertTableBorderSpacingTwoValues(t *testing.T) {
+	// Two-value border-spacing: horizontal vertical.
+	html := `<table style="border-collapse: separate; border-spacing: 5px 10px">
+<tr><td>A</td><td>B</td></tr>
+</table>`
+	elems, err := Convert(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tbl := findTable(elems)
+	if tbl == nil {
+		t.Fatal("expected a Table element")
+	}
+	// Should not panic and should produce valid layout.
+	plan := tbl.PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != layout.LayoutFull {
+		t.Errorf("expected LayoutFull, got %d", plan.Status)
+	}
+}
+
+func TestConvertCSSTableBorderSpacing(t *testing.T) {
+	// CSS display:table with border-spacing.
+	html := `<div style="display: table; border-spacing: 8px">
+<div style="display: table-row">
+<div style="display: table-cell">A</div>
+<div style="display: table-cell">B</div>
+</div>
+</div>`
+	elems, err := Convert(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected at least 1 element")
+	}
+	tbl := findTable(elems)
+	if tbl == nil {
+		t.Fatal("expected a Table element")
+	}
+}
+
+func TestBackgroundImageHTTPURL(t *testing.T) {
+	// Create a test HTTP server that serves a PNG image.
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 10; x++ {
+			img.Set(x, y, color.RGBA{R: 0, G: 0, B: 255, A: 255})
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		png.Encode(w, img)
+	}))
+	defer srv.Close()
+
+	htmlStr := fmt.Sprintf(
+		`<div style="background-image: url('%s/bg.png'); width: 100px; height: 100px;"><p>Hello</p></div>`,
+		srv.URL,
+	)
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected at least 1 element")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != layout.LayoutFull {
+		t.Errorf("expected LayoutFull, got %v", plan.Status)
+	}
+	if plan.Consumed <= 0 {
+		t.Error("expected positive consumed height")
 	}
 }

--- a/html/style.go
+++ b/html/style.go
@@ -118,8 +118,10 @@ type computedStyle struct {
 	Widows  int // minimum lines at top of page (0 = not set)
 
 	// Table
-	BorderCollapse string // "separate", "collapse"
-	VerticalAlign  string // "top", "middle", "bottom" (for table cells)
+	BorderCollapse  string  // "separate", "collapse"
+	BorderSpacingH  float64 // horizontal border-spacing (points)
+	BorderSpacingV  float64 // vertical border-spacing (points)
+	VerticalAlign   string  // "top", "middle", "bottom" (for table cells)
 
 	// Visual effects
 	BorderRadius float64 // corner radius (points, 0 = sharp)

--- a/layout/table.go
+++ b/layout/table.go
@@ -248,6 +248,8 @@ type Table struct {
 	borderCollapse bool        // if true, collapse adjacent cell borders
 	minWidth       float64     // minimum total table width (0 = no minimum)
 	minWidthUnit   *UnitValue  // lazy-resolved min-width (overrides minWidth when set)
+	cellSpacingH   float64     // horizontal spacing between cells (CSS border-spacing)
+	cellSpacingV   float64     // vertical spacing between cells (CSS border-spacing)
 }
 
 // NewTable creates a new empty table.
@@ -276,6 +278,44 @@ func (t *Table) SetBorderCollapse(enabled bool) *Table {
 // BorderCollapse reports whether border-collapse is enabled.
 func (t *Table) BorderCollapse() bool {
 	return t.borderCollapse
+}
+
+// SetCellSpacing sets horizontal and vertical spacing between cells,
+// corresponding to the CSS border-spacing property. Spacing is added
+// between adjacent cells and at the table edges. Ignored when
+// border-collapse is enabled.
+func (t *Table) SetCellSpacing(h, v float64) *Table {
+	t.cellSpacingH = h
+	t.cellSpacingV = v
+	return t
+}
+
+// effectiveSpacingH returns the horizontal cell spacing, or 0 when
+// border-collapse is active.
+func (t *Table) effectiveSpacingH() float64 {
+	if t.borderCollapse {
+		return 0
+	}
+	return t.cellSpacingH
+}
+
+// effectiveSpacingV returns the vertical cell spacing, or 0 when
+// border-collapse is active.
+func (t *Table) effectiveSpacingV() float64 {
+	if t.borderCollapse {
+		return 0
+	}
+	return t.cellSpacingV
+}
+
+// totalSpacingH returns the total horizontal space consumed by cell spacing.
+// For N columns there are N+1 gaps (left edge, between each pair, right edge).
+func (t *Table) totalSpacingH(nCols int) float64 {
+	sh := t.effectiveSpacingH()
+	if sh == 0 || nCols == 0 {
+		return 0
+	}
+	return float64(nCols+1) * sh
 }
 
 // SetMinWidth sets the minimum total table width in points.
@@ -366,14 +406,20 @@ func (t *Table) resolveColWidths(maxWidth float64) []float64 {
 		return nil
 	}
 
+	// Subtract horizontal cell spacing so columns fill the remaining space.
+	availW := maxWidth - t.totalSpacingH(nCols)
+	if availW < 0 {
+		availW = 0
+	}
+
 	// Auto-sizing from cell content.
 	if t.autoWidths {
-		return t.computeAutoWidths(nCols, maxWidth)
+		return t.computeAutoWidths(nCols, availW)
 	}
 
 	// UnitValue widths (supports mixed point/percent).
 	if len(t.colUnitWidths) >= nCols {
-		return ResolveAll(t.colUnitWidths[:nCols], maxWidth)
+		return ResolveAll(t.colUnitWidths[:nCols], availW)
 	}
 
 	// Explicit point widths.
@@ -382,7 +428,7 @@ func (t *Table) resolveColWidths(maxWidth float64) []float64 {
 	}
 
 	// Equal distribution.
-	w := maxWidth / float64(nCols)
+	w := availW / float64(nCols)
 	widths := make([]float64, nCols)
 	for i := range widths {
 		widths[i] = w
@@ -729,16 +775,20 @@ func (t *Table) Layout(maxWidth float64) []Line {
 	if t.borderCollapse {
 		collapseBorders(grid)
 	}
-	totalH := 0.0
-	for _, gr := range grid {
-		totalH += gr.height
-	}
+
+	sv := t.effectiveSpacingV()
 
 	// Return one "line" per grid row so the renderer can page-break between rows.
+	// Each line's height includes the spacing gap before the row (and the
+	// bottom-edge gap is added to the last row).
 	lines := make([]Line, len(grid))
 	for i, gr := range grid {
+		h := gr.height + sv // gap before this row
+		if i == len(grid)-1 {
+			h += sv // bottom edge after last row
+		}
 		lines[i] = Line{
-			Height: gr.height,
+			Height: h,
 			IsLast: i == len(grid)-1,
 			Align:  AlignLeft,
 			tableRow: &tableRowRef{
@@ -792,6 +842,8 @@ func (t *Table) PlanLayout(area LayoutArea) LayoutPlan {
 
 	bodyEnd := len(grid) - footerRowCount // index where body rows end
 
+	sv := t.effectiveSpacingV()
+
 	// Build blocks row by row, checking height.
 	var blocks []PlacedBlock
 	curY := 0.0
@@ -802,6 +854,10 @@ func (t *Table) PlanLayout(area LayoutArea) LayoutPlan {
 		if gr.isFooter {
 			continue
 		}
+
+		// Add vertical spacing before this row.
+		curY += sv
+
 		// Check if this body row fits (reserve space for footer if splitting).
 		needsFooter := footerRowCount > 0 && i > headerRowCount
 		reserveH := 0.0
@@ -817,16 +873,20 @@ func (t *Table) PlanLayout(area LayoutArea) LayoutPlan {
 		capturedRowIdx := i
 		capturedColWidths := colWidths
 		capturedMaxW := area.Width
+		capturedTable := t
 
 		blocks = append(blocks, PlacedBlock{
 			X: 0, Y: curY, Width: area.Width, Height: gr.height,
 			Tag: "TR",
 			Draw: func(ctx DrawContext, absX, absTopY float64) {
-				drawTableRowDirect(ctx, capturedGrid, capturedRowIdx, capturedColWidths, capturedMaxW, absX, absTopY)
+				drawTableRowDirect(ctx, capturedTable, capturedGrid, capturedRowIdx, capturedColWidths, capturedMaxW, absX, absTopY)
 			},
 		})
 		curY += gr.height
 	}
+
+	// Bottom edge spacing after last body row.
+	curY += sv
 
 	// Append footer rows at the bottom (whether splitting or not).
 	if footerRowCount > 0 {
@@ -836,12 +896,13 @@ func (t *Table) PlanLayout(area LayoutArea) LayoutPlan {
 			capturedRowIdx := i
 			capturedColWidths := colWidths
 			capturedMaxW := area.Width
+			capturedTable := t
 
 			blocks = append(blocks, PlacedBlock{
 				X: 0, Y: curY, Width: area.Width, Height: gr.height,
 				Tag: "TR",
 				Draw: func(ctx DrawContext, absX, absTopY float64) {
-					drawTableRowDirect(ctx, capturedGrid, capturedRowIdx, capturedColWidths, capturedMaxW, absX, absTopY)
+					drawTableRowDirect(ctx, capturedTable, capturedGrid, capturedRowIdx, capturedColWidths, capturedMaxW, absX, absTopY)
 				},
 			})
 			curY += gr.height
@@ -865,7 +926,13 @@ func (t *Table) PlanLayout(area LayoutArea) LayoutPlan {
 	}
 
 	// Build overflow table with header + footer rows + remaining data rows.
-	overflowTable := &Table{colWidths: t.colWidths, colUnitWidths: t.colUnitWidths}
+	overflowTable := &Table{
+		colWidths:      t.colWidths,
+		colUnitWidths:  t.colUnitWidths,
+		borderCollapse: t.borderCollapse,
+		cellSpacingH:   t.cellSpacingH,
+		cellSpacingV:   t.cellSpacingV,
+	}
 	// Re-add header rows.
 	for _, row := range t.rows {
 		if row.isHeader {
@@ -1031,13 +1098,17 @@ func (l *Line) IsTable() bool {
 
 // drawTableRowDirect renders a table row directly using draw.go functions,
 // without going through the old Renderer emit methods.
-func drawTableRowDirect(ctx DrawContext, grid []gridRow, rowIndex int, colWidths []float64, maxWidth, x, topY float64) {
+func drawTableRowDirect(ctx DrawContext, tbl *Table, grid []gridRow, rowIndex int, colWidths []float64, maxWidth, x, topY float64) {
 	gr := grid[rowIndex]
 
+	sh := tbl.effectiveSpacingH()
+
 	for _, gc := range gr.cells {
-		cellX := x
+		// Start after the left-edge spacing gap, then advance past
+		// each preceding column plus its inter-column gap.
+		cellX := x + sh
 		for c := range gc.col {
-			cellX += colWidths[c]
+			cellX += colWidths[c] + sh
 		}
 		cellBottomY := topY - gr.height
 

--- a/layout/table_test.go
+++ b/layout/table_test.go
@@ -603,3 +603,139 @@ func TestTableZeroWidthColumn(t *testing.T) {
 		t.Fatalf("expected 1 line, got %d", len(lines))
 	}
 }
+
+// --- border-spacing tests ---
+
+func TestTableCellSpacingColumnWidths(t *testing.T) {
+	// With 2 columns and 5pt horizontal spacing, 3 gaps (left, between, right)
+	// consume 15pt, leaving 385pt for 2 columns = 192.5pt each.
+	tbl := NewTable()
+	tbl.SetCellSpacing(5, 0)
+	r := tbl.AddRow()
+	r.AddCell("A", font.Helvetica, 10)
+	r.AddCell("B", font.Helvetica, 10)
+
+	widths := tbl.resolveColWidths(400)
+	if len(widths) != 2 {
+		t.Fatalf("expected 2 widths, got %d", len(widths))
+	}
+	expected := (400.0 - 3*5.0) / 2.0 // 192.5
+	if math.Abs(widths[0]-expected) > 0.01 {
+		t.Errorf("expected column width %.2f, got %.2f", expected, widths[0])
+	}
+	if math.Abs(widths[1]-expected) > 0.01 {
+		t.Errorf("expected column width %.2f, got %.2f", expected, widths[1])
+	}
+}
+
+func TestTableCellSpacingVerticalHeight(t *testing.T) {
+	// 2 rows with 10pt vertical spacing: 3 gaps (top, between, bottom) = 30pt.
+	// Each row is about 20pt (10pt*1.2 + 2*4pt padding).
+	// Total height via Layout lines should include spacing.
+	tbl := NewTable()
+	tbl.SetCellSpacing(0, 10)
+	for range 2 {
+		r := tbl.AddRow()
+		r.AddCell("X", font.Helvetica, 10)
+	}
+
+	lines := tbl.Layout(400)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+
+	totalH := 0.0
+	for _, l := range lines {
+		totalH += l.Height
+	}
+
+	// Without spacing, total would be ~40pt. With 3 gaps of 10pt each, ~70pt.
+	rowH := 10.0*1.2 + 2*4.0 // 20pt per row
+	expectedTotal := 2*rowH + 3*10.0
+	if math.Abs(totalH-expectedTotal) > 0.1 {
+		t.Errorf("expected total height ~%.1f, got %.1f", expectedTotal, totalH)
+	}
+}
+
+func TestTableCellSpacingPlanLayout(t *testing.T) {
+	// Verify PlanLayout positions rows with spacing gaps.
+	tbl := NewTable()
+	tbl.SetCellSpacing(0, 10)
+	for range 2 {
+		r := tbl.AddRow()
+		r.AddCell("X", font.Helvetica, 10)
+	}
+
+	plan := tbl.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != LayoutFull {
+		t.Fatalf("expected LayoutFull, got %d", plan.Status)
+	}
+
+	// The outer Table block wraps all TR blocks.
+	if len(plan.Blocks) != 1 || plan.Blocks[0].Tag != "Table" {
+		t.Fatal("expected a single Table wrapper block")
+	}
+	rowBlocks := plan.Blocks[0].Children
+	if len(rowBlocks) != 2 {
+		t.Fatalf("expected 2 row blocks, got %d", len(rowBlocks))
+	}
+
+	// First row should be at Y = 10 (top spacing gap).
+	if math.Abs(rowBlocks[0].Y-10) > 0.01 {
+		t.Errorf("first row Y: expected 10, got %.2f", rowBlocks[0].Y)
+	}
+
+	// Second row should be at Y = 10 + rowH + 10.
+	rowH := rowBlocks[0].Height
+	expectedY2 := 10 + rowH + 10
+	if math.Abs(rowBlocks[1].Y-expectedY2) > 0.01 {
+		t.Errorf("second row Y: expected %.2f, got %.2f", expectedY2, rowBlocks[1].Y)
+	}
+
+	// Consumed height should include bottom spacing.
+	expectedConsumed := 10 + rowH + 10 + rowH + 10
+	if math.Abs(plan.Consumed-expectedConsumed) > 0.01 {
+		t.Errorf("consumed: expected %.2f, got %.2f", expectedConsumed, plan.Consumed)
+	}
+}
+
+func TestTableCellSpacingIgnoredWithCollapse(t *testing.T) {
+	// When border-collapse is enabled, spacing should be ignored.
+	tbl := NewTable()
+	tbl.SetCellSpacing(10, 10)
+	tbl.SetBorderCollapse(true)
+	r := tbl.AddRow()
+	r.AddCell("A", font.Helvetica, 10)
+	r.AddCell("B", font.Helvetica, 10)
+
+	// Column widths should not be reduced by spacing.
+	widths := tbl.resolveColWidths(400)
+	if len(widths) != 2 {
+		t.Fatalf("expected 2 widths, got %d", len(widths))
+	}
+	if math.Abs(widths[0]-200) > 0.01 {
+		t.Errorf("expected column width 200 (collapse ignores spacing), got %.2f", widths[0])
+	}
+
+	// Total height via Layout should not include any spacing gaps.
+	lines := tbl.Layout(400)
+	totalH := 0.0
+	for _, l := range lines {
+		totalH += l.Height
+	}
+	rowH := 10.0*1.2 + 2*4.0
+	if math.Abs(totalH-rowH) > 0.1 {
+		t.Errorf("expected height ~%.1f (no spacing), got %.1f", rowH, totalH)
+	}
+}
+
+func TestTableCellSpacingSetMethod(t *testing.T) {
+	tbl := NewTable()
+	ret := tbl.SetCellSpacing(5, 8)
+	if ret != tbl {
+		t.Error("SetCellSpacing should return the table for chaining")
+	}
+	if tbl.cellSpacingH != 5 || tbl.cellSpacingV != 8 {
+		t.Errorf("expected spacing 5/8, got %.1f/%.1f", tbl.cellSpacingH, tbl.cellSpacingV)
+	}
+}


### PR DESCRIPTION
C ABI (export/ package — 115 exported symbols):
Complete C ABI for the Folio PDF engine, enabling Java (Panama FFI),
.NET (P/Invoke), Python (ctypes), and Node (N-API) SDK wrappers.

Architecture:
- Opaque uint64 handle table with mutex-protected map
- Error convention: int32 return codes + folio_last_error()
- C-allocated byte buffers (folio_buffer_data/len/free)
- Hand-maintained header (export/folio.h) with ownership docs and enums

Domains covered:
- Document lifecycle: new, save, write_to_buffer, metadata, margins
- Page operations: text, images, links, opacity, rotation
- Layout engine: Paragraph, Heading, Table, Div, List, LineSeparator, AreaBreak
- Fonts: 14 standard fonts (singletons) + TTF/OTF load/parse
- Images: JPEG/PNG load from file or memory, layout flow elements
- HTML to PDF: one-shot, buffer, and document-handle APIs
- Reader: open/parse, page count, text extraction, dimensions
- Forms: text fields, checkboxes, dropdowns, signatures
- Callbacks: header/footer decorators via C function pointers
- Features: tagged PDF, PDF/A, encryption, auto-bookmarks

Build: make cshared (7.6MB .dylib) / make test-cabi (83 assertions)

PDF/A enhancements:
- Full sRGB IEC61966-2.1 ICC v2 profile (~2.6KB) with 9 required tags
  and 1024-entry LUT for accurate sRGB piecewise transfer function
- PDF/A-1b and PDF/A-1a support (ISO 19005-1, PDF 1.4)
- Transparency validation for PDF/A-1, automatic PDF version selection

CSS improvements:
- border-spacing support for tables (horizontal + vertical)
- HTTP URL support in CSS background-image url()
