### PR TITLE
Fix links inside headings (<h1>–<h6>) not clickable in PDF

### DIFF
--- a/html/converter.go
+++ b/html/converter.go
@@ -928,34 +928,28 @@ func (c *converter) convertElementInner(n *html.Node, style computedStyle) []lay
 
 // convertHeading creates a layout.Heading from an <h1>-<h6> element.
 func (c *converter) convertHeading(n *html.Node, style computedStyle, level layout.HeadingLevel) []layout.Element {
-	text := collectText(n)
-	if text == "" {
+	// Use collectRuns instead of collectText so that inline elements
+	// like <a href="..."> are preserved as styled TextRuns with LinkURI.
+	runs := c.collectRuns(n, style)
+	if len(runs) == 0 {
 		return nil
 	}
-	text = applyTextTransform(text, style.TextTransform)
 
-	stdFont, embFont := c.resolveFontPair(style)
-	run := layout.TextRun{
-		Text:            text,
-		Font:            stdFont,
-		Embedded:        embFont,
-		FontSize:        style.FontSize,
-		Color:           style.Color,
-		Decoration:      style.TextDecoration,
-		DecorationColor: style.TextDecorationColor,
-		DecorationStyle: style.TextDecorationStyle,
-		LetterSpacing:   style.LetterSpacing,
-		WordSpacing:     style.WordSpacing,
-		BaselineShift:   baselineShiftFromStyle(style),
+	// Apply text-transform to each run.
+	for i := range runs {
+		runs[i].Text = applyTextTransform(runs[i].Text, style.TextTransform)
 	}
+
+	text := collectText(n)
+	stdFont, embFont := c.resolveFontPair(style)
 	var h *layout.Heading
 	if embFont != nil {
 		h = layout.NewHeadingEmbedded(text, level, embFont)
 	} else {
 		h = layout.NewHeadingWithFont(text, level, stdFont, style.FontSize)
 	}
-	// Replace the default run with the fully styled one.
-	h.SetRuns([]layout.TextRun{run})
+	// Replace the default run with the fully styled runs from collectRuns.
+	h.SetRuns(runs)
 	h.SetAlign(style.TextAlign)
 
 	// Wrap in a Div if the heading has box-model properties.

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -53,6 +53,65 @@ func TestConvertHeadings(t *testing.T) {
 	}
 }
 
+// TestConvertHeadingWithLink verifies that <a href> inside headings
+// produces clickable link annotations. Regression test for #26.
+func TestConvertHeadingWithLink(t *testing.T) {
+	htmlStr := `<h2><a href="https://example.com">Linked Heading</a></h2>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected at least 1 element")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if !planContainsLink(plan, "https://example.com") {
+		t.Error("expected link annotation with URI 'https://example.com' on heading")
+	}
+}
+
+// TestConvertHeadingMixedTextAndLink verifies that a heading with both
+// plain text and an inline link produces a link only for the linked part.
+func TestConvertHeadingMixedTextAndLink(t *testing.T) {
+	htmlStr := `<h3>Read the <a href="https://example.com/docs">documentation</a> first</h3>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected at least 1 element")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if !planContainsLink(plan, "https://example.com/docs") {
+		t.Error("expected link annotation for 'https://example.com/docs' in heading")
+	}
+}
+
+// planContainsLink recursively searches a LayoutPlan's blocks (including
+// children) for a link annotation with the given URI.
+func planContainsLink(plan layout.LayoutPlan, uri string) bool {
+	for _, b := range plan.Blocks {
+		if blockContainsLink(b, uri) {
+			return true
+		}
+	}
+	return false
+}
+
+func blockContainsLink(b layout.PlacedBlock, uri string) bool {
+	for _, link := range b.Links {
+		if link.URI == uri {
+			return true
+		}
+	}
+	for _, child := range b.Children {
+		if blockContainsLink(child, uri) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestConvertInlineStyles(t *testing.T) {
 	html := `<p>Normal <strong>bold</strong> <em>italic</em> text.</p>`
 	elems, err := Convert(html, nil)


### PR DESCRIPTION
## Description

convertHeading used collectText which flattened all child nodes to a plain string, discarding <a> elements and their href attributes.

Changed to use collectRuns (the same pipeline convertParagraph uses) which preserves inline elements including links. The heading's inner Paragraph already propagates TextRun.LinkURI through to PlacedBlock annotations, so no layout-layer changes were needed.

## Related issue

Closes #26

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
