### PR TITLE
Add GoDoc comments in packages

### DIFF
--- a/barcode/qr.go
+++ b/barcode/qr.go
@@ -233,8 +233,8 @@ func QRWithECC(data string, level ECCLevel) (*Barcode, error) {
 	return &Barcode{modules: bestModules, width: size, height: size}, nil
 }
 
-// --- Byte capacity table: [41][4]int, index 0 unused, columns L/M/Q/H ---
-
+// qrByteCapacity holds the maximum number of data bytes for each QR version (1-40)
+// and ECC level (L/M/Q/H). Index 0 is unused.
 var qrByteCapacity = [41][4]int{
 	{0, 0, 0, 0},             // version 0 unused
 	{17, 14, 11, 7},          // version 1
@@ -279,8 +279,8 @@ var qrByteCapacity = [41][4]int{
 	{2953, 2331, 1663, 1273}, // version 40
 }
 
-// --- Data codewords table: [41][4]int, columns L/M/Q/H ---
-
+// qrDataCodewords holds the number of data codewords for each QR version (1-40)
+// and ECC level (L/M/Q/H). Index 0 is unused.
 var qrDataCodewords = [41][4]int{
 	{0, 0, 0, 0},             // version 0 unused
 	{19, 16, 13, 9},          // version 1
@@ -325,8 +325,8 @@ var qrDataCodewords = [41][4]int{
 	{2956, 2334, 1666, 1276}, // version 40
 }
 
-// --- ECC codewords per block: [41][4]int, columns L/M/Q/H ---
-
+// qrECCPerBlock holds the number of error correction codewords per block for each
+// QR version (1-40) and ECC level (L/M/Q/H). Index 0 is unused.
 var qrECCPerBlock = [41][4]int{
 	{0, 0, 0, 0},     // version 0 unused
 	{7, 10, 13, 17},  // version 1
@@ -379,7 +379,8 @@ type qrBlockInfo struct {
 	group2DataCW int // data codewords per block in group 2 (= group1DataCW + 1, or 0)
 }
 
-// qrBlockTable: [41][4]qrBlockInfo, columns L/M/Q/H.
+// qrBlockTable holds the block structure for each QR version (1-40)
+// and ECC level (L/M/Q/H). Index 0 is unused.
 var qrBlockTable = [41][4]qrBlockInfo{
 	{}, // version 0 unused
 	// version 1
@@ -464,8 +465,8 @@ var qrBlockTable = [41][4]qrBlockInfo{
 	{{19, 118, 6, 119}, {18, 47, 31, 48}, {34, 24, 34, 25}, {20, 15, 61, 16}},
 }
 
-// --- Alignment pattern positions for versions 1-40 ---
-
+// alignmentTable holds the alignment pattern center coordinates for each QR
+// version (1-40). Version 1 has no alignment patterns. Index 0 is unused.
 var alignmentTable = [41][]int{
 	{},                             // version 0
 	{},                             // version 1 (no alignment)
@@ -510,6 +511,7 @@ var alignmentTable = [41][]int{
 	{6, 30, 58, 86, 114, 142, 170}, // version 40
 }
 
+// alignmentPositions returns the alignment pattern center coordinates for the given version.
 func alignmentPositions(version int) []int {
 	if version < 1 || version > 40 {
 		return nil
@@ -517,9 +519,8 @@ func alignmentPositions(version int) []int {
 	return alignmentTable[version]
 }
 
-// --- Format info lookup table: [4][8]uint16 — [eccLevel][maskPattern] ---
-// Pre-computed BCH(15,5) encoded with XOR mask 0x5412.
-
+// qrFormatInfo holds pre-computed BCH(15,5) format information strings for each
+// ECC level and mask pattern combination, XORed with mask 0x5412.
 var qrFormatInfo = [4][8]uint16{
 	// ECCLevelL
 	{0x77C4, 0x72F3, 0x7DAA, 0x789D, 0x662F, 0x6318, 0x6C41, 0x6976},
@@ -531,9 +532,8 @@ var qrFormatInfo = [4][8]uint16{
 	{0x1689, 0x13BE, 0x1CE7, 0x19D0, 0x0762, 0x0255, 0x0D0C, 0x083B},
 }
 
-// --- Version info lookup table for versions 7-40 ---
-// BCH(18,6) encoded with generator polynomial 0x1F25.
-
+// qrVersionInfo holds BCH(18,6) encoded version information for versions 7-40,
+// using generator polynomial 0x1F25. Versions 0-6 have no version info.
 var qrVersionInfo = [41]uint32{
 	0, 0, 0, 0, 0, 0, 0, // versions 0-6: no version info
 	0x07C94, // version 7
@@ -572,9 +572,8 @@ var qrVersionInfo = [41]uint32{
 	0x28C69, // version 40
 }
 
-// --- Finder and alignment pattern placement ---
-
-// placeFinder places a 7x7 finder pattern at (row, col).
+// placeFinder places a 7x7 finder pattern at (row, col) and reserves the
+// surrounding one-module-wide separator zone.
 func placeFinder(modules, reserved [][]bool, row, col int) {
 	for r := -1; r <= 7; r++ {
 		for c := -1; c <= 7; c++ {
@@ -612,8 +611,6 @@ func placeAlignment(modules, reserved [][]bool, row, col int) {
 		}
 	}
 }
-
-// --- Data encoding ---
 
 // appendBitsN appends the lowest n bits of val (MSB first) to bits.
 func appendBitsN(bits []bool, val, n int) []bool {
@@ -699,7 +696,8 @@ func encodeByteData(data string, version int) []bool {
 	return bits
 }
 
-// encodeQRData encodes data with the specified ECC level and encoding mode.
+// encodeQRData encodes data with the specified ECC level and encoding mode,
+// returning the complete bitstream including interleaved error correction codewords.
 func encodeQRData(data string, version int, level ECCLevel, mode qrMode) []bool {
 	var bits []bool
 
@@ -825,8 +823,6 @@ func appendECCInterleaved(dataBits []bool, version int, level ECCLevel) []bool {
 	return result
 }
 
-// --- GF(256) arithmetic for Reed-Solomon ---
-
 // gfExp and gfLog are lookup tables for GF(256) with primitive polynomial 0x11D.
 var gfExp [512]byte
 var gfLog [256]byte
@@ -846,6 +842,7 @@ func init() {
 	}
 }
 
+// gfMul returns the product of a and b in GF(256).
 func gfMul(a, b byte) byte {
 	if a == 0 || b == 0 {
 		return 0
@@ -867,7 +864,7 @@ func rsGeneratorPoly(n int) []byte {
 	return g
 }
 
-// rsEncode performs Reed-Solomon encoding.
+// rsEncode performs Reed-Solomon encoding, returning eccLen error correction codewords.
 func rsEncode(data []byte, generator []byte, eccLen int) []byte {
 	// Extend data with zero ECC bytes.
 	msg := make([]byte, len(data)+eccLen)
@@ -885,8 +882,6 @@ func rsEncode(data []byte, generator []byte, eccLen int) []byte {
 
 	return msg[len(data):]
 }
-
-// --- Data placement ---
 
 // placeData places data bits into the QR matrix in the zigzag pattern.
 func placeData(modules, reserved [][]bool, bits []bool, size int) {
@@ -926,8 +921,6 @@ func placeData(modules, reserved [][]bool, bits []bool, size int) {
 		upward = !upward
 	}
 }
-
-// --- Mask patterns ---
 
 // qrMaskFunc returns true if the module at (row, col) should be flipped for the given mask.
 func qrMaskFunc(mask int, row, col int) bool {
@@ -988,8 +981,8 @@ func evaluateMasks(modules, reserved [][]bool, size int) (int, [][]bool) {
 	return bestMask, bestModules
 }
 
-// --- Penalty scoring (ISO 18004 §7.8.3) ---
-
+// penaltyScore computes the total penalty score for a masked QR matrix
+// using all four rules from ISO 18004 section 7.8.3.
 func penaltyScore(modules [][]bool, size int) int {
 	return penaltyRule1(modules, size) +
 		penaltyRule2(modules, size) +
@@ -997,8 +990,8 @@ func penaltyScore(modules [][]bool, size int) int {
 		penaltyRule4(modules, size)
 }
 
-// Rule 1: Adjacent modules in row/column in same color.
-// For each run of 5+ same-colored modules: penalty = 3 + (run - 5).
+// penaltyRule1 scores adjacent same-colored modules in rows and columns.
+// Each run of 5 or more adds a penalty of 3 + (run length - 5).
 func penaltyRule1(modules [][]bool, size int) int {
 	penalty := 0
 
@@ -1041,7 +1034,7 @@ func penaltyRule1(modules [][]bool, size int) int {
 	return penalty
 }
 
-// Rule 2: 2x2 blocks of same color. Penalty = 3 * count.
+// penaltyRule2 scores 2x2 blocks of same-colored modules, adding 3 per block.
 func penaltyRule2(modules [][]bool, size int) int {
 	count := 0
 	for r := range size - 1 {
@@ -1055,8 +1048,8 @@ func penaltyRule2(modules [][]bool, size int) int {
 	return 3 * count
 }
 
-// Rule 3: Finder-like patterns (1:1:3:1:1 with 4-module light on one side).
-// Penalty = 40 * count.
+// penaltyRule3 scores finder-like patterns (1:1:3:1:1 ratio with a 4-module
+// light zone on either side), adding 40 per occurrence.
 func penaltyRule3(modules [][]bool, size int) int {
 	count := 0
 	// Pattern: dark, light, dark dark dark, light, dark, light light light light
@@ -1109,7 +1102,8 @@ func penaltyRule3(modules [][]bool, size int) int {
 	return 40 * count
 }
 
-// Rule 4: Color balance. Penalty = 10 * k where k = floor(|50 - percentDark| / 5) * 2.
+// penaltyRule4 scores color imbalance. The penalty is 10 * k where
+// k = floor(|50 - percentDark| / 5) * 2.
 func penaltyRule4(modules [][]bool, size int) int {
 	dark := 0
 	total := size * size
@@ -1128,8 +1122,6 @@ func penaltyRule4(modules [][]bool, size int) int {
 	k := (diff / 5) * 2
 	return 10 * k
 }
-
-// --- Format and version info placement ---
 
 // placeFormatInfo places the 15-bit format information string.
 func placeFormatInfo(modules [][]bool, size int, level ECCLevel, mask int) {

--- a/cmd/folio/main.go
+++ b/cmd/folio/main.go
@@ -8,9 +8,13 @@
 //	folio merge -o output.pdf input1.pdf input2.pdf [input3.pdf ...]
 //	folio info file.pdf
 //	folio pages file.pdf
-//	folio text file.pdf [page]
-//	folio create -o output.pdf -title "Title" -text "Hello World"
-//	folio blank -o output.pdf [-size letter|a4] [-pages 1]
+//	folio text file.pdf [page_number]
+//	folio extract file.pdf [-page N] [-strategy simple|location]
+//	folio sign -cert cert.pem -key key.pem [-o signed.pdf] input.pdf
+//	folio create -o output.pdf [-title "Title"] [-text "Content"]
+//	folio blank -o output.pdf [-size letter|a4] [-pages N]
+//	folio version
+//	folio help
 package main
 
 import (
@@ -72,6 +76,7 @@ func main() {
 	}
 }
 
+// printUsage writes the CLI help text to standard output.
 func printUsage() {
 	fmt.Print(`folio — A modern PDF toolkit
 
@@ -91,7 +96,7 @@ Commands:
   info     Show PDF metadata (title, author, pages, version)
   pages    List page dimensions
   text     Extract text from a page (simple extraction)
-  extract  Extract text with strategy (simple, location, region)
+  extract  Extract text with strategy (simple, location)
   sign     Digitally sign a PDF with PAdES
   create   Create a simple PDF with text content
   blank    Create a blank PDF with N pages
@@ -99,8 +104,7 @@ Commands:
 `)
 }
 
-// --- merge ---
-
+// cmdMerge concatenates multiple PDF files into a single output file.
 func cmdMerge(args []string) error {
 	output, inputs := parseMergeArgs(args)
 	if output == "" || len(inputs) < 1 {
@@ -133,6 +137,7 @@ func cmdMerge(args []string) error {
 	return nil
 }
 
+// parseMergeArgs extracts the output path and input file paths from the merge command arguments.
 func parseMergeArgs(args []string) (output string, inputs []string) {
 	for i := 0; i < len(args); i++ {
 		if args[i] == "-o" && i+1 < len(args) {
@@ -145,8 +150,7 @@ func parseMergeArgs(args []string) (output string, inputs []string) {
 	return
 }
 
-// --- info ---
-
+// cmdInfo displays PDF metadata including title, author, version, and page count.
 func cmdInfo(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: folio info file.pdf")
@@ -181,8 +185,7 @@ func cmdInfo(args []string) error {
 	return nil
 }
 
-// --- pages ---
-
+// cmdPages lists the dimensions and rotation of each page in the PDF.
 func cmdPages(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: folio pages file.pdf")
@@ -208,8 +211,7 @@ func cmdPages(args []string) error {
 	return nil
 }
 
-// --- text ---
-
+// cmdText extracts text from all pages or a specific page using simple extraction.
 func cmdText(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: folio text file.pdf [page_number]")
@@ -252,8 +254,7 @@ func cmdText(args []string) error {
 	return nil
 }
 
-// --- create ---
-
+// cmdCreate generates a new PDF with optional title and text content.
 func cmdCreate(args []string) error {
 	output := ""
 	title := ""
@@ -300,8 +301,7 @@ func cmdCreate(args []string) error {
 	return nil
 }
 
-// --- blank ---
-
+// cmdBlank creates a PDF with the specified number of empty pages and page size.
 func cmdBlank(args []string) error {
 	output := ""
 	size := "letter"
@@ -359,8 +359,7 @@ func cmdBlank(args []string) error {
 	return nil
 }
 
-// --- extract ---
-
+// cmdExtract extracts text from a PDF using a specified strategy (simple or location).
 func cmdExtract(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: folio extract file.pdf [-page N] [-strategy simple|location]")
@@ -434,8 +433,7 @@ func cmdExtract(args []string) error {
 	return nil
 }
 
-// --- sign ---
-
+// cmdSign digitally signs a PDF using a PEM-encoded certificate and private key.
 func cmdSign(args []string) error {
 	certFile := ""
 	keyFile := ""

--- a/content/stream.go
+++ b/content/stream.go
@@ -515,6 +515,8 @@ func (s *Stream) ToPdfStream() *core.PdfStream {
 
 // --- Internals ---
 
+// writeln appends a single operator line to the content stream,
+// inserting a newline separator if the buffer is non-empty.
 func (s *Stream) writeln(line string) {
 	if s.buf.Len() > 0 {
 		s.buf.WriteByte('\n')

--- a/core/doc.go
+++ b/core/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package core implements the fundamental PDF object types defined in
+// ISO 32000 §7.3 — Boolean, Number, String, Name, Array, Dictionary,
+// Stream, and Null — plus indirect references (§7.3.10) and standard
+// security handler encryption (§7.6).
+//
+// Every object type satisfies the [PdfObject] interface, which provides
+// WriteTo for serialization and Type for runtime type discrimination.
+// Composite types (Array, Dictionary, Stream) preserve insertion order
+// to produce deterministic output.
+//
+// Encryption covers three standard security handler revisions:
+//
+//   - RC4-128  (V=2, R=3): legacy, widely compatible
+//   - AES-128  (V=4, R=4): recommended minimum
+//   - AES-256  (V=5, R=6): strongest, PDF 2.0
+package core

--- a/core/encrypt.go
+++ b/core/encrypt.go
@@ -1,12 +1,6 @@
 // Copyright 2026 Carlos Munoz and the Folio Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package core — PDF encryption support (ISO 32000 §7.6).
-//
-// Supports three standard security handler revisions:
-//   - RC4-128  (V=2, R=3): legacy, widely compatible
-//   - AES-128  (V=4, R=4): recommended minimum
-//   - AES-256  (V=5, R=6): strongest, PDF 2.0
 package core
 
 import (
@@ -135,6 +129,8 @@ func (e *Encryptor) EncryptObject(obj PdfObject, objNum, genNum int) error {
 	return e.walkEncrypt(obj, objNum, genNum)
 }
 
+// walkEncrypt recursively visits a PdfObject tree, encrypting strings and
+// stream data in place.
 func (e *Encryptor) walkEncrypt(obj PdfObject, objNum, genNum int) error {
 	switch o := obj.(type) {
 	case *PdfString:
@@ -241,6 +237,7 @@ func (e *Encryptor) BuildEncryptDict() *PdfDictionary {
 
 // --- Revision 3 (RC4-128) ---
 
+// newEncryptorR3 creates an Encryptor using RC4-128 (Revision 3).
 func newEncryptorR3(userPwd, ownerPwd string, p int32, fileID []byte) (*Encryptor, error) {
 	const keyLen = 16
 	o := computeOwnerHashR3(userPwd, ownerPwd, keyLen)
@@ -253,7 +250,8 @@ func newEncryptorR3(userPwd, ownerPwd string, p int32, fileID []byte) (*Encrypto
 	}, nil
 }
 
-// Algorithm 3: compute owner password hash (O value).
+// computeOwnerHashR3 computes the owner password hash (O value) using Algorithm 3
+// from ISO 32000 §7.6.3.3.
 func computeOwnerHashR3(userPwd, ownerPwd string, keyLen int) []byte {
 	// Step a-d: hash the owner password.
 	padded := padPassword([]byte(ownerPwd))
@@ -274,7 +272,8 @@ func computeOwnerHashR3(userPwd, ownerPwd string, keyLen int) []byte {
 	return result // 32 bytes
 }
 
-// Algorithm 2: compute file encryption key.
+// computeFileKeyR3 computes the file encryption key using Algorithm 2
+// from ISO 32000 §7.6.3.3.
 func computeFileKeyR3(userPwd string, o []byte, p int32, fileID []byte, keyLen int) []byte {
 	padded := padPassword([]byte(userPwd))
 	h := md5.New()
@@ -292,7 +291,8 @@ func computeFileKeyR3(userPwd string, o []byte, p int32, fileID []byte, keyLen i
 	return sum[:keyLen]
 }
 
-// Algorithm 5: compute user password hash (U value) for R=3.
+// computeUserHashR3 computes the user password hash (U value) for R=3 using
+// Algorithm 5 from ISO 32000 §7.6.3.4.
 func computeUserHashR3(fileKey, fileID []byte) []byte {
 	h := md5.New()
 	h.Write(pdfPadding[:])
@@ -330,6 +330,7 @@ func (e *Encryptor) objectKeyRC4(objNum, genNum int) []byte {
 
 // --- Revision 4 (AES-128) ---
 
+// newEncryptorR4 creates an Encryptor using AES-128-CBC (Revision 4).
 func newEncryptorR4(userPwd, ownerPwd string, p int32, fileID []byte) (*Encryptor, error) {
 	const keyLen = 16
 	o := computeOwnerHashR3(userPwd, ownerPwd, keyLen) // same algorithm
@@ -360,6 +361,7 @@ func (e *Encryptor) objectKeyAES(objNum, genNum int) []byte {
 
 // --- Revision 6 (AES-256) ---
 
+// newEncryptorR6 creates an Encryptor using AES-256-CBC (Revision 6, PDF 2.0).
 func newEncryptorR6(userPwd, ownerPwd string, p int32, fileID []byte) (*Encryptor, error) {
 	// Truncate passwords to 127 bytes (UTF-8).
 	uPwd := truncatePassword(userPwd)
@@ -501,6 +503,8 @@ func buildPermsBlock(p int32) []byte {
 
 // --- Cryptographic helpers ---
 
+// padPassword pads or truncates pwd to exactly 32 bytes using the standard
+// PDF padding string.
 func padPassword(pwd []byte) [32]byte {
 	var result [32]byte
 	n := copy(result[:], pwd)
@@ -510,6 +514,8 @@ func padPassword(pwd []byte) [32]byte {
 	return result
 }
 
+// truncatePassword truncates a UTF-8 password to at most 127 bytes, as
+// required by ISO 32000-2 §7.6.4.3.3.
 func truncatePassword(pwd string) []byte {
 	b := []byte(pwd)
 	if len(b) > 127 {
@@ -518,6 +524,7 @@ func truncatePassword(pwd string) []byte {
 	return b
 }
 
+// rc4Encrypt encrypts (or decrypts) data using RC4 with the given key.
 func rc4Encrypt(key, data []byte) []byte {
 	c, _ := rc4.NewCipher(key)
 	dst := make([]byte, len(data))
@@ -572,6 +579,7 @@ func aesECBEncryptBlock(key, block16 []byte) []byte {
 	return dst
 }
 
+// pkcs7Pad appends PKCS#7 padding to data so its length is a multiple of blockSize.
 func pkcs7Pad(data []byte, blockSize int) []byte {
 	padding := blockSize - len(data)%blockSize
 	padded := make([]byte, len(data)+padding)
@@ -582,6 +590,7 @@ func pkcs7Pad(data []byte, blockSize int) []byte {
 	return padded
 }
 
+// randomBytes returns n cryptographically random bytes.
 func randomBytes(n int) ([]byte, error) {
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {

--- a/core/object.go
+++ b/core/object.go
@@ -1,8 +1,6 @@
 // Copyright 2026 Carlos Munoz and the Folio Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package core implements the eight fundamental PDF object types
-// defined in ISO 32000 §7.3, plus indirect references.
 package core
 
 import "io"

--- a/core/writer_util.go
+++ b/core/writer_util.go
@@ -15,12 +15,14 @@ type countingWriter struct {
 	n int64
 }
 
+// Write writes p to the underlying writer and accumulates the byte count.
 func (cw *countingWriter) Write(p []byte) (int, error) {
 	n, err := cw.w.Write(p)
 	cw.n += int64(n)
 	return n, err
 }
 
+// WriteString writes s to the underlying writer and accumulates the byte count.
 func (cw *countingWriter) WriteString(s string) (int, error) {
 	n, err := io.WriteString(cw.w, s)
 	cw.n += int64(n)

--- a/document/page.go
+++ b/document/page.go
@@ -64,10 +64,14 @@ type imageResource struct {
 type MarkupType int
 
 const (
-	MarkupHighlight MarkupType = iota // yellow highlight
-	MarkupUnderline                   // red underline
-	MarkupSquiggly                    // wavy underline
-	MarkupStrikeOut                   // strikethrough
+	// MarkupHighlight represents a yellow highlight annotation.
+	MarkupHighlight MarkupType = iota
+	// MarkupUnderline represents a red underline annotation.
+	MarkupUnderline
+	// MarkupSquiggly represents a wavy underline annotation.
+	MarkupSquiggly
+	// MarkupStrikeOut represents a strikethrough annotation.
+	MarkupStrikeOut
 )
 
 // Annotation represents a PDF annotation on a page.
@@ -441,6 +445,7 @@ func (p *Page) ContentStream() *content.Stream {
 	return p.stream
 }
 
+// ensureStream initializes the content stream if it has not been created yet.
 func (p *Page) ensureStream() {
 	if p.stream == nil {
 		p.stream = content.NewStream()

--- a/document/pagelabels.go
+++ b/document/pagelabels.go
@@ -9,12 +9,18 @@ import "github.com/carlos7ags/folio/core"
 type LabelStyle string
 
 const (
-	LabelDecimal    LabelStyle = "D" // 1, 2, 3, ...
-	LabelRomanUpper LabelStyle = "R" // I, II, III, ...
-	LabelRomanLower LabelStyle = "r" // i, ii, iii, ...
-	LabelAlphaUpper LabelStyle = "A" // A, B, C, ...
-	LabelAlphaLower LabelStyle = "a" // a, b, c, ...
-	LabelNone       LabelStyle = ""  // no numbering (prefix only)
+	// LabelDecimal uses decimal numbering (1, 2, 3, ...).
+	LabelDecimal LabelStyle = "D"
+	// LabelRomanUpper uses uppercase Roman numerals (I, II, III, ...).
+	LabelRomanUpper LabelStyle = "R"
+	// LabelRomanLower uses lowercase Roman numerals (i, ii, iii, ...).
+	LabelRomanLower LabelStyle = "r"
+	// LabelAlphaUpper uses uppercase alphabetic labels (A, B, C, ...).
+	LabelAlphaUpper LabelStyle = "A"
+	// LabelAlphaLower uses lowercase alphabetic labels (a, b, c, ...).
+	LabelAlphaLower LabelStyle = "a"
+	// LabelNone disables numbering, showing only the prefix.
+	LabelNone LabelStyle = ""
 )
 
 // PageLabelRange defines a page label range starting at a given page index.

--- a/document/structtree.go
+++ b/document/structtree.go
@@ -9,32 +9,58 @@ import "github.com/carlos7ags/folio/core"
 type StructTag string
 
 const (
-	TagDocument   StructTag = "Document"
-	TagPart       StructTag = "Part"
-	TagSection    StructTag = "Sect"
-	TagH1         StructTag = "H1"
-	TagH2         StructTag = "H2"
-	TagH3         StructTag = "H3"
-	TagH4         StructTag = "H4"
-	TagH5         StructTag = "H5"
-	TagH6         StructTag = "H6"
-	TagP          StructTag = "P"
-	TagSpan       StructTag = "Span"
-	TagTable      StructTag = "Table"
-	TagTR         StructTag = "TR"
-	TagTH         StructTag = "TH"
-	TagTD         StructTag = "TD"
-	TagTHead      StructTag = "THead"
-	TagTBody      StructTag = "TBody"
-	TagL          StructTag = "L"     // list
-	TagLI         StructTag = "LI"    // list item
-	TagLbl        StructTag = "Lbl"   // list label (bullet/number)
-	TagLBody      StructTag = "LBody" // list item body
-	TagFigure     StructTag = "Figure"
-	TagCaption    StructTag = "Caption"
-	TagLink       StructTag = "Link"
+	// TagDocument is the root structure element for the entire document.
+	TagDocument StructTag = "Document"
+	// TagPart represents a large division of a document.
+	TagPart StructTag = "Part"
+	// TagSection represents a section within a document part.
+	TagSection StructTag = "Sect"
+	// TagH1 represents a level-1 heading.
+	TagH1 StructTag = "H1"
+	// TagH2 represents a level-2 heading.
+	TagH2 StructTag = "H2"
+	// TagH3 represents a level-3 heading.
+	TagH3 StructTag = "H3"
+	// TagH4 represents a level-4 heading.
+	TagH4 StructTag = "H4"
+	// TagH5 represents a level-5 heading.
+	TagH5 StructTag = "H5"
+	// TagH6 represents a level-6 heading.
+	TagH6 StructTag = "H6"
+	// TagP represents a paragraph.
+	TagP StructTag = "P"
+	// TagSpan represents an inline span of text.
+	TagSpan StructTag = "Span"
+	// TagTable represents a table.
+	TagTable StructTag = "Table"
+	// TagTR represents a table row.
+	TagTR StructTag = "TR"
+	// TagTH represents a table header cell.
+	TagTH StructTag = "TH"
+	// TagTD represents a table data cell.
+	TagTD StructTag = "TD"
+	// TagTHead represents a table header row group.
+	TagTHead StructTag = "THead"
+	// TagTBody represents a table body row group.
+	TagTBody StructTag = "TBody"
+	// TagL represents a list.
+	TagL StructTag = "L"
+	// TagLI represents a list item.
+	TagLI StructTag = "LI"
+	// TagLbl represents a list label (bullet or number).
+	TagLbl StructTag = "Lbl"
+	// TagLBody represents the body content of a list item.
+	TagLBody StructTag = "LBody"
+	// TagFigure represents an image or illustration.
+	TagFigure StructTag = "Figure"
+	// TagCaption represents a caption for a figure or table.
+	TagCaption StructTag = "Caption"
+	// TagLink represents a hyperlink.
+	TagLink StructTag = "Link"
+	// TagBlockQuote represents a block quotation.
 	TagBlockQuote StructTag = "BlockQuote"
-	TagDiv        StructTag = "Div"
+	// TagDiv represents a generic block-level grouping element.
+	TagDiv StructTag = "Div"
 )
 
 // structNode is a node in the document structure tree.

--- a/document/viewer.go
+++ b/document/viewer.go
@@ -9,24 +9,36 @@ import "github.com/carlos7ags/folio/core"
 type PageLayout string
 
 const (
-	LayoutSinglePage     PageLayout = "SinglePage"     // one page at a time
-	LayoutOneColumn      PageLayout = "OneColumn"      // continuous scrolling
-	LayoutTwoColumnLeft  PageLayout = "TwoColumnLeft"  // two columns, odd pages left
-	LayoutTwoColumnRight PageLayout = "TwoColumnRight" // two columns, odd pages right
-	LayoutTwoPageLeft    PageLayout = "TwoPageLeft"    // two pages, odd left
-	LayoutTwoPageRight   PageLayout = "TwoPageRight"   // two pages, odd right
+	// LayoutSinglePage displays one page at a time.
+	LayoutSinglePage PageLayout = "SinglePage"
+	// LayoutOneColumn displays pages in a single continuous scrolling column.
+	LayoutOneColumn PageLayout = "OneColumn"
+	// LayoutTwoColumnLeft displays pages in two columns with odd pages on the left.
+	LayoutTwoColumnLeft PageLayout = "TwoColumnLeft"
+	// LayoutTwoColumnRight displays pages in two columns with odd pages on the right.
+	LayoutTwoColumnRight PageLayout = "TwoColumnRight"
+	// LayoutTwoPageLeft displays two pages at a time with odd pages on the left.
+	LayoutTwoPageLeft PageLayout = "TwoPageLeft"
+	// LayoutTwoPageRight displays two pages at a time with odd pages on the right.
+	LayoutTwoPageRight PageLayout = "TwoPageRight"
 )
 
 // PageMode controls what panel is visible when the document is opened.
 type PageMode string
 
 const (
-	ModeNone       PageMode = "UseNone"        // no panel (default)
-	ModeOutlines   PageMode = "UseOutlines"    // bookmarks panel
-	ModeThumbs     PageMode = "UseThumbs"      // thumbnails panel
-	ModeFullScreen PageMode = "FullScreen"     // full screen
-	ModeOC         PageMode = "UseOC"          // optional content panel
-	ModeAttach     PageMode = "UseAttachments" // attachments panel
+	// ModeNone shows no panel when the document is opened (default).
+	ModeNone PageMode = "UseNone"
+	// ModeOutlines shows the bookmarks panel when the document is opened.
+	ModeOutlines PageMode = "UseOutlines"
+	// ModeThumbs shows the page thumbnails panel when the document is opened.
+	ModeThumbs PageMode = "UseThumbs"
+	// ModeFullScreen opens the document in full-screen mode.
+	ModeFullScreen PageMode = "FullScreen"
+	// ModeOC shows the optional content panel when the document is opened.
+	ModeOC PageMode = "UseOC"
+	// ModeAttach shows the attachments panel when the document is opened.
+	ModeAttach PageMode = "UseAttachments"
 )
 
 // ViewerPreferences controls how the PDF viewer displays the document.

--- a/document/watermark.go
+++ b/document/watermark.go
@@ -59,7 +59,7 @@ func (d *Document) SetWatermarkConfig(cfg WatermarkConfig) {
 	d.watermark = &cfg
 }
 
-// applyWatermark prepends watermark drawing commands to a page's content stream
+// applyWatermark appends watermark drawing commands to a page's content stream
 // and registers the required font and ExtGState resources on the page.
 func (d *Document) applyWatermark(p *Page) {
 	wm := d.watermark

--- a/document/writer.go
+++ b/document/writer.go
@@ -168,6 +168,7 @@ type countingWriter struct {
 	n int64
 }
 
+// Write writes p to the underlying writer and adds the number of bytes written to the total.
 func (cw *countingWriter) Write(p []byte) (int, error) {
 	n, err := cw.w.Write(p)
 	cw.n += int64(n)

--- a/export/cabi.go
+++ b/export/cabi.go
@@ -51,6 +51,7 @@ type handleTable struct {
 	next    uint64
 }
 
+// ht is the global handle table shared by all C ABI functions.
 var ht = &handleTable{
 	handles: make(map[uint64]any),
 	next:    1,
@@ -127,11 +128,15 @@ func setErr(code C.int32_t, err error) C.int32_t {
 	return code
 }
 
+// folio_version returns the library version as a C string.
+//
 //export folio_version
 func folio_version() *C.char {
 	return versionCStr
 }
 
+// folio_last_error returns the most recent error message, or nil if none.
+//
 //export folio_last_error
 func folio_last_error() *C.char {
 	lastErrorMu.Lock()

--- a/export/cabi_buffer.go
+++ b/export/cabi_buffer.go
@@ -31,6 +31,8 @@ func newCBuffer(data []byte) *cBuffer {
 	return &cBuffer{ptr: ptr, len: n}
 }
 
+// folio_buffer_data returns a pointer to the raw bytes of a buffer handle.
+//
 //export folio_buffer_data
 func folio_buffer_data(buf C.uint64_t) unsafe.Pointer {
 	v := ht.load(uint64(buf))
@@ -44,6 +46,8 @@ func folio_buffer_data(buf C.uint64_t) unsafe.Pointer {
 	return b.ptr
 }
 
+// folio_buffer_len returns the byte length of a buffer handle.
+//
 //export folio_buffer_len
 func folio_buffer_len(buf C.uint64_t) C.int32_t {
 	v := ht.load(uint64(buf))
@@ -57,6 +61,8 @@ func folio_buffer_len(buf C.uint64_t) C.int32_t {
 	return C.int32_t(b.len)
 }
 
+// folio_buffer_free releases the C-allocated memory and removes the buffer handle.
+//
 //export folio_buffer_free
 func folio_buffer_free(buf C.uint64_t) {
 	v := ht.load(uint64(buf))

--- a/export/cabi_callback.go
+++ b/export/cabi_callback.go
@@ -24,6 +24,8 @@ import (
 	"github.com/carlos7ags/folio/document"
 )
 
+// folio_document_set_header registers a C callback invoked on each page to render a header.
+//
 //export folio_document_set_header
 func folio_document_set_header(docH C.uint64_t, fn C.folio_page_decorator_fn, userData unsafe.Pointer) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -38,6 +40,8 @@ func folio_document_set_header(docH C.uint64_t, fn C.folio_page_decorator_fn, us
 	return errOK
 }
 
+// folio_document_set_footer registers a C callback invoked on each page to render a footer.
+//
 //export folio_document_set_footer
 func folio_document_set_footer(docH C.uint64_t, fn C.folio_page_decorator_fn, userData unsafe.Pointer) C.int32_t {
 	doc, errCode := loadDoc(docH)

--- a/export/cabi_div.go
+++ b/export/cabi_div.go
@@ -15,11 +15,15 @@ import (
 	"github.com/carlos7ags/folio/layout"
 )
 
+// folio_div_new creates a new empty div container and returns its handle.
+//
 //export folio_div_new
 func folio_div_new() C.uint64_t {
 	return C.uint64_t(ht.store(layout.NewDiv()))
 }
 
+// folio_div_add appends a layout element to a div.
+//
 //export folio_div_add
 func folio_div_add(divH C.uint64_t, elemH C.uint64_t) C.int32_t {
 	div, errCode := loadDiv(divH)
@@ -40,6 +44,8 @@ func folio_div_add(divH C.uint64_t, elemH C.uint64_t) C.int32_t {
 	return errOK
 }
 
+// folio_div_set_padding sets the padding on all four sides of a div in points.
+//
 //export folio_div_set_padding
 func folio_div_set_padding(divH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
 	div, errCode := loadDiv(divH)
@@ -53,6 +59,8 @@ func folio_div_set_padding(divH C.uint64_t, top, right, bottom, left C.double) C
 	return errOK
 }
 
+// folio_div_set_background sets the background color of a div using RGB values in [0,1].
+//
 //export folio_div_set_background
 func folio_div_set_background(divH C.uint64_t, r, g, b C.double) C.int32_t {
 	div, errCode := loadDiv(divH)
@@ -63,6 +71,8 @@ func folio_div_set_background(divH C.uint64_t, r, g, b C.double) C.int32_t {
 	return errOK
 }
 
+// folio_div_set_border sets a solid border on a div with the given width and RGB color.
+//
 //export folio_div_set_border
 func folio_div_set_border(divH C.uint64_t, width C.double, r, g, b C.double) C.int32_t {
 	div, errCode := loadDiv(divH)
@@ -73,6 +83,8 @@ func folio_div_set_border(divH C.uint64_t, width C.double, r, g, b C.double) C.i
 	return errOK
 }
 
+// folio_div_set_width sets the fixed width of a div in points.
+//
 //export folio_div_set_width
 func folio_div_set_width(divH C.uint64_t, pts C.double) C.int32_t {
 	div, errCode := loadDiv(divH)
@@ -83,6 +95,8 @@ func folio_div_set_width(divH C.uint64_t, pts C.double) C.int32_t {
 	return errOK
 }
 
+// folio_div_set_min_height sets the minimum height of a div in points.
+//
 //export folio_div_set_min_height
 func folio_div_set_min_height(divH C.uint64_t, pts C.double) C.int32_t {
 	div, errCode := loadDiv(divH)
@@ -93,6 +107,8 @@ func folio_div_set_min_height(divH C.uint64_t, pts C.double) C.int32_t {
 	return errOK
 }
 
+// folio_div_set_space_before sets the vertical spacing before a div in points.
+//
 //export folio_div_set_space_before
 func folio_div_set_space_before(divH C.uint64_t, pts C.double) C.int32_t {
 	div, errCode := loadDiv(divH)
@@ -103,6 +119,8 @@ func folio_div_set_space_before(divH C.uint64_t, pts C.double) C.int32_t {
 	return errOK
 }
 
+// folio_div_set_space_after sets the vertical spacing after a div in points.
+//
 //export folio_div_set_space_after
 func folio_div_set_space_after(divH C.uint64_t, pts C.double) C.int32_t {
 	div, errCode := loadDiv(divH)
@@ -113,25 +131,28 @@ func folio_div_set_space_after(divH C.uint64_t, pts C.double) C.int32_t {
 	return errOK
 }
 
+// folio_div_free removes a div handle from the handle table.
+//
 //export folio_div_free
 func folio_div_free(divH C.uint64_t) {
 	ht.delete(uint64(divH))
 }
 
-// --- LineSeparator ---
-
+// folio_line_separator_new creates a horizontal line separator element and returns its handle.
+//
 //export folio_line_separator_new
 func folio_line_separator_new() C.uint64_t {
 	return C.uint64_t(ht.store(layout.NewLineSeparator()))
 }
 
-// --- AreaBreak (page break) ---
-
+// folio_area_break_new creates a page break element and returns its handle.
+//
 //export folio_area_break_new
 func folio_area_break_new() C.uint64_t {
 	return C.uint64_t(ht.store(layout.NewAreaBreak()))
 }
 
+// loadDiv retrieves a *layout.Div from the handle table.
 func loadDiv(h C.uint64_t) (*layout.Div, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_document.go
+++ b/export/cabi_document.go
@@ -17,6 +17,8 @@ import (
 	"github.com/carlos7ags/folio/layout"
 )
 
+// folio_document_new creates a new document with a custom page size in points.
+//
 //export folio_document_new
 func folio_document_new(width, height C.double) C.uint64_t {
 	doc := document.NewDocument(document.PageSize{
@@ -26,18 +28,24 @@ func folio_document_new(width, height C.double) C.uint64_t {
 	return C.uint64_t(ht.store(doc))
 }
 
+// folio_document_new_letter creates a new document with US Letter page size.
+//
 //export folio_document_new_letter
 func folio_document_new_letter() C.uint64_t {
 	doc := document.NewDocument(document.PageSizeLetter)
 	return C.uint64_t(ht.store(doc))
 }
 
+// folio_document_new_a4 creates a new document with A4 page size.
+//
 //export folio_document_new_a4
 func folio_document_new_a4() C.uint64_t {
 	doc := document.NewDocument(document.PageSizeA4)
 	return C.uint64_t(ht.store(doc))
 }
 
+// folio_document_set_title sets the PDF document title metadata.
+//
 //export folio_document_set_title
 func folio_document_set_title(docH C.uint64_t, title *C.char) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -48,6 +56,8 @@ func folio_document_set_title(docH C.uint64_t, title *C.char) C.int32_t {
 	return errOK
 }
 
+// folio_document_set_author sets the PDF document author metadata.
+//
 //export folio_document_set_author
 func folio_document_set_author(docH C.uint64_t, author *C.char) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -58,6 +68,8 @@ func folio_document_set_author(docH C.uint64_t, author *C.char) C.int32_t {
 	return errOK
 }
 
+// folio_document_set_margins sets the page margins in points (top, right, bottom, left).
+//
 //export folio_document_set_margins
 func folio_document_set_margins(docH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -73,6 +85,8 @@ func folio_document_set_margins(docH C.uint64_t, top, right, bottom, left C.doub
 	return errOK
 }
 
+// folio_document_add_page adds a new low-level page to the document and returns its handle.
+//
 //export folio_document_add_page
 func folio_document_add_page(docH C.uint64_t) C.uint64_t {
 	doc, errCode := loadDoc(docH)
@@ -83,6 +97,8 @@ func folio_document_add_page(docH C.uint64_t) C.uint64_t {
 	return C.uint64_t(ht.store(page))
 }
 
+// folio_document_page_count returns the number of pages in the document.
+//
 //export folio_document_page_count
 func folio_document_page_count(docH C.uint64_t) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -92,6 +108,8 @@ func folio_document_page_count(docH C.uint64_t) C.int32_t {
 	return C.int32_t(doc.PageCount())
 }
 
+// folio_document_add appends a layout element to the document for automatic pagination.
+//
 //export folio_document_add
 func folio_document_add(docH C.uint64_t, elemH C.uint64_t) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -112,6 +130,8 @@ func folio_document_add(docH C.uint64_t, elemH C.uint64_t) C.int32_t {
 	return errOK
 }
 
+// folio_document_save writes the document to a PDF file at the given path.
+//
 //export folio_document_save
 func folio_document_save(docH C.uint64_t, path *C.char) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -124,6 +144,8 @@ func folio_document_save(docH C.uint64_t, path *C.char) C.int32_t {
 	return errOK
 }
 
+// folio_document_write_to_buffer renders the document to an in-memory buffer and returns its handle.
+//
 //export folio_document_write_to_buffer
 func folio_document_write_to_buffer(docH C.uint64_t) C.uint64_t {
 	doc, errCode := loadDoc(docH)
@@ -138,12 +160,14 @@ func folio_document_write_to_buffer(docH C.uint64_t) C.uint64_t {
 	return C.uint64_t(ht.store(newCBuffer(buf.Bytes())))
 }
 
+// folio_document_free removes a document handle from the handle table.
+//
 //export folio_document_free
 func folio_document_free(docH C.uint64_t) {
 	ht.delete(uint64(docH))
 }
 
-// loadDoc is a helper that loads a *document.Document from the handle table.
+// loadDoc retrieves a *document.Document from the handle table.
 func loadDoc(h C.uint64_t) (*document.Document, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_font.go
+++ b/export/cabi_font.go
@@ -34,6 +34,8 @@ func init() {
 	}
 }
 
+// folio_font_standard returns a handle for a PDF standard font looked up by name.
+//
 //export folio_font_standard
 func folio_font_standard(name *C.char) C.uint64_t {
 	goName := C.GoString(name)
@@ -45,31 +47,43 @@ func folio_font_standard(name *C.char) C.uint64_t {
 	return C.uint64_t(id)
 }
 
+// folio_font_helvetica returns the handle for the Helvetica standard font.
+//
 //export folio_font_helvetica
 func folio_font_helvetica() C.uint64_t {
 	return C.uint64_t(standardFontHandles[font.Helvetica.Name()])
 }
 
+// folio_font_helvetica_bold returns the handle for the Helvetica-Bold standard font.
+//
 //export folio_font_helvetica_bold
 func folio_font_helvetica_bold() C.uint64_t {
 	return C.uint64_t(standardFontHandles[font.HelveticaBold.Name()])
 }
 
+// folio_font_times_roman returns the handle for the Times-Roman standard font.
+//
 //export folio_font_times_roman
 func folio_font_times_roman() C.uint64_t {
 	return C.uint64_t(standardFontHandles[font.TimesRoman.Name()])
 }
 
+// folio_font_times_bold returns the handle for the Times-Bold standard font.
+//
 //export folio_font_times_bold
 func folio_font_times_bold() C.uint64_t {
 	return C.uint64_t(standardFontHandles[font.TimesBold.Name()])
 }
 
+// folio_font_courier returns the handle for the Courier standard font.
+//
 //export folio_font_courier
 func folio_font_courier() C.uint64_t {
 	return C.uint64_t(standardFontHandles[font.Courier.Name()])
 }
 
+// folio_font_load_ttf loads a TrueType font from a file path and returns its handle.
+//
 //export folio_font_load_ttf
 func folio_font_load_ttf(path *C.char) C.uint64_t {
 	face, err := font.LoadTTF(C.GoString(path))
@@ -81,6 +95,8 @@ func folio_font_load_ttf(path *C.char) C.uint64_t {
 	return C.uint64_t(ht.store(ef))
 }
 
+// folio_font_parse_ttf parses a TrueType font from in-memory bytes and returns its handle.
+//
 //export folio_font_parse_ttf
 func folio_font_parse_ttf(data unsafe.Pointer, length C.int32_t) C.uint64_t {
 	if data == nil || length <= 0 {
@@ -97,6 +113,8 @@ func folio_font_parse_ttf(data unsafe.Pointer, length C.int32_t) C.uint64_t {
 	return C.uint64_t(ht.store(ef))
 }
 
+// folio_font_free releases an embedded font handle. Standard fonts are singletons and are not freed.
+//
 //export folio_font_free
 func folio_font_free(fontH C.uint64_t) {
 	// Standard fonts are singletons — don't delete them.
@@ -110,7 +128,7 @@ func folio_font_free(fontH C.uint64_t) {
 	ht.delete(uint64(fontH))
 }
 
-// loadEmbeddedFont loads a *font.EmbeddedFont from the handle table.
+// loadEmbeddedFont retrieves a *font.EmbeddedFont from the handle table.
 func loadEmbeddedFont(h C.uint64_t) (*font.EmbeddedFont, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_forms.go
+++ b/export/cabi_forms.go
@@ -17,13 +17,15 @@ import (
 	"github.com/carlos7ags/folio/forms"
 )
 
-// --- AcroForm ---
-
+// folio_form_new creates a new empty AcroForm and returns its handle.
+//
 //export folio_form_new
 func folio_form_new() C.uint64_t {
 	return C.uint64_t(ht.store(forms.NewAcroForm()))
 }
 
+// folio_form_add_text_field adds a text input field to the form at the given rectangle and page.
+//
 //export folio_form_add_text_field
 func folio_form_add_text_field(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t) C.int32_t {
 	af, errCode := loadForm(formH)
@@ -35,6 +37,8 @@ func folio_form_add_text_field(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.
 	return errOK
 }
 
+// folio_form_add_checkbox adds a checkbox field to the form at the given rectangle and page.
+//
 //export folio_form_add_checkbox
 func folio_form_add_checkbox(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t, checked C.int32_t) C.int32_t {
 	af, errCode := loadForm(formH)
@@ -46,6 +50,8 @@ func folio_form_add_checkbox(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.do
 	return errOK
 }
 
+// folio_form_add_dropdown adds a dropdown (choice) field to the form with the given options.
+//
 //export folio_form_add_dropdown
 func folio_form_add_dropdown(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t, options **C.char, optCount C.int32_t) C.int32_t {
 	af, errCode := loadForm(formH)
@@ -65,6 +71,8 @@ func folio_form_add_dropdown(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.do
 	return errOK
 }
 
+// folio_form_add_signature adds a digital signature field to the form at the given rectangle and page.
+//
 //export folio_form_add_signature
 func folio_form_add_signature(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t) C.int32_t {
 	af, errCode := loadForm(formH)
@@ -76,6 +84,8 @@ func folio_form_add_signature(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.d
 	return errOK
 }
 
+// folio_document_set_form attaches an AcroForm to the document.
+//
 //export folio_document_set_form
 func folio_document_set_form(docH C.uint64_t, formH C.uint64_t) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -90,13 +100,15 @@ func folio_document_set_form(docH C.uint64_t, formH C.uint64_t) C.int32_t {
 	return errOK
 }
 
+// folio_form_free removes a form handle from the handle table.
+//
 //export folio_form_free
 func folio_form_free(formH C.uint64_t) {
 	ht.delete(uint64(formH))
 }
 
-// --- Document feature flags ---
-
+// folio_document_set_tagged enables or disables tagged PDF (accessibility) output.
+//
 //export folio_document_set_tagged
 func folio_document_set_tagged(docH C.uint64_t, enabled C.int32_t) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -107,6 +119,8 @@ func folio_document_set_tagged(docH C.uint64_t, enabled C.int32_t) C.int32_t {
 	return errOK
 }
 
+// folio_document_set_pdfa configures PDF/A conformance at the specified level.
+//
 //export folio_document_set_pdfa
 func folio_document_set_pdfa(docH C.uint64_t, level C.int32_t) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -117,6 +131,8 @@ func folio_document_set_pdfa(docH C.uint64_t, level C.int32_t) C.int32_t {
 	return errOK
 }
 
+// folio_document_set_encryption configures PDF encryption with user/owner passwords and an algorithm.
+//
 //export folio_document_set_encryption
 func folio_document_set_encryption(docH C.uint64_t, userPw, ownerPw *C.char, algorithm C.int32_t) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -131,6 +147,8 @@ func folio_document_set_encryption(docH C.uint64_t, userPw, ownerPw *C.char, alg
 	return errOK
 }
 
+// folio_document_set_auto_bookmarks enables or disables automatic bookmark generation from headings.
+//
 //export folio_document_set_auto_bookmarks
 func folio_document_set_auto_bookmarks(docH C.uint64_t, enabled C.int32_t) C.int32_t {
 	doc, errCode := loadDoc(docH)
@@ -141,6 +159,7 @@ func folio_document_set_auto_bookmarks(docH C.uint64_t, enabled C.int32_t) C.int
 	return errOK
 }
 
+// loadForm retrieves a *forms.AcroForm from the handle table.
 func loadForm(h C.uint64_t) (*forms.AcroForm, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_heading.go
+++ b/export/cabi_heading.go
@@ -15,12 +15,16 @@ import (
 	"github.com/carlos7ags/folio/layout"
 )
 
+// folio_heading_new creates a heading element with the given text and level.
+//
 //export folio_heading_new
 func folio_heading_new(text *C.char, level C.int32_t) C.uint64_t {
 	h := layout.NewHeading(C.GoString(text), layout.HeadingLevel(level))
 	return C.uint64_t(ht.store(h))
 }
 
+// folio_heading_new_with_font creates a heading with a specific standard font and size.
+//
 //export folio_heading_new_with_font
 func folio_heading_new_with_font(text *C.char, level C.int32_t, fontH C.uint64_t, fontSize C.double) C.uint64_t {
 	f, errCode := loadStandardFont(fontH)
@@ -31,6 +35,8 @@ func folio_heading_new_with_font(text *C.char, level C.int32_t, fontH C.uint64_t
 	return C.uint64_t(ht.store(h))
 }
 
+// folio_heading_new_embedded creates a heading using an embedded TrueType font.
+//
 //export folio_heading_new_embedded
 func folio_heading_new_embedded(text *C.char, level C.int32_t, fontH C.uint64_t) C.uint64_t {
 	ef, errCode := loadEmbeddedFont(fontH)
@@ -41,6 +47,8 @@ func folio_heading_new_embedded(text *C.char, level C.int32_t, fontH C.uint64_t)
 	return C.uint64_t(ht.store(h))
 }
 
+// folio_heading_set_align sets the text alignment of a heading.
+//
 //export folio_heading_set_align
 func folio_heading_set_align(hH C.uint64_t, align C.int32_t) C.int32_t {
 	h, errCode := loadHeading(hH)
@@ -51,12 +59,14 @@ func folio_heading_set_align(hH C.uint64_t, align C.int32_t) C.int32_t {
 	return errOK
 }
 
+// folio_heading_free removes a heading handle from the handle table.
+//
 //export folio_heading_free
 func folio_heading_free(hH C.uint64_t) {
 	ht.delete(uint64(hH))
 }
 
-// loadHeading loads a *layout.Heading from the handle table.
+// loadHeading retrieves a *layout.Heading from the handle table.
 func loadHeading(h C.uint64_t) (*layout.Heading, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_html.go
+++ b/export/cabi_html.go
@@ -17,6 +17,8 @@ import (
 	"github.com/carlos7ags/folio/layout"
 )
 
+// folio_html_to_pdf converts an HTML string to a PDF file at the given output path.
+//
 //export folio_html_to_pdf
 func folio_html_to_pdf(htmlStr *C.char, outputPath *C.char) C.int32_t {
 	doc, err := htmlToDocument(C.GoString(htmlStr), 0, 0)
@@ -29,6 +31,8 @@ func folio_html_to_pdf(htmlStr *C.char, outputPath *C.char) C.int32_t {
 	return errOK
 }
 
+// folio_html_to_buffer converts an HTML string to an in-memory PDF buffer with optional page dimensions.
+//
 //export folio_html_to_buffer
 func folio_html_to_buffer(htmlStr *C.char, pageWidth, pageHeight C.double) C.uint64_t {
 	doc, err := htmlToDocument(C.GoString(htmlStr), float64(pageWidth), float64(pageHeight))
@@ -43,6 +47,8 @@ func folio_html_to_buffer(htmlStr *C.char, pageWidth, pageHeight C.double) C.uin
 	return C.uint64_t(ht.store(newCBuffer(buf.Bytes())))
 }
 
+// folio_html_convert converts an HTML string to a document handle for further manipulation.
+//
 //export folio_html_convert
 func folio_html_convert(htmlStr *C.char, pageWidth, pageHeight C.double) C.uint64_t {
 	doc, err := htmlToDocument(C.GoString(htmlStr), float64(pageWidth), float64(pageHeight))

--- a/export/cabi_image.go
+++ b/export/cabi_image.go
@@ -17,6 +17,8 @@ import (
 	"github.com/carlos7ags/folio/layout"
 )
 
+// folio_image_load_jpeg loads a JPEG image from a file path and returns its handle.
+//
 //export folio_image_load_jpeg
 func folio_image_load_jpeg(path *C.char) C.uint64_t {
 	img, err := folioimage.LoadJPEG(C.GoString(path))
@@ -27,6 +29,8 @@ func folio_image_load_jpeg(path *C.char) C.uint64_t {
 	return C.uint64_t(ht.store(img))
 }
 
+// folio_image_load_png loads a PNG image from a file path and returns its handle.
+//
 //export folio_image_load_png
 func folio_image_load_png(path *C.char) C.uint64_t {
 	img, err := folioimage.LoadPNG(C.GoString(path))
@@ -37,6 +41,8 @@ func folio_image_load_png(path *C.char) C.uint64_t {
 	return C.uint64_t(ht.store(img))
 }
 
+// folio_image_parse_jpeg parses a JPEG image from in-memory bytes and returns its handle.
+//
 //export folio_image_parse_jpeg
 func folio_image_parse_jpeg(data unsafe.Pointer, length C.int32_t) C.uint64_t {
 	if data == nil || length <= 0 {
@@ -52,6 +58,8 @@ func folio_image_parse_jpeg(data unsafe.Pointer, length C.int32_t) C.uint64_t {
 	return C.uint64_t(ht.store(img))
 }
 
+// folio_image_parse_png parses a PNG image from in-memory bytes and returns its handle.
+//
 //export folio_image_parse_png
 func folio_image_parse_png(data unsafe.Pointer, length C.int32_t) C.uint64_t {
 	if data == nil || length <= 0 {
@@ -67,6 +75,8 @@ func folio_image_parse_png(data unsafe.Pointer, length C.int32_t) C.uint64_t {
 	return C.uint64_t(ht.store(img))
 }
 
+// folio_image_width returns the pixel width of an image.
+//
 //export folio_image_width
 func folio_image_width(imgH C.uint64_t) C.int32_t {
 	img, errCode := loadImage(imgH)
@@ -76,6 +86,8 @@ func folio_image_width(imgH C.uint64_t) C.int32_t {
 	return C.int32_t(img.Width())
 }
 
+// folio_image_height returns the pixel height of an image.
+//
 //export folio_image_height
 func folio_image_height(imgH C.uint64_t) C.int32_t {
 	img, errCode := loadImage(imgH)
@@ -85,11 +97,15 @@ func folio_image_height(imgH C.uint64_t) C.int32_t {
 	return C.int32_t(img.Height())
 }
 
+// folio_image_free removes an image handle from the handle table.
+//
 //export folio_image_free
 func folio_image_free(imgH C.uint64_t) {
 	ht.delete(uint64(imgH))
 }
 
+// folio_page_add_image draws an image on a low-level page at the given position and size in points.
+//
 //export folio_page_add_image
 func folio_page_add_image(pageH C.uint64_t, imgH C.uint64_t, x, y, w, h C.double) C.int32_t {
 	page, errCode := loadPage(pageH)
@@ -104,6 +120,8 @@ func folio_page_add_image(pageH C.uint64_t, imgH C.uint64_t, x, y, w, h C.double
 	return errOK
 }
 
+// folio_image_element_new wraps an image in a layout element for automatic pagination.
+//
 //export folio_image_element_new
 func folio_image_element_new(imgH C.uint64_t) C.uint64_t {
 	img, errCode := loadImage(imgH)
@@ -114,6 +132,8 @@ func folio_image_element_new(imgH C.uint64_t) C.uint64_t {
 	return C.uint64_t(ht.store(ie))
 }
 
+// folio_image_element_set_size sets the display width and height of an image element in points.
+//
 //export folio_image_element_set_size
 func folio_image_element_set_size(ieH C.uint64_t, w, h C.double) C.int32_t {
 	v := ht.load(uint64(ieH))
@@ -130,11 +150,14 @@ func folio_image_element_set_size(ieH C.uint64_t, w, h C.double) C.int32_t {
 	return errOK
 }
 
+// folio_image_element_free removes an image element handle from the handle table.
+//
 //export folio_image_element_free
 func folio_image_element_free(ieH C.uint64_t) {
 	ht.delete(uint64(ieH))
 }
 
+// loadImage retrieves a *folioimage.Image from the handle table.
 func loadImage(h C.uint64_t) (*folioimage.Image, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_list.go
+++ b/export/cabi_list.go
@@ -15,6 +15,8 @@ import (
 	"github.com/carlos7ags/folio/layout"
 )
 
+// folio_list_new creates a new list element using a standard font and returns its handle.
+//
 //export folio_list_new
 func folio_list_new(fontH C.uint64_t, fontSize C.double) C.uint64_t {
 	f, errCode := loadStandardFont(fontH)
@@ -24,6 +26,8 @@ func folio_list_new(fontH C.uint64_t, fontSize C.double) C.uint64_t {
 	return C.uint64_t(ht.store(layout.NewList(f, float64(fontSize))))
 }
 
+// folio_list_new_embedded creates a new list element using an embedded TrueType font.
+//
 //export folio_list_new_embedded
 func folio_list_new_embedded(fontH C.uint64_t, fontSize C.double) C.uint64_t {
 	ef, errCode := loadEmbeddedFont(fontH)
@@ -33,6 +37,8 @@ func folio_list_new_embedded(fontH C.uint64_t, fontSize C.double) C.uint64_t {
 	return C.uint64_t(ht.store(layout.NewListEmbedded(ef, float64(fontSize))))
 }
 
+// folio_list_set_style sets the list style (bullet, numbered, etc.).
+//
 //export folio_list_set_style
 func folio_list_set_style(listH C.uint64_t, style C.int32_t) C.int32_t {
 	l, errCode := loadList(listH)
@@ -43,6 +49,8 @@ func folio_list_set_style(listH C.uint64_t, style C.int32_t) C.int32_t {
 	return errOK
 }
 
+// folio_list_set_indent sets the left indentation of list items in points.
+//
 //export folio_list_set_indent
 func folio_list_set_indent(listH C.uint64_t, indent C.double) C.int32_t {
 	l, errCode := loadList(listH)
@@ -53,6 +61,8 @@ func folio_list_set_indent(listH C.uint64_t, indent C.double) C.int32_t {
 	return errOK
 }
 
+// folio_list_add_item appends a text item to the list.
+//
 //export folio_list_add_item
 func folio_list_add_item(listH C.uint64_t, text *C.char) C.int32_t {
 	l, errCode := loadList(listH)
@@ -63,11 +73,14 @@ func folio_list_add_item(listH C.uint64_t, text *C.char) C.int32_t {
 	return errOK
 }
 
+// folio_list_free removes a list handle from the handle table.
+//
 //export folio_list_free
 func folio_list_free(listH C.uint64_t) {
 	ht.delete(uint64(listH))
 }
 
+// loadList retrieves a *layout.List from the handle table.
 func loadList(h C.uint64_t) (*layout.List, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_page.go
+++ b/export/cabi_page.go
@@ -16,6 +16,8 @@ import (
 	"github.com/carlos7ags/folio/font"
 )
 
+// folio_page_add_text draws text on a low-level page using a standard font at the given position.
+//
 //export folio_page_add_text
 func folio_page_add_text(pageH C.uint64_t, text *C.char, fontH C.uint64_t, size, x, y C.double) C.int32_t {
 	page, errCode := loadPage(pageH)
@@ -30,6 +32,8 @@ func folio_page_add_text(pageH C.uint64_t, text *C.char, fontH C.uint64_t, size,
 	return errOK
 }
 
+// folio_page_add_text_embedded draws text on a low-level page using an embedded font at the given position.
+//
 //export folio_page_add_text_embedded
 func folio_page_add_text_embedded(pageH C.uint64_t, text *C.char, fontH C.uint64_t, size, x, y C.double) C.int32_t {
 	page, errCode := loadPage(pageH)
@@ -44,6 +48,8 @@ func folio_page_add_text_embedded(pageH C.uint64_t, text *C.char, fontH C.uint64
 	return errOK
 }
 
+// folio_page_add_link adds a URI link annotation to a page within the given rectangle.
+//
 //export folio_page_add_link
 func folio_page_add_link(pageH C.uint64_t, x1, y1, x2, y2 C.double, uri *C.char) C.int32_t {
 	page, errCode := loadPage(pageH)
@@ -54,6 +60,8 @@ func folio_page_add_link(pageH C.uint64_t, x1, y1, x2, y2 C.double, uri *C.char)
 	return errOK
 }
 
+// folio_page_set_opacity sets the global opacity for subsequent drawing operations on a page.
+//
 //export folio_page_set_opacity
 func folio_page_set_opacity(pageH C.uint64_t, alpha C.double) C.int32_t {
 	page, errCode := loadPage(pageH)
@@ -64,6 +72,8 @@ func folio_page_set_opacity(pageH C.uint64_t, alpha C.double) C.int32_t {
 	return errOK
 }
 
+// folio_page_set_rotate sets the page rotation in degrees (must be a multiple of 90).
+//
 //export folio_page_set_rotate
 func folio_page_set_rotate(pageH C.uint64_t, degrees C.int32_t) C.int32_t {
 	page, errCode := loadPage(pageH)
@@ -74,7 +84,7 @@ func folio_page_set_rotate(pageH C.uint64_t, degrees C.int32_t) C.int32_t {
 	return errOK
 }
 
-// loadPage is a helper that loads a *document.Page from the handle table.
+// loadPage retrieves a *document.Page from the handle table.
 func loadPage(h C.uint64_t) (*document.Page, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {
@@ -89,7 +99,7 @@ func loadPage(h C.uint64_t) (*document.Page, C.int32_t) {
 	return page, errOK
 }
 
-// loadStandardFont loads a *font.Standard from the handle table.
+// loadStandardFont retrieves a *font.Standard from the handle table.
 func loadStandardFont(h C.uint64_t) (*font.Standard, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_paragraph.go
+++ b/export/cabi_paragraph.go
@@ -16,6 +16,8 @@ import (
 	"github.com/carlos7ags/folio/layout"
 )
 
+// folio_paragraph_new creates a paragraph with a standard font and returns its handle.
+//
 //export folio_paragraph_new
 func folio_paragraph_new(text *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
 	f, errCode := loadStandardFont(fontH)
@@ -26,6 +28,8 @@ func folio_paragraph_new(text *C.char, fontH C.uint64_t, fontSize C.double) C.ui
 	return C.uint64_t(ht.store(p))
 }
 
+// folio_paragraph_new_embedded creates a paragraph with an embedded TrueType font.
+//
 //export folio_paragraph_new_embedded
 func folio_paragraph_new_embedded(text *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
 	ef, errCode := loadEmbeddedFont(fontH)
@@ -36,6 +40,8 @@ func folio_paragraph_new_embedded(text *C.char, fontH C.uint64_t, fontSize C.dou
 	return C.uint64_t(ht.store(p))
 }
 
+// folio_paragraph_set_align sets the text alignment of a paragraph.
+//
 //export folio_paragraph_set_align
 func folio_paragraph_set_align(pH C.uint64_t, align C.int32_t) C.int32_t {
 	p, errCode := loadParagraph(pH)
@@ -46,6 +52,8 @@ func folio_paragraph_set_align(pH C.uint64_t, align C.int32_t) C.int32_t {
 	return errOK
 }
 
+// folio_paragraph_set_leading sets the line spacing (leading) of a paragraph in points.
+//
 //export folio_paragraph_set_leading
 func folio_paragraph_set_leading(pH C.uint64_t, leading C.double) C.int32_t {
 	p, errCode := loadParagraph(pH)
@@ -56,6 +64,8 @@ func folio_paragraph_set_leading(pH C.uint64_t, leading C.double) C.int32_t {
 	return errOK
 }
 
+// folio_paragraph_set_space_before sets the vertical spacing before a paragraph in points.
+//
 //export folio_paragraph_set_space_before
 func folio_paragraph_set_space_before(pH C.uint64_t, pts C.double) C.int32_t {
 	p, errCode := loadParagraph(pH)
@@ -66,6 +76,8 @@ func folio_paragraph_set_space_before(pH C.uint64_t, pts C.double) C.int32_t {
 	return errOK
 }
 
+// folio_paragraph_set_space_after sets the vertical spacing after a paragraph in points.
+//
 //export folio_paragraph_set_space_after
 func folio_paragraph_set_space_after(pH C.uint64_t, pts C.double) C.int32_t {
 	p, errCode := loadParagraph(pH)
@@ -76,6 +88,8 @@ func folio_paragraph_set_space_after(pH C.uint64_t, pts C.double) C.int32_t {
 	return errOK
 }
 
+// folio_paragraph_set_background sets the background color of a paragraph using RGB values in [0,1].
+//
 //export folio_paragraph_set_background
 func folio_paragraph_set_background(pH C.uint64_t, r, g, b C.double) C.int32_t {
 	p, errCode := loadParagraph(pH)
@@ -86,6 +100,8 @@ func folio_paragraph_set_background(pH C.uint64_t, r, g, b C.double) C.int32_t {
 	return errOK
 }
 
+// folio_paragraph_set_first_indent sets the first-line indentation of a paragraph in points.
+//
 //export folio_paragraph_set_first_indent
 func folio_paragraph_set_first_indent(pH C.uint64_t, pts C.double) C.int32_t {
 	p, errCode := loadParagraph(pH)
@@ -96,6 +112,8 @@ func folio_paragraph_set_first_indent(pH C.uint64_t, pts C.double) C.int32_t {
 	return errOK
 }
 
+// folio_paragraph_add_run appends a styled text run to a paragraph with the given font and color.
+//
 //export folio_paragraph_add_run
 func folio_paragraph_add_run(pH C.uint64_t, text *C.char, fontH C.uint64_t, fontSize C.double, r, g, b C.double) C.int32_t {
 	p, errCode := loadParagraph(pH)
@@ -126,12 +144,14 @@ func folio_paragraph_add_run(pH C.uint64_t, text *C.char, fontH C.uint64_t, font
 	return errOK
 }
 
+// folio_paragraph_free removes a paragraph handle from the handle table.
+//
 //export folio_paragraph_free
 func folio_paragraph_free(pH C.uint64_t) {
 	ht.delete(uint64(pH))
 }
 
-// loadParagraph loads a *layout.Paragraph from the handle table.
+// loadParagraph retrieves a *layout.Paragraph from the handle table.
 func loadParagraph(h C.uint64_t) (*layout.Paragraph, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_reader.go
+++ b/export/cabi_reader.go
@@ -16,6 +16,8 @@ import (
 	"github.com/carlos7ags/folio/reader"
 )
 
+// folio_reader_open opens an existing PDF file for reading and returns a reader handle.
+//
 //export folio_reader_open
 func folio_reader_open(path *C.char) C.uint64_t {
 	r, err := reader.Open(C.GoString(path))
@@ -26,6 +28,8 @@ func folio_reader_open(path *C.char) C.uint64_t {
 	return C.uint64_t(ht.store(r))
 }
 
+// folio_reader_parse parses a PDF from in-memory bytes and returns a reader handle.
+//
 //export folio_reader_parse
 func folio_reader_parse(data unsafe.Pointer, length C.int32_t) C.uint64_t {
 	if data == nil || length <= 0 {
@@ -41,6 +45,8 @@ func folio_reader_parse(data unsafe.Pointer, length C.int32_t) C.uint64_t {
 	return C.uint64_t(ht.store(r))
 }
 
+// folio_reader_page_count returns the number of pages in the PDF.
+//
 //export folio_reader_page_count
 func folio_reader_page_count(rH C.uint64_t) C.int32_t {
 	r, errCode := loadReader(rH)
@@ -50,6 +56,8 @@ func folio_reader_page_count(rH C.uint64_t) C.int32_t {
 	return C.int32_t(r.PageCount())
 }
 
+// folio_reader_version returns the PDF version string as a buffer handle.
+//
 //export folio_reader_version
 func folio_reader_version(rH C.uint64_t) C.uint64_t {
 	r, errCode := loadReader(rH)
@@ -59,6 +67,8 @@ func folio_reader_version(rH C.uint64_t) C.uint64_t {
 	return C.uint64_t(ht.store(newCBuffer([]byte(r.Version()))))
 }
 
+// folio_reader_info_title returns the PDF document title as a buffer handle.
+//
 //export folio_reader_info_title
 func folio_reader_info_title(rH C.uint64_t) C.uint64_t {
 	r, errCode := loadReader(rH)
@@ -69,6 +79,8 @@ func folio_reader_info_title(rH C.uint64_t) C.uint64_t {
 	return C.uint64_t(ht.store(newCBuffer([]byte(title))))
 }
 
+// folio_reader_info_author returns the PDF document author as a buffer handle.
+//
 //export folio_reader_info_author
 func folio_reader_info_author(rH C.uint64_t) C.uint64_t {
 	r, errCode := loadReader(rH)
@@ -79,6 +91,8 @@ func folio_reader_info_author(rH C.uint64_t) C.uint64_t {
 	return C.uint64_t(ht.store(newCBuffer([]byte(author))))
 }
 
+// folio_reader_extract_text extracts the text content of a page as a buffer handle.
+//
 //export folio_reader_extract_text
 func folio_reader_extract_text(rH C.uint64_t, pageIndex C.int32_t) C.uint64_t {
 	r, errCode := loadReader(rH)
@@ -98,6 +112,8 @@ func folio_reader_extract_text(rH C.uint64_t, pageIndex C.int32_t) C.uint64_t {
 	return C.uint64_t(ht.store(newCBuffer([]byte(text))))
 }
 
+// folio_reader_page_width returns the width of a page in points.
+//
 //export folio_reader_page_width
 func folio_reader_page_width(rH C.uint64_t, pageIndex C.int32_t) C.double {
 	r, errCode := loadReader(rH)
@@ -111,6 +127,8 @@ func folio_reader_page_width(rH C.uint64_t, pageIndex C.int32_t) C.double {
 	return C.double(page.Width)
 }
 
+// folio_reader_page_height returns the height of a page in points.
+//
 //export folio_reader_page_height
 func folio_reader_page_height(rH C.uint64_t, pageIndex C.int32_t) C.double {
 	r, errCode := loadReader(rH)
@@ -124,11 +142,14 @@ func folio_reader_page_height(rH C.uint64_t, pageIndex C.int32_t) C.double {
 	return C.double(page.Height)
 }
 
+// folio_reader_free removes a reader handle from the handle table.
+//
 //export folio_reader_free
 func folio_reader_free(rH C.uint64_t) {
 	ht.delete(uint64(rH))
 }
 
+// loadReader retrieves a *reader.PdfReader from the handle table.
 func loadReader(h C.uint64_t) (*reader.PdfReader, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/export/cabi_table.go
+++ b/export/cabi_table.go
@@ -16,12 +16,16 @@ import (
 	"github.com/carlos7ags/folio/layout"
 )
 
+// folio_table_new creates an empty table element and returns its handle.
+//
 //export folio_table_new
 func folio_table_new() C.uint64_t {
 	t := layout.NewTable()
 	return C.uint64_t(ht.store(t))
 }
 
+// folio_table_set_column_widths sets the relative column widths for the table.
+//
 //export folio_table_set_column_widths
 func folio_table_set_column_widths(tH C.uint64_t, widths *C.double, count C.int32_t) C.int32_t {
 	t, errCode := loadTable(tH)
@@ -38,6 +42,8 @@ func folio_table_set_column_widths(tH C.uint64_t, widths *C.double, count C.int3
 	return errOK
 }
 
+// folio_table_set_border_collapse enables or disables border collapsing between adjacent cells.
+//
 //export folio_table_set_border_collapse
 func folio_table_set_border_collapse(tH C.uint64_t, enabled C.int32_t) C.int32_t {
 	t, errCode := loadTable(tH)
@@ -48,6 +54,8 @@ func folio_table_set_border_collapse(tH C.uint64_t, enabled C.int32_t) C.int32_t
 	return errOK
 }
 
+// folio_table_add_row appends a new body row to the table and returns its handle.
+//
 //export folio_table_add_row
 func folio_table_add_row(tH C.uint64_t) C.uint64_t {
 	t, errCode := loadTable(tH)
@@ -58,6 +66,8 @@ func folio_table_add_row(tH C.uint64_t) C.uint64_t {
 	return C.uint64_t(ht.store(row))
 }
 
+// folio_table_add_header_row appends a header row that repeats on each page and returns its handle.
+//
 //export folio_table_add_header_row
 func folio_table_add_header_row(tH C.uint64_t) C.uint64_t {
 	t, errCode := loadTable(tH)
@@ -68,6 +78,8 @@ func folio_table_add_header_row(tH C.uint64_t) C.uint64_t {
 	return C.uint64_t(ht.store(row))
 }
 
+// folio_row_add_cell adds a text cell to a row using a standard font and returns the cell handle.
+//
 //export folio_row_add_cell
 func folio_row_add_cell(rowH C.uint64_t, text *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
 	row, errCode := loadRow(rowH)
@@ -82,6 +94,8 @@ func folio_row_add_cell(rowH C.uint64_t, text *C.char, fontH C.uint64_t, fontSiz
 	return C.uint64_t(ht.store(cell))
 }
 
+// folio_row_add_cell_embedded adds a text cell to a row using an embedded font and returns the cell handle.
+//
 //export folio_row_add_cell_embedded
 func folio_row_add_cell_embedded(rowH C.uint64_t, text *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
 	row, errCode := loadRow(rowH)
@@ -96,6 +110,8 @@ func folio_row_add_cell_embedded(rowH C.uint64_t, text *C.char, fontH C.uint64_t
 	return C.uint64_t(ht.store(cell))
 }
 
+// folio_row_add_cell_element adds a cell containing a layout element to a row and returns the cell handle.
+//
 //export folio_row_add_cell_element
 func folio_row_add_cell_element(rowH C.uint64_t, elemH C.uint64_t) C.uint64_t {
 	row, errCode := loadRow(rowH)
@@ -116,6 +132,8 @@ func folio_row_add_cell_element(rowH C.uint64_t, elemH C.uint64_t) C.uint64_t {
 	return C.uint64_t(ht.store(cell))
 }
 
+// folio_cell_set_align sets the text alignment within a table cell.
+//
 //export folio_cell_set_align
 func folio_cell_set_align(cH C.uint64_t, align C.int32_t) C.int32_t {
 	cell, errCode := loadCell(cH)
@@ -126,6 +144,8 @@ func folio_cell_set_align(cH C.uint64_t, align C.int32_t) C.int32_t {
 	return errOK
 }
 
+// folio_cell_set_padding sets uniform padding on all sides of a table cell in points.
+//
 //export folio_cell_set_padding
 func folio_cell_set_padding(cH C.uint64_t, padding C.double) C.int32_t {
 	cell, errCode := loadCell(cH)
@@ -136,6 +156,8 @@ func folio_cell_set_padding(cH C.uint64_t, padding C.double) C.int32_t {
 	return errOK
 }
 
+// folio_cell_set_background sets the background color of a table cell using RGB values in [0,1].
+//
 //export folio_cell_set_background
 func folio_cell_set_background(cH C.uint64_t, r, g, b C.double) C.int32_t {
 	cell, errCode := loadCell(cH)
@@ -146,6 +168,8 @@ func folio_cell_set_background(cH C.uint64_t, r, g, b C.double) C.int32_t {
 	return errOK
 }
 
+// folio_cell_set_colspan sets the number of columns a cell spans.
+//
 //export folio_cell_set_colspan
 func folio_cell_set_colspan(cH C.uint64_t, n C.int32_t) C.int32_t {
 	cell, errCode := loadCell(cH)
@@ -156,6 +180,8 @@ func folio_cell_set_colspan(cH C.uint64_t, n C.int32_t) C.int32_t {
 	return errOK
 }
 
+// folio_cell_set_rowspan sets the number of rows a cell spans.
+//
 //export folio_cell_set_rowspan
 func folio_cell_set_rowspan(cH C.uint64_t, n C.int32_t) C.int32_t {
 	cell, errCode := loadCell(cH)
@@ -166,21 +192,28 @@ func folio_cell_set_rowspan(cH C.uint64_t, n C.int32_t) C.int32_t {
 	return errOK
 }
 
+// folio_row_free removes a row handle from the handle table.
+//
 //export folio_row_free
 func folio_row_free(rowH C.uint64_t) {
 	ht.delete(uint64(rowH))
 }
 
+// folio_cell_free removes a cell handle from the handle table.
+//
 //export folio_cell_free
 func folio_cell_free(cH C.uint64_t) {
 	ht.delete(uint64(cH))
 }
 
+// folio_table_free removes a table handle from the handle table.
+//
 //export folio_table_free
 func folio_table_free(tH C.uint64_t) {
 	ht.delete(uint64(tH))
 }
 
+// loadTable retrieves a *layout.Table from the handle table.
 func loadTable(h C.uint64_t) (*layout.Table, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {
@@ -195,6 +228,7 @@ func loadTable(h C.uint64_t) (*layout.Table, C.int32_t) {
 	return t, errOK
 }
 
+// loadRow retrieves a *layout.Row from the handle table.
 func loadRow(h C.uint64_t) (*layout.Row, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {
@@ -209,6 +243,7 @@ func loadRow(h C.uint64_t) (*layout.Row, C.int32_t) {
 	return r, errOK
 }
 
+// loadCell retrieves a *layout.Cell from the handle table.
 func loadCell(h C.uint64_t) (*layout.Cell, C.int32_t) {
 	v := ht.load(uint64(h))
 	if v == nil {

--- a/font/embed.go
+++ b/font/embed.go
@@ -80,7 +80,7 @@ func (ef *EmbeddedFont) Kern(left, right rune) float64 {
 	return float64(kernUnits) * 1000.0 / float64(ef.face.UnitsPerEm())
 }
 
-// PdfObjects builds the complete set of PDF objects for this embedded font.
+// BuildObjects builds the complete set of PDF objects for this embedded font.
 // The caller is responsible for registering these as indirect objects.
 //
 // Returns:

--- a/font/standard.go
+++ b/font/standard.go
@@ -1,7 +1,16 @@
 // Copyright 2026 Carlos Munoz and the Folio Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package font provides PDF font definitions and (later) font parsing.
+// Package font handles font loading, parsing, subsetting, and PDF embedding.
+//
+// It supports the 14 standard PDF fonts (which require no embedding),
+// TrueType/OpenType fonts parsed via golang.org/x/image/font/sfnt,
+// and WOFF1 web fonts decoded to TTF. Embedded fonts are subset to
+// include only the glyphs actually used, reducing file size.
+//
+// Text measurement and kerning are available for both standard and
+// embedded fonts through the [TextMeasurer] interface and the Kern
+// methods.
 package font
 
 import "github.com/carlos7ags/folio/core"

--- a/font/truetype.go
+++ b/font/truetype.go
@@ -53,6 +53,8 @@ func LoadTTF(path string) (Face, error) {
 	return ParseTTF(data)
 }
 
+// PostScriptName returns the PostScript name, falling back to the full name
+// if the PostScript name entry is missing or empty.
 func (f *sfntFace) PostScriptName() string {
 	name, err := f.font.Name(&f.buf, sfnt.NameIDPostScript)
 	if err != nil || name == "" {
@@ -61,10 +63,12 @@ func (f *sfntFace) PostScriptName() string {
 	return name
 }
 
+// UnitsPerEm returns the font's design units per em.
 func (f *sfntFace) UnitsPerEm() int {
 	return int(f.font.UnitsPerEm())
 }
 
+// GlyphIndex returns the glyph ID for r, or 0 if the rune is not in the font.
 func (f *sfntFace) GlyphIndex(r rune) uint16 {
 	idx, err := f.font.GlyphIndex(&f.buf, r)
 	if err != nil {
@@ -73,6 +77,7 @@ func (f *sfntFace) GlyphIndex(r rune) uint16 {
 	return uint16(idx)
 }
 
+// GlyphAdvance returns the advance width in font design units, or 0 on error.
 func (f *sfntFace) GlyphAdvance(glyphID uint16) int {
 	adv, err := f.font.GlyphAdvance(&f.buf, sfnt.GlyphIndex(glyphID), f.ppem, xfont.HintingNone)
 	if err != nil {
@@ -81,6 +86,7 @@ func (f *sfntFace) GlyphAdvance(glyphID uint16) int {
 	return fix26_6ToInt(adv)
 }
 
+// Ascent returns the typographic ascent in font design units.
 func (f *sfntFace) Ascent() int {
 	metrics, err := f.font.Metrics(&f.buf, f.ppem, xfont.HintingNone)
 	if err != nil {
@@ -89,6 +95,8 @@ func (f *sfntFace) Ascent() int {
 	return fix26_6ToInt(metrics.Ascent)
 }
 
+// Descent returns the typographic descent as a negative value in font design
+// units. The sfnt library returns descent as positive, so this method negates it.
 func (f *sfntFace) Descent() int {
 	metrics, err := f.font.Metrics(&f.buf, f.ppem, xfont.HintingNone)
 	if err != nil {
@@ -98,6 +106,8 @@ func (f *sfntFace) Descent() int {
 	return -fix26_6ToInt(metrics.Descent)
 }
 
+// BBox returns the font bounding box as [xMin, yMin, xMax, yMax] in font
+// design units, converted from sfnt's Y-down coordinates to PDF's Y-up system.
 func (f *sfntFace) BBox() [4]int {
 	bounds, err := f.font.Bounds(&f.buf, f.ppem, xfont.HintingNone)
 	if err != nil {
@@ -113,6 +123,7 @@ func (f *sfntFace) BBox() [4]int {
 	}
 }
 
+// rawTables lazily parses the raw TTF table directory and caches the result.
 func (f *sfntFace) rawTables() map[string][]byte {
 	if !f.tablesParsed {
 		f.tables, _ = parseTTFTables(f.rawData)
@@ -121,6 +132,8 @@ func (f *sfntFace) rawTables() map[string][]byte {
 	return f.tables
 }
 
+// ItalicAngle returns the italic angle by parsing the post table's Fixed 16.16
+// field at offset 4. Returns 0 if the post table is missing or too short.
 func (f *sfntFace) ItalicAngle() float64 {
 	// Parse italic angle from the post table (offset 4, Fixed 16.16).
 	tables := f.rawTables()
@@ -138,6 +151,8 @@ func (f *sfntFace) ItalicAngle() float64 {
 	return float64(intPart) + fracPart
 }
 
+// CapHeight returns the cap height from the OS/2 table (sCapHeight at offset
+// 88). Requires OS/2 version >= 2. Returns 0 if unavailable.
 func (f *sfntFace) CapHeight() int {
 	// OS/2 table, sCapHeight at offset 88 (requires version >= 2).
 	tables := f.rawTables()
@@ -156,6 +171,9 @@ func (f *sfntFace) CapHeight() int {
 	return int(int16(binary.BigEndian.Uint16(os2[88:90])))
 }
 
+// StemV derives the dominant vertical stem width from the OS/2 usWeightClass
+// using the formula: 10 + 220*(weightClass-50)/900, clamped to a minimum of 10.
+// Returns 80 as a fallback if the OS/2 table is missing.
 func (f *sfntFace) StemV() int {
 	// Derive from OS/2 usWeightClass (offset 4).
 	// Formula: StemV = 10 + 220 * (weightClass - 50) / 900
@@ -173,6 +191,8 @@ func (f *sfntFace) StemV() int {
 	return max(stemV, 10)
 }
 
+// Kern returns the kerning adjustment between two glyphs by looking up the
+// kern table. Returns 0 if no kern table exists or no pair entry is found.
 func (f *sfntFace) Kern(left, right uint16) int {
 	tables := f.rawTables()
 	if tables == nil {
@@ -289,6 +309,8 @@ func lookupKernFormat0(data []byte, left, right uint16) int {
 	return 0
 }
 
+// Flags returns the PDF font flags. Currently hardcoded to 32 (Nonsymbolic),
+// which is appropriate for TrueType fonts with Unicode cmap tables.
 func (f *sfntFace) Flags() uint32 {
 	// PDF font flags (Table 123 in ISO 32000):
 	// Bit 6 (value 32): Nonsymbolic — using standard Latin encoding.
@@ -296,10 +318,12 @@ func (f *sfntFace) Flags() uint32 {
 	return 32
 }
 
+// RawData returns the complete, unmodified font file bytes.
 func (f *sfntFace) RawData() []byte {
 	return f.rawData
 }
 
+// NumGlyphs returns the total number of glyphs in the font.
 func (f *sfntFace) NumGlyphs() int {
 	return f.font.NumGlyphs()
 }

--- a/forms/acroform.go
+++ b/forms/acroform.go
@@ -9,15 +9,16 @@ import (
 
 // AcroForm manages the interactive form fields for a PDF document.
 type AcroForm struct {
+	// fields holds the top-level form fields in insertion order.
 	fields []*Field
 }
 
-// NewAcroForm creates an empty form.
+// NewAcroForm creates an empty AcroForm with no fields.
 func NewAcroForm() *AcroForm {
 	return &AcroForm{}
 }
 
-// Add adds a field to the form.
+// Add appends a field to the form and returns the AcroForm for chaining.
 func (af *AcroForm) Add(f *Field) *AcroForm {
 	af.fields = append(af.fields, f)
 	return af
@@ -29,8 +30,8 @@ func (af *AcroForm) Fields() []*Field {
 }
 
 // Build creates the /AcroForm dictionary and all field/widget objects.
-// Returns the AcroForm dictionary reference and a map of pageIndex → widget refs
-// (so the document layer can add them to each page's /Annots array).
+// It returns the AcroForm indirect reference and a map from page index to widget
+// references, so the document layer can add them to each page's /Annots array.
 func (af *AcroForm) Build(
 	addObject func(core.PdfObject) *core.PdfIndirectReference,
 	pageRefs []*core.PdfIndirectReference,

--- a/forms/appearance.go
+++ b/forms/appearance.go
@@ -27,8 +27,8 @@ func buildDA(f *Field) string {
 		fmtNum(r), fmtNum(g), fmtNum(b))
 }
 
-// buildCheckboxAppearance creates /AP dictionary for a checkbox.
-// Contains /N (normal) dict with /Yes and /Off appearance streams.
+// buildCheckboxAppearance creates the /AP dictionary for a checkbox field.
+// The returned dictionary contains a /N (normal) sub-dictionary with /Yes and /Off appearance streams.
 func buildCheckboxAppearance(f *Field, addObject func(core.PdfObject) *core.PdfIndirectReference) *core.PdfDictionary {
 	w := f.Rect[2] - f.Rect[0]
 	h := f.Rect[3] - f.Rect[1]
@@ -77,7 +77,8 @@ func buildCheckboxAppearance(f *Field, addObject func(core.PdfObject) *core.PdfI
 	return ap
 }
 
-// buildWidgetDict creates a standalone widget annotation for radio buttons.
+// buildWidgetDict creates a standalone widget annotation dictionary for a radio button child.
+// The widget is linked to its parent field and, when valid, to the target page.
 func buildWidgetDict(child *Field, parentRef *core.PdfIndirectReference, pageRefs []*core.PdfIndirectReference) *core.PdfDictionary {
 	w := core.NewPdfDictionary()
 	w.Set("Type", core.NewPdfName("Annot"))
@@ -100,7 +101,8 @@ func buildWidgetDict(child *Field, parentRef *core.PdfIndirectReference, pageRef
 	return w
 }
 
-// fmtNum formats a number for PDF appearance strings.
+// fmtNum formats a float64 as a compact string for PDF content streams.
+// Integers are rendered without a decimal point; others use two decimal places.
 func fmtNum(v float64) string {
 	if v == float64(int(v)) {
 		return fmt.Sprintf("%d", int(v))

--- a/forms/field.go
+++ b/forms/field.go
@@ -35,21 +35,21 @@ const (
 	FlagMultiline       FieldFlags = 1 << 12 // multi-line text
 	FlagPassword        FieldFlags = 1 << 13 // password (hidden chars)
 	FlagFileSelect      FieldFlags = 1 << 20 // file path input
-	FlagDoNotSpellCheck FieldFlags = 1 << 22
-	FlagDoNotScroll     FieldFlags = 1 << 23
+	FlagDoNotSpellCheck FieldFlags = 1 << 22 // disable spell check
+	FlagDoNotScroll     FieldFlags = 1 << 23 // disable scrolling for long text
 	FlagComb            FieldFlags = 1 << 24 // evenly spaced characters
-	FlagRichText        FieldFlags = 1 << 25
+	FlagRichText        FieldFlags = 1 << 25 // rich text value
 
 	// Choice field specific flags.
 	FlagCombo       FieldFlags = 1 << 17 // combo box (dropdown) vs list box
 	FlagEdit        FieldFlags = 1 << 18 // editable combo box
 	FlagSort        FieldFlags = 1 << 19 // sorted options
-	FlagMultiSelect FieldFlags = 1 << 21
+	FlagMultiSelect FieldFlags = 1 << 21 // allow multiple selections
 
 	// Button specific flags.
-	FlagNoToggleToOff  FieldFlags = 1 << 14
+	FlagNoToggleToOff  FieldFlags = 1 << 14 // one radio button must always be selected
 	FlagRadioFlag      FieldFlags = 1 << 15 // radio button (vs checkbox)
-	FlagPushButtonFlag FieldFlags = 1 << 16
+	FlagPushButtonFlag FieldFlags = 1 << 16 // push button (no persistent value)
 )
 
 // Field represents a single form field.
@@ -76,7 +76,7 @@ type Field struct {
 	// Radio/checkbox.
 	ExportValue string // /AS or /V value when checked (default "Yes")
 
-	// Children for radio button groups.
+	// children holds the individual buttons in a radio button group.
 	children []*Field
 }
 
@@ -127,7 +127,7 @@ func Checkbox(name string, rect [4]float64, pageIndex int, checked bool) *Field 
 }
 
 // RadioGroup creates a radio button group with the given options.
-// Each option is a Field that represents one radio button.
+// Each RadioOption becomes a child widget field representing one button.
 func RadioGroup(name string, options []RadioOption) *Field {
 	parent := &Field{
 		Name:  name,
@@ -152,7 +152,7 @@ func RadioGroup(name string, options []RadioOption) *Field {
 type RadioOption struct {
 	Value     string     // export value when selected
 	Rect      [4]float64 // position on page
-	PageIndex int
+	PageIndex int        // zero-based page index
 }
 
 // Dropdown creates a dropdown (combo box) field.
@@ -225,7 +225,7 @@ func (f *Field) SetBorderColor(r, g, b float64) *Field {
 	return f
 }
 
-// ftName returns the PDF field type name.
+// ftName returns the PDF /FT name for the given FieldType.
 func ftName(ft FieldType) string {
 	switch ft {
 	case FieldText:
@@ -241,8 +241,8 @@ func ftName(ft FieldType) string {
 	}
 }
 
-// ToDict converts the field to a PDF dictionary for the AcroForm.
-// Returns the field dict and any widget annotation dicts.
+// ToDict converts the field to a PDF dictionary and registers it via addObject.
+// It returns the field's indirect reference and widget info for page annotation placement.
 func (f *Field) ToDict(addObject func(core.PdfObject) *core.PdfIndirectReference, pageRefs []*core.PdfIndirectReference) (*core.PdfIndirectReference, []*widgetInfo) {
 	dict := core.NewPdfDictionary()
 	dict.Set("T", core.NewPdfLiteralString(f.Name))
@@ -336,8 +336,10 @@ func (f *Field) ToDict(addObject func(core.PdfObject) *core.PdfIndirectReference
 	return fieldRef, widgets
 }
 
-// widgetInfo tracks a widget reference and its target page.
+// widgetInfo pairs a widget annotation's indirect reference with the page it belongs to.
 type widgetInfo struct {
-	ref       *core.PdfIndirectReference
+	// ref is the indirect reference to the widget annotation object.
+	ref *core.PdfIndirectReference
+	// pageIndex is the zero-based index of the page containing this widget.
 	pageIndex int
 }

--- a/forms/fill.go
+++ b/forms/fill.go
@@ -13,6 +13,7 @@ import (
 // FormFiller reads form fields from an existing PDF and allows
 // modifying their values before saving.
 type FormFiller struct {
+	// reader is the parsed PDF whose form fields are being modified.
 	reader *reader.PdfReader
 }
 
@@ -53,8 +54,8 @@ func (ff *FormFiller) GetValue(fieldName string) (string, error) {
 }
 
 // SetValue sets the value of a form field.
-// The change is applied to the in-memory PDF objects.
-// Call reader.Merge to save the modified document.
+// The change is applied to the in-memory PDF objects. To persist the change,
+// pass the reader to reader.Merge and call SaveTo or WriteTo on the result.
 func (ff *FormFiller) SetValue(fieldName, value string) error {
 	fields, err := ff.getFieldDicts()
 	if err != nil {
@@ -107,7 +108,8 @@ func (ff *FormFiller) SetCheckbox(fieldName string, checked bool) error {
 	return fmt.Errorf("forms: field %q not found", fieldName)
 }
 
-// getFieldDicts extracts all field dictionaries from the AcroForm.
+// getFieldDicts extracts all field dictionaries from the AcroForm,
+// including child widgets of radio button groups.
 func (ff *FormFiller) getFieldDicts() ([]*core.PdfDictionary, error) {
 	catalog := ff.reader.Catalog()
 	acroFormObj := catalog.Get("AcroForm")

--- a/html/converter.go
+++ b/html/converter.go
@@ -37,6 +37,7 @@ type Options struct {
 	FallbackFontPath string
 }
 
+// defaults returns a copy of Options with zero-value fields replaced by sensible defaults.
 func (o *Options) defaults() Options {
 	out := Options{DefaultFontSize: 12, PageWidth: 612, PageHeight: 792}
 	if o != nil {
@@ -73,7 +74,6 @@ type DocMetadata struct {
 	Subject     string // from <meta name="subject">
 }
 
-// PageMargins holds margin values for a page variant.
 // MarginBoxContent holds the parsed content of a CSS margin box (e.g. @top-center).
 type MarginBoxContent struct {
 	Content  string     // resolved content string (after evaluating counter(), string literals, etc.)
@@ -81,6 +81,8 @@ type MarginBoxContent struct {
 	Color    [3]float64 // RGB color (0-1 each; all zero = default gray)
 }
 
+// PageMargins holds the margin values and margin-box content for a
+// page variant (e.g. :first, :left, :right) parsed from a CSS @page rule.
 type PageMargins struct {
 	Top, Right, Bottom, Left float64
 	HasMargins               bool                        // true if any margin property was explicitly set (even to 0)
@@ -1821,7 +1823,6 @@ func (c *converter) convertFigure(n *html.Node, style computedStyle) []layout.El
 	return []layout.Element{div}
 }
 
-// convertTable converts a <table> element into a layout.Table.
 // convertCSSTable handles elements with display:table — builds a layout.Table
 // from children with display:table-row and display:table-cell.
 func (c *converter) convertCSSTable(n *html.Node, style computedStyle) []layout.Element {
@@ -1914,6 +1915,7 @@ func (c *converter) convertCSSTable(n *html.Node, style computedStyle) []layout.
 	return []layout.Element{tbl}
 }
 
+// convertTable converts a <table> element into a layout.Table.
 func (c *converter) convertTable(n *html.Node, style computedStyle) []layout.Element {
 	// Save parent containerWidth for resolving the table's own width properties.
 	parentContainerWidth := c.containerWidth
@@ -3773,6 +3775,7 @@ func collectText(n *html.Node) string {
 	return collapseWhitespace(sb.String())
 }
 
+// collectTextInto appends all text content from n and its descendants to sb.
 func collectTextInto(n *html.Node, sb *strings.Builder) {
 	if n.Type == html.TextNode {
 		sb.WriteString(n.Data)
@@ -3790,6 +3793,7 @@ func collectRawText(n *html.Node) string {
 	return sb.String()
 }
 
+// collectRawTextInto appends raw text from n and its descendants to sb, preserving whitespace.
 func collectRawTextInto(n *html.Node, sb *strings.Builder) {
 	if n.Type == html.TextNode {
 		sb.WriteString(n.Data)
@@ -3895,7 +3899,6 @@ func processWhitespace(s, whiteSpace string) string {
 	}
 }
 
-// getAttr returns the value of the named attribute, or "".
 // textContent returns the concatenated text of all descendant text nodes.
 func textContent(n *html.Node) string {
 	if n.Type == html.TextNode {
@@ -3929,6 +3932,7 @@ func (c *converter) extractMeta(n *html.Node) {
 	}
 }
 
+// getAttr returns the value of the named attribute on n, or the empty string.
 func getAttr(n *html.Node, name string) string {
 	for _, a := range n.Attr {
 		if a.Key == name {

--- a/html/doc.go
+++ b/html/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package html converts HTML+CSS markup into layout elements that the
+// [github.com/carlos7ags/folio/layout] package can render to PDF.
+//
+// The converter parses an HTML string (via golang.org/x/net/html),
+// resolves inline and <style> CSS, and produces a tree of
+// [layout.Element] values — Paragraphs, Divs, Tables, Lists, Images,
+// and so on — ready to be fed to the layout engine.
+//
+// Supported HTML elements include headings (<h1>–<h6>), paragraphs,
+// spans, divs, tables, lists, images, SVG, links, and line breaks.
+// CSS features include selectors, the box model, flexbox, grid,
+// floats, absolute positioning, @page rules with margin boxes,
+// CSS counters, and web fonts via @font-face.
+package html

--- a/html/page.go
+++ b/html/page.go
@@ -324,6 +324,7 @@ func parseCSSLengthWithUnit(val string) *cssLength {
 	return nil
 }
 
+// parseFloat extracts a float64 from the numeric prefix of s.
 func parseFloat(s string) float64 {
 	s = strings.TrimSpace(s)
 	var v float64

--- a/html/style.go
+++ b/html/style.go
@@ -202,10 +202,10 @@ type cssLength struct {
 type calcOp int
 
 const (
-	calcAdd calcOp = iota
-	calcSub
-	calcMul
-	calcDiv
+	calcAdd calcOp = iota // calcAdd represents addition (+).
+	calcSub               // calcSub represents subtraction (-).
+	calcMul               // calcMul represents multiplication (*).
+	calcDiv               // calcDiv represents division (/).
 )
 
 // calcExpr represents a parsed calc() expression tree.

--- a/image/image.go
+++ b/image/image.go
@@ -17,7 +17,7 @@ type Image struct {
 	height     int
 	colorSpace string // "DeviceRGB", "DeviceGray", "DeviceCMYK"
 	bpc        int    // bits per component (usually 8)
-	filter     string // "DCTDecode" for JPEG, "FlateDecode" for PNG
+	filter     string // "DCTDecode" for JPEG, "FlateDecode" for PNG/TIFF
 	smask      []byte // soft mask (alpha channel) for PNG with transparency
 	smaskW     int    // smask width (same as image width for alpha)
 	smaskH     int    // smask height
@@ -29,7 +29,7 @@ func (img *Image) Width() int { return img.width }
 // Height returns the image height in pixels.
 func (img *Image) Height() int { return img.height }
 
-// AspectRatio returns width/height.
+// AspectRatio returns the ratio of width to height.
 func (img *Image) AspectRatio() float64 {
 	if img.height == 0 {
 		return 1
@@ -40,7 +40,8 @@ func (img *Image) AspectRatio() float64 {
 // NewFromGoImage creates an Image from a Go image.RGBA.
 // The pixel data is extracted as raw RGB bytes for FlateDecode embedding.
 // If the image has any non-opaque pixels, an SMask is generated.
-// Returns nil if the image has zero or negative dimensions.
+// NewFromGoImage returns nil if src is nil, has non-positive dimensions,
+// or has an invalid stride.
 func NewFromGoImage(src *goimage.RGBA) *Image {
 	if src == nil {
 		return nil
@@ -94,8 +95,9 @@ func NewFromGoImage(src *goimage.RGBA) *Image {
 }
 
 // BuildXObject creates the PDF image XObject dictionary and stream.
-// Returns the XObject and optionally an SMask reference (for PNG alpha).
-// addObject is used to register indirect objects.
+// It returns the image XObject reference and, if the image has an alpha
+// channel, a separate SMask XObject reference. The addObject callback
+// registers each indirect object in the PDF file.
 func (img *Image) BuildXObject(addObject func(core.PdfObject) *core.PdfIndirectReference) (*core.PdfIndirectReference, *core.PdfIndirectReference) {
 	var stream *core.PdfStream
 	if img.filter == "DCTDecode" {

--- a/image/jpeg.go
+++ b/image/jpeg.go
@@ -18,7 +18,7 @@ const (
 )
 
 // NewJPEG creates an Image from raw JPEG data.
-// Parses the JPEG header to extract dimensions and color space.
+// It parses the JPEG header to extract dimensions and color space.
 func NewJPEG(data []byte) (*Image, error) {
 	w, h, ncomp, err := parseJPEGHeader(data)
 	if err != nil {
@@ -57,7 +57,7 @@ func LoadJPEG(path string) (*Image, error) {
 }
 
 // parseJPEGHeader reads the JPEG header to find dimensions and component count.
-// Scans for SOF0, SOF1, or SOF2 markers.
+// It scans for SOF0, SOF1, or SOF2 markers.
 func parseJPEGHeader(data []byte) (width, height, numComponents int, err error) {
 	if len(data) < 2 || binary.BigEndian.Uint16(data[0:2]) != markerSOI {
 		return 0, 0, 0, fmt.Errorf("not a JPEG file")

--- a/image/png.go
+++ b/image/png.go
@@ -13,7 +13,7 @@ import (
 )
 
 // NewPNG creates an Image from raw PNG data.
-// Decodes the PNG to extract pixel data, then re-compresses with FlateDecode.
+// It decodes the PNG to extract pixel data, then re-compresses with FlateDecode.
 // Alpha channels are extracted into a separate SMask.
 func NewPNG(data []byte) (*Image, error) {
 	img, err := png.Decode(bytes.NewReader(data))
@@ -42,7 +42,8 @@ func LoadPNG(path string) (*Image, error) {
 	return NewPNG(data)
 }
 
-// buildRGB extracts RGB pixel data (no alpha).
+// buildRGB extracts pixel data without alpha. Grayscale images are encoded
+// as DeviceGray; all others are encoded as DeviceRGB.
 func buildRGB(img goimage.Image, w, h int) (*Image, error) {
 	bounds := img.Bounds()
 
@@ -110,7 +111,7 @@ func buildRGBA(img goimage.Image, w, h int) (*Image, error) {
 	}, nil
 }
 
-// imageHasAlpha checks if any pixel has non-opaque alpha.
+// imageHasAlpha reports whether any pixel in the image has non-opaque alpha.
 func imageHasAlpha(img goimage.Image) bool {
 	switch img.(type) {
 	case *goimage.NRGBA, *goimage.NRGBA64, *goimage.RGBA, *goimage.RGBA64:
@@ -128,7 +129,7 @@ func imageHasAlpha(img goimage.Image) bool {
 	return false
 }
 
-// isGrayscale checks if the image model is grayscale.
+// isGrayscale reports whether the image uses a grayscale color model.
 func isGrayscale(img goimage.Image) bool {
 	switch img.ColorModel() {
 	case color.GrayModel, color.Gray16Model:

--- a/image/tiff.go
+++ b/image/tiff.go
@@ -12,8 +12,9 @@ import (
 )
 
 // NewTIFF creates an Image from raw TIFF data.
-// Decodes the TIFF to extract pixel data, then uses FlateDecode for PDF embedding.
-// Alpha channels are not extracted; TIFF alpha is uncommon in PDF workflows.
+// It decodes the TIFF to extract pixel data, then uses FlateDecode for PDF
+// embedding. Grayscale images are preserved as DeviceGray. Alpha channels
+// are discarded because TIFF alpha is uncommon in PDF workflows.
 func NewTIFF(data []byte) (*Image, error) {
 	img, err := tiff.Decode(bytes.NewReader(data))
 	if err != nil {

--- a/layout/barcode_element.go
+++ b/layout/barcode_element.go
@@ -37,6 +37,8 @@ func (be *BarcodeElement) SetAlign(a Align) *BarcodeElement {
 	return be
 }
 
+// resolveHeight returns the display height, computing it from the barcode
+// aspect ratio if no explicit height was set.
 func (be *BarcodeElement) resolveHeight() float64 {
 	if be.height > 0 {
 		return be.height

--- a/layout/doc.go
+++ b/layout/doc.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package layout implements a high-level, CSS-like element model for
+// building PDF pages from composable building blocks.
+//
+// Elements are positioned through a two-phase process: layout then
+// render. During layout, each [Element] is given a [LayoutArea] and
+// returns a [LayoutPlan] describing the placed content and any
+// overflow that did not fit. During render, [PlacedBlock] draw
+// closures emit PDF content-stream operators.
+//
+// Available elements:
+//
+//   - [Paragraph]: text with word wrapping, alignment, and rich-text spans
+//   - [Div]: block container with padding, borders, and background
+//   - [Table]: row/column grid with cell spanning and border collapse
+//   - [List]: ordered and unordered lists with nested sub-lists
+//   - [ImageElement]: raster image placement with aspect-ratio control
+//   - [BarcodeElement]: inline barcode (QR, Code 128, EAN-13)
+//   - [Heading]: section heading for auto-generated bookmarks
+//   - [Flex]: flexbox-style row/column layout
+//   - [Grid]: CSS Grid-style two-dimensional layout
+//   - [Columns]: multi-column text flow with balanced filling
+//   - [Float]: float-left/right content wrapping
+//   - [LineSeparator]: horizontal rule
+//   - [AreaBreak]: force a new page or column
+//   - [Link]: clickable hyperlink annotation
+//   - [TabbedLine]: tabular alignment with tab stops
+//   - [SVGElement]: inline SVG rendering
+//
+// Affine transformations (rotate, scale, translate) are supported via
+// [Div.SetTransform] using [TransformOp] values computed by
+// [ComputeTransformMatrix].
+//
+// The [Renderer] drives the layout loop: it feeds elements into pages,
+// handles page breaks and overflow, and collects [PageResult] values
+// containing content streams and resource references.
+package layout

--- a/layout/element.go
+++ b/layout/element.go
@@ -81,6 +81,7 @@ func Hex(hex string) Color {
 	return Color{R: float64(r) / 255, G: float64(g) / 255, B: float64(b) / 255}
 }
 
+// hexByte parses a two-character hexadecimal string into a byte.
 func hexByte(s string) byte {
 	var v byte
 	for _, c := range []byte(s) {

--- a/layout/flex.go
+++ b/layout/flex.go
@@ -307,6 +307,7 @@ type flexLine struct {
 	resolvedSizes []float64 // resolved width per item after grow/shrink
 }
 
+// planRow handles layout for flex-direction: row.
 func (f *Flex) planRow(area LayoutArea) LayoutPlan {
 	innerWidth := area.Width - f.padding.Left - f.padding.Right
 	innerHeight := area.Height - f.padding.Top - f.padding.Bottom - f.spaceBefore - f.spaceAfter
@@ -477,6 +478,7 @@ func (fi *FlexItem) effectiveBasis(available float64) float64 {
 	return fi.basis
 }
 
+// resolveRowBasis computes the flex-basis width for each item in a row layout.
 func (f *Flex) resolveRowBasis(innerWidth float64) []float64 {
 	widths := make([]float64, len(f.items))
 	for i, item := range f.items {
@@ -491,6 +493,7 @@ func (f *Flex) resolveRowBasis(innerWidth float64) []float64 {
 	return widths
 }
 
+// partitionRowLines groups items into flex lines based on wrapping behavior.
 func (f *Flex) partitionRowLines(basisWidths []float64, innerWidth float64) []flexLine {
 	if f.wrap == FlexNoWrap || len(f.items) == 0 {
 		return []flexLine{{items: f.items, resolvedSizes: basisWidths}}
@@ -521,6 +524,7 @@ func (f *Flex) partitionRowLines(basisWidths []float64, innerWidth float64) []fl
 	return lines
 }
 
+// resolveGrowShrink distributes free space among items using flex-grow and flex-shrink factors.
 func (f *Flex) resolveGrowShrink(line flexLine, innerWidth float64) []float64 {
 	n := len(line.items)
 	// Compute basis for this line's items.
@@ -578,6 +582,7 @@ func (f *Flex) resolveGrowShrink(line flexLine, innerWidth float64) []float64 {
 	return resolved
 }
 
+// computeJustifyOffsets computes the X offset for each item based on justify-content.
 func (f *Flex) computeJustifyOffsets(widths []float64, innerWidth float64) []float64 {
 	n := len(widths)
 	offsets := make([]float64, n)
@@ -648,6 +653,7 @@ func (f *Flex) computeJustifyOffsets(widths []float64, innerWidth float64) []flo
 	return offsets
 }
 
+// computeAlignOffset computes the cross-axis offset for an item based on align-items/align-self.
 func (f *Flex) computeAlignOffset(item *FlexItem, lineSize, itemSize float64) float64 {
 	align := f.alignItems
 	if item.alignSelf != nil {
@@ -663,6 +669,7 @@ func (f *Flex) computeAlignOffset(item *FlexItem, lineSize, itemSize float64) fl
 	}
 }
 
+// overflowFrom creates a new Flex containing the items from unfitted lines.
 func (f *Flex) overflowFrom(fittedLineCount int, lines []flexLine) *Flex {
 	var remaining []*FlexItem
 	for i := fittedLineCount; i < len(lines); i++ {
@@ -685,6 +692,7 @@ func (f *Flex) overflowFrom(fittedLineCount int, lines []flexLine) *Flex {
 
 // --- Column direction layout ---
 
+// planColumn handles layout for flex-direction: column.
 func (f *Flex) planColumn(area LayoutArea) LayoutPlan {
 	innerWidth := area.Width - f.padding.Left - f.padding.Right
 	innerHeight := area.Height - f.padding.Top - f.padding.Bottom - f.spaceBefore - f.spaceAfter
@@ -939,6 +947,7 @@ func (f *Flex) planColumn(area LayoutArea) LayoutPlan {
 	return LayoutPlan{Status: LayoutFull, Consumed: consumed, Blocks: []PlacedBlock{containerBlock}}
 }
 
+// columnAlignOffset computes the horizontal offset for cross-axis alignment in column layout.
 func (f *Flex) columnAlignOffset(align AlignItems, innerWidth, itemWidth float64) float64 {
 	switch align {
 	case CrossAlignEnd:
@@ -950,6 +959,7 @@ func (f *Flex) columnAlignOffset(align AlignItems, innerWidth, itemWidth float64
 	}
 }
 
+// buildColumnResult assembles a LayoutPlan for a column flex that needs to split across pages.
 func (f *Flex) buildColumnResult(fittedBlocks []PlacedBlock, curY, areaWidth float64, overflowItems []*FlexItem) LayoutPlan {
 	totalH := curY + f.padding.Bottom
 	consumed := f.spaceBefore + totalH + f.spaceAfter
@@ -972,6 +982,7 @@ func (f *Flex) buildColumnResult(fittedBlocks []PlacedBlock, curY, areaWidth flo
 
 // --- Shared helpers ---
 
+// makeContainerBlock creates the wrapper PlacedBlock with background and borders.
 func (f *Flex) makeContainerBlock(children []PlacedBlock, totalH, outerWidth float64) PlacedBlock {
 	capturedFlex := f
 	capturedH := totalH
@@ -994,7 +1005,8 @@ func (f *Flex) makeContainerBlock(children []PlacedBlock, totalH, outerWidth flo
 	}
 }
 
-// justifyContent also applies to column direction for Y positioning.
+// computeColumnJustifyOffsets computes the Y offset for each item in column direction
+// based on justify-content.
 func (f *Flex) computeColumnJustifyOffsets(heights []float64, innerHeight float64) []float64 {
 	n := len(heights)
 	offsets := make([]float64, n)

--- a/layout/heading.go
+++ b/layout/heading.go
@@ -101,6 +101,7 @@ func (h *Heading) Layout(maxWidth float64) []Line {
 	return lines
 }
 
+// headingSize returns the default font size in points for the given heading level.
 func headingSize(level HeadingLevel) float64 {
 	if level >= H1 && level <= H6 {
 		return headingSizes[level]

--- a/layout/layouter.go
+++ b/layout/layouter.go
@@ -22,8 +22,8 @@ const (
 	// is in LayoutPlan.Blocks; the remainder is in LayoutPlan.Overflow.
 	LayoutPartial
 
-	// LayoutNothing means the element could not fit at all
-	// (the area is too small even for the first line/row).
+	// LayoutNothing means the element could not fit at all;
+	// the area is too small even for the first line or row.
 	LayoutNothing
 )
 
@@ -115,8 +115,6 @@ func maxBlockWidth(blocks []PlacedBlock) float64 {
 	return w
 }
 
-// Measurable is an optional interface that elements can implement
-// to report their intrinsic width constraints. This enables features
 // Clearable is implemented by elements that support the CSS clear property.
 type Clearable interface {
 	ClearValue() string // "left", "right", "both", or ""
@@ -130,6 +128,8 @@ type HeightSettable interface {
 	HasExplicitHeight() bool // true if element has a CSS height set
 }
 
+// Measurable is an optional interface that elements can implement
+// to report their intrinsic width constraints. This enables features
 // like auto-sizing table columns based on cell content.
 type Measurable interface {
 	// MinWidth returns the narrowest width this element can be rendered

--- a/layout/list.go
+++ b/layout/list.go
@@ -33,6 +33,7 @@ type List struct {
 	leading  float64
 }
 
+// listItem is a single entry in a list, optionally containing a nested sub-list.
 type listItem struct {
 	text    string
 	subList *List // optional nested list
@@ -66,7 +67,7 @@ func NewListEmbedded(ef *font.EmbeddedFont, fontSize float64) *List {
 	}
 }
 
-// SetStyle sets ordered or unordered.
+// SetStyle sets the list marker style (bullet, decimal, roman, alpha, or none).
 func (l *List) SetStyle(s ListStyle) *List {
 	l.style = s
 	return l
@@ -205,6 +206,7 @@ func (l *List) MaxWidth() float64 {
 	return l.indent + maxW
 }
 
+// measurer returns the text measurer for this list's font.
 func (l *List) measurer() font.TextMeasurer {
 	if l.embedded != nil {
 		return l.embedded
@@ -335,6 +337,7 @@ func wrapListBlocks(blocks []PlacedBlock, width, height float64) []PlacedBlock {
 	}}
 }
 
+// marker returns the marker string (bullet, number, letter) for the item at index.
 func (l *List) marker(index int) string {
 	n := index + 1
 	switch l.style {

--- a/layout/tab.go
+++ b/layout/tab.go
@@ -226,6 +226,7 @@ func (tl *TabbedLine) measureSegment(text string, measurer font.TextMeasurer) []
 	return words
 }
 
+// measurer returns the text measurer for this tabbed line's font.
 func (tl *TabbedLine) measurer() font.TextMeasurer {
 	if tl.embedded != nil {
 		return tl.embedded

--- a/layout/table.go
+++ b/layout/table.go
@@ -752,6 +752,7 @@ func (t *Table) cellContentHeight(gc *gridCell) float64 {
 	return float64(lines)*cell.fontSize*1.2 + padH
 }
 
+// cellMeasurer returns the text measurer for a cell's font, or nil if none is set.
 func (t *Table) cellMeasurer(cell *Cell) font.TextMeasurer {
 	if cell.embedded != nil {
 		return cell.embedded
@@ -1081,6 +1082,7 @@ func drawStyledBorder(stream *content.Stream, b Border, x1, y1, x2, y2 float64) 
 	stream.RestoreState()
 }
 
+// cellTextMeasurer returns the text measurer for a cell's font, or nil if none is set.
 func cellTextMeasurer(cell *Cell) font.TextMeasurer {
 	if cell.embedded != nil {
 		return cell.embedded

--- a/reader/cmap.go
+++ b/reader/cmap.go
@@ -16,11 +16,13 @@ type CMap struct {
 	bfRanges        []bfRange
 }
 
+// codeSpaceRange defines a range of valid character codes and their byte width.
 type codeSpaceRange struct {
 	low, high uint32
 	bytes     int // number of bytes per code (1 or 2)
 }
 
+// bfRange maps a contiguous range of character codes to Unicode strings.
 type bfRange struct {
 	low, high uint32
 	dst       string // unicode string for low; subsequent codes increment first rune

--- a/reader/content_parser.go
+++ b/reader/content_parser.go
@@ -385,6 +385,7 @@ func tokenFloat(t Token) float64 {
 	return t.Real
 }
 
+// appendSpaceIfNeeded appends a space unless the last byte is already a space or newline.
 func appendSpaceIfNeeded(b []byte) []byte {
 	if len(b) > 0 && b[len(b)-1] != ' ' && b[len(b)-1] != '\n' {
 		return append(b, ' ')
@@ -392,6 +393,7 @@ func appendSpaceIfNeeded(b []byte) []byte {
 	return b
 }
 
+// appendNewlineIfNeeded appends a newline unless the last byte is already a newline.
 func appendNewlineIfNeeded(b []byte) []byte {
 	if len(b) > 0 && b[len(b)-1] != '\n' {
 		return append(b, '\n')

--- a/reader/copier.go
+++ b/reader/copier.go
@@ -56,6 +56,7 @@ func (c *Copier) CopyPage(pageIndex int) (*core.PdfIndirectReference, error) {
 	return c.addObj(copiedDict), nil
 }
 
+// copyDeep recursively copies a PDF object, remapping all indirect references.
 func (c *Copier) copyDeep(obj core.PdfObject) (core.PdfObject, error) {
 	if obj == nil {
 		return core.NewPdfNull(), nil
@@ -84,6 +85,8 @@ func (c *Copier) copyDeep(obj core.PdfObject) (core.PdfObject, error) {
 	}
 }
 
+// copyIndirectRef resolves and deep-copies an indirect reference, using a
+// placeholder to handle circular references.
 func (c *Copier) copyIndirectRef(ref *core.PdfIndirectReference) (core.PdfObject, error) {
 	// Check if already copied.
 	if newRef, ok := c.refMap[ref.ObjectNumber]; ok {
@@ -124,6 +127,7 @@ func (c *Copier) copyIndirectRef(ref *core.PdfIndirectReference) (core.PdfObject
 	return newRef, nil
 }
 
+// copyDict deep-copies a PDF dictionary, recursively copying all values.
 func (c *Copier) copyDict(dict *core.PdfDictionary) (*core.PdfDictionary, error) {
 	newDict := core.NewPdfDictionary()
 	for _, entry := range dict.Entries {
@@ -136,6 +140,7 @@ func (c *Copier) copyDict(dict *core.PdfDictionary) (*core.PdfDictionary, error)
 	return newDict, nil
 }
 
+// copyArray deep-copies a PDF array, recursively copying all elements.
 func (c *Copier) copyArray(arr *core.PdfArray) (*core.PdfArray, error) {
 	newArr := core.NewPdfArray()
 	for _, elem := range arr.Elements {
@@ -148,6 +153,7 @@ func (c *Copier) copyArray(arr *core.PdfArray) (*core.PdfArray, error) {
 	return newArr, nil
 }
 
+// copyStream deep-copies a PDF stream, including its dictionary and raw data.
 func (c *Copier) copyStream(stream *core.PdfStream) (*core.PdfStream, error) {
 	// Copy the dictionary entries.
 	newStream := core.NewPdfStream(stream.Data)

--- a/reader/encoding.go
+++ b/reader/encoding.go
@@ -34,6 +34,7 @@ var MacRomanEncoding = makeMacRomanEncoding()
 // StandardEncoding is Adobe's standard encoding for Type1 fonts.
 var StandardEncoding = makeStandardEncoding()
 
+// makeWinAnsiEncoding builds the Windows-1252 encoding table.
 func makeWinAnsiEncoding() *Encoding {
 	var e Encoding
 	// ASCII range maps 1:1.
@@ -59,6 +60,7 @@ func makeWinAnsiEncoding() *Encoding {
 	return &e
 }
 
+// makeMacRomanEncoding builds the Mac OS Roman encoding table.
 func makeMacRomanEncoding() *Encoding {
 	var e Encoding
 	for i := range 128 {
@@ -89,6 +91,7 @@ func makeMacRomanEncoding() *Encoding {
 	return &e
 }
 
+// makeStandardEncoding builds Adobe's standard encoding table for Type1 fonts.
 func makeStandardEncoding() *Encoding {
 	var e Encoding
 	// ASCII printable range is mostly the same.

--- a/reader/limits.go
+++ b/reader/limits.go
@@ -35,6 +35,7 @@ type MemoryLimits struct {
 	MaxObjectCount int
 }
 
+// Default memory limits used when the caller does not override them.
 const (
 	defaultMaxStreamSize  = 256 << 20 // 256 MB
 	defaultMaxTotalAlloc  = 1 << 30   // 1 GB
@@ -92,6 +93,7 @@ type memoryTracker struct {
 	totalUsed int64
 }
 
+// newMemoryTracker creates a memoryTracker with the given limits.
 func newMemoryTracker(limits MemoryLimits) *memoryTracker {
 	return &memoryTracker{limits: limits}
 }

--- a/reader/merge.go
+++ b/reader/merge.go
@@ -54,6 +54,8 @@ type Modifier struct {
 	info      *core.PdfDictionary
 }
 
+// newModifier creates an empty Modifier with a fresh PDF 1.7 writer,
+// catalog, and page tree root.
 func newModifier() *Modifier {
 	w := document.NewWriter("1.7")
 

--- a/reader/parser.go
+++ b/reader/parser.go
@@ -16,6 +16,8 @@ type Parser struct {
 	depth int // recursion depth guard
 }
 
+// maxParseDepth limits recursion depth to prevent stack overflow on
+// deeply nested or malicious PDF objects.
 const maxParseDepth = 100
 
 // NewParser creates a parser wrapping a tokenizer.

--- a/reader/processor.go
+++ b/reader/processor.go
@@ -135,6 +135,7 @@ type ContentProcessor struct {
 	depth        int // recursion depth (0 = top-level call)
 }
 
+// pathSegment is a single segment of a path being constructed.
 type pathSegment struct {
 	typ    PathType
 	points [][2]float64

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -30,7 +30,8 @@ const (
 	StrictnessStrict
 )
 
-// PdfReader opens and reads an existing PDF file.
+// PdfReader holds the parsed state of an existing PDF file, including
+// the cross-reference table, object resolver, document catalog, and pages.
 type PdfReader struct {
 	data       []byte
 	xref       *xrefTable

--- a/reader/resolver.go
+++ b/reader/resolver.go
@@ -23,6 +23,8 @@ type resolver struct {
 	strictness Strictness     // controls error handling behavior
 }
 
+// newResolver creates a resolver that fetches objects from data using the
+// given xref table, enforcing the specified memory limits and strictness.
 func newResolver(data []byte, xref *xrefTable, mem *memoryTracker, strictness Strictness) *resolver {
 	return &resolver{
 		data:       data,
@@ -521,6 +523,7 @@ func paethPredictor(a, b, c byte) byte {
 	return c
 }
 
+// abs returns the absolute value of x.
 func abs(x int) int {
 	if x < 0 {
 		return -x

--- a/reader/strategy.go
+++ b/reader/strategy.go
@@ -28,6 +28,8 @@ type SimpleStrategy struct {
 	hadText bool
 }
 
+// ProcessSpan appends the span's text, inserting spaces for gaps and
+// newlines for line changes.
 func (s *SimpleStrategy) ProcessSpan(span TextSpan) {
 	// Skip invisible text (Tr mode 3).
 	if !span.Visible {
@@ -65,16 +67,19 @@ func (s *SimpleStrategy) ProcessSpan(span TextSpan) {
 	s.hadText = true
 }
 
+// Result returns the assembled text.
 func (s *SimpleStrategy) Result() string {
 	return string(s.result)
 }
 
+// appendSpace adds a space unless the last character is already a space or newline.
 func (s *SimpleStrategy) appendSpace() {
 	if len(s.result) > 0 && s.result[len(s.result)-1] != ' ' && s.result[len(s.result)-1] != '\n' {
 		s.result = append(s.result, ' ')
 	}
 }
 
+// appendNewline adds a newline unless the last character is already a newline.
 func (s *SimpleStrategy) appendNewline() {
 	if len(s.result) > 0 && s.result[len(s.result)-1] != '\n' {
 		s.result = append(s.result, '\n')
@@ -90,6 +95,7 @@ type LocationStrategy struct {
 	spans []TextSpan
 }
 
+// ProcessSpan collects visible spans for later spatial sorting.
 func (l *LocationStrategy) ProcessSpan(span TextSpan) {
 	if !span.Visible {
 		return
@@ -97,6 +103,7 @@ func (l *LocationStrategy) ProcessSpan(span TextSpan) {
 	l.spans = append(l.spans, span)
 }
 
+// Result sorts spans top-to-bottom, left-to-right and returns the assembled text.
 func (l *LocationStrategy) Result() string {
 	if len(l.spans) == 0 {
 		return ""
@@ -178,6 +185,7 @@ func NewRegionStrategy(x, y, w, h float64, inner ExtractionStrategy) *RegionStra
 	return &RegionStrategy{x: x, y: y, w: w, h: h, inner: inner}
 }
 
+// ProcessSpan forwards the span to the inner strategy if it overlaps the region.
 func (r *RegionStrategy) ProcessSpan(span TextSpan) {
 	// Check if span overlaps the region.
 	if span.X+span.Width < r.x || span.X > r.x+r.w {
@@ -189,6 +197,7 @@ func (r *RegionStrategy) ProcessSpan(span TextSpan) {
 	r.inner.ProcessSpan(span)
 }
 
+// Result returns the inner strategy's assembled text.
 func (r *RegionStrategy) Result() string {
 	return r.inner.Result()
 }
@@ -209,6 +218,7 @@ func NewTaggedStrategy(tree *StructureTree, pageNum int) *TaggedStrategy {
 	return &TaggedStrategy{tree: tree, pageNum: pageNum}
 }
 
+// ProcessSpan collects visible spans for later structure-tree-ordered assembly.
 func (s *TaggedStrategy) ProcessSpan(span TextSpan) {
 	if !span.Visible {
 		return
@@ -227,6 +237,8 @@ var blockLevelTags = map[string]bool{
 	"Part": true, "Sect": true, "Art": true,
 }
 
+// Result walks the structure tree and returns text assembled in logical
+// reading order, with block-level tags producing line breaks.
 func (s *TaggedStrategy) Result() string {
 	if len(s.spans) == 0 {
 		return ""

--- a/reader/tokenizer.go
+++ b/reader/tokenizer.go
@@ -425,10 +425,12 @@ func (t *Tokenizer) AtEnd() bool {
 
 // --- Helper functions ---
 
+// isWhitespace reports whether ch is a PDF whitespace character.
 func isWhitespace(ch byte) bool {
 	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f' || ch == 0
 }
 
+// isDelimiter reports whether ch is a PDF delimiter character.
 func isDelimiter(ch byte) bool {
 	switch ch {
 	case '(', ')', '<', '>', '[', ']', '{', '}', '/', '%':
@@ -437,10 +439,13 @@ func isDelimiter(ch byte) bool {
 	return false
 }
 
+// isDigit reports whether ch is an ASCII digit.
 func isDigit(ch byte) bool {
 	return ch >= '0' && ch <= '9'
 }
 
+// hexVal returns the numeric value of a hexadecimal digit (0-15).
+// Returns 0 for non-hex characters.
 func hexVal(ch byte) byte {
 	switch {
 	case ch >= '0' && ch <= '9':

--- a/sign/asn1.go
+++ b/sign/asn1.go
@@ -45,11 +45,22 @@ var (
 type Algorithm int
 
 const (
+	// SHA256WithRSA is RSA PKCS#1 v1.5 with SHA-256.
 	SHA256WithRSA Algorithm = iota
+
+	// SHA384WithRSA is RSA PKCS#1 v1.5 with SHA-384.
 	SHA384WithRSA
+
+	// SHA512WithRSA is RSA PKCS#1 v1.5 with SHA-512.
 	SHA512WithRSA
+
+	// SHA256WithECDSA is ECDSA with SHA-256.
 	SHA256WithECDSA
+
+	// SHA384WithECDSA is ECDSA with SHA-384.
 	SHA384WithECDSA
+
+	// SHA512WithECDSA is ECDSA with SHA-512.
 	SHA512WithECDSA
 )
 

--- a/sign/doctimestamp.go
+++ b/sign/doctimestamp.go
@@ -19,8 +19,11 @@ import (
 // It uses /SubFilter /ETSI.RFC3161 and /Type /DocTimeStamp.
 type docTimestampDict struct{}
 
+// Type returns ObjectTypeDictionary.
 func (d *docTimestampDict) Type() core.ObjectType { return core.ObjectTypeDictionary }
 
+// WriteTo serializes the document timestamp dictionary with placeholder
+// /ByteRange and /Contents values for later patching.
 func (d *docTimestampDict) WriteTo(w io.Writer) (int64, error) {
 	var total int64
 	write := func(str string) error {

--- a/sign/dss.go
+++ b/sign/dss.go
@@ -86,9 +86,8 @@ func (d *DSS) AddSignatureValidation(sigContents []byte, chain []*x509.Certifica
 }
 
 // Build creates the DSS dictionary and all referenced stream objects.
-// It returns the DSS dictionary and a slice of stream objects that must
-// be added as indirect objects. The addObject callback assigns object
-// numbers and returns indirect references.
+// The addObject callback assigns object numbers to each stream and returns
+// indirect references for embedding in the dictionary.
 func (d *DSS) Build(addObject func(core.PdfObject) *core.PdfIndirectReference) *core.PdfDictionary {
 	dss := core.NewPdfDictionary()
 
@@ -138,24 +137,28 @@ func (d *DSS) buildStreamArray(items [][]byte, addObject func(core.PdfObject) *c
 	return core.NewPdfArray(refs...)
 }
 
+// addCert appends a DER-encoded certificate if not already present.
 func (d *DSS) addCert(der []byte) {
 	if !d.containsBytes(d.Certs, der) {
 		d.Certs = append(d.Certs, der)
 	}
 }
 
+// addOCSP appends a DER-encoded OCSP response if not already present.
 func (d *DSS) addOCSP(der []byte) {
 	if !d.containsBytes(d.OCSPs, der) {
 		d.OCSPs = append(d.OCSPs, der)
 	}
 }
 
+// addCRL appends a DER-encoded CRL if not already present.
 func (d *DSS) addCRL(der []byte) {
 	if !d.containsBytes(d.CRLs, der) {
 		d.CRLs = append(d.CRLs, der)
 	}
 }
 
+// containsBytes reports whether slice already contains an entry with the same SHA-256 hash as item.
 func (d *DSS) containsBytes(slice [][]byte, item []byte) bool {
 	itemHash := hashBytes(crypto.SHA256, item)
 	for _, existing := range slice {

--- a/sign/ocsp.go
+++ b/sign/ocsp.go
@@ -84,20 +84,22 @@ func (c *OCSPClient) FetchChainResponses(chain []*x509.Certificate) ([][]byte, e
 	return responses, nil
 }
 
-// ASN.1 OCSP structures (RFC 6960).
-
+// ocspRequest is the ASN.1 OCSPRequest structure (RFC 6960).
 type ocspRequest struct {
 	TBSRequest tbsRequest
 }
 
+// tbsRequest is the TBSRequest body of an OCSPRequest.
 type tbsRequest struct {
 	RequestList []request
 }
 
+// request is a single entry in an OCSP request list.
 type request struct {
 	ReqCert certID
 }
 
+// certID identifies the certificate being queried in an OCSP request.
 type certID struct {
 	HashAlgorithm  algorithmIdentifier
 	IssuerNameHash []byte
@@ -105,11 +107,13 @@ type certID struct {
 	SerialNumber   asn1.RawValue
 }
 
+// ocspResponse is the ASN.1 OCSPResponse structure (RFC 6960).
 type ocspResponse struct {
 	ResponseStatus asn1.Enumerated
 	ResponseBytes  responseBytes `asn1:"explicit,tag:0,optional"`
 }
 
+// responseBytes carries the response type and DER-encoded response body.
 type responseBytes struct {
 	ResponseType asn1.ObjectIdentifier
 	Response     []byte

--- a/sign/placeholder.go
+++ b/sign/placeholder.go
@@ -74,8 +74,11 @@ type sigDictionary struct {
 	contactInfo string
 }
 
+// Type returns ObjectTypeDictionary.
 func (s *sigDictionary) Type() core.ObjectType { return core.ObjectTypeDictionary }
 
+// WriteTo serializes the signature dictionary with placeholder /ByteRange
+// and /Contents values for later patching.
 func (s *sigDictionary) WriteTo(w io.Writer) (int64, error) {
 	var total int64
 	write := func(str string) error {

--- a/sign/signer.go
+++ b/sign/signer.go
@@ -59,13 +59,18 @@ func (s *LocalSigner) SetAlgorithm(algo Algorithm) {
 	s.algo = algo
 }
 
+// Sign signs the given digest using the local private key.
 func (s *LocalSigner) Sign(digest []byte) ([]byte, error) {
 	return s.key.Sign(rand.Reader, digest, s.hashOpts())
 }
 
-func (s *LocalSigner) Algorithm() Algorithm                  { return s.algo }
+// Algorithm returns the signature algorithm.
+func (s *LocalSigner) Algorithm() Algorithm { return s.algo }
+
+// CertificateChain returns the signer's certificate chain.
 func (s *LocalSigner) CertificateChain() []*x509.Certificate { return s.certs }
 
+// hashOpts returns the crypto.SignerOpts for the configured algorithm.
 func (s *LocalSigner) hashOpts() crypto.SignerOpts {
 	return s.algo.HashFunc()
 }
@@ -93,11 +98,15 @@ func NewExternalSigner(
 	return &ExternalSigner{signFn: signFn, certs: certs, algo: algo}, nil
 }
 
+// Sign delegates signing of the given digest to the external function.
 func (s *ExternalSigner) Sign(digest []byte) ([]byte, error) {
 	return s.signFn(digest)
 }
 
-func (s *ExternalSigner) Algorithm() Algorithm                  { return s.algo }
+// Algorithm returns the signature algorithm.
+func (s *ExternalSigner) Algorithm() Algorithm { return s.algo }
+
+// CertificateChain returns the signer's certificate chain.
 func (s *ExternalSigner) CertificateChain() []*x509.Certificate { return s.certs }
 
 // LoadPKCS12 loads a PKCS#12 (.p12/.pfx) file and returns a LocalSigner.

--- a/sign/tsa.go
+++ b/sign/tsa.go
@@ -65,28 +65,26 @@ func (c *TSAClient) Timestamp(digest []byte, hashFunc crypto.Hash) ([]byte, erro
 	return parseTimestampResp(body)
 }
 
-// RFC 3161 ASN.1 structures.
-
-// timeStampReq is the RFC 3161 TimeStampReq.
+// timeStampReq is the ASN.1 TimeStampReq structure (RFC 3161).
 type timeStampReq struct {
 	Version        int
 	MessageImprint messageImprint
 	CertReq        bool `asn1:"optional"`
 }
 
-// messageImprint identifies the hash algorithm and digest value.
+// messageImprint identifies the hash algorithm and digest value in a timestamp request.
 type messageImprint struct {
 	HashAlgorithm algorithmIdentifier
 	HashedMessage []byte
 }
 
-// timeStampResp is the RFC 3161 TimeStampResp.
+// timeStampResp is the ASN.1 TimeStampResp structure (RFC 3161).
 type timeStampResp struct {
 	Status         pkiStatusInfo
 	TimeStampToken asn1.RawValue `asn1:"optional"`
 }
 
-// pkiStatusInfo is the status field in TimeStampResp.
+// pkiStatusInfo is the status field of a TimeStampResp.
 type pkiStatusInfo struct {
 	Status int
 }

--- a/svg/color.go
+++ b/svg/color.go
@@ -54,6 +54,7 @@ func ParseColor(s string) (Color, bool) {
 	return Color{}, false
 }
 
+// parseHexColor parses a 3- or 6-digit hex color string (without the leading '#').
 func parseHexColor(hex string) (Color, bool) {
 	switch len(hex) {
 	case 3:
@@ -80,6 +81,7 @@ func parseHexColor(hex string) (Color, bool) {
 	}
 }
 
+// parseRGB parses the arguments of an rgb() color function into a Color.
 func parseRGB(args string) (Color, bool) {
 	parts := splitColorArgs(args)
 	if len(parts) != 3 {
@@ -94,6 +96,7 @@ func parseRGB(args string) (Color, bool) {
 	return Color{R: r, G: g, B: b, A: 1}, true
 }
 
+// parseRGBA parses the arguments of an rgba() color function into a Color.
 func parseRGBA(args string) (Color, bool) {
 	parts := splitColorArgs(args)
 	if len(parts) != 4 {
@@ -118,6 +121,7 @@ func parseRGBA(args string) (Color, bool) {
 	return Color{R: r, G: g, B: b, A: a}, true
 }
 
+// splitColorArgs splits a comma-separated color argument string into its parts.
 func splitColorArgs(s string) []string {
 	return strings.Split(s, ",")
 }
@@ -141,6 +145,7 @@ func parseColorComponent(s string) (float64, bool) {
 	return v, true
 }
 
+// clamp01 clamps v to the range [0, 1].
 func clamp01(v float64) float64 {
 	if v < 0 {
 		return 0

--- a/svg/doc.go
+++ b/svg/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package svg parses SVG markup and renders it into PDF content streams
+// as native vector graphics — no rasterization is involved.
+//
+// Supported SVG elements include path, rect, circle, ellipse, line,
+// polyline, polygon, text, use, g, defs, linearGradient, and radialGradient.
+// Style attributes (fill, stroke, opacity, transform) are mapped to
+// the equivalent PDF content-stream operators.
+//
+// Usage:
+//
+//	doc, _ := svg.Parse(svgString)
+//	doc.Draw(stream, x, y, width, height)
+package svg

--- a/svg/path.go
+++ b/svg/path.go
@@ -316,6 +316,8 @@ func vecAngle(ux, uy, vx, vy float64) float64 {
 
 // --- Tokenizer ---
 
+// pathToken represents a single token from SVG path data: either a command
+// letter or a numeric value.
 type pathToken struct {
 	value     string
 	isCommand bool
@@ -431,6 +433,7 @@ func commandArgCount(cmd byte) int {
 	return 0
 }
 
+// toUpper converts a lowercase ASCII letter to uppercase.
 func toUpper(cmd byte) byte {
 	if cmd >= 'a' && cmd <= 'z' {
 		return cmd - 32


### PR DESCRIPTION
## Description

Audit and add missing documentation for every package in the repository, covering both exported and unexported symbols.

Package-level changes:
- core: consolidate two conflicting package docs into doc.go
- font: update stale package doc (parsing is fully implemented)
- layout: add doc.go with element catalog and architecture overview
- html: add doc.go describing HTML+CSS to layout conversion
- svg: add doc.go describing SVG-to-PDF vector rendering

Documentation fixes across 70 files:
- Fix stale/inaccurate comments (e.g. watermark "prepends" → "appends", dss.Build return description, PdfObjects → BuildObjects)
- Fix merged/scrambled doc comments (html converter, layout interfaces)
- Convert inline comments to proper doc comments on constant groups
- Add doc comments to all unexported types, functions, and methods
- Add doc comments to ~80 C ABI export functions
- Fix cmd/folio printUsage referencing nonexistent "region" strategy
- Ensure all comments follow Go conventions: start with the name, use full sentences, end with periods

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests