### PR TITLE
Fix punctuation spacing at styled paragraph run boundaries

### DIFF
--- a/html/roundtrip_test.go
+++ b/html/roundtrip_test.go
@@ -94,11 +94,21 @@ func extractAllText(t *testing.T, r *reader.PdfReader) string {
 // assertTextContains checks that extracted PDF text contains all expected strings.
 func assertTextContains(t *testing.T, text string, expected ...string) {
 	t.Helper()
+	// Normalize whitespace so line breaks from word-wrapping don't cause
+	// false negatives when checking for multi-word phrases.
+	normalized := normalizeWhitespace(text)
 	for _, s := range expected {
-		if !strings.Contains(text, s) {
-			t.Errorf("extracted text missing %q (got %d chars: %q...)", s, len(text), truncate(text, 200))
+		if !strings.Contains(normalized, s) {
+			t.Errorf("extracted text missing %q (got %d chars: %q...)", s, len(normalized), truncate(normalized, 200))
 		}
 	}
+}
+
+// normalizeWhitespace collapses all runs of whitespace (including newlines)
+// into a single space. This makes text assertions resilient to line-break
+// changes caused by word-width differences.
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 func truncate(s string, maxLen int) string {

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -760,6 +760,12 @@ func (p *Paragraph) PlanLayout(area LayoutArea) LayoutPlan {
 }
 
 // measureWords flattens all runs into measured words.
+//
+// When a run's text starts with punctuation and no leading whitespace
+// (e.g. ". Then" after a bold run), the leading punctuation characters
+// are appended to the last word of the previous run. This produces
+// "here." as one word instead of "here" + "." as two, matching standard
+// typographic behavior at style boundaries.
 func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 	var measured []Word
 	var maxFontSize float64
@@ -767,7 +773,27 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 	for _, run := range p.runs {
 		measurer := runMeasurer(run)
 		spaceW := measurer.MeasureString(" ", run.FontSize) + run.WordSpacing
-		words := splitWords(run.Text)
+		text := run.Text
+
+		// If the run starts with punctuation (no leading space) and we
+		// already have words, append the punctuation to the previous word.
+		// The punctuation renders in the previous word's font, which is
+		// visually correct — "here." should look like one word.
+		if len(measured) > 0 && len(text) > 0 && !isSpace(rune(text[0])) {
+			punct, rest := splitLeadingPunct(text)
+			if punct != "" {
+				prev := &measured[len(measured)-1]
+				prev.Text += punct
+				prevMeasurer := wordMeasurer(*prev)
+				prev.Width = prevMeasurer.MeasureString(prev.Text, prev.FontSize)
+				if prev.LetterSpacing != 0 {
+					prev.Width += prev.LetterSpacing * float64(len([]rune(prev.Text))-1)
+				}
+				text = rest
+			}
+		}
+
+		words := splitWords(text)
 		for _, w := range words {
 			wordW := measurer.MeasureString(w, run.FontSize)
 			if run.LetterSpacing != 0 && len([]rune(w)) > 1 {
@@ -797,6 +823,47 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 
 	measured = breakLongWords(measured, maxWidth)
 	return measured, maxFontSize
+}
+
+// splitLeadingPunct splits a string into a leading punctuation prefix
+// and the remainder. Returns ("", s) if s does not start with punctuation.
+func splitLeadingPunct(s string) (punct, rest string) {
+	i := 0
+	for _, r := range s {
+		if isPunctuation(r) {
+			i += len(string(r))
+		} else {
+			break
+		}
+	}
+	if i == 0 {
+		return "", s
+	}
+	return s[:i], s[i:]
+}
+
+// isPunctuation reports whether r is a punctuation character that should
+// attach to the preceding word rather than stand alone.
+func isPunctuation(r rune) bool {
+	switch r {
+	case '.', ',', ';', ':', '!', '?', ')', ']', '}', '"', '\'',
+		'\u2019', '\u201D': // right single/double quotes
+		return true
+	}
+	return false
+}
+
+// isSpace reports whether r is a whitespace character.
+func isSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+// wordMeasurer returns a TextMeasurer for the given word's font.
+func wordMeasurer(w Word) font.TextMeasurer {
+	if w.Embedded != nil {
+		return w.Embedded
+	}
+	return w.Font
 }
 
 // wrapWords performs greedy word-wrapping, returning groups of words per line.

--- a/layout/richtext_test.go
+++ b/layout/richtext_test.go
@@ -209,3 +209,147 @@ func TestRGBConstructor(t *testing.T) {
 		t.Errorf("unexpected color: %+v", c)
 	}
 }
+
+// TestPunctuationMergedAcrossRuns verifies that a period at the start of
+// a new run is merged into the last word of the previous run, producing
+// "here." as one word instead of "here" + "." as two separate words.
+// Regression test for #25.
+func TestPunctuationMergedAcrossRuns(t *testing.T) {
+	p := NewStyledParagraph(
+		Run("click here", font.HelveticaBold, 12),
+		Run(". Then continue.", font.Helvetica, 12),
+	)
+	words, _ := p.measureWords(400)
+	// Expected words: ["click", "here.", "Then", "continue."]
+	// NOT: ["click", "here", ".", "Then", "continue."]
+	for _, w := range words {
+		if w.Text == "." {
+			t.Errorf("period should be merged into previous word, but found standalone '.' word")
+		}
+	}
+	foundHereDot := false
+	for _, w := range words {
+		if w.Text == "here." {
+			foundHereDot = true
+		}
+	}
+	if !foundHereDot {
+		texts := make([]string, len(words))
+		for i, w := range words {
+			texts[i] = w.Text
+		}
+		t.Errorf("expected word 'here.' but got words: %v", texts)
+	}
+}
+
+// TestPunctuationMergeMatchesSingleRun verifies that cross-run punctuation
+// merging produces identical words to a single-run paragraph with the same
+// text. This ensures the merge is a true root fix, not a rendering patch.
+func TestPunctuationMergeMatchesSingleRun(t *testing.T) {
+	single := NewParagraph("click here. Then continue.", font.Helvetica, 12)
+	multi := NewStyledParagraph(
+		Run("click here", font.Helvetica, 12),
+		Run(". Then continue.", font.Helvetica, 12),
+	)
+	singleWords, _ := single.measureWords(400)
+	multiWords, _ := multi.measureWords(400)
+	if len(singleWords) != len(multiWords) {
+		t.Fatalf("word count differs: single=%d multi=%d", len(singleWords), len(multiWords))
+	}
+	for i := range singleWords {
+		if singleWords[i].Text != multiWords[i].Text {
+			t.Errorf("word %d: single=%q multi=%q", i, singleWords[i].Text, multiWords[i].Text)
+		}
+	}
+}
+
+// TestPunctuationCommaAfterStyledRun verifies that a comma at a style
+// boundary merges into the preceding word.
+func TestPunctuationCommaAfterStyledRun(t *testing.T) {
+	p := NewStyledParagraph(
+		Run("see ", font.Helvetica, 12),
+		Run("this", font.HelveticaBold, 12),
+		Run(", that.", font.Helvetica, 12),
+	)
+	words, _ := p.measureWords(400)
+	foundThisComma := false
+	for _, w := range words {
+		if w.Text == "this," {
+			foundThisComma = true
+		}
+		if w.Text == "," {
+			t.Error("comma should be merged, not standalone")
+		}
+	}
+	if !foundThisComma {
+		texts := make([]string, len(words))
+		for i, w := range words {
+			texts[i] = w.Text
+		}
+		t.Errorf("expected word 'this,' but got: %v", texts)
+	}
+}
+
+// TestPunctuationLeadingSpaceNotMerged verifies that when a run starts
+// with whitespace before punctuation (e.g. " . word"), the space acts as
+// a word boundary and the period is NOT merged into the previous word.
+func TestPunctuationLeadingSpaceNotMerged(t *testing.T) {
+	p := NewStyledParagraph(
+		Run("word", font.Helvetica, 12),
+		Run(" . separate", font.Helvetica, 12),
+	)
+	words, _ := p.measureWords(400)
+	// The "." should be a standalone word because the run starts with a space.
+	foundStandaloneDot := false
+	for _, w := range words {
+		if w.Text == "." {
+			foundStandaloneDot = true
+		}
+	}
+	if !foundStandaloneDot {
+		texts := make([]string, len(words))
+		for i, w := range words {
+			texts[i] = w.Text
+		}
+		t.Errorf("expected standalone '.' word (space prevents merge), got: %v", texts)
+	}
+}
+
+// TestPunctuationMultipleChars verifies that multiple leading punctuation
+// characters (e.g. ")." or "...") are all merged.
+func TestPunctuationMultipleChars(t *testing.T) {
+	p := NewStyledParagraph(
+		Run("end", font.Helvetica, 12),
+		Run(").", font.Helvetica, 12),
+	)
+	words, _ := p.measureWords(400)
+	foundMerged := false
+	for _, w := range words {
+		if w.Text == "end)." {
+			foundMerged = true
+		}
+	}
+	if !foundMerged {
+		texts := make([]string, len(words))
+		for i, w := range words {
+			texts[i] = w.Text
+		}
+		t.Errorf("expected 'end).' but got: %v", texts)
+	}
+}
+
+// TestPunctuationFirstRunNotMerged verifies that punctuation at the very
+// start of the paragraph (no preceding word) is not merged anywhere.
+func TestPunctuationFirstRunNotMerged(t *testing.T) {
+	p := NewStyledParagraph(
+		Run("...start", font.Helvetica, 12),
+	)
+	words, _ := p.measureWords(400)
+	if len(words) != 1 || words[0].Text != "...start" {
+		texts := make([]string, len(words))
+		for i, w := range words {
+			texts[i] = w.Text
+		}
+		t.Errorf("expected ['...start'] but got: %v", texts)
+	}
+}


### PR DESCRIPTION
## Description

When consecutive TextRuns form one sentence (e.g. a bold link followed by ". next sentence"), the period became its own word with a full inter-word space before it because measureWords splits each run independently via strings.Fields.

Fixed measureWords to detect when a run starts with punctuation and no leading whitespace, and append those characters to the last word of the previous run. This produces "here." as one word instead of "here" + "." as two — matching standard typographic behavior.

The punctuation renders in the previous word's font, which is visually correct since typographically the period belongs to the preceding word. Word wrapping, justified spacing, and all other layout calculations work correctly because the merge happens at the word-construction level, not as a post-hoc rendering adjustment.

## Related issue

Closes #25

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
