### PR TITLE
Fix custom @font-face family names ignored during font resolution

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ go run ./examples/hello
 ```
 examples/
 ├── hello/          # minimal one-page PDF
+├── fonts/          # standard, custom, and Unicode fonts (CJK, Cyrillic)
 └── README.md
 ```
 

--- a/examples/fonts/main.go
+++ b/examples/fonts/main.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Fonts demonstrates PDF generation with multiple fonts: the 14 standard
+// PDF fonts, custom embedded fonts via @font-face, and Unicode text
+// including Chinese, Russian, and Japanese.
+//
+// Custom fonts are loaded from common system paths. On macOS this uses
+// fonts from /System/Library/Fonts/Supplemental; on Linux from
+// /usr/share/fonts. If a font is not found, that section is skipped.
+//
+// Usage:
+//
+//	go run ./examples/fonts
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/html"
+)
+
+func main() {
+	fonts := discoverFonts()
+
+	// Build @font-face rules and matching CSS classes.
+	// Class names must be lowercase because the CSS selector parser lowercases them.
+	var css string
+	for _, f := range fonts {
+		cls := strings.ToLower(f.name)
+		css += fmt.Sprintf(
+			"@font-face { font-family: '%s'; src: url('%s'); }\n",
+			f.name, f.path,
+		)
+		css += fmt.Sprintf(".cf-%s { font-family: '%s'; }\n", cls, f.name)
+	}
+
+	htmlStr := `<html><head><style>
+` + css + `
+body { margin: 30px; }
+h1 { font-size: 22px; color: #1a1a2e; margin-bottom: 8px; }
+h2 { font-size: 14px; color: #16213e; margin-top: 14px; margin-bottom: 4px; }
+p { margin-bottom: 6px; font-size: 12px; }
+.helvetica { font-family: Helvetica; }
+.times { font-family: "Times New Roman", serif; }
+.courier { font-family: "Courier New", monospace; }
+hr { margin: 12px 0; }
+</style></head><body>
+
+<h1 class="helvetica">Folio Font Showcase</h1>
+<p class="helvetica">This PDF demonstrates standard and custom fonts rendered by the Folio library.</p>
+
+<hr/>
+<h2 class="helvetica">Standard PDF Fonts</h2>
+
+<p class="helvetica"><b>Helvetica:</b> The quick brown fox jumps over the lazy dog. 0123456789</p>
+<p class="times"><b>Times:</b> The quick brown fox jumps over the lazy dog. 0123456789</p>
+<p class="courier"><b>Courier:</b> The quick brown fox jumps over the lazy dog. 0123456789</p>
+`
+
+	// Add a section for each discovered custom font.
+	for _, f := range fonts {
+		cls := strings.ToLower(f.name)
+		htmlStr += fmt.Sprintf(`
+<hr/>
+<h2 class="cf-%s">%s (custom @font-face)</h2>
+<p class="cf-%s">The quick brown fox jumps over the lazy dog. 0123456789</p>
+`, cls, f.label, cls)
+
+		if f.unicode {
+			htmlStr += fmt.Sprintf(`
+<p class="cf-%s">Chinese: 你好世界！这是一个使用自定义字体的PDF测试。</p>
+<p class="cf-%s">Russian: Привет мир! Быстрая коричневая лиса перепрыгнула через ленивую собаку.</p>
+<p class="cf-%s">Japanese: こんにちは世界！カスタムフォントを使用したPDFテストです。</p>
+<p class="cf-%s">Mixed: English meets 中文 meets Русский meets 日本語 — all in one paragraph!</p>
+`, cls, cls, cls, cls)
+		}
+	}
+
+	htmlStr += `</body></html>`
+
+	result, err := html.ConvertFull(htmlStr, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "convert: %v\n", err)
+		os.Exit(1)
+	}
+
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.Info.Title = "Folio Font Showcase"
+	doc.Info.Author = "Folio"
+
+	for _, e := range result.Elements {
+		doc.Add(e)
+	}
+
+	if err := doc.Save("fonts.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created fonts.pdf")
+}
+
+type fontEntry struct {
+	name    string // CSS font-family name (no spaces, used as class suffix)
+	label   string // human-readable display label
+	path    string // filesystem path to the font file
+	unicode bool   // true if the font covers CJK and Cyrillic
+}
+
+// discoverFonts returns custom fonts available on the current system.
+func discoverFonts() []fontEntry {
+	var candidates []fontEntry
+
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = []fontEntry{
+			{"Verdana", "Verdana", "/System/Library/Fonts/Supplemental/Verdana.ttf", false},
+			{"Georgia", "Georgia", "/System/Library/Fonts/Supplemental/Georgia.ttf", false},
+			{"Impact", "Impact", "/System/Library/Fonts/Supplemental/Impact.ttf", false},
+			{"ComicSans", "Comic Sans MS", "/System/Library/Fonts/Supplemental/Comic Sans MS.ttf", false},
+			{"Chalkduster", "Chalkduster", "/System/Library/Fonts/Supplemental/Chalkduster.ttf", false},
+			{"BrushScript", "Brush Script", "/System/Library/Fonts/Supplemental/Brush Script.ttf", false},
+			{"ArialUnicode", "Arial Unicode MS", "/Library/Fonts/Arial Unicode.ttf", true},
+		}
+	case "linux":
+		candidates = []fontEntry{
+			{"NotoSans", "Noto Sans", "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf", false},
+			{"DejaVu", "DejaVu Sans", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", false},
+			{"NotoSansCJK", "Noto Sans CJK", "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc", true},
+		}
+	case "windows":
+		candidates = []fontEntry{
+			{"Verdana", "Verdana", `C:\Windows\Fonts\verdana.ttf`, false},
+			{"Georgia", "Georgia", `C:\Windows\Fonts\georgia.ttf`, false},
+			{"Impact", "Impact", `C:\Windows\Fonts\impact.ttf`, false},
+			{"ComicSans", "Comic Sans MS", `C:\Windows\Fonts\comic.ttf`, false},
+			{"Arial", "Arial", `C:\Windows\Fonts\arial.ttf`, true},
+		}
+	}
+
+	var found []fontEntry
+	for _, c := range candidates {
+		if _, err := os.Stat(c.path); err == nil {
+			found = append(found, c)
+		}
+	}
+	return found
+}

