### PR TITLE
Add examples directory with hello world example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,26 @@
+# Examples
+
+Each subdirectory is a self-contained example that produces a PDF.
+
+## Running
+
+```bash
+go run ./examples/hello
+```
+
+## Structure
+
+```
+examples/
+├── hello/          # minimal one-page PDF
+└── README.md
+```
+
+## Adding an example
+
+1. Create a new directory under `examples/` (e.g., `examples/invoice/`).
+2. Add a single `main.go` that produces one PDF.
+3. Include any required data files in the same directory (XML, images, etc.).
+4. Keep it self-contained — no shared code between examples.
+5. Add a doc comment at the top of `main.go` describing what the example does and how to run it.
+6. Add the directory to the structure list above.

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Hello creates a one-page PDF with a heading and a paragraph.
+//
+// Usage:
+//
+//	go run ./examples/hello
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+)
+
+func main() {
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.Info.Title = "Hello World"
+	doc.Info.Author = "Folio"
+
+	doc.Add(layout.NewHeading("Hello, Folio!", layout.H1))
+	doc.Add(layout.NewParagraph(
+		"This is a simple PDF created with the Folio library. "+
+			"Folio is a pure-Go library for creating, reading, and signing PDF documents.",
+		font.Helvetica, 12,
+	))
+
+	if err := doc.Save("hello.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created hello.pdf")
+}


### PR DESCRIPTION
Establish the examples/ structure for self-contained, runnable examples that each produce a single PDF. Includes a README with conventions for contributors adding more examples.

## Description

Brief description of the changes.

## Related issue

Closes #

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
