### PR TITLE
Fix links inside list items (<li>) not clickable in PDF

### DIFF
--- a/examples/links/main.go
+++ b/examples/links/main.go
@@ -74,11 +74,17 @@ hr { margin: 6px 0; }
 <p><b><a href="https://example.com/bold" style="color: #1e40af;">Bold blue link</a></b></p>
 <p class="subtle">Subtle style: <a href="https://example.com/subtle">no underline, muted color</a></p>
 
+<h2><a href="https://example.com/heading-link">Linked Heading (clickable)</a></h2>
+
+<h2>Links in Lists</h2>
+<ul>
+<li><a href="https://example.com/li1">Linked item</a></li>
+<li>Text with <a href="https://example.com/li2">inline link</a></li>
+</ul>
+
 <h2>Edge Cases</h2>
 <p><a href="https://example.com/start">Link at start</a> then text, and text then <a href="https://example.com/end">link at end</a></p>
-<p><a href="https://example.com/full">This entire paragraph is one clickable link</a></p>
-<p><a href="https://example.com/adj-a">Adjacent</a><a href="https://example.com/adj-b">Links</a> — two links with no space between them.</p>
-<p><a href="https://example.com/nested"><b>Bold</b> and <i>italic</i> inside one link</a></p>
+<p><a href="https://example.com/adj-a">Adjacent</a><a href="https://example.com/adj-b">Links</a> with no gap between them.</p>
 
 
 </body></html>`
@@ -151,11 +157,42 @@ hr { margin: 6px 0; }
 		font.HelveticaBold, 11,
 	).SetColor(layout.RGB(0.58, 0.17, 0.83)).SetUnderline())
 
-	// Edge cases via layout API
+	// Linked heading via layout API
 	doc.Add(spacer(4))
-	doc.Add(sectionHeading("Edge Cases"))
+	doc.Add(sectionHeading("Linked Heading"))
+	h2 := layout.NewHeadingWithFont("Resources", layout.H3, font.HelveticaBold, 13)
+	h2.SetRuns([]layout.TextRun{
+		layout.Run("Resources", font.HelveticaBold, 13).
+			WithColor(layout.RGB(0.15, 0.39, 0.92)).
+			WithDecoration(layout.DecorationUnderline).
+			WithLinkURI("https://example.com/resources"),
+	})
+	doc.Add(h2)
 
-	// Two different links in one styled paragraph
+	// Linked list items via layout API
+	doc.Add(spacer(2))
+	doc.Add(sectionHeading("Linked List Items"))
+	list := layout.NewList(font.Helvetica, 10)
+	list.AddItemRuns([]layout.TextRun{
+		layout.Run("Folio repository", font.Helvetica, 10).
+			WithColor(layout.RGB(0.15, 0.39, 0.92)).
+			WithDecoration(layout.DecorationUnderline).
+			WithLinkURI("https://github.com/carlos7ags/folio"),
+	})
+	list.AddItemRuns([]layout.TextRun{
+		layout.Run("See the ", font.Helvetica, 10),
+		layout.Run("Go docs", font.HelveticaBold, 10).
+			WithColor(layout.RGB(0.15, 0.39, 0.92)).
+			WithDecoration(layout.DecorationUnderline).
+			WithLinkURI("https://pkg.go.dev"),
+		layout.Run(" for details.", font.Helvetica, 10),
+	})
+	list.AddItem("Plain item (no link)")
+	doc.Add(list)
+
+	// Multiple links on one line
+	doc.Add(spacer(4))
+	doc.Add(sectionHeading("Multiple Links Per Line"))
 	doc.Add(layout.NewStyledParagraph(
 		layout.Run("Compare ", font.Helvetica, 10),
 		layout.Run("GitHub", font.HelveticaBold, 10).
@@ -169,14 +206,6 @@ hr { margin: 6px 0; }
 			WithLinkURI("https://gitlab.com"),
 		layout.Run(" for hosting.", font.Helvetica, 10),
 	))
-
-	// Link with different font
-	doc.Add(spacer(2))
-	doc.Add(layout.NewLink(
-		"Link in Times font",
-		"https://example.com/times",
-		font.TimesRoman, 10,
-	).SetColor(layout.RGB(0.15, 0.39, 0.92)).SetUnderline())
 
 	// Register named destinations and bookmarks.
 	doc.AddNamedDest(document.NamedDest{

--- a/html/converter.go
+++ b/html/converter.go
@@ -1694,30 +1694,72 @@ func (c *converter) convertList(n *html.Node, style computedStyle, ordered bool)
 }
 
 // populateList fills a list with items from <li> children, handling nesting.
+// Uses collectRuns (instead of collectDirectText) so inline elements like
+// <a href="..."> are preserved as styled TextRuns with LinkURI.
 func (c *converter) populateList(n *html.Node, list *layout.List, style computedStyle) {
 	for child := n.FirstChild; child != nil; child = child.NextSibling {
 		if child.Type != html.ElementNode || child.DataAtom != atom.Li {
 			continue
 		}
 
-		text := collectDirectText(child)
+		runs := c.collectListItemRuns(child, style)
 		nestedList := findNestedList(child)
 
 		if nestedList != nil {
-			if text == "" {
-				text = " "
+			if len(runs) == 0 {
+				runs = []layout.TextRun{{Text: " ", Font: font.Helvetica, FontSize: style.FontSize}}
 			}
-			sub := list.AddItemWithSubList(text)
+			sub := list.AddItemRunsWithSubList(runs)
 			if nestedList.DataAtom == atom.Ol {
 				sub.SetStyle(layout.ListOrdered)
 			}
 			c.populateList(nestedList, sub, style)
 		} else {
-			if text != "" {
-				list.AddItem(text)
+			if len(runs) > 0 {
+				list.AddItemRuns(runs)
 			}
 		}
 	}
+}
+
+// collectListItemRuns collects styled TextRuns from a <li> element,
+// skipping nested <ul>/<ol> elements (which are handled as sub-lists).
+func (c *converter) collectListItemRuns(li *html.Node, style computedStyle) []layout.TextRun {
+	var runs []layout.TextRun
+	for child := li.FirstChild; child != nil; child = child.NextSibling {
+		if child.Type == html.ElementNode &&
+			(child.DataAtom == atom.Ul || child.DataAtom == atom.Ol) {
+			continue // skip nested lists
+		}
+		switch child.Type {
+		case html.TextNode:
+			text := processWhitespace(child.Data, style.WhiteSpace)
+			if text == "" {
+				continue
+			}
+			stdFont, embFont := c.resolveFontForText(style, text)
+			runs = append(runs, layout.TextRun{
+				Text:     text,
+				Font:     stdFont,
+				Embedded: embFont,
+				FontSize: style.FontSize,
+				Color:    style.Color,
+			})
+		case html.ElementNode:
+			childStyle := c.computeElementStyle(child, style)
+			childRuns := c.collectRuns(child, childStyle)
+			if child.DataAtom == atom.A {
+				href := getAttr(child, "href")
+				if href != "" {
+					for i := range childRuns {
+						childRuns[i].LinkURI = href
+					}
+				}
+			}
+			runs = append(runs, childRuns...)
+		}
+	}
+	return runs
 }
 
 // convertBlockquote renders a <blockquote> as an indented block with a left border.
@@ -3860,22 +3902,6 @@ func collectRawTextInto(n *html.Node, sb *strings.Builder) {
 	for child := n.FirstChild; child != nil; child = child.NextSibling {
 		collectRawTextInto(child, sb)
 	}
-}
-
-// collectDirectText collects text only from direct text node children,
-// skipping nested <ul>/<ol> elements (for list item text extraction).
-func collectDirectText(n *html.Node) string {
-	var sb strings.Builder
-	for child := n.FirstChild; child != nil; child = child.NextSibling {
-		if child.Type == html.TextNode {
-			sb.WriteString(child.Data)
-		} else if child.Type == html.ElementNode &&
-			child.DataAtom != atom.Ul && child.DataAtom != atom.Ol {
-			// Recurse into inline elements but not nested lists.
-			collectTextInto(child, &sb)
-		}
-	}
-	return collapseWhitespace(sb.String())
 }
 
 // findNestedList finds the first <ul> or <ol> child of a node.

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -153,6 +153,40 @@ func TestConvertOrderedList(t *testing.T) {
 	}
 }
 
+// TestConvertListItemWithLink verifies that <a href> inside <li> produces
+// clickable link annotations. Regression test for #27.
+func TestConvertListItemWithLink(t *testing.T) {
+	htmlStr := `<ul><li><a href="https://example.com">Linked item</a></li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected at least 1 element")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if !planContainsLink(plan, "https://example.com") {
+		t.Error("expected link annotation with URI 'https://example.com' in list item")
+	}
+}
+
+// TestConvertListItemMixedTextAndLink verifies inline links within list
+// item text produce link annotations.
+func TestConvertListItemMixedTextAndLink(t *testing.T) {
+	htmlStr := `<ul><li>Visit <a href="https://example.com">our site</a> today</li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected at least 1 element")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if !planContainsLink(plan, "https://example.com") {
+		t.Error("expected link annotation in list item with mixed text")
+	}
+}
+
 func TestConvertDiv(t *testing.T) {
 	html := `<div style="padding: 10px; background-color: #f0f0f0"><p>Inside div</p></div>`
 	elems, err := Convert(html, nil)

--- a/layout/list.go
+++ b/layout/list.go
@@ -34,9 +34,12 @@ type List struct {
 }
 
 // listItem is a single entry in a list, optionally containing a nested sub-list.
+// When runs is non-nil, the item renders as a styled paragraph (supporting
+// links, mixed fonts, etc.); otherwise it uses the plain text field.
 type listItem struct {
 	text    string
-	subList *List // optional nested list
+	runs    []TextRun // styled runs (nil = use plain text)
+	subList *List     // optional nested list
 }
 
 // listLayoutRef carries list-specific rendering info on a Line.
@@ -91,6 +94,28 @@ func (l *List) AddItem(text string) *List {
 	return l
 }
 
+// AddItemRuns adds an item with styled text runs, supporting links,
+// mixed fonts, and other inline formatting within the list item.
+func (l *List) AddItemRuns(runs []TextRun) *List {
+	l.items = append(l.items, listItem{runs: runs})
+	return l
+}
+
+// AddItemRunsWithSubList adds a styled-runs item and returns a nested
+// sub-list under it.
+func (l *List) AddItemRunsWithSubList(runs []TextRun) *List {
+	sub := &List{
+		style:    ListUnordered,
+		font:     l.font,
+		embedded: l.embedded,
+		fontSize: l.fontSize,
+		indent:   l.indent,
+		leading:  l.leading,
+	}
+	l.items = append(l.items, listItem{runs: runs, subList: sub})
+	return sub
+}
+
 // AddItemWithSubList adds a text item and returns a nested sub-list
 // under that item. The sub-list inherits the parent's font and font size.
 func (l *List) AddItemWithSubList(text string) *List {
@@ -133,12 +158,7 @@ func (l *List) layoutAt(maxWidth float64, baseIndent float64) []Line {
 		markerLines := markerPara.Layout(l.indent)
 
 		// Create a paragraph for the item text.
-		var textPara *Paragraph
-		if l.embedded != nil {
-			textPara = NewParagraphEmbedded(item.text, l.embedded, l.fontSize)
-		} else {
-			textPara = NewParagraph(item.text, l.font, l.fontSize)
-		}
+		textPara := l.itemParagraph(item)
 		textPara.SetLeading(l.leading)
 		textLines := textPara.Layout(itemWidth)
 
@@ -182,8 +202,9 @@ func (l *List) layoutAt(maxWidth float64, baseIndent float64) []Line {
 func (l *List) MinWidth() float64 {
 	maxW := 0.0
 	for _, item := range l.items {
+		text := l.itemText(item)
 		measurer := l.measurer()
-		for _, w := range splitWords(item.text) {
+		for _, w := range splitWords(text) {
 			ww := measurer.MeasureString(w, l.fontSize)
 			if ww > maxW {
 				maxW = ww
@@ -198,12 +219,37 @@ func (l *List) MaxWidth() float64 {
 	maxW := 0.0
 	measurer := l.measurer()
 	for _, item := range l.items {
-		ww := measurer.MeasureString(item.text, l.fontSize)
+		text := l.itemText(item)
+		ww := measurer.MeasureString(text, l.fontSize)
 		if ww > maxW {
 			maxW = ww
 		}
 	}
 	return l.indent + maxW
+}
+
+// itemParagraph creates a Paragraph for a list item's text content.
+// Uses styled runs when available, falling back to plain text.
+func (l *List) itemParagraph(item listItem) *Paragraph {
+	if len(item.runs) > 0 {
+		return NewStyledParagraph(item.runs...)
+	}
+	if l.embedded != nil {
+		return NewParagraphEmbedded(item.text, l.embedded, l.fontSize)
+	}
+	return NewParagraph(item.text, l.font, l.fontSize)
+}
+
+// itemText returns the plain text of a list item for measurement.
+func (l *List) itemText(item listItem) string {
+	if len(item.runs) > 0 {
+		var s string
+		for _, r := range item.runs {
+			s += r.Text
+		}
+		return s
+	}
+	return item.text
 }
 
 // measurer returns the text measurer for this list's font.
@@ -249,12 +295,7 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 		markerWords, _ := markerPara.measureWords(l.indent)
 
 		// Measure and wrap item text directly.
-		var textPara *Paragraph
-		if l.embedded != nil {
-			textPara = NewParagraphEmbedded(item.text, l.embedded, l.fontSize)
-		} else {
-			textPara = NewParagraph(item.text, l.font, l.fontSize)
-		}
+		textPara := l.itemParagraph(item)
 		textPara.SetLeading(l.leading)
 		textWords, maxFS := textPara.measureWords(itemWidth)
 		lineHeight := maxFS * l.leading
@@ -277,9 +318,10 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 				capturedMarker = markerWords
 			}
 
-			blocks = append(blocks, PlacedBlock{
+			block := PlacedBlock{
 				X: 0, Y: curY, Width: lineWidth(wl), Height: lineHeight,
-				Tag: "LI",
+				Tag:   "LI",
+				Links: linkSpans(wl),
 				Draw: func(ctx DrawContext, absX, absTopY float64) {
 					baselineY := absTopY - capturedHeight
 					if len(capturedMarker) > 0 {
@@ -287,7 +329,13 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 					}
 					drawTextLine(ctx, capturedWords, absX+capturedIndent, baselineY, capturedMaxW-capturedIndent, AlignLeft, capturedIsLast)
 				},
-			})
+			}
+			// Offset link annotation x-coords by the indent since the
+			// text starts after the marker column.
+			for k := range block.Links {
+				block.Links[k].X += capturedIndent
+			}
+			blocks = append(blocks, block)
 			curY += lineHeight
 		}
 


### PR DESCRIPTION
## Description

populateList used collectDirectText which flattened <li> content to plain strings, discarding <a> elements and their href attributes.

Changes:
- layout: Added AddItemRuns and AddItemRunsWithSubList to List, allowing list items to carry styled TextRuns (with LinkURI, colors, etc.) instead of only plain text. List.planAt uses linkSpans to produce precise annotation rects offset by the marker indent.
- html: Added collectListItemRuns which works like collectRuns but skips nested <ul>/<ol> elements. populateList now uses it instead of collectDirectText.
- Updated links example to showcase linked headings and list items.

## Related issue

Closes #27

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