--- a/html/converter.go
+++ b/html/converter.go
@@ -3767,7 +3767,7 @@ func resolveFont(style computedStyle) *font.Standard {
 	bold := style.FontWeight == "bold"
 	italic := style.FontStyle == "italic"
 
-	switch style.FontFamily {
+	switch mapToStandardFamily(style.FontFamily) {
 	case "courier":
 		switch {
 		case bold && italic:

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/carlos7ags/folio/font"
 	"github.com/carlos7ags/folio/layout"
 )
 
@@ -756,18 +757,47 @@ func TestParseFontFamily(t *testing.T) {
 		want  string
 	}{
 		{"Courier", "courier"},
-		{"'Courier New', monospace", "courier"},
-		{"monospace", "courier"},
-		{"Times New Roman", "times"},
-		{"serif", "times"},
-		{"Arial", "helvetica"},
-		{"sans-serif", "helvetica"},
+		{"'Courier New', monospace", "courier new"},
+		{"monospace", "monospace"},
+		{"Times New Roman", "times new roman"},
+		{"serif", "serif"},
+		{"Arial", "arial"},
+		{"sans-serif", "sans-serif"},
 		{"Helvetica", "helvetica"},
+		{`"CustomFont"`, "customfont"},
+		{`'Noto Sans', sans-serif`, "noto sans"},
+		{`  "My Font"  `, "my font"},
 	}
 	for _, tt := range tests {
 		got := parseFontFamily(tt.input)
 		if got != tt.want {
 			t.Errorf("parseFontFamily(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestMapToStandardFamily(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"courier", "courier"},
+		{"courier new", "courier"},
+		{"monospace", "courier"},
+		{"mono", "courier"},
+		{"times new roman", "times"},
+		{"times", "times"},
+		{"serif", "times"},
+		{"arial", "helvetica"},
+		{"sans-serif", "helvetica"},
+		{"helvetica", "helvetica"},
+		{"noto sans", "helvetica"},
+		{"customfont", "helvetica"},
+	}
+	for _, tt := range tests {
+		got := mapToStandardFamily(tt.input)
+		if got != tt.want {
+			t.Errorf("mapToStandardFamily(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }
@@ -2651,6 +2681,106 @@ func TestConvertFontFaceParsing(t *testing.T) {
 	}
 	if len(elems) == 0 {
 		t.Fatal("expected elements even with missing font")
+	}
+}
+
+// TestCustomFontFamilyResolution verifies that a custom @font-face family
+// name is preserved through CSS parsing and matched against embedded fonts
+// during resolution, rather than being mapped to "helvetica". This is the
+// regression test for https://github.com/carlos7ags/folio/issues/16.
+func TestCustomFontFamilyResolution(t *testing.T) {
+	// Construct a converter with a mock embedded font entry keyed as
+	// "noto|normal|normal" — simulating a loaded @font-face with
+	// font-family: "Noto".
+	mockEF := font.NewEmbeddedFont(nil)
+	c := &converter{
+		embeddedFonts: map[string]*font.EmbeddedFont{
+			"noto|normal|normal": mockEF,
+		},
+	}
+
+	// Simulate the CSS pipeline: parseFontFamily normalizes "Noto" to "noto",
+	// then resolveFontPair should match the embedded font.
+	style := defaultStyle()
+	style.FontFamily = parseFontFamily(`"Noto"`)
+
+	if style.FontFamily != "noto" {
+		t.Fatalf("parseFontFamily(%q) = %q, want %q", `"Noto"`, style.FontFamily, "noto")
+	}
+
+	std, ef := c.resolveFontPair(style)
+	if ef != mockEF {
+		t.Errorf("expected embedded font for family %q, got standard font %v", style.FontFamily, std)
+	}
+	if std != nil {
+		t.Errorf("expected nil standard font when embedded font matches, got %v", std)
+	}
+}
+
+// TestCustomFontFamilyFallback verifies that an unknown family name that
+// does not match any @font-face still falls back to a standard font.
+func TestCustomFontFamilyFallback(t *testing.T) {
+	c := &converter{
+		embeddedFonts: make(map[string]*font.EmbeddedFont),
+	}
+
+	style := defaultStyle()
+	style.FontFamily = parseFontFamily(`"UnknownFont"`)
+
+	std, ef := c.resolveFontPair(style)
+	if ef != nil {
+		t.Error("expected nil embedded font for unknown family")
+	}
+	if std != font.Helvetica {
+		t.Errorf("expected Helvetica fallback, got %v", std)
+	}
+}
+
+// TestCustomFontFamilyWithFontShorthand verifies that the font shorthand
+// property also preserves custom family names.
+func TestCustomFontFamilyWithFontShorthand(t *testing.T) {
+	_, _, _, _, family := parseFontShorthand("12px CustomFont", 12)
+	if family != "customfont" {
+		t.Errorf("parseFontShorthand font-family = %q, want %q", family, "customfont")
+	}
+
+	_, _, _, _, family = parseFontShorthand("bold 16px 'Noto Sans', sans-serif", 12)
+	if family != "noto sans" {
+		t.Errorf("parseFontShorthand font-family = %q, want %q", family, "noto sans")
+	}
+}
+
+// TestStandardFontFamilyStillWorks verifies that standard font names
+// (courier, times, helvetica) still resolve correctly after the refactor.
+func TestStandardFontFamilyStillWorks(t *testing.T) {
+	c := &converter{
+		embeddedFonts: make(map[string]*font.EmbeddedFont),
+	}
+
+	tests := []struct {
+		family string
+		want   *font.Standard
+	}{
+		{"courier", font.Courier},
+		{"courier new", font.Courier},
+		{"monospace", font.Courier},
+		{"times", font.TimesRoman},
+		{"times new roman", font.TimesRoman},
+		{"serif", font.TimesRoman},
+		{"helvetica", font.Helvetica},
+		{"arial", font.Helvetica},
+		{"sans-serif", font.Helvetica},
+	}
+	for _, tt := range tests {
+		style := defaultStyle()
+		style.FontFamily = tt.family
+		std, ef := c.resolveFontPair(style)
+		if ef != nil {
+			t.Errorf("family %q: expected nil embedded font", tt.family)
+		}
+		if std != tt.want {
+			t.Errorf("family %q: got %v, want %v", tt.family, std.Name(), tt.want.Name())
+		}
 	}
 }
 

--- a/html/css.go
+++ b/html/css.go
@@ -171,7 +171,7 @@ func (ss *styleSheet) parseCSS(css string) {
 			for _, d := range decls {
 				switch d.property {
 				case "font-family":
-					ff.family = strings.Trim(strings.TrimSpace(d.value), `"'`)
+					ff.family = strings.ToLower(strings.Trim(strings.TrimSpace(d.value), `"'`))
 				case "src":
 					ff.src = parseFontFaceSrc(d.value)
 				case "font-weight":

--- a/html/properties.go
+++ b/html/properties.go
@@ -403,20 +403,30 @@ func parseBorderFull(value string, fontSize float64) (float64, string, layout.Co
 	return width, style, color
 }
 
-// parseFontFamily maps a CSS font-family to our supported families.
+// parseFontFamily normalizes a CSS font-family value by lowercasing,
+// stripping quotes, and selecting the first family from a comma-separated
+// list. The raw family name is preserved so that custom @font-face names
+// are not lost. Standard font mapping happens later in resolveFont.
 func parseFontFamily(value string) string {
 	value = strings.ToLower(strings.TrimSpace(value))
 	// Strip quotes.
 	value = strings.Trim(value, `"'`)
-	// Check first family in the list.
+	// Select the first family in the list.
 	if idx := strings.IndexByte(value, ','); idx >= 0 {
 		value = strings.TrimSpace(value[:idx])
 		value = strings.Trim(value, `"'`)
 	}
+	return value
+}
+
+// mapToStandardFamily maps a CSS font-family name to one of the three
+// standard PDF font families: "courier", "times", or "helvetica".
+// This is used as the final fallback when no @font-face match is found.
+func mapToStandardFamily(family string) string {
 	switch {
-	case strings.Contains(value, "courier") || strings.Contains(value, "monospace") || value == "mono":
+	case strings.Contains(family, "courier") || strings.Contains(family, "monospace") || family == "mono":
 		return "courier"
-	case strings.Contains(value, "times") || strings.Contains(value, "serif") && !strings.Contains(value, "sans"):
+	case strings.Contains(family, "times") || strings.Contains(family, "serif") && !strings.Contains(family, "sans"):
 		return "times"
 	default:
 		return "helvetica"


### PR DESCRIPTION
## Description

parseFontFamily was mapping all font-family values to one of three standard fonts (helvetica/courier/times) during CSS parsing, which destroyed custom @font-face names like "Noto" before resolveFontPair could match them against loaded embedded fonts.

Split into two functions:
- parseFontFamily: normalizes CSS syntax (lowercase, strip quotes, pick first from comma list) but preserves the original family name
- mapToStandardFamily: maps to standard PDF fonts, called only as a fallback in resolveFont when no embedded font matches

Also lowercase the @font-face family name when storing it, so the key matches the lowercased lookup in resolveFontPair.

Add fonts example with custom @font-face and Unicode text

Demonstrates standard PDF fonts (Helvetica, Times, Courier) alongside custom fonts loaded via @font-face, including Chinese, Russian, and Japanese text via Arial Unicode MS.

Fonts are auto-discovered from common system paths (macOS, Linux, Windows). Missing fonts are silently skipped.

Brief description of the changes.

## Related issue

Closes #16

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests