### PR TITLE
Fix page-break-after ignored when body has width: 100%

### DIFF
--- a/html/converter.go
+++ b/html/converter.go
@@ -1440,6 +1440,14 @@ func (c *converter) convertBlock(n *html.Node, style computedStyle) []layout.Ele
 		return children
 	}
 
+	// If any child is an AreaBreak, split into multiple Divs separated
+	// by the breaks. AreaBreak only works at the top level (the renderer
+	// checks for it by type assertion), so burying one inside a Div
+	// would silently suppress the page break.
+	if containsAreaBreak(children) {
+		return c.splitOnAreaBreaks(children, style)
+	}
+
 	div := layout.NewDiv()
 	for _, child := range children {
 		div.Add(child)
@@ -1452,6 +1460,52 @@ func (c *converter) convertBlock(n *html.Node, style computedStyle) []layout.Ele
 	}
 
 	return []layout.Element{div}
+}
+
+// containsAreaBreak reports whether any element in the slice is an AreaBreak.
+func containsAreaBreak(elems []layout.Element) bool {
+	for _, e := range elems {
+		if _, ok := e.(*layout.AreaBreak); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// splitOnAreaBreaks produces a sequence of Divs separated by AreaBreak
+// elements. Each Div gets the same styles applied. This ensures AreaBreak
+// elements appear at the top level where the renderer can act on them.
+func (c *converter) splitOnAreaBreaks(children []layout.Element, style computedStyle) []layout.Element {
+	var result []layout.Element
+	var group []layout.Element
+
+	flush := func() {
+		if len(group) == 0 {
+			return
+		}
+		div := layout.NewDiv()
+		for _, child := range group {
+			div.Add(child)
+		}
+		applyDivStyles(div, style, c.containerWidth)
+		if bgImg := c.resolveBackgroundImage(style); bgImg != nil {
+			div.SetBackgroundImage(bgImg)
+		}
+		result = append(result, div)
+		group = nil
+	}
+
+	for _, child := range children {
+		if _, ok := child.(*layout.AreaBreak); ok {
+			flush()
+			result = append(result, child)
+		} else {
+			group = append(group, child)
+		}
+	}
+	flush()
+
+	return result
 }
 
 // applyDivStyles applies common computed style properties to a layout.Div.

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -952,6 +952,62 @@ func TestConvertPageBreakAfter(t *testing.T) {
 	}
 }
 
+// TestPageBreakInsideBodyWithWidth verifies that page-break-after works
+// when <body> has width: 100%, which causes convertBlock to wrap children
+// in a Div. AreaBreak elements must be hoisted out of the Div so the
+// renderer can see them. Regression test for #21.
+func TestPageBreakInsideBodyWithWidth(t *testing.T) {
+	htmlStr := `<!DOCTYPE html><head><style>
+.pagebreak { page-break-after: always; }
+html, body { width: 100%; margin: 0; padding: 0; }
+</style></head><body>
+<div class="pagebreak"><p>Page 1</p></div>
+<div class="pagebreak"><p>Page 2</p></div>
+<div class="pagebreak"><p>Page 3</p></div>
+</body>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	breakCount := 0
+	for _, e := range elems {
+		if _, ok := e.(*layout.AreaBreak); ok {
+			breakCount++
+		}
+	}
+	if breakCount < 3 {
+		t.Errorf("expected at least 3 AreaBreaks, got %d (elements: %d)", breakCount, len(elems))
+		for i, e := range elems {
+			t.Logf("  [%d] %T", i, e)
+		}
+	}
+}
+
+// TestPageBreakInsideDivWrapper verifies that page-break-after works
+// even when the parent has box-model properties that trigger a Div wrapper.
+func TestPageBreakInsideDivWrapper(t *testing.T) {
+	htmlStr := `<div style="padding: 10px; background-color: #eee">
+<div style="page-break-after: always"><p>Section 1</p></div>
+<div style="page-break-after: always"><p>Section 2</p></div>
+</div>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	breakCount := 0
+	for _, e := range elems {
+		if _, ok := e.(*layout.AreaBreak); ok {
+			breakCount++
+		}
+	}
+	if breakCount < 2 {
+		t.Errorf("expected at least 2 AreaBreaks hoisted from Div, got %d", breakCount)
+		for i, e := range elems {
+			t.Logf("  [%d] %T", i, e)
+		}
+	}
+}
+
 // --- !important ---
 
 func TestCSSImportant(t *testing.T) {


### PR DESCRIPTION
## Description

- convertBlock now detects AreaBreak children and splits them out of the Div wrapper so the renderer can see them
- Fixes the general case, not just <body> — any block element with box-model properties that wraps children in a Div
- Based on the root cause analysis from #21 by @Forceu

## Test plan

- Exact reproduction from #21 produces 3 pages
- TestPageBreakInsideBodyWithWidth — body with width: 100%
- TestPageBreakInsideDivWrapper — div with padding containing page breaks
- Full test suite passes

## Related issue

Closes #21

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests