### PR TITLE
Expand C ABI to 281 exported functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.25'
+          cache: true
 
       - name: Install qpdf
         run: sudo apt-get update && sudo apt-get install -y qpdf
@@ -35,10 +36,7 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test ./... -race -count=1 -timeout 300s
-
-      - name: Test coverage
-        run: go test ./... -coverprofile=coverage.out -count=1
+        run: go test ./... -race -coverprofile=coverage.out -count=1 -timeout 300s
 
       - name: Check no competitor references in source
         run: |
@@ -46,6 +44,19 @@ jobs:
             echo "ERROR: Source code must not reference competitor libraries"
             exit 1
           fi
+
+      - name: Audit C ABI (header vs exports)
+        run: bash scripts/audit-cabi.sh
+
+      - name: Build shared library
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          CGO_ENABLED=1 go build -ldflags "-X main.version=$VERSION" -buildmode=c-shared -o libfolio.so ./export/
+
+      - name: Test C ABI
+        run: |
+          cc -o export/testdata/test_cabi export/testdata/test_cabi.c -L. -lfolio -Wl,-rpath,.
+          ./export/testdata/test_cabi
 
   fuzz:
     runs-on: ubuntu-latest
@@ -56,6 +67,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.25'
+          cache: true
 
       - name: Fuzz tokenizer
         run: go test ./reader/... -fuzz=FuzzTokenizer -fuzztime=30s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,21 +8,104 @@ permissions:
   contents: write
 
 jobs:
+  build-native:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            artifact: libfolio-linux-x86_64.so
+            cc: gcc
+          - os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+            artifact: libfolio-linux-aarch64.so
+            cc: aarch64-linux-gnu-gcc
+            packages: gcc-aarch64-linux-gnu
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+            artifact: libfolio-macos-aarch64.dylib
+          - os: macos-13
+            goos: darwin
+            goarch: amd64
+            artifact: libfolio-macos-x86_64.dylib
+          - os: ubuntu-latest
+            goos: windows
+            goarch: amd64
+            artifact: folio-windows-x86_64.dll
+            cc: x86_64-w64-mingw32-gcc
+            packages: gcc-mingw-w64-x86-64
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Install cross-compiler
+        if: matrix.packages
+        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.packages }}
+
+      - name: Build shared library
+        run: |
+          export CGO_ENABLED=1
+          export GOOS=${{ matrix.goos }}
+          export GOARCH=${{ matrix.goarch }}
+          if [ -n "${{ matrix.cc }}" ]; then
+            export CC=${{ matrix.cc }}
+          fi
+          go build -ldflags "-X main.version=${GITHUB_REF_NAME}" -buildmode=c-shared -o ${{ matrix.artifact }} ./export/
+          ls -lh ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
   release:
+    needs: build-native
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
+          cache: true
 
       - name: Build WASM
         run: GOOS=js GOARCH=wasm go build -o folio.wasm ./cmd/wasm/
 
+      - name: Download all native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+
+      - name: Collect release artifacts
+        run: |
+          mkdir -p release
+          cp folio.wasm release/
+          cp export/folio.h release/
+          find dist -type f \( -name '*.so' -o -name '*.dylib' -o -name '*.dll' \) -exec cp {} release/ \;
+          ls -lh release/
+
+      - name: Generate checksums
+        run: |
+          cd release
+          sha256sum * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: folio.wasm
+          files: release/*
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 
 # Go build output
 /folio
+libfolio.h
+
+# C ABI test binary
+export/testdata/test_cabi
 *.wasm
 /samples
 /showcase

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet fmt fuzz check clean wasm cshared test-cabi
+.PHONY: build test vet fmt fuzz check clean wasm cshared test-cabi audit cross-all
 
 build:
 	go build ./...
@@ -19,7 +19,7 @@ fuzz:
 	go test ./reader/... -fuzz=FuzzTokenizer -fuzztime=30s || true
 	go test ./reader/... -fuzz=FuzzParse -fuzztime=30s || true
 
-check: fmt-check vet test
+check: fmt-check vet test audit
 
 coverage:
 	go test ./... -coverprofile=coverage.out -count=1
@@ -29,13 +29,73 @@ wasm:
 	GOOS=js GOARCH=wasm go build -o folio.wasm ./cmd/wasm/
 	@echo "Built folio.wasm ($$(du -h folio.wasm | cut -f1))"
 
+# Detect platform for shared library extension
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+  LIB_EXT := dylib
+  RPATH_FLAG := -Wl,-rpath,.
+else ifeq ($(UNAME_S),Linux)
+  LIB_EXT := so
+  RPATH_FLAG := -Wl,-rpath,.
+else
+  LIB_EXT := dll
+  RPATH_FLAG :=
+endif
+
+LIBFOLIO := libfolio.$(LIB_EXT)
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS := -X main.version=$(VERSION)
+
 cshared:
-	CGO_ENABLED=1 go build -buildmode=c-shared -o libfolio.dylib ./export/
-	@echo "Built libfolio.dylib ($$(du -h libfolio.dylib | cut -f1)) — header: libfolio.h"
+	CGO_ENABLED=1 go build -ldflags '$(LDFLAGS)' -buildmode=c-shared -o $(LIBFOLIO) ./export/
+	@echo "Built $(LIBFOLIO) $(VERSION) ($$(du -h $(LIBFOLIO) | cut -f1))"
 
 test-cabi: cshared
-	cc -o export/testdata/test_cabi export/testdata/test_cabi.c -L. -lfolio -Wl,-rpath,.
+	cc -o export/testdata/test_cabi export/testdata/test_cabi.c -L. -lfolio $(RPATH_FLAG)
 	./export/testdata/test_cabi
+
+audit:
+	@bash scripts/audit-cabi.sh
+
+audit-build:
+	@bash scripts/audit-cabi.sh --build
+
+# Cross-compilation targets (requires cross-compilers installed)
+DIST_DIR := dist
+
+cross-linux-amd64:
+	@mkdir -p $(DIST_DIR)
+	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC=x86_64-linux-gnu-gcc \
+		go build -ldflags '$(LDFLAGS)' -buildmode=c-shared -o $(DIST_DIR)/libfolio-linux-x86_64.so ./export/
+	@echo "Built $(DIST_DIR)/libfolio-linux-x86_64.so"
+
+cross-linux-arm64:
+	@mkdir -p $(DIST_DIR)
+	CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc \
+		go build -ldflags '$(LDFLAGS)' -buildmode=c-shared -o $(DIST_DIR)/libfolio-linux-aarch64.so ./export/
+	@echo "Built $(DIST_DIR)/libfolio-linux-aarch64.so"
+
+cross-windows-amd64:
+	@mkdir -p $(DIST_DIR)
+	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc \
+		go build -ldflags '$(LDFLAGS)' -buildmode=c-shared -o $(DIST_DIR)/folio-windows-x86_64.dll ./export/
+	@echo "Built $(DIST_DIR)/folio-windows-x86_64.dll"
+
+cross-macos-arm64:
+	@mkdir -p $(DIST_DIR)
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 \
+		go build -ldflags '$(LDFLAGS)' -buildmode=c-shared -o $(DIST_DIR)/libfolio-macos-aarch64.dylib ./export/
+	@echo "Built $(DIST_DIR)/libfolio-macos-aarch64.dylib"
+
+cross-macos-amd64:
+	@mkdir -p $(DIST_DIR)
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 \
+		go build -ldflags '$(LDFLAGS)' -buildmode=c-shared -o $(DIST_DIR)/libfolio-macos-x86_64.dylib ./export/
+	@echo "Built $(DIST_DIR)/libfolio-macos-x86_64.dylib"
+
+cross-all: cross-linux-amd64 cross-linux-arm64 cross-windows-amd64 cross-macos-arm64 cross-macos-amd64
+	@echo "All platforms built in $(DIST_DIR)/"
+	@ls -lh $(DIST_DIR)/
 
 clean:
 	rm -f coverage.out coverage.html
@@ -44,3 +104,4 @@ clean:
 	rm -f libfolio.dylib libfolio.h libfolio.so folio.dll
 	rm -f export/testdata/test_cabi
 	rm -f *.pdf
+	rm -rf dist/

--- a/export/cabi.go
+++ b/export/cabi.go
@@ -21,8 +21,12 @@ import (
 	"unsafe"
 )
 
-// version is the library version, set at build time or hardcoded.
-const version = "0.2.0-dev"
+// version is the library version, injected at build time via:
+//
+//	-ldflags "-X main.version=v1.2.3"
+//
+// Falls back to "dev" for local development builds.
+var version = "dev"
 
 // versionCStr is a persistent C string for folio_version().
 // Allocated once, never freed — avoids per-call memory leaks.

--- a/export/cabi_barcode.go
+++ b/export/cabi_barcode.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/barcode"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// folio_barcode_qr generates a QR code barcode and returns its handle.
+//
+//export folio_barcode_qr
+func folio_barcode_qr(data *C.char) C.uint64_t {
+	bc, err := barcode.QR(C.GoString(data))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(bc))
+}
+
+// folio_barcode_qr_ecc generates a QR code with the specified error correction level.
+//
+//export folio_barcode_qr_ecc
+func folio_barcode_qr_ecc(data *C.char, level C.int32_t) C.uint64_t {
+	bc, err := barcode.QRWithECC(C.GoString(data), barcode.ECCLevel(level))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(bc))
+}
+
+// folio_barcode_code128 generates a Code 128 barcode and returns its handle.
+//
+//export folio_barcode_code128
+func folio_barcode_code128(data *C.char) C.uint64_t {
+	bc, err := barcode.Code128(C.GoString(data))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(bc))
+}
+
+// folio_barcode_ean13 generates an EAN-13 barcode and returns its handle.
+//
+//export folio_barcode_ean13
+func folio_barcode_ean13(data *C.char) C.uint64_t {
+	bc, err := barcode.EAN13(C.GoString(data))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(bc))
+}
+
+// folio_barcode_width returns the pixel width of a barcode.
+//
+//export folio_barcode_width
+func folio_barcode_width(bcH C.uint64_t) C.int32_t {
+	bc, errCode := loadBarcode(bcH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.int32_t(bc.Width())
+}
+
+// folio_barcode_height returns the pixel height of a barcode.
+//
+//export folio_barcode_height
+func folio_barcode_height(bcH C.uint64_t) C.int32_t {
+	bc, errCode := loadBarcode(bcH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.int32_t(bc.Height())
+}
+
+// folio_barcode_element_new wraps a barcode in a layout element with the given display width.
+//
+//export folio_barcode_element_new
+func folio_barcode_element_new(bcH C.uint64_t, width C.double) C.uint64_t {
+	bc, errCode := loadBarcode(bcH)
+	if errCode != errOK {
+		return 0
+	}
+	be := layout.NewBarcodeElement(bc, float64(width))
+	return C.uint64_t(ht.store(be))
+}
+
+// folio_barcode_element_set_height sets the display height of a barcode element in points.
+//
+//export folio_barcode_element_set_height
+func folio_barcode_element_set_height(beH C.uint64_t, height C.double) C.int32_t {
+	be, errCode := loadBarcodeElement(beH)
+	if errCode != errOK {
+		return errCode
+	}
+	be.SetHeight(float64(height))
+	return errOK
+}
+
+// folio_barcode_element_set_align sets the alignment of a barcode element.
+//
+//export folio_barcode_element_set_align
+func folio_barcode_element_set_align(beH C.uint64_t, align C.int32_t) C.int32_t {
+	be, errCode := loadBarcodeElement(beH)
+	if errCode != errOK {
+		return errCode
+	}
+	be.SetAlign(layout.Align(align))
+	return errOK
+}
+
+// folio_barcode_free removes a barcode handle from the handle table.
+//
+//export folio_barcode_free
+func folio_barcode_free(bcH C.uint64_t) {
+	ht.delete(uint64(bcH))
+}
+
+// folio_barcode_element_free removes a barcode element handle from the handle table.
+//
+//export folio_barcode_element_free
+func folio_barcode_element_free(beH C.uint64_t) {
+	ht.delete(uint64(beH))
+}
+
+func loadBarcode(h C.uint64_t) (*barcode.Barcode, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid barcode handle")
+		return nil, errInvalidHandle
+	}
+	bc, ok := v.(*barcode.Barcode)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a barcode (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return bc, errOK
+}
+
+func loadBarcodeElement(h C.uint64_t) (*layout.BarcodeElement, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid barcode element handle")
+		return nil, errInvalidHandle
+	}
+	be, ok := v.(*layout.BarcodeElement)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a barcode element (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return be, errOK
+}

--- a/export/cabi_columns.go
+++ b/export/cabi_columns.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_columns_new
+func folio_columns_new(cols C.int32_t) C.uint64_t {
+	if cols < 1 {
+		setLastError("columns must be >= 1")
+		return 0
+	}
+	return C.uint64_t(ht.store(layout.NewColumns(int(cols))))
+}
+
+//export folio_columns_set_gap
+func folio_columns_set_gap(colsH C.uint64_t, gap C.double) C.int32_t {
+	c, errCode := loadColumns(colsH)
+	if errCode != errOK {
+		return errCode
+	}
+	c.SetGap(float64(gap))
+	return errOK
+}
+
+//export folio_columns_set_widths
+func folio_columns_set_widths(colsH C.uint64_t, widths *C.double, count C.int32_t) C.int32_t {
+	c, errCode := loadColumns(colsH)
+	if errCode != errOK {
+		return errCode
+	}
+	n := int(count)
+	goWidths := make([]float64, n)
+	cWidths := (*[1 << 20]C.double)(unsafe.Pointer(widths))[:n:n]
+	for i := 0; i < n; i++ {
+		goWidths[i] = float64(cWidths[i])
+	}
+	c.SetWidths(goWidths)
+	return errOK
+}
+
+//export folio_columns_add
+func folio_columns_add(colsH C.uint64_t, colIndex C.int32_t, elemH C.uint64_t) C.int32_t {
+	c, errCode := loadColumns(colsH)
+	if errCode != errOK {
+		return errCode
+	}
+	v := ht.load(uint64(elemH))
+	if v == nil {
+		setLastError("invalid element handle")
+		return errInvalidHandle
+	}
+	elem, ok := v.(layout.Element)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a layout element", uint64(elemH)))
+		return errTypeMismatch
+	}
+	c.Add(int(colIndex), elem)
+	return errOK
+}
+
+//export folio_columns_free
+func folio_columns_free(colsH C.uint64_t) {
+	ht.delete(uint64(colsH))
+}
+
+func loadColumns(h C.uint64_t) (*layout.Columns, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid columns handle")
+		return nil, errInvalidHandle
+	}
+	c, ok := v.(*layout.Columns)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a columns layout (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return c, errOK
+}

--- a/export/cabi_document_ext.go
+++ b/export/cabi_document_ext.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"sync"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_document_set_watermark
+func folio_document_set_watermark(docH C.uint64_t, text *C.char) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetWatermark(C.GoString(text))
+	return errOK
+}
+
+//export folio_document_set_watermark_config
+func folio_document_set_watermark_config(docH C.uint64_t, text *C.char,
+	fontSize, colorR, colorG, colorB, angle, opacity C.double) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetWatermarkConfig(document.WatermarkConfig{
+		Text:     C.GoString(text),
+		FontSize: float64(fontSize),
+		ColorR:   float64(colorR),
+		ColorG:   float64(colorG),
+		ColorB:   float64(colorB),
+		Angle:    float64(angle),
+		Opacity:  float64(opacity),
+	})
+	return errOK
+}
+
+//export folio_document_add_outline
+func folio_document_add_outline(docH C.uint64_t, title *C.char, pageIndex C.int32_t) C.uint64_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return 0
+	}
+	outline := doc.AddOutline(C.GoString(title), document.FitDest(int(pageIndex)))
+	return C.uint64_t(ht.store(outline))
+}
+
+//export folio_document_add_outline_xyz
+func folio_document_add_outline_xyz(docH C.uint64_t, title *C.char,
+	pageIndex C.int32_t, left, top, zoom C.double) C.uint64_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return 0
+	}
+	outline := doc.AddOutline(C.GoString(title),
+		document.XYZDest(int(pageIndex), float64(left), float64(top), float64(zoom)))
+	return C.uint64_t(ht.store(outline))
+}
+
+//export folio_outline_add_child
+func folio_outline_add_child(outlineH C.uint64_t, title *C.char, pageIndex C.int32_t) C.uint64_t {
+	o, errCode := loadOutline(outlineH)
+	if errCode != errOK {
+		return 0
+	}
+	child := o.AddChild(C.GoString(title), document.FitDest(int(pageIndex)))
+	return C.uint64_t(ht.store(child))
+}
+
+//export folio_outline_add_child_xyz
+func folio_outline_add_child_xyz(outlineH C.uint64_t, title *C.char,
+	pageIndex C.int32_t, left, top, zoom C.double) C.uint64_t {
+	o, errCode := loadOutline(outlineH)
+	if errCode != errOK {
+		return 0
+	}
+	child := o.AddChild(C.GoString(title),
+		document.XYZDest(int(pageIndex), float64(left), float64(top), float64(zoom)))
+	return C.uint64_t(ht.store(child))
+}
+
+//export folio_document_add_named_dest
+func folio_document_add_named_dest(docH C.uint64_t, name *C.char, pageIndex C.int32_t,
+	fitType *C.char, top, left, zoom C.double) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.AddNamedDest(document.NamedDest{
+		Name:      C.GoString(name),
+		PageIndex: int(pageIndex),
+		FitType:   C.GoString(fitType),
+		Top:       float64(top),
+		Left:      float64(left),
+		Zoom:      float64(zoom),
+	})
+	return errOK
+}
+
+//export folio_document_set_viewer_preferences
+func folio_document_set_viewer_preferences(docH C.uint64_t,
+	pageLayout, pageMode *C.char,
+	hideToolbar, hideMenubar, hideWindowUI, fitWindow, centerWindow, displayDocTitle C.int32_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetViewerPreferences(document.ViewerPreferences{
+		PageLayout:      document.PageLayout(C.GoString(pageLayout)),
+		PageMode:        document.PageMode(C.GoString(pageMode)),
+		HideToolbar:     hideToolbar != 0,
+		HideMenubar:     hideMenubar != 0,
+		HideWindowUI:    hideWindowUI != 0,
+		FitWindow:       fitWindow != 0,
+		CenterWindow:    centerWindow != 0,
+		DisplayDocTitle: displayDocTitle != 0,
+	})
+	return errOK
+}
+
+//export folio_document_add_page_label
+func folio_document_add_page_label(docH C.uint64_t, pageIndex C.int32_t,
+	style, prefix *C.char, start C.int32_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	label := document.PageLabelRange{
+		PageIndex: int(pageIndex),
+		Style:     document.LabelStyle(C.GoString(style)),
+		Prefix:    C.GoString(prefix),
+		Start:     int(start),
+	}
+	pageLabelsMuImpl.Lock()
+	labels := pageLabels[uint64(docH)]
+	labels = append(labels, label)
+	pageLabels[uint64(docH)] = labels
+	pageLabelsMuImpl.Unlock()
+	doc.SetPageLabels(labels...)
+	return errOK
+}
+
+//export folio_document_remove_page
+func folio_document_remove_page(docH C.uint64_t, index C.int32_t) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	if err := doc.RemovePage(int(index)); err != nil {
+		return setErr(errInvalidArg, err)
+	}
+	return errOK
+}
+
+//export folio_document_add_absolute
+func folio_document_add_absolute(docH C.uint64_t, elemH C.uint64_t, x, y, width C.double) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	v := ht.load(uint64(elemH))
+	if v == nil {
+		setLastError("invalid element handle")
+		return errInvalidHandle
+	}
+	elem, ok := v.(layout.Element)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a layout element", uint64(elemH)))
+		return errTypeMismatch
+	}
+	doc.AddAbsolute(elem, float64(x), float64(y), float64(width))
+	return errOK
+}
+
+//export folio_page_add_internal_link
+func folio_page_add_internal_link(pageH C.uint64_t, x1, y1, x2, y2 C.double, destName *C.char) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.AddInternalLink([4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}, C.GoString(destName))
+	return errOK
+}
+
+//export folio_page_add_text_annotation
+func folio_page_add_text_annotation(pageH C.uint64_t, x1, y1, x2, y2 C.double, text, icon *C.char) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.AddTextAnnotation(
+		[4]float64{float64(x1), float64(y1), float64(x2), float64(y2)},
+		C.GoString(text), C.GoString(icon))
+	return errOK
+}
+
+//export folio_page_set_crop_box
+func folio_page_set_crop_box(pageH C.uint64_t, x1, y1, x2, y2 C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.SetCropBox([4]float64{float64(x1), float64(y1), float64(x2), float64(y2)})
+	return errOK
+}
+
+//export folio_page_set_trim_box
+func folio_page_set_trim_box(pageH C.uint64_t, x1, y1, x2, y2 C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.SetTrimBox([4]float64{float64(x1), float64(y1), float64(x2), float64(y2)})
+	return errOK
+}
+
+//export folio_page_set_bleed_box
+func folio_page_set_bleed_box(pageH C.uint64_t, x1, y1, x2, y2 C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.SetBleedBox([4]float64{float64(x1), float64(y1), float64(x2), float64(y2)})
+	return errOK
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+var (
+	pageLabelsMuImpl sync.Mutex
+	pageLabels       = make(map[uint64][]document.PageLabelRange)
+)
+
+func loadOutline(h C.uint64_t) (*document.Outline, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid outline handle")
+		return nil, errInvalidHandle
+	}
+	o, ok := v.(*document.Outline)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not an outline (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return o, errOK
+}

--- a/export/cabi_document_ext2.go
+++ b/export/cabi_document_ext2.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/carlos7ags/folio/document"
+	foliohtml "github.com/carlos7ags/folio/html"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// ── File attachments ───────────────────────────────────────────────
+
+//export folio_document_attach_file
+func folio_document_attach_file(docH C.uint64_t, data unsafe.Pointer, length C.int32_t,
+	fileName, mimeType, description, afRelationship *C.char) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	if data == nil || length <= 0 {
+		setLastError("invalid attachment data")
+		return errInvalidArg
+	}
+	goData := C.GoBytes(data, C.int(length))
+	doc.AttachFile(document.FileAttachment{
+		FileName:       C.GoString(fileName),
+		MIMEType:       C.GoString(mimeType),
+		Description:    C.GoString(description),
+		AFRelationship: C.GoString(afRelationship),
+		Data:           goData,
+	})
+	return errOK
+}
+
+// ── Inline HTML ────────────────────────────────────────────────────
+
+//export folio_document_add_html
+func folio_document_add_html(docH C.uint64_t, htmlStr *C.char) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	if err := doc.AddHTML(C.GoString(htmlStr), nil); err != nil {
+		return setErr(errPDF, err)
+	}
+	return errOK
+}
+
+//export folio_document_add_html_with_options
+func folio_document_add_html_with_options(docH C.uint64_t, htmlStr *C.char,
+	defaultFontSize, pageWidth, pageHeight C.double,
+	basePath, fallbackFontPath *C.char) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	opts := &foliohtml.Options{
+		DefaultFontSize:  float64(defaultFontSize),
+		PageWidth:        float64(pageWidth),
+		PageHeight:       float64(pageHeight),
+		BasePath:         C.GoString(basePath),
+		FallbackFontPath: C.GoString(fallbackFontPath),
+	}
+	if err := doc.AddHTML(C.GoString(htmlStr), opts); err != nil {
+		return setErr(errPDF, err)
+	}
+	return errOK
+}
+
+// ── Page-specific margins ──────────────────────────────────────────
+
+//export folio_document_set_first_margins
+func folio_document_set_first_margins(docH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetFirstMargins(layout.Margins{
+		Top: float64(top), Right: float64(right),
+		Bottom: float64(bottom), Left: float64(left),
+	})
+	return errOK
+}
+
+//export folio_document_set_left_margins
+func folio_document_set_left_margins(docH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetLeftMargins(layout.Margins{
+		Top: float64(top), Right: float64(right),
+		Bottom: float64(bottom), Left: float64(left),
+	})
+	return errOK
+}
+
+//export folio_document_set_right_margins
+func folio_document_set_right_margins(docH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.SetRightMargins(layout.Margins{
+		Top: float64(top), Right: float64(right),
+		Bottom: float64(bottom), Left: float64(left),
+	})
+	return errOK
+}

--- a/export/cabi_flex.go
+++ b/export/cabi_flex.go
@@ -1,0 +1,248 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_flex_new
+func folio_flex_new() C.uint64_t {
+	return C.uint64_t(ht.store(layout.NewFlex()))
+}
+
+//export folio_flex_add
+func folio_flex_add(flexH C.uint64_t, elemH C.uint64_t) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	v := ht.load(uint64(elemH))
+	if v == nil {
+		setLastError("invalid element handle")
+		return errInvalidHandle
+	}
+	elem, ok := v.(layout.Element)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a layout element", uint64(elemH)))
+		return errTypeMismatch
+	}
+	flex.Add(elem)
+	return errOK
+}
+
+//export folio_flex_add_item
+func folio_flex_add_item(flexH C.uint64_t, itemH C.uint64_t) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	item, errCode := loadFlexItem(itemH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.AddItem(item)
+	return errOK
+}
+
+//export folio_flex_set_direction
+func folio_flex_set_direction(flexH C.uint64_t, direction C.int32_t) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetDirection(layout.FlexDirection(direction))
+	return errOK
+}
+
+//export folio_flex_set_justify_content
+func folio_flex_set_justify_content(flexH C.uint64_t, justify C.int32_t) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetJustifyContent(layout.JustifyContent(justify))
+	return errOK
+}
+
+//export folio_flex_set_align_items
+func folio_flex_set_align_items(flexH C.uint64_t, align C.int32_t) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetAlignItems(layout.AlignItems(align))
+	return errOK
+}
+
+//export folio_flex_set_wrap
+func folio_flex_set_wrap(flexH C.uint64_t, wrap C.int32_t) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetWrap(layout.FlexWrap(wrap))
+	return errOK
+}
+
+//export folio_flex_set_gap
+func folio_flex_set_gap(flexH C.uint64_t, gap C.double) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetGap(float64(gap))
+	return errOK
+}
+
+//export folio_flex_set_padding
+func folio_flex_set_padding(flexH C.uint64_t, padding C.double) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetPadding(float64(padding))
+	return errOK
+}
+
+//export folio_flex_set_background
+func folio_flex_set_background(flexH C.uint64_t, r, g, b C.double) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetBackground(layout.RGB(float64(r), float64(g), float64(b)))
+	return errOK
+}
+
+//export folio_flex_set_space_before
+func folio_flex_set_space_before(flexH C.uint64_t, pts C.double) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetSpaceBefore(float64(pts))
+	return errOK
+}
+
+//export folio_flex_set_space_after
+func folio_flex_set_space_after(flexH C.uint64_t, pts C.double) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetSpaceAfter(float64(pts))
+	return errOK
+}
+
+//export folio_flex_free
+func folio_flex_free(flexH C.uint64_t) {
+	ht.delete(uint64(flexH))
+}
+
+//export folio_flex_item_new
+func folio_flex_item_new(elemH C.uint64_t) C.uint64_t {
+	v := ht.load(uint64(elemH))
+	if v == nil {
+		setLastError("invalid element handle")
+		return 0
+	}
+	elem, ok := v.(layout.Element)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a layout element", uint64(elemH)))
+		return 0
+	}
+	return C.uint64_t(ht.store(layout.NewFlexItem(elem)))
+}
+
+//export folio_flex_item_set_grow
+func folio_flex_item_set_grow(itemH C.uint64_t, grow C.double) C.int32_t {
+	item, errCode := loadFlexItem(itemH)
+	if errCode != errOK {
+		return errCode
+	}
+	item.SetGrow(float64(grow))
+	return errOK
+}
+
+//export folio_flex_item_set_shrink
+func folio_flex_item_set_shrink(itemH C.uint64_t, shrink C.double) C.int32_t {
+	item, errCode := loadFlexItem(itemH)
+	if errCode != errOK {
+		return errCode
+	}
+	item.SetShrink(float64(shrink))
+	return errOK
+}
+
+//export folio_flex_item_set_basis
+func folio_flex_item_set_basis(itemH C.uint64_t, basis C.double) C.int32_t {
+	item, errCode := loadFlexItem(itemH)
+	if errCode != errOK {
+		return errCode
+	}
+	item.SetBasis(float64(basis))
+	return errOK
+}
+
+//export folio_flex_item_set_align_self
+func folio_flex_item_set_align_self(itemH C.uint64_t, align C.int32_t) C.int32_t {
+	item, errCode := loadFlexItem(itemH)
+	if errCode != errOK {
+		return errCode
+	}
+	item.SetAlignSelf(layout.AlignItems(align))
+	return errOK
+}
+
+//export folio_flex_item_set_margins
+func folio_flex_item_set_margins(itemH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
+	item, errCode := loadFlexItem(itemH)
+	if errCode != errOK {
+		return errCode
+	}
+	item.SetMargins(float64(top), float64(right), float64(bottom), float64(left))
+	return errOK
+}
+
+//export folio_flex_item_free
+func folio_flex_item_free(itemH C.uint64_t) {
+	ht.delete(uint64(itemH))
+}
+
+func loadFlex(h C.uint64_t) (*layout.Flex, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid flex handle")
+		return nil, errInvalidHandle
+	}
+	f, ok := v.(*layout.Flex)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a flex container (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return f, errOK
+}
+
+func loadFlexItem(h C.uint64_t) (*layout.FlexItem, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid flex item handle")
+		return nil, errInvalidHandle
+	}
+	item, ok := v.(*layout.FlexItem)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a flex item (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return item, errOK
+}

--- a/export/cabi_float.go
+++ b/export/cabi_float.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_float_new
+func folio_float_new(side C.int32_t, elemH C.uint64_t) C.uint64_t {
+	v := ht.load(uint64(elemH))
+	if v == nil {
+		setLastError("invalid element handle")
+		return 0
+	}
+	elem, ok := v.(layout.Element)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a layout element", uint64(elemH)))
+		return 0
+	}
+	f := layout.NewFloat(layout.FloatSide(side), elem)
+	return C.uint64_t(ht.store(f))
+}
+
+//export folio_float_set_margin
+func folio_float_set_margin(floatH C.uint64_t, margin C.double) C.int32_t {
+	f, errCode := loadFloat(floatH)
+	if errCode != errOK {
+		return errCode
+	}
+	f.SetMargin(float64(margin))
+	return errOK
+}
+
+//export folio_float_free
+func folio_float_free(floatH C.uint64_t) {
+	ht.delete(uint64(floatH))
+}
+
+func loadFloat(h C.uint64_t) (*layout.Float, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid float handle")
+		return nil, errInvalidHandle
+	}
+	f, ok := v.(*layout.Float)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a float (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return f, errOK
+}

--- a/export/cabi_font.go
+++ b/export/cabi_font.go
@@ -82,6 +82,69 @@ func folio_font_courier() C.uint64_t {
 	return C.uint64_t(standardFontHandles[font.Courier.Name()])
 }
 
+// folio_font_helvetica_oblique returns the handle for the Helvetica-Oblique standard font.
+//
+//export folio_font_helvetica_oblique
+func folio_font_helvetica_oblique() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.HelveticaOblique.Name()])
+}
+
+// folio_font_helvetica_bold_oblique returns the handle for the Helvetica-BoldOblique standard font.
+//
+//export folio_font_helvetica_bold_oblique
+func folio_font_helvetica_bold_oblique() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.HelveticaBoldOblique.Name()])
+}
+
+// folio_font_times_italic returns the handle for the Times-Italic standard font.
+//
+//export folio_font_times_italic
+func folio_font_times_italic() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.TimesItalic.Name()])
+}
+
+// folio_font_times_bold_italic returns the handle for the Times-BoldItalic standard font.
+//
+//export folio_font_times_bold_italic
+func folio_font_times_bold_italic() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.TimesBoldItalic.Name()])
+}
+
+// folio_font_courier_bold returns the handle for the Courier-Bold standard font.
+//
+//export folio_font_courier_bold
+func folio_font_courier_bold() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.CourierBold.Name()])
+}
+
+// folio_font_courier_oblique returns the handle for the Courier-Oblique standard font.
+//
+//export folio_font_courier_oblique
+func folio_font_courier_oblique() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.CourierOblique.Name()])
+}
+
+// folio_font_courier_bold_oblique returns the handle for the Courier-BoldOblique standard font.
+//
+//export folio_font_courier_bold_oblique
+func folio_font_courier_bold_oblique() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.CourierBoldOblique.Name()])
+}
+
+// folio_font_symbol returns the handle for the Symbol standard font.
+//
+//export folio_font_symbol
+func folio_font_symbol() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.Symbol.Name()])
+}
+
+// folio_font_zapf_dingbats returns the handle for the ZapfDingbats standard font.
+//
+//export folio_font_zapf_dingbats
+func folio_font_zapf_dingbats() C.uint64_t {
+	return C.uint64_t(standardFontHandles[font.ZapfDingbats.Name()])
+}
+
 // folio_font_load_ttf loads a TrueType font from a file path and returns its handle.
 //
 //export folio_font_load_ttf

--- a/export/cabi_forms_ext.go
+++ b/export/cabi_forms_ext.go
@@ -1,0 +1,280 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/carlos7ags/folio/forms"
+)
+
+// ── Form field configuration ───────────────────────────────────────
+
+//export folio_form_add_multiline_text_field
+func folio_form_add_multiline_text_field(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t) C.int32_t {
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	af.Add(forms.MultilineTextField(C.GoString(name), rect, int(pageIndex)))
+	return errOK
+}
+
+//export folio_form_add_password_field
+func folio_form_add_password_field(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t) C.int32_t {
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	af.Add(forms.PasswordField(C.GoString(name), rect, int(pageIndex)))
+	return errOK
+}
+
+//export folio_form_add_listbox
+func folio_form_add_listbox(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t, options **C.char, optCount C.int32_t) C.int32_t {
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	n := int(optCount)
+	goOpts := make([]string, n)
+	if n > 0 && options != nil {
+		cArray := (*[1 << 20]*C.char)(unsafe.Pointer(options))[:n:n]
+		for i := 0; i < n; i++ {
+			goOpts[i] = C.GoString(cArray[i])
+		}
+	}
+	af.Add(forms.ListBox(C.GoString(name), rect, int(pageIndex), goOpts))
+	return errOK
+}
+
+//export folio_form_add_radio_group
+func folio_form_add_radio_group(formH C.uint64_t, name *C.char,
+	values **C.char, rects *C.double, pageIndices *C.int32_t, count C.int32_t) C.int32_t {
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	n := int(count)
+	if n <= 0 {
+		setLastError("radio group requires at least one option")
+		return errInvalidArg
+	}
+	cValues := (*[1 << 20]*C.char)(unsafe.Pointer(values))[:n:n]
+	cRects := (*[1 << 20]C.double)(unsafe.Pointer(rects))[: n*4 : n*4]
+	cPages := (*[1 << 20]C.int32_t)(unsafe.Pointer(pageIndices))[:n:n]
+
+	opts := make([]forms.RadioOption, n)
+	for i := 0; i < n; i++ {
+		opts[i] = forms.RadioOption{
+			Value:     C.GoString(cValues[i]),
+			Rect:      [4]float64{float64(cRects[i*4]), float64(cRects[i*4+1]), float64(cRects[i*4+2]), float64(cRects[i*4+3])},
+			PageIndex: int(cPages[i]),
+		}
+	}
+	af.Add(forms.RadioGroup(C.GoString(name), opts))
+	return errOK
+}
+
+//export folio_form_field_set_value
+func folio_form_field_set_value(fieldH C.uint64_t, value *C.char) C.int32_t {
+	f, errCode := loadField(fieldH)
+	if errCode != errOK {
+		return errCode
+	}
+	f.SetValue(C.GoString(value))
+	return errOK
+}
+
+//export folio_form_field_set_read_only
+func folio_form_field_set_read_only(fieldH C.uint64_t) C.int32_t {
+	f, errCode := loadField(fieldH)
+	if errCode != errOK {
+		return errCode
+	}
+	f.SetReadOnly()
+	return errOK
+}
+
+//export folio_form_field_set_required
+func folio_form_field_set_required(fieldH C.uint64_t) C.int32_t {
+	f, errCode := loadField(fieldH)
+	if errCode != errOK {
+		return errCode
+	}
+	f.SetRequired()
+	return errOK
+}
+
+//export folio_form_field_set_background_color
+func folio_form_field_set_background_color(fieldH C.uint64_t, r, g, b C.double) C.int32_t {
+	f, errCode := loadField(fieldH)
+	if errCode != errOK {
+		return errCode
+	}
+	f.SetBackgroundColor(float64(r), float64(g), float64(b))
+	return errOK
+}
+
+//export folio_form_field_set_border_color
+func folio_form_field_set_border_color(fieldH C.uint64_t, r, g, b C.double) C.int32_t {
+	f, errCode := loadField(fieldH)
+	if errCode != errOK {
+		return errCode
+	}
+	f.SetBorderColor(float64(r), float64(g), float64(b))
+	return errOK
+}
+
+// ── Form field creation returning handles ──────────────────────────
+
+//export folio_form_create_text_field
+func folio_form_create_text_field(name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t) C.uint64_t {
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	f := forms.TextField(C.GoString(name), rect, int(pageIndex))
+	return C.uint64_t(ht.store(f))
+}
+
+//export folio_form_create_checkbox
+func folio_form_create_checkbox(name *C.char, x1, y1, x2, y2 C.double, pageIndex C.int32_t, checked C.int32_t) C.uint64_t {
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	f := forms.Checkbox(C.GoString(name), rect, int(pageIndex), checked != 0)
+	return C.uint64_t(ht.store(f))
+}
+
+//export folio_form_add_field
+func folio_form_add_field(formH C.uint64_t, fieldH C.uint64_t) C.int32_t {
+	af, errCode := loadForm(formH)
+	if errCode != errOK {
+		return errCode
+	}
+	f, errCode := loadField(fieldH)
+	if errCode != errOK {
+		return errCode
+	}
+	af.Add(f)
+	return errOK
+}
+
+//export folio_form_field_free
+func folio_form_field_free(fieldH C.uint64_t) {
+	ht.delete(uint64(fieldH))
+}
+
+// ── Form Filling ───────────────────────────────────────────────────
+
+//export folio_form_filler_new
+func folio_form_filler_new(readerH C.uint64_t) C.uint64_t {
+	r, errCode := loadReader(readerH)
+	if errCode != errOK {
+		return 0
+	}
+	ff := forms.NewFormFiller(r)
+	return C.uint64_t(ht.store(ff))
+}
+
+//export folio_form_filler_field_names
+func folio_form_filler_field_names(ffH C.uint64_t) C.uint64_t {
+	ff, errCode := loadFormFiller(ffH)
+	if errCode != errOK {
+		return 0
+	}
+	names, err := ff.FieldNames()
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	// Join with newlines and return as buffer.
+	result := ""
+	for i, n := range names {
+		if i > 0 {
+			result += "\n"
+		}
+		result += n
+	}
+	return C.uint64_t(ht.store(newCBuffer([]byte(result))))
+}
+
+//export folio_form_filler_get_value
+func folio_form_filler_get_value(ffH C.uint64_t, fieldName *C.char) C.uint64_t {
+	ff, errCode := loadFormFiller(ffH)
+	if errCode != errOK {
+		return 0
+	}
+	val, err := ff.GetValue(C.GoString(fieldName))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(newCBuffer([]byte(val))))
+}
+
+//export folio_form_filler_set_value
+func folio_form_filler_set_value(ffH C.uint64_t, fieldName, value *C.char) C.int32_t {
+	ff, errCode := loadFormFiller(ffH)
+	if errCode != errOK {
+		return errCode
+	}
+	if err := ff.SetValue(C.GoString(fieldName), C.GoString(value)); err != nil {
+		return setErr(errInvalidArg, err)
+	}
+	return errOK
+}
+
+//export folio_form_filler_set_checkbox
+func folio_form_filler_set_checkbox(ffH C.uint64_t, fieldName *C.char, checked C.int32_t) C.int32_t {
+	ff, errCode := loadFormFiller(ffH)
+	if errCode != errOK {
+		return errCode
+	}
+	if err := ff.SetCheckbox(C.GoString(fieldName), checked != 0); err != nil {
+		return setErr(errInvalidArg, err)
+	}
+	return errOK
+}
+
+//export folio_form_filler_free
+func folio_form_filler_free(ffH C.uint64_t) {
+	ht.delete(uint64(ffH))
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+func loadField(h C.uint64_t) (*forms.Field, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid field handle")
+		return nil, errInvalidHandle
+	}
+	f, ok := v.(*forms.Field)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a form field (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return f, errOK
+}
+
+func loadFormFiller(h C.uint64_t) (*forms.FormFiller, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid form filler handle")
+		return nil, errInvalidHandle
+	}
+	ff, ok := v.(*forms.FormFiller)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a form filler (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return ff, errOK
+}

--- a/export/cabi_grid.go
+++ b/export/cabi_grid.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_grid_new
+func folio_grid_new() C.uint64_t {
+	return C.uint64_t(ht.store(layout.NewGrid()))
+}
+
+//export folio_grid_add_child
+func folio_grid_add_child(gridH C.uint64_t, elemH C.uint64_t) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	v := ht.load(uint64(elemH))
+	if v == nil {
+		setLastError("invalid element handle")
+		return errInvalidHandle
+	}
+	elem, ok := v.(layout.Element)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a layout element", uint64(elemH)))
+		return errTypeMismatch
+	}
+	g.AddChild(elem)
+	return errOK
+}
+
+// folio_grid_set_template_columns sets column tracks.
+// types and values are parallel arrays of length count.
+// Types: 0=px, 1=percent, 2=fr, 3=auto.
+//
+//export folio_grid_set_template_columns
+func folio_grid_set_template_columns(gridH C.uint64_t, types *C.int32_t, values *C.double, count C.int32_t) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	n := int(count)
+	tracks := parseGridTracks(types, values, n)
+	g.SetTemplateColumns(tracks)
+	return errOK
+}
+
+//export folio_grid_set_template_rows
+func folio_grid_set_template_rows(gridH C.uint64_t, types *C.int32_t, values *C.double, count C.int32_t) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	n := int(count)
+	tracks := parseGridTracks(types, values, n)
+	g.SetTemplateRows(tracks)
+	return errOK
+}
+
+//export folio_grid_set_auto_rows
+func folio_grid_set_auto_rows(gridH C.uint64_t, types *C.int32_t, values *C.double, count C.int32_t) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	n := int(count)
+	tracks := parseGridTracks(types, values, n)
+	g.SetAutoRows(tracks)
+	return errOK
+}
+
+//export folio_grid_set_gap
+func folio_grid_set_gap(gridH C.uint64_t, rowGap, colGap C.double) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetGap(float64(rowGap), float64(colGap))
+	return errOK
+}
+
+//export folio_grid_set_placement
+func folio_grid_set_placement(gridH C.uint64_t, childIndex C.int32_t,
+	colStart, colEnd, rowStart, rowEnd C.int32_t) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetPlacement(int(childIndex), layout.GridPlacement{
+		ColStart: int(colStart), ColEnd: int(colEnd),
+		RowStart: int(rowStart), RowEnd: int(rowEnd),
+	})
+	return errOK
+}
+
+//export folio_grid_set_padding
+func folio_grid_set_padding(gridH C.uint64_t, padding C.double) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetPadding(float64(padding))
+	return errOK
+}
+
+//export folio_grid_set_background
+func folio_grid_set_background(gridH C.uint64_t, r, g2, b C.double) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetBackground(layout.RGB(float64(r), float64(g2), float64(b)))
+	return errOK
+}
+
+//export folio_grid_set_justify_items
+func folio_grid_set_justify_items(gridH C.uint64_t, align C.int32_t) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetJustifyItems(layout.AlignItems(align))
+	return errOK
+}
+
+//export folio_grid_set_align_items
+func folio_grid_set_align_items(gridH C.uint64_t, align C.int32_t) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetAlignItems(layout.AlignItems(align))
+	return errOK
+}
+
+//export folio_grid_set_justify_content
+func folio_grid_set_justify_content(gridH C.uint64_t, justify C.int32_t) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetJustifyContent(layout.JustifyContent(justify))
+	return errOK
+}
+
+//export folio_grid_set_align_content
+func folio_grid_set_align_content(gridH C.uint64_t, align C.int32_t) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetAlignContent(layout.JustifyContent(align))
+	return errOK
+}
+
+//export folio_grid_set_space_before
+func folio_grid_set_space_before(gridH C.uint64_t, pts C.double) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetSpaceBefore(float64(pts))
+	return errOK
+}
+
+//export folio_grid_set_space_after
+func folio_grid_set_space_after(gridH C.uint64_t, pts C.double) C.int32_t {
+	g, errCode := loadGrid(gridH)
+	if errCode != errOK {
+		return errCode
+	}
+	g.SetSpaceAfter(float64(pts))
+	return errOK
+}
+
+//export folio_grid_free
+func folio_grid_free(gridH C.uint64_t) {
+	ht.delete(uint64(gridH))
+}
+
+func parseGridTracks(types *C.int32_t, values *C.double, n int) []layout.GridTrack {
+	tracks := make([]layout.GridTrack, n)
+	cTypes := (*[1 << 20]C.int32_t)(unsafe.Pointer(types))[:n:n]
+	cValues := (*[1 << 20]C.double)(unsafe.Pointer(values))[:n:n]
+	for i := 0; i < n; i++ {
+		tracks[i] = layout.GridTrack{
+			Type:  layout.GridTrackType(cTypes[i]),
+			Value: float64(cValues[i]),
+		}
+	}
+	return tracks
+}
+
+func loadGrid(h C.uint64_t) (*layout.Grid, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid grid handle")
+		return nil, errInvalidHandle
+	}
+	g, ok := v.(*layout.Grid)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a grid (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return g, errOK
+}

--- a/export/cabi_layout_ext.go
+++ b/export/cabi_layout_ext.go
@@ -1,0 +1,352 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	folioimage "github.com/carlos7ags/folio/image"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// ── Paragraph extensions ───────────────────────────────────────────
+
+//export folio_paragraph_set_orphans
+func folio_paragraph_set_orphans(pH C.uint64_t, n C.int32_t) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetOrphans(int(n))
+	return errOK
+}
+
+//export folio_paragraph_set_widows
+func folio_paragraph_set_widows(pH C.uint64_t, n C.int32_t) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetWidows(int(n))
+	return errOK
+}
+
+//export folio_paragraph_set_ellipsis
+func folio_paragraph_set_ellipsis(pH C.uint64_t, enabled C.int32_t) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetEllipsis(enabled != 0)
+	return errOK
+}
+
+//export folio_paragraph_set_word_break
+func folio_paragraph_set_word_break(pH C.uint64_t, wb *C.char) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetWordBreak(C.GoString(wb))
+	return errOK
+}
+
+//export folio_paragraph_set_hyphens
+func folio_paragraph_set_hyphens(pH C.uint64_t, h *C.char) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	p.SetHyphens(C.GoString(h))
+	return errOK
+}
+
+// ── Table extensions ───────────────────────────────────────────────
+
+//export folio_table_add_footer_row
+func folio_table_add_footer_row(tH C.uint64_t) C.uint64_t {
+	t, errCode := loadTable(tH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.uint64_t(ht.store(t.AddFooterRow()))
+}
+
+//export folio_table_set_cell_spacing
+func folio_table_set_cell_spacing(tH C.uint64_t, h, v C.double) C.int32_t {
+	t, errCode := loadTable(tH)
+	if errCode != errOK {
+		return errCode
+	}
+	t.SetCellSpacing(float64(h), float64(v))
+	return errOK
+}
+
+//export folio_table_set_auto_column_widths
+func folio_table_set_auto_column_widths(tH C.uint64_t) C.int32_t {
+	t, errCode := loadTable(tH)
+	if errCode != errOK {
+		return errCode
+	}
+	t.SetAutoColumnWidths()
+	return errOK
+}
+
+//export folio_table_set_min_width
+func folio_table_set_min_width(tH C.uint64_t, pts C.double) C.int32_t {
+	t, errCode := loadTable(tH)
+	if errCode != errOK {
+		return errCode
+	}
+	t.SetMinWidth(float64(pts))
+	return errOK
+}
+
+// ── Cell extensions ────────────────────────────────────────────────
+
+//export folio_cell_set_padding_sides
+func folio_cell_set_padding_sides(cH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	cell.SetPaddingSides(layout.Padding{
+		Top: float64(top), Right: float64(right),
+		Bottom: float64(bottom), Left: float64(left),
+	})
+	return errOK
+}
+
+//export folio_cell_set_valign
+func folio_cell_set_valign(cH C.uint64_t, valign C.int32_t) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	cell.SetVAlign(layout.VAlign(valign))
+	return errOK
+}
+
+//export folio_cell_set_borders
+func folio_cell_set_borders(cH C.uint64_t,
+	topW, topR, topG, topB C.double,
+	rightW, rightR, rightG, rightB C.double,
+	bottomW, bottomR, bottomG, bottomB C.double,
+	leftW, leftR, leftG, leftB C.double) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	cell.SetBorders(layout.CellBorders{
+		Top:    layout.Border{Width: float64(topW), Color: layout.RGB(float64(topR), float64(topG), float64(topB))},
+		Right:  layout.Border{Width: float64(rightW), Color: layout.RGB(float64(rightR), float64(rightG), float64(rightB))},
+		Bottom: layout.Border{Width: float64(bottomW), Color: layout.RGB(float64(bottomR), float64(bottomG), float64(bottomB))},
+		Left:   layout.Border{Width: float64(leftW), Color: layout.RGB(float64(leftR), float64(leftG), float64(leftB))},
+	})
+	return errOK
+}
+
+//export folio_cell_set_border
+func folio_cell_set_border(cH C.uint64_t, width, r, g, b C.double) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	b1 := layout.Border{Width: float64(width), Color: layout.RGB(float64(r), float64(g), float64(b))}
+	cell.SetBorders(layout.CellBorders{Top: b1, Right: b1, Bottom: b1, Left: b1})
+	return errOK
+}
+
+//export folio_cell_set_width_hint
+func folio_cell_set_width_hint(cH C.uint64_t, pts C.double) C.int32_t {
+	cell, errCode := loadCell(cH)
+	if errCode != errOK {
+		return errCode
+	}
+	cell.SetWidthHint(float64(pts))
+	return errOK
+}
+
+// ── Div extensions ─────────────────────────────────────────────────
+
+//export folio_div_set_border_radius
+func folio_div_set_border_radius(divH C.uint64_t, r C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetBorderRadius(float64(r))
+	return errOK
+}
+
+//export folio_div_set_opacity
+func folio_div_set_opacity(divH C.uint64_t, opacity C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetOpacity(float64(opacity))
+	return errOK
+}
+
+//export folio_div_set_overflow
+func folio_div_set_overflow(divH C.uint64_t, overflow *C.char) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetOverflow(C.GoString(overflow))
+	return errOK
+}
+
+//export folio_div_set_max_width
+func folio_div_set_max_width(divH C.uint64_t, pts C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetMaxWidth(float64(pts))
+	return errOK
+}
+
+//export folio_div_set_min_width
+func folio_div_set_min_width(divH C.uint64_t, pts C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetMinWidth(float64(pts))
+	return errOK
+}
+
+// ── List extensions ────────────────────────────────────────────────
+
+//export folio_list_set_leading
+func folio_list_set_leading(listH C.uint64_t, leading C.double) C.int32_t {
+	l, errCode := loadList(listH)
+	if errCode != errOK {
+		return errCode
+	}
+	l.SetLeading(float64(leading))
+	return errOK
+}
+
+//export folio_list_add_nested_item
+func folio_list_add_nested_item(listH C.uint64_t, text *C.char) C.uint64_t {
+	l, errCode := loadList(listH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.uint64_t(ht.store(l.AddItemWithSubList(C.GoString(text))))
+}
+
+// ── Image element extensions ───────────────────────────────────────
+
+//export folio_image_element_set_align
+func folio_image_element_set_align(ieH C.uint64_t, align C.int32_t) C.int32_t {
+	v := ht.load(uint64(ieH))
+	if v == nil {
+		setLastError("invalid image element handle")
+		return errInvalidHandle
+	}
+	ie, ok := v.(*layout.ImageElement)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not an image element", uint64(ieH)))
+		return errTypeMismatch
+	}
+	ie.SetAlign(layout.Align(align))
+	return errOK
+}
+
+// ── Flex extensions ────────────────────────────────────────────────
+
+//export folio_flex_set_row_gap
+func folio_flex_set_row_gap(flexH C.uint64_t, gap C.double) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetRowGap(float64(gap))
+	return errOK
+}
+
+//export folio_flex_set_column_gap
+func folio_flex_set_column_gap(flexH C.uint64_t, gap C.double) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetColumnGap(float64(gap))
+	return errOK
+}
+
+//export folio_flex_set_padding_all
+func folio_flex_set_padding_all(flexH C.uint64_t, top, right, bottom, left C.double) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetPaddingAll(layout.Padding{
+		Top: float64(top), Right: float64(right),
+		Bottom: float64(bottom), Left: float64(left),
+	})
+	return errOK
+}
+
+//export folio_flex_set_border
+func folio_flex_set_border(flexH C.uint64_t, width, r, g, b C.double) C.int32_t {
+	flex, errCode := loadFlex(flexH)
+	if errCode != errOK {
+		return errCode
+	}
+	flex.SetBorder(layout.SolidBorder(float64(width), layout.RGB(float64(r), float64(g), float64(b))))
+	return errOK
+}
+
+// ── Div box shadow ─────────────────────────────────────────────────
+
+//export folio_div_set_box_shadow
+func folio_div_set_box_shadow(divH C.uint64_t,
+	offsetX, offsetY, blur, spread C.double, r, g, b C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetBoxShadow(layout.BoxShadow{
+		OffsetX: float64(offsetX),
+		OffsetY: float64(offsetY),
+		Blur:    float64(blur),
+		Spread:  float64(spread),
+		Color:   layout.RGB(float64(r), float64(g), float64(b)),
+	})
+	return errOK
+}
+
+//export folio_div_set_max_height
+func folio_div_set_max_height(divH C.uint64_t, pts C.double) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetMaxHeight(float64(pts))
+	return errOK
+}
+
+// ── Image TIFF support ─────────────────────────────────────────────
+
+//export folio_image_load_tiff
+func folio_image_load_tiff(path *C.char) C.uint64_t {
+	img, err := folioimage.LoadTIFF(C.GoString(path))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(img))
+}

--- a/export/cabi_link.go
+++ b/export/cabi_link.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+//export folio_link_new
+func folio_link_new(text, uri *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	f, errCode := loadStandardFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	lnk := layout.NewLink(C.GoString(text), C.GoString(uri), f, float64(fontSize))
+	return C.uint64_t(ht.store(lnk))
+}
+
+//export folio_link_new_embedded
+func folio_link_new_embedded(text, uri *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	ef, errCode := loadEmbeddedFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	lnk := layout.NewLinkEmbedded(C.GoString(text), C.GoString(uri), ef, float64(fontSize))
+	return C.uint64_t(ht.store(lnk))
+}
+
+//export folio_link_new_internal
+func folio_link_new_internal(text, destName *C.char, fontH C.uint64_t, fontSize C.double) C.uint64_t {
+	f, errCode := loadStandardFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	lnk := layout.NewInternalLink(C.GoString(text), C.GoString(destName), f, float64(fontSize))
+	return C.uint64_t(ht.store(lnk))
+}
+
+//export folio_link_set_color
+func folio_link_set_color(linkH C.uint64_t, r, g, b C.double) C.int32_t {
+	lnk, errCode := loadLink(linkH)
+	if errCode != errOK {
+		return errCode
+	}
+	lnk.SetColor(layout.RGB(float64(r), float64(g), float64(b)))
+	return errOK
+}
+
+//export folio_link_set_underline
+func folio_link_set_underline(linkH C.uint64_t) C.int32_t {
+	lnk, errCode := loadLink(linkH)
+	if errCode != errOK {
+		return errCode
+	}
+	lnk.SetUnderline()
+	return errOK
+}
+
+//export folio_link_set_align
+func folio_link_set_align(linkH C.uint64_t, align C.int32_t) C.int32_t {
+	lnk, errCode := loadLink(linkH)
+	if errCode != errOK {
+		return errCode
+	}
+	lnk.SetAlign(layout.Align(align))
+	return errOK
+}
+
+//export folio_link_free
+func folio_link_free(linkH C.uint64_t) {
+	ht.delete(uint64(linkH))
+}
+
+func loadLink(h C.uint64_t) (*layout.Link, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid link handle")
+		return nil, errInvalidHandle
+	}
+	lnk, ok := v.(*layout.Link)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a link (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return lnk, errOK
+}

--- a/export/cabi_page_ext.go
+++ b/export/cabi_page_ext.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/carlos7ags/folio/document"
+)
+
+//export folio_page_set_art_box
+func folio_page_set_art_box(pageH C.uint64_t, x1, y1, x2, y2 C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.SetArtBox([4]float64{float64(x1), float64(y1), float64(x2), float64(y2)})
+	return errOK
+}
+
+//export folio_page_set_size
+func folio_page_set_size(pageH C.uint64_t, width, height C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.SetSize(document.PageSize{Width: float64(width), Height: float64(height)})
+	return errOK
+}
+
+//export folio_page_add_page_link
+func folio_page_add_page_link(pageH C.uint64_t, x1, y1, x2, y2 C.double, targetPage C.int32_t) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.AddPageLink([4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}, int(targetPage))
+	return errOK
+}
+
+//export folio_page_set_opacity_fill_stroke
+func folio_page_set_opacity_fill_stroke(pageH C.uint64_t, fillAlpha, strokeAlpha C.double) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	page.SetOpacityFillStroke(float64(fillAlpha), float64(strokeAlpha))
+	return errOK
+}
+
+//export folio_page_add_highlight
+func folio_page_add_highlight(pageH C.uint64_t, x1, y1, x2, y2 C.double,
+	r, g, b C.double, quadPoints unsafe.Pointer, quadCount C.int32_t) C.int32_t {
+	return pageTextMarkup(pageH, document.MarkupHighlight, x1, y1, x2, y2, r, g, b, quadPoints, quadCount)
+}
+
+//export folio_page_add_underline_annotation
+func folio_page_add_underline_annotation(pageH C.uint64_t, x1, y1, x2, y2 C.double,
+	r, g, b C.double, quadPoints unsafe.Pointer, quadCount C.int32_t) C.int32_t {
+	return pageTextMarkup(pageH, document.MarkupUnderline, x1, y1, x2, y2, r, g, b, quadPoints, quadCount)
+}
+
+//export folio_page_add_squiggly
+func folio_page_add_squiggly(pageH C.uint64_t, x1, y1, x2, y2 C.double,
+	r, g, b C.double, quadPoints unsafe.Pointer, quadCount C.int32_t) C.int32_t {
+	return pageTextMarkup(pageH, document.MarkupSquiggly, x1, y1, x2, y2, r, g, b, quadPoints, quadCount)
+}
+
+//export folio_page_add_strikeout
+func folio_page_add_strikeout(pageH C.uint64_t, x1, y1, x2, y2 C.double,
+	r, g, b C.double, quadPoints unsafe.Pointer, quadCount C.int32_t) C.int32_t {
+	return pageTextMarkup(pageH, document.MarkupStrikeOut, x1, y1, x2, y2, r, g, b, quadPoints, quadCount)
+}
+
+// pageTextMarkup is a helper for all text markup annotations.
+// quadPoints is a flat array of 8*quadCount doubles.
+func pageTextMarkup(pageH C.uint64_t, markupType document.MarkupType,
+	x1, y1, x2, y2, r, g, b C.double,
+	quadPoints unsafe.Pointer, quadCount C.int32_t) C.int32_t {
+	page, errCode := loadPage(pageH)
+	if errCode != errOK {
+		return errCode
+	}
+	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
+	color := [3]float64{float64(r), float64(g), float64(b)}
+
+	n := int(quadCount)
+	var qp [][8]float64
+	if n > 0 && quadPoints != nil {
+		flat := (*[1 << 20]C.double)(quadPoints)[: n*8 : n*8]
+		qp = make([][8]float64, n)
+		for i := 0; i < n; i++ {
+			for j := 0; j < 8; j++ {
+				qp[i][j] = float64(flat[i*8+j])
+			}
+		}
+	}
+	page.AddTextMarkup(markupType, rect, color, qp)
+	return errOK
+}

--- a/export/cabi_svg.go
+++ b/export/cabi_svg.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/carlos7ags/folio/layout"
+	"github.com/carlos7ags/folio/svg"
+)
+
+//export folio_svg_parse
+func folio_svg_parse(svgXML *C.char) C.uint64_t {
+	s, err := svg.Parse(C.GoString(svgXML))
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(s))
+}
+
+//export folio_svg_parse_bytes
+func folio_svg_parse_bytes(data unsafe.Pointer, length C.int32_t) C.uint64_t {
+	if data == nil || length <= 0 {
+		setLastError("invalid SVG data")
+		return 0
+	}
+	goData := C.GoBytes(data, C.int(length))
+	s, err := svg.ParseBytes(goData)
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(s))
+}
+
+//export folio_svg_width
+func folio_svg_width(svgH C.uint64_t) C.double {
+	s, errCode := loadSVG(svgH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.double(s.Width())
+}
+
+//export folio_svg_height
+func folio_svg_height(svgH C.uint64_t) C.double {
+	s, errCode := loadSVG(svgH)
+	if errCode != errOK {
+		return 0
+	}
+	return C.double(s.Height())
+}
+
+//export folio_svg_element_new
+func folio_svg_element_new(svgH C.uint64_t) C.uint64_t {
+	s, errCode := loadSVG(svgH)
+	if errCode != errOK {
+		return 0
+	}
+	se := layout.NewSVGElement(s)
+	return C.uint64_t(ht.store(se))
+}
+
+//export folio_svg_element_set_size
+func folio_svg_element_set_size(seH C.uint64_t, w, h C.double) C.int32_t {
+	se, errCode := loadSVGElement(seH)
+	if errCode != errOK {
+		return errCode
+	}
+	se.SetSize(float64(w), float64(h))
+	return errOK
+}
+
+//export folio_svg_element_set_align
+func folio_svg_element_set_align(seH C.uint64_t, align C.int32_t) C.int32_t {
+	se, errCode := loadSVGElement(seH)
+	if errCode != errOK {
+		return errCode
+	}
+	se.SetAlign(layout.Align(align))
+	return errOK
+}
+
+//export folio_svg_free
+func folio_svg_free(svgH C.uint64_t) {
+	ht.delete(uint64(svgH))
+}
+
+//export folio_svg_element_free
+func folio_svg_element_free(seH C.uint64_t) {
+	ht.delete(uint64(seH))
+}
+
+func loadSVG(h C.uint64_t) (*svg.SVG, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid SVG handle")
+		return nil, errInvalidHandle
+	}
+	s, ok := v.(*svg.SVG)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not an SVG (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return s, errOK
+}
+
+func loadSVGElement(h C.uint64_t) (*layout.SVGElement, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid SVG element handle")
+		return nil, errInvalidHandle
+	}
+	se, ok := v.(*layout.SVGElement)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not an SVG element (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return se, errOK
+}

--- a/export/cabi_tab.go
+++ b/export/cabi_tab.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// folio_tabbed_line_new creates a tabbed line with tab stops.
+// positions, aligns, leaders are parallel arrays of length count.
+// aligns: 0=left, 1=right, 2=center. leaders: rune value (0=none, '.'=dot).
+//
+//export folio_tabbed_line_new
+func folio_tabbed_line_new(fontH C.uint64_t, fontSize C.double,
+	positions *C.double, aligns *C.int32_t, leaders *C.int32_t, count C.int32_t) C.uint64_t {
+	f, errCode := loadStandardFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	n := int(count)
+	stops := parseTabs(positions, aligns, leaders, n)
+	tl := layout.NewTabbedLine(f, float64(fontSize), stops...)
+	return C.uint64_t(ht.store(tl))
+}
+
+//export folio_tabbed_line_new_embedded
+func folio_tabbed_line_new_embedded(fontH C.uint64_t, fontSize C.double,
+	positions *C.double, aligns *C.int32_t, leaders *C.int32_t, count C.int32_t) C.uint64_t {
+	ef, errCode := loadEmbeddedFont(fontH)
+	if errCode != errOK {
+		return 0
+	}
+	n := int(count)
+	stops := parseTabs(positions, aligns, leaders, n)
+	tl := layout.NewTabbedLineEmbedded(ef, float64(fontSize), stops...)
+	return C.uint64_t(ht.store(tl))
+}
+
+// folio_tabbed_line_set_segments sets the text segments.
+// segments is an array of C strings of length count.
+//
+//export folio_tabbed_line_set_segments
+func folio_tabbed_line_set_segments(tlH C.uint64_t, segments **C.char, count C.int32_t) C.int32_t {
+	tl, errCode := loadTabbedLine(tlH)
+	if errCode != errOK {
+		return errCode
+	}
+	n := int(count)
+	goSegs := make([]string, n)
+	if n > 0 && segments != nil {
+		cArray := (*[1 << 20]*C.char)(unsafe.Pointer(segments))[:n:n]
+		for i := 0; i < n; i++ {
+			goSegs[i] = C.GoString(cArray[i])
+		}
+	}
+	tl.SetSegments(goSegs...)
+	return errOK
+}
+
+//export folio_tabbed_line_set_color
+func folio_tabbed_line_set_color(tlH C.uint64_t, r, g, b C.double) C.int32_t {
+	tl, errCode := loadTabbedLine(tlH)
+	if errCode != errOK {
+		return errCode
+	}
+	tl.SetColor(layout.RGB(float64(r), float64(g), float64(b)))
+	return errOK
+}
+
+//export folio_tabbed_line_set_leading
+func folio_tabbed_line_set_leading(tlH C.uint64_t, leading C.double) C.int32_t {
+	tl, errCode := loadTabbedLine(tlH)
+	if errCode != errOK {
+		return errCode
+	}
+	tl.SetLeading(float64(leading))
+	return errOK
+}
+
+//export folio_tabbed_line_free
+func folio_tabbed_line_free(tlH C.uint64_t) {
+	ht.delete(uint64(tlH))
+}
+
+func parseTabs(positions *C.double, aligns *C.int32_t, leaders *C.int32_t, n int) []layout.TabStop {
+	stops := make([]layout.TabStop, n)
+	cPos := (*[1 << 20]C.double)(unsafe.Pointer(positions))[:n:n]
+	cAlign := (*[1 << 20]C.int32_t)(unsafe.Pointer(aligns))[:n:n]
+	cLeader := (*[1 << 20]C.int32_t)(unsafe.Pointer(leaders))[:n:n]
+	for i := 0; i < n; i++ {
+		stops[i] = layout.TabStop{
+			Position: float64(cPos[i]),
+			Align:    layout.TabAlign(cAlign[i]),
+			Leader:   rune(cLeader[i]),
+		}
+	}
+	return stops
+}
+
+func loadTabbedLine(h C.uint64_t) (*layout.TabbedLine, C.int32_t) {
+	v := ht.load(uint64(h))
+	if v == nil {
+		setLastError("invalid tabbed line handle")
+		return nil, errInvalidHandle
+	}
+	tl, ok := v.(*layout.TabbedLine)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not a tabbed line (type %T)", uint64(h), v))
+		return nil, errTypeMismatch
+	}
+	return tl, errOK
+}

--- a/export/folio.h
+++ b/export/folio.h
@@ -59,6 +59,11 @@ extern "C" {
 #define FOLIO_ALIGN_RIGHT      2
 #define FOLIO_ALIGN_JUSTIFY    3
 
+/* Vertical alignment (layout.VAlign) */
+#define FOLIO_VALIGN_TOP       0
+#define FOLIO_VALIGN_MIDDLE    1
+#define FOLIO_VALIGN_BOTTOM    2
+
 /* Heading levels (layout.HeadingLevel) */
 #define FOLIO_H1               1
 #define FOLIO_H2               2
@@ -88,6 +93,34 @@ extern "C" {
 #define FOLIO_ENCRYPT_AES_128  1
 #define FOLIO_ENCRYPT_AES_256  2
 
+/* QR error correction levels (barcode.ECCLevel) */
+#define FOLIO_ECC_L            0   /* 7% recovery */
+#define FOLIO_ECC_M            1   /* 15% recovery */
+#define FOLIO_ECC_Q            2   /* 25% recovery */
+#define FOLIO_ECC_H            3   /* 30% recovery */
+
+/* Flex direction (layout.FlexDirection) */
+#define FOLIO_FLEX_ROW         0
+#define FOLIO_FLEX_COLUMN      1
+
+/* Flex justify-content (layout.JustifyContent) */
+#define FOLIO_JUSTIFY_START         0
+#define FOLIO_JUSTIFY_END           1
+#define FOLIO_JUSTIFY_CENTER        2
+#define FOLIO_JUSTIFY_SPACE_BETWEEN 3
+#define FOLIO_JUSTIFY_SPACE_AROUND  4
+#define FOLIO_JUSTIFY_SPACE_EVENLY  5
+
+/* Flex align-items / align-self (layout.AlignItems) */
+#define FOLIO_CROSS_STRETCH    0
+#define FOLIO_CROSS_START      1
+#define FOLIO_CROSS_END        2
+#define FOLIO_CROSS_CENTER     3
+
+/* Flex wrap (layout.FlexWrap) */
+#define FOLIO_FLEX_NOWRAP      0
+#define FOLIO_FLEX_WRAP        1
+
 /* ── Callback types ────────────────────────────────────────────────── */
 
 /*
@@ -103,16 +136,11 @@ typedef void (*folio_page_decorator_fn)(
 
 /* ── Core ──────────────────────────────────────────────────────────── */
 
-/* Returns the library version string. Persistent — do NOT free. */
 const char *folio_version(void);
-
-/* Returns the last error message. Library-owned — do NOT free.
- * Valid until the next folio_* call. NULL if no error. */
 const char *folio_last_error(void);
 
 /* ── Buffer ────────────────────────────────────────────────────────── */
 
-/* Returns a pointer to the buffer's data. Valid until folio_buffer_free(). */
 void    *folio_buffer_data(uint64_t buf);
 int32_t  folio_buffer_len(uint64_t buf);
 void     folio_buffer_free(uint64_t buf);
@@ -128,23 +156,72 @@ int32_t  folio_document_set_title(uint64_t doc, const char *title);
 int32_t  folio_document_set_author(uint64_t doc, const char *author);
 int32_t  folio_document_set_margins(uint64_t doc, double top, double right, double bottom, double left);
 
-uint64_t folio_document_add_page(uint64_t doc);  /* returns page handle */
+uint64_t folio_document_add_page(uint64_t doc);
 int32_t  folio_document_page_count(uint64_t doc);
-int32_t  folio_document_add(uint64_t doc, uint64_t element);  /* any layout element */
+int32_t  folio_document_add(uint64_t doc, uint64_t element);
 
 int32_t  folio_document_save(uint64_t doc, const char *path);
-uint64_t folio_document_write_to_buffer(uint64_t doc);  /* returns buffer handle */
+uint64_t folio_document_write_to_buffer(uint64_t doc);
 
 /* Document features */
 int32_t  folio_document_set_tagged(uint64_t doc, int32_t enabled);
-int32_t  folio_document_set_pdfa(uint64_t doc, int32_t level);  /* FOLIO_PDFA_* */
+int32_t  folio_document_set_pdfa(uint64_t doc, int32_t level);
 int32_t  folio_document_set_encryption(uint64_t doc, const char *user_pw, const char *owner_pw, int32_t algorithm);
 int32_t  folio_document_set_auto_bookmarks(uint64_t doc, int32_t enabled);
 int32_t  folio_document_set_form(uint64_t doc, uint64_t form);
 
-/* Callbacks — fn must NOT be NULL */
+/* Callbacks */
 int32_t  folio_document_set_header(uint64_t doc, folio_page_decorator_fn fn, void *user_data);
 int32_t  folio_document_set_footer(uint64_t doc, folio_page_decorator_fn fn, void *user_data);
+
+/* Watermark */
+int32_t  folio_document_set_watermark(uint64_t doc, const char *text);
+int32_t  folio_document_set_watermark_config(uint64_t doc, const char *text,
+             double font_size, double color_r, double color_g, double color_b,
+             double angle, double opacity);
+
+/* Outlines / Bookmarks */
+uint64_t folio_document_add_outline(uint64_t doc, const char *title, int32_t page_index);
+uint64_t folio_document_add_outline_xyz(uint64_t doc, const char *title,
+             int32_t page_index, double left, double top, double zoom);
+uint64_t folio_outline_add_child(uint64_t outline, const char *title, int32_t page_index);
+uint64_t folio_outline_add_child_xyz(uint64_t outline, const char *title,
+             int32_t page_index, double left, double top, double zoom);
+
+/* Named Destinations */
+int32_t  folio_document_add_named_dest(uint64_t doc, const char *name, int32_t page_index,
+             const char *fit_type, double top, double left, double zoom);
+
+/* Viewer Preferences */
+int32_t  folio_document_set_viewer_preferences(uint64_t doc,
+             const char *page_layout, const char *page_mode,
+             int32_t hide_toolbar, int32_t hide_menubar, int32_t hide_window_ui,
+             int32_t fit_window, int32_t center_window, int32_t display_doc_title);
+
+/* Page Labels */
+int32_t  folio_document_add_page_label(uint64_t doc, int32_t page_index,
+             const char *style, const char *prefix, int32_t start);
+
+/* Page management */
+int32_t  folio_document_remove_page(uint64_t doc, int32_t index);
+
+/* Absolute positioning */
+int32_t  folio_document_add_absolute(uint64_t doc, uint64_t element, double x, double y, double width);
+
+/* File attachments (PDF/A-3b) */
+int32_t  folio_document_attach_file(uint64_t doc, const void *data, int32_t length,
+             const char *file_name, const char *mime_type, const char *description, const char *af_relationship);
+
+/* Inline HTML */
+int32_t  folio_document_add_html(uint64_t doc, const char *html);
+int32_t  folio_document_add_html_with_options(uint64_t doc, const char *html,
+             double default_font_size, double page_width, double page_height,
+             const char *base_path, const char *fallback_font_path);
+
+/* Page-specific margins (@page :first/:left/:right) */
+int32_t  folio_document_set_first_margins(uint64_t doc, double top, double right, double bottom, double left);
+int32_t  folio_document_set_left_margins(uint64_t doc, double top, double right, double bottom, double left);
+int32_t  folio_document_set_right_margins(uint64_t doc, double top, double right, double bottom, double left);
 
 /* ── Page ──────────────────────────────────────────────────────────── */
 
@@ -152,23 +229,47 @@ int32_t  folio_page_add_text(uint64_t page, const char *text, uint64_t font, dou
 int32_t  folio_page_add_text_embedded(uint64_t page, const char *text, uint64_t font, double size, double x, double y);
 int32_t  folio_page_add_image(uint64_t page, uint64_t img, double x, double y, double w, double h);
 int32_t  folio_page_add_link(uint64_t page, double x1, double y1, double x2, double y2, const char *uri);
+int32_t  folio_page_add_internal_link(uint64_t page, double x1, double y1, double x2, double y2, const char *dest_name);
+int32_t  folio_page_add_text_annotation(uint64_t page, double x1, double y1, double x2, double y2, const char *text, const char *icon);
 int32_t  folio_page_set_opacity(uint64_t page, double alpha);
 int32_t  folio_page_set_rotate(uint64_t page, int32_t degrees);
+int32_t  folio_page_set_crop_box(uint64_t page, double x1, double y1, double x2, double y2);
+int32_t  folio_page_set_trim_box(uint64_t page, double x1, double y1, double x2, double y2);
+int32_t  folio_page_set_bleed_box(uint64_t page, double x1, double y1, double x2, double y2);
+int32_t  folio_page_set_art_box(uint64_t page, double x1, double y1, double x2, double y2);
+int32_t  folio_page_set_size(uint64_t page, double width, double height);
+int32_t  folio_page_add_page_link(uint64_t page, double x1, double y1, double x2, double y2, int32_t target_page);
+int32_t  folio_page_set_opacity_fill_stroke(uint64_t page, double fill_alpha, double stroke_alpha);
+int32_t  folio_page_add_highlight(uint64_t page, double x1, double y1, double x2, double y2,
+             double r, double g, double b, const double *quad_points, int32_t quad_count);
+int32_t  folio_page_add_underline_annotation(uint64_t page, double x1, double y1, double x2, double y2,
+             double r, double g, double b, const double *quad_points, int32_t quad_count);
+int32_t  folio_page_add_squiggly(uint64_t page, double x1, double y1, double x2, double y2,
+             double r, double g, double b, const double *quad_points, int32_t quad_count);
+int32_t  folio_page_add_strikeout(uint64_t page, double x1, double y1, double x2, double y2,
+             double r, double g, double b, const double *quad_points, int32_t quad_count);
 
 /* ── Font ──────────────────────────────────────────────────────────── */
 
-/* Standard PDF fonts (singletons — folio_font_free is a no-op) */
-uint64_t folio_font_standard(const char *name);  /* e.g. "Helvetica", "Courier-Bold" */
+uint64_t folio_font_standard(const char *name);
 uint64_t folio_font_helvetica(void);
 uint64_t folio_font_helvetica_bold(void);
+uint64_t folio_font_helvetica_oblique(void);
+uint64_t folio_font_helvetica_bold_oblique(void);
 uint64_t folio_font_times_roman(void);
 uint64_t folio_font_times_bold(void);
+uint64_t folio_font_times_italic(void);
+uint64_t folio_font_times_bold_italic(void);
 uint64_t folio_font_courier(void);
+uint64_t folio_font_courier_bold(void);
+uint64_t folio_font_courier_oblique(void);
+uint64_t folio_font_courier_bold_oblique(void);
+uint64_t folio_font_symbol(void);
+uint64_t folio_font_zapf_dingbats(void);
 
-/* Embedded fonts (TTF/OTF) — must call folio_font_free when done */
 uint64_t folio_font_load_ttf(const char *path);
 uint64_t folio_font_parse_ttf(const void *data, int32_t length);
-void     folio_font_free(uint64_t font);  /* no-op for standard fonts */
+void     folio_font_free(uint64_t font);
 
 /* ── Paragraph ─────────────────────────────────────────────────────── */
 
@@ -176,19 +277,23 @@ uint64_t folio_paragraph_new(const char *text, uint64_t font, double font_size);
 uint64_t folio_paragraph_new_embedded(const char *text, uint64_t font, double font_size);
 void     folio_paragraph_free(uint64_t para);
 
-int32_t  folio_paragraph_set_align(uint64_t para, int32_t align);  /* FOLIO_ALIGN_* */
+int32_t  folio_paragraph_set_align(uint64_t para, int32_t align);
 int32_t  folio_paragraph_set_leading(uint64_t para, double leading);
 int32_t  folio_paragraph_set_space_before(uint64_t para, double pts);
 int32_t  folio_paragraph_set_space_after(uint64_t para, double pts);
 int32_t  folio_paragraph_set_background(uint64_t para, double r, double g, double b);
 int32_t  folio_paragraph_set_first_indent(uint64_t para, double pts);
+int32_t  folio_paragraph_set_orphans(uint64_t para, int32_t n);
+int32_t  folio_paragraph_set_widows(uint64_t para, int32_t n);
+int32_t  folio_paragraph_set_ellipsis(uint64_t para, int32_t enabled);
+int32_t  folio_paragraph_set_word_break(uint64_t para, const char *mode);
+int32_t  folio_paragraph_set_hyphens(uint64_t para, const char *mode);
 
-/* Add a styled text run. Font can be standard or embedded. Color is RGB 0-1. */
 int32_t  folio_paragraph_add_run(uint64_t para, const char *text, uint64_t font, double font_size, double r, double g, double b);
 
 /* ── Heading ───────────────────────────────────────────────────────── */
 
-uint64_t folio_heading_new(const char *text, int32_t level);  /* FOLIO_H1..H6 */
+uint64_t folio_heading_new(const char *text, int32_t level);
 uint64_t folio_heading_new_with_font(const char *text, int32_t level, uint64_t font, double font_size);
 uint64_t folio_heading_new_embedded(const char *text, int32_t level, uint64_t font);
 void     folio_heading_free(uint64_t heading);
@@ -202,9 +307,13 @@ void     folio_table_free(uint64_t table);
 
 int32_t  folio_table_set_column_widths(uint64_t table, const double *widths, int32_t count);
 int32_t  folio_table_set_border_collapse(uint64_t table, int32_t enabled);
+int32_t  folio_table_set_cell_spacing(uint64_t table, double h, double v);
+int32_t  folio_table_set_auto_column_widths(uint64_t table);
+int32_t  folio_table_set_min_width(uint64_t table, double pts);
 
-uint64_t folio_table_add_row(uint64_t table);         /* returns row handle */
-uint64_t folio_table_add_header_row(uint64_t table);   /* returns row handle */
+uint64_t folio_table_add_row(uint64_t table);
+uint64_t folio_table_add_header_row(uint64_t table);
+uint64_t folio_table_add_footer_row(uint64_t table);
 void     folio_row_free(uint64_t row);
 
 uint64_t folio_row_add_cell(uint64_t row, const char *text, uint64_t font, double font_size);
@@ -214,23 +323,33 @@ void     folio_cell_free(uint64_t cell);
 
 int32_t  folio_cell_set_align(uint64_t cell, int32_t align);
 int32_t  folio_cell_set_padding(uint64_t cell, double padding);
+int32_t  folio_cell_set_padding_sides(uint64_t cell, double top, double right, double bottom, double left);
+int32_t  folio_cell_set_valign(uint64_t cell, int32_t valign);
 int32_t  folio_cell_set_background(uint64_t cell, double r, double g, double b);
 int32_t  folio_cell_set_colspan(uint64_t cell, int32_t n);
 int32_t  folio_cell_set_rowspan(uint64_t cell, int32_t n);
+int32_t  folio_cell_set_border(uint64_t cell, double width, double r, double g, double b);
+int32_t  folio_cell_set_borders(uint64_t cell,
+             double top_w, double top_r, double top_g, double top_b,
+             double right_w, double right_r, double right_g, double right_b,
+             double bottom_w, double bottom_r, double bottom_g, double bottom_b,
+             double left_w, double left_r, double left_g, double left_b);
+int32_t  folio_cell_set_width_hint(uint64_t cell, double pts);
 
 /* ── Image ─────────────────────────────────────────────────────────── */
 
 uint64_t folio_image_load_jpeg(const char *path);
 uint64_t folio_image_load_png(const char *path);
+uint64_t folio_image_load_tiff(const char *path);
 uint64_t folio_image_parse_jpeg(const void *data, int32_t length);
 uint64_t folio_image_parse_png(const void *data, int32_t length);
 int32_t  folio_image_width(uint64_t img);
 int32_t  folio_image_height(uint64_t img);
 void     folio_image_free(uint64_t img);
 
-/* Image as layout element (for document flow) */
 uint64_t folio_image_element_new(uint64_t img);
 int32_t  folio_image_element_set_size(uint64_t elem, double w, double h);
+int32_t  folio_image_element_set_align(uint64_t elem, int32_t align);
 void     folio_image_element_free(uint64_t elem);
 
 /* ── Div (container) ───────────────────────────────────────────────── */
@@ -244,8 +363,16 @@ int32_t  folio_div_set_background(uint64_t div, double r, double g, double b);
 int32_t  folio_div_set_border(uint64_t div, double width, double r, double g, double b);
 int32_t  folio_div_set_width(uint64_t div, double pts);
 int32_t  folio_div_set_min_height(uint64_t div, double pts);
+int32_t  folio_div_set_max_width(uint64_t div, double pts);
+int32_t  folio_div_set_min_width(uint64_t div, double pts);
 int32_t  folio_div_set_space_before(uint64_t div, double pts);
 int32_t  folio_div_set_space_after(uint64_t div, double pts);
+int32_t  folio_div_set_border_radius(uint64_t div, double radius);
+int32_t  folio_div_set_opacity(uint64_t div, double opacity);
+int32_t  folio_div_set_overflow(uint64_t div, const char *mode);
+int32_t  folio_div_set_box_shadow(uint64_t div, double offset_x, double offset_y,
+             double blur, double spread, double r, double g, double b);
+int32_t  folio_div_set_max_height(uint64_t div, double pts);
 
 /* ── List ──────────────────────────────────────────────────────────── */
 
@@ -253,24 +380,90 @@ uint64_t folio_list_new(uint64_t font, double font_size);
 uint64_t folio_list_new_embedded(uint64_t font, double font_size);
 void     folio_list_free(uint64_t list);
 
-int32_t  folio_list_set_style(uint64_t list, int32_t style);  /* FOLIO_LIST_* */
+int32_t  folio_list_set_style(uint64_t list, int32_t style);
 int32_t  folio_list_set_indent(uint64_t list, double indent);
+int32_t  folio_list_set_leading(uint64_t list, double leading);
 int32_t  folio_list_add_item(uint64_t list, const char *text);
+uint64_t folio_list_add_nested_item(uint64_t list, const char *text);
+
+/* ── Link (layout element) ────────────────────────────────────────── */
+
+uint64_t folio_link_new(const char *text, const char *uri, uint64_t font, double font_size);
+uint64_t folio_link_new_embedded(const char *text, const char *uri, uint64_t font, double font_size);
+uint64_t folio_link_new_internal(const char *text, const char *dest_name, uint64_t font, double font_size);
+void     folio_link_free(uint64_t link);
+
+int32_t  folio_link_set_color(uint64_t link, double r, double g, double b);
+int32_t  folio_link_set_underline(uint64_t link);
+int32_t  folio_link_set_align(uint64_t link, int32_t align);
 
 /* ── Misc layout elements ──────────────────────────────────────────── */
 
 uint64_t folio_line_separator_new(void);
 uint64_t folio_area_break_new(void);
 
+/* ── Barcode ──────────────────────────────────────────────────────── */
+
+uint64_t folio_barcode_qr(const char *data);
+uint64_t folio_barcode_qr_ecc(const char *data, int32_t level);
+uint64_t folio_barcode_code128(const char *data);
+uint64_t folio_barcode_ean13(const char *data);
+int32_t  folio_barcode_width(uint64_t bc);
+int32_t  folio_barcode_height(uint64_t bc);
+void     folio_barcode_free(uint64_t bc);
+
+uint64_t folio_barcode_element_new(uint64_t bc, double width);
+int32_t  folio_barcode_element_set_height(uint64_t elem, double height);
+int32_t  folio_barcode_element_set_align(uint64_t elem, int32_t align);
+void     folio_barcode_element_free(uint64_t elem);
+
+/* ── SVG ──────────────────────────────────────────────────────────── */
+
+uint64_t folio_svg_parse(const char *svg_xml);
+uint64_t folio_svg_parse_bytes(const void *data, int32_t length);
+double   folio_svg_width(uint64_t svg);
+double   folio_svg_height(uint64_t svg);
+void     folio_svg_free(uint64_t svg);
+
+uint64_t folio_svg_element_new(uint64_t svg);
+int32_t  folio_svg_element_set_size(uint64_t elem, double w, double h);
+int32_t  folio_svg_element_set_align(uint64_t elem, int32_t align);
+void     folio_svg_element_free(uint64_t elem);
+
+/* ── Flex (container) ─────────────────────────────────────────────── */
+
+uint64_t folio_flex_new(void);
+void     folio_flex_free(uint64_t flex);
+
+int32_t  folio_flex_add(uint64_t flex, uint64_t element);
+int32_t  folio_flex_add_item(uint64_t flex, uint64_t item);
+int32_t  folio_flex_set_direction(uint64_t flex, int32_t direction);
+int32_t  folio_flex_set_justify_content(uint64_t flex, int32_t justify);
+int32_t  folio_flex_set_align_items(uint64_t flex, int32_t align);
+int32_t  folio_flex_set_wrap(uint64_t flex, int32_t wrap);
+int32_t  folio_flex_set_gap(uint64_t flex, double gap);
+int32_t  folio_flex_set_padding(uint64_t flex, double padding);
+int32_t  folio_flex_set_background(uint64_t flex, double r, double g, double b);
+int32_t  folio_flex_set_space_before(uint64_t flex, double pts);
+int32_t  folio_flex_set_space_after(uint64_t flex, double pts);
+int32_t  folio_flex_set_row_gap(uint64_t flex, double gap);
+int32_t  folio_flex_set_column_gap(uint64_t flex, double gap);
+int32_t  folio_flex_set_padding_all(uint64_t flex, double top, double right, double bottom, double left);
+int32_t  folio_flex_set_border(uint64_t flex, double width, double r, double g, double b);
+
+uint64_t folio_flex_item_new(uint64_t element);
+void     folio_flex_item_free(uint64_t item);
+
+int32_t  folio_flex_item_set_grow(uint64_t item, double grow);
+int32_t  folio_flex_item_set_shrink(uint64_t item, double shrink);
+int32_t  folio_flex_item_set_basis(uint64_t item, double basis);
+int32_t  folio_flex_item_set_align_self(uint64_t item, int32_t align);
+int32_t  folio_flex_item_set_margins(uint64_t item, double top, double right, double bottom, double left);
+
 /* ── HTML to PDF ───────────────────────────────────────────────────── */
 
-/* One-shot: HTML string → PDF file */
 int32_t  folio_html_to_pdf(const char *html, const char *output_path);
-
-/* HTML string → buffer handle (caller must folio_buffer_free) */
 uint64_t folio_html_to_buffer(const char *html, double page_width, double page_height);
-
-/* HTML string → document handle (for further manipulation before save) */
 uint64_t folio_html_convert(const char *html, double page_width, double page_height);
 
 /* ── Reader (PDF parsing) ──────────────────────────────────────────── */
@@ -280,10 +473,10 @@ uint64_t folio_reader_parse(const void *data, int32_t length);
 void     folio_reader_free(uint64_t reader);
 
 int32_t  folio_reader_page_count(uint64_t reader);
-uint64_t folio_reader_version(uint64_t reader);       /* returns buffer handle */
-uint64_t folio_reader_info_title(uint64_t reader);     /* returns buffer handle */
-uint64_t folio_reader_info_author(uint64_t reader);    /* returns buffer handle */
-uint64_t folio_reader_extract_text(uint64_t reader, int32_t page_index);  /* returns buffer handle */
+uint64_t folio_reader_version(uint64_t reader);
+uint64_t folio_reader_info_title(uint64_t reader);
+uint64_t folio_reader_info_author(uint64_t reader);
+uint64_t folio_reader_extract_text(uint64_t reader, int32_t page_index);
 double   folio_reader_page_width(uint64_t reader, int32_t page_index);
 double   folio_reader_page_height(uint64_t reader, int32_t page_index);
 
@@ -296,6 +489,93 @@ int32_t  folio_form_add_text_field(uint64_t form, const char *name, double x1, d
 int32_t  folio_form_add_checkbox(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index, int32_t checked);
 int32_t  folio_form_add_dropdown(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index, const char **options, int32_t opt_count);
 int32_t  folio_form_add_signature(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index);
+int32_t  folio_form_add_multiline_text_field(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index);
+int32_t  folio_form_add_password_field(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index);
+int32_t  folio_form_add_listbox(uint64_t form, const char *name, double x1, double y1, double x2, double y2, int32_t page_index, const char **options, int32_t opt_count);
+int32_t  folio_form_add_radio_group(uint64_t form, const char *name,
+             const char **values, const double *rects, const int32_t *page_indices, int32_t count);
+
+/* Form field builder — create field, configure, then add to form */
+uint64_t folio_form_create_text_field(const char *name, double x1, double y1, double x2, double y2, int32_t page_index);
+uint64_t folio_form_create_checkbox(const char *name, double x1, double y1, double x2, double y2, int32_t page_index, int32_t checked);
+int32_t  folio_form_add_field(uint64_t form, uint64_t field);
+void     folio_form_field_free(uint64_t field);
+
+int32_t  folio_form_field_set_value(uint64_t field, const char *value);
+int32_t  folio_form_field_set_read_only(uint64_t field);
+int32_t  folio_form_field_set_required(uint64_t field);
+int32_t  folio_form_field_set_background_color(uint64_t field, double r, double g, double b);
+int32_t  folio_form_field_set_border_color(uint64_t field, double r, double g, double b);
+
+/* Form filling (modify existing PDF forms) */
+uint64_t folio_form_filler_new(uint64_t reader);
+void     folio_form_filler_free(uint64_t filler);
+uint64_t folio_form_filler_field_names(uint64_t filler);     /* returns buffer handle (newline-separated) */
+uint64_t folio_form_filler_get_value(uint64_t filler, const char *field_name);  /* returns buffer handle */
+int32_t  folio_form_filler_set_value(uint64_t filler, const char *field_name, const char *value);
+int32_t  folio_form_filler_set_checkbox(uint64_t filler, const char *field_name, int32_t checked);
+
+/* ── Grid (container) ─────────────────────────────────────────────── */
+
+/* Grid track types: 0=px, 1=percent, 2=fr, 3=auto */
+#define FOLIO_GRID_PX          0
+#define FOLIO_GRID_PERCENT     1
+#define FOLIO_GRID_FR          2
+#define FOLIO_GRID_AUTO        3
+
+/* Float sides */
+#define FOLIO_FLOAT_LEFT       0
+#define FOLIO_FLOAT_RIGHT      1
+
+/* Tab alignment */
+#define FOLIO_TAB_LEFT         0
+#define FOLIO_TAB_RIGHT        1
+#define FOLIO_TAB_CENTER       2
+
+uint64_t folio_grid_new(void);
+void     folio_grid_free(uint64_t grid);
+
+int32_t  folio_grid_add_child(uint64_t grid, uint64_t element);
+int32_t  folio_grid_set_template_columns(uint64_t grid, const int32_t *types, const double *values, int32_t count);
+int32_t  folio_grid_set_template_rows(uint64_t grid, const int32_t *types, const double *values, int32_t count);
+int32_t  folio_grid_set_auto_rows(uint64_t grid, const int32_t *types, const double *values, int32_t count);
+int32_t  folio_grid_set_gap(uint64_t grid, double row_gap, double col_gap);
+int32_t  folio_grid_set_placement(uint64_t grid, int32_t child_index, int32_t col_start, int32_t col_end, int32_t row_start, int32_t row_end);
+int32_t  folio_grid_set_padding(uint64_t grid, double padding);
+int32_t  folio_grid_set_background(uint64_t grid, double r, double g, double b);
+int32_t  folio_grid_set_justify_items(uint64_t grid, int32_t align);
+int32_t  folio_grid_set_align_items(uint64_t grid, int32_t align);
+int32_t  folio_grid_set_justify_content(uint64_t grid, int32_t justify);
+int32_t  folio_grid_set_align_content(uint64_t grid, int32_t align);
+int32_t  folio_grid_set_space_before(uint64_t grid, double pts);
+int32_t  folio_grid_set_space_after(uint64_t grid, double pts);
+
+/* ── Columns (multi-column layout) ────────────────────────────────── */
+
+uint64_t folio_columns_new(int32_t cols);
+void     folio_columns_free(uint64_t columns);
+
+int32_t  folio_columns_set_gap(uint64_t columns, double gap);
+int32_t  folio_columns_set_widths(uint64_t columns, const double *widths, int32_t count);
+int32_t  folio_columns_add(uint64_t columns, int32_t col_index, uint64_t element);
+
+/* ── Float (text wrapping) ────────────────────────────────────────── */
+
+uint64_t folio_float_new(int32_t side, uint64_t element);  /* FOLIO_FLOAT_LEFT/RIGHT */
+void     folio_float_free(uint64_t flt);
+int32_t  folio_float_set_margin(uint64_t flt, double margin);
+
+/* ── TabbedLine (tab-stop text) ───────────────────────────────────── */
+
+uint64_t folio_tabbed_line_new(uint64_t font, double font_size,
+             const double *positions, const int32_t *aligns, const int32_t *leaders, int32_t count);
+uint64_t folio_tabbed_line_new_embedded(uint64_t font, double font_size,
+             const double *positions, const int32_t *aligns, const int32_t *leaders, int32_t count);
+void     folio_tabbed_line_free(uint64_t tl);
+
+int32_t  folio_tabbed_line_set_segments(uint64_t tl, const char **segments, int32_t count);
+int32_t  folio_tabbed_line_set_color(uint64_t tl, double r, double g, double b);
+int32_t  folio_tabbed_line_set_leading(uint64_t tl, double leading);
 
 #ifdef __cplusplus
 }

--- a/export/testdata/test_cabi.c
+++ b/export/testdata/test_cabi.c
@@ -353,6 +353,696 @@ int main(void) {
 
     folio_document_free(doc);
 
+    /* ===== Stage 12: All 14 standard font accessors ===== */
+    printf("Testing all standard font accessors...\n");
+    ASSERT(folio_font_helvetica() != 0, "font_helvetica");
+    ASSERT(folio_font_helvetica_bold() != 0, "font_helvetica_bold");
+    ASSERT(folio_font_helvetica_oblique() != 0, "font_helvetica_oblique");
+    ASSERT(folio_font_helvetica_bold_oblique() != 0, "font_helvetica_bold_oblique");
+    ASSERT(folio_font_times_roman() != 0, "font_times_roman");
+    ASSERT(folio_font_times_bold() != 0, "font_times_bold");
+    ASSERT(folio_font_times_italic() != 0, "font_times_italic");
+    ASSERT(folio_font_times_bold_italic() != 0, "font_times_bold_italic");
+    ASSERT(folio_font_courier() != 0, "font_courier");
+    ASSERT(folio_font_courier_bold() != 0, "font_courier_bold");
+    ASSERT(folio_font_courier_oblique() != 0, "font_courier_oblique");
+    ASSERT(folio_font_courier_bold_oblique() != 0, "font_courier_bold_oblique");
+    ASSERT(folio_font_symbol() != 0, "font_symbol");
+    ASSERT(folio_font_zapf_dingbats() != 0, "font_zapf_dingbats");
+
+    /* ===== Stage 13: Paragraph extensions ===== */
+    printf("Testing paragraph extensions...\n");
+    helv = folio_font_helvetica();
+    para = folio_paragraph_new("Orphans/widows test paragraph.", helv, 12.0);
+    ASSERT(para != 0, "paragraph for extensions");
+
+    rc = folio_paragraph_set_orphans(para, 2);
+    ASSERT(rc == 0, "paragraph_set_orphans succeeds");
+
+    rc = folio_paragraph_set_widows(para, 2);
+    ASSERT(rc == 0, "paragraph_set_widows succeeds");
+
+    rc = folio_paragraph_set_ellipsis(para, 1);
+    ASSERT(rc == 0, "paragraph_set_ellipsis succeeds");
+
+    rc = folio_paragraph_set_word_break(para, "break-all");
+    ASSERT(rc == 0, "paragraph_set_word_break succeeds");
+
+    rc = folio_paragraph_set_hyphens(para, "auto");
+    ASSERT(rc == 0, "paragraph_set_hyphens succeeds");
+
+    folio_paragraph_free(para);
+
+    /* ===== Stage 14: Table extensions ===== */
+    printf("Testing table extensions...\n");
+    helv = folio_font_helvetica();
+
+    uint64_t tbl2 = folio_table_new();
+    ASSERT(tbl2 != 0, "table for extensions");
+
+    rc = folio_table_set_cell_spacing(tbl2, 2.0, 2.0);
+    ASSERT(rc == 0, "table_set_cell_spacing succeeds");
+
+    rc = folio_table_set_auto_column_widths(tbl2);
+    ASSERT(rc == 0, "table_set_auto_column_widths succeeds");
+
+    rc = folio_table_set_min_width(tbl2, 200.0);
+    ASSERT(rc == 0, "table_set_min_width succeeds");
+
+    /* Footer row */
+    uint64_t frow = folio_table_add_footer_row(tbl2);
+    ASSERT(frow != 0, "table_add_footer_row returns handle");
+
+    uint64_t fcell = folio_row_add_cell(frow, "Footer", helv, 10.0);
+    ASSERT(fcell != 0, "footer cell created");
+
+    /* Header row with cell extensions */
+    uint64_t hrow2 = folio_table_add_header_row(tbl2);
+    uint64_t hcell = folio_row_add_cell(hrow2, "Header", helv, 12.0);
+
+    rc = folio_cell_set_padding_sides(hcell, 4.0, 8.0, 4.0, 8.0);
+    ASSERT(rc == 0, "cell_set_padding_sides succeeds");
+
+    rc = folio_cell_set_valign(hcell, 1); /* VAlignMiddle */
+    ASSERT(rc == 0, "cell_set_valign succeeds");
+
+    rc = folio_cell_set_border(hcell, 1.0, 0.0, 0.0, 0.0);
+    ASSERT(rc == 0, "cell_set_border succeeds");
+
+    rc = folio_cell_set_width_hint(hcell, 150.0);
+    ASSERT(rc == 0, "cell_set_width_hint succeeds");
+
+    /* Cell with element content */
+    uint64_t drow2 = folio_table_add_row(tbl2);
+    uint64_t cellPara = folio_paragraph_new("Cell content", helv, 10.0);
+    uint64_t elemCell = folio_row_add_cell_element(drow2, cellPara);
+    ASSERT(elemCell != 0, "row_add_cell_element returns handle");
+
+    folio_table_free(tbl2);
+
+    /* ===== Stage 15: Div extensions ===== */
+    printf("Testing div extensions...\n");
+
+    div = folio_div_new();
+    rc = folio_div_set_border_radius(div, 8.0);
+    ASSERT(rc == 0, "div_set_border_radius succeeds");
+
+    rc = folio_div_set_opacity(div, 0.8);
+    ASSERT(rc == 0, "div_set_opacity succeeds");
+
+    rc = folio_div_set_overflow(div, "hidden");
+    ASSERT(rc == 0, "div_set_overflow succeeds");
+
+    rc = folio_div_set_max_width(div, 400.0);
+    ASSERT(rc == 0, "div_set_max_width succeeds");
+
+    rc = folio_div_set_min_width(div, 100.0);
+    ASSERT(rc == 0, "div_set_min_width succeeds");
+
+    rc = folio_div_set_box_shadow(div, 2.0, 2.0, 4.0, 0.0, 0.5, 0.5, 0.5);
+    ASSERT(rc == 0, "div_set_box_shadow succeeds");
+
+    rc = folio_div_set_max_height(div, 300.0);
+    ASSERT(rc == 0, "div_set_max_height succeeds");
+
+    rc = folio_div_set_space_before(div, 10.0);
+    ASSERT(rc == 0, "div_set_space_before succeeds");
+
+    rc = folio_div_set_space_after(div, 10.0);
+    ASSERT(rc == 0, "div_set_space_after succeeds");
+
+    folio_div_free(div);
+
+    /* ===== Stage 16: Link element ===== */
+    printf("Testing link element...\n");
+    helv = folio_font_helvetica();
+
+    uint64_t lnk = folio_link_new("Click here", "https://example.com", helv, 12.0);
+    ASSERT(lnk != 0, "link_new returns handle");
+
+    rc = folio_link_set_color(lnk, 0.0, 0.0, 1.0);
+    ASSERT(rc == 0, "link_set_color succeeds");
+
+    rc = folio_link_set_underline(lnk);
+    ASSERT(rc == 0, "link_set_underline succeeds");
+
+    rc = folio_link_set_align(lnk, 0);
+    ASSERT(rc == 0, "link_set_align succeeds");
+
+    folio_link_free(lnk);
+
+    uint64_t intLnk = folio_link_new_internal("Go to chapter", "ch1", helv, 12.0);
+    ASSERT(intLnk != 0, "link_new_internal returns handle");
+    folio_link_free(intLnk);
+
+    /* ===== Stage 17: Barcode ===== */
+    printf("Testing barcode...\n");
+
+    uint64_t qr = folio_barcode_qr("https://folio.dev");
+    ASSERT(qr != 0, "barcode_qr returns handle");
+    ASSERT(folio_barcode_width(qr) > 0, "barcode_width > 0");
+    ASSERT(folio_barcode_height(qr) > 0, "barcode_height > 0");
+
+    uint64_t qrElem = folio_barcode_element_new(qr, 150.0);
+    ASSERT(qrElem != 0, "barcode_element_new returns handle");
+
+    rc = folio_barcode_element_set_height(qrElem, 150.0);
+    ASSERT(rc == 0, "barcode_element_set_height succeeds");
+
+    rc = folio_barcode_element_set_align(qrElem, 1); /* center */
+    ASSERT(rc == 0, "barcode_element_set_align succeeds");
+
+    folio_barcode_element_free(qrElem);
+    folio_barcode_free(qr);
+
+    uint64_t qrH = folio_barcode_qr_ecc("test", 3); /* ECC_H */
+    ASSERT(qrH != 0, "barcode_qr_ecc returns handle");
+    folio_barcode_free(qrH);
+
+    uint64_t c128 = folio_barcode_code128("ABC-123");
+    ASSERT(c128 != 0, "barcode_code128 returns handle");
+    folio_barcode_free(c128);
+
+    uint64_t ean = folio_barcode_ean13("978020137962");
+    ASSERT(ean != 0, "barcode_ean13 returns handle");
+    folio_barcode_free(ean);
+
+    /* ===== Stage 18: SVG ===== */
+    printf("Testing SVG...\n");
+
+    const char* svgXml = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"100\">"
+                         "<circle cx=\"50\" cy=\"50\" r=\"40\" fill=\"red\"/></svg>";
+    uint64_t svg = folio_svg_parse(svgXml);
+    ASSERT(svg != 0, "svg_parse returns handle");
+
+    double svgW = folio_svg_width(svg);
+    ASSERT(svgW > 0, "svg_width > 0");
+
+    double svgH = folio_svg_height(svg);
+    ASSERT(svgH > 0, "svg_height > 0");
+
+    uint64_t svgElem = folio_svg_element_new(svg);
+    ASSERT(svgElem != 0, "svg_element_new returns handle");
+
+    rc = folio_svg_element_set_size(svgElem, 200.0, 200.0);
+    ASSERT(rc == 0, "svg_element_set_size succeeds");
+
+    rc = folio_svg_element_set_align(svgElem, 1);
+    ASSERT(rc == 0, "svg_element_set_align succeeds");
+
+    folio_svg_element_free(svgElem);
+    folio_svg_free(svg);
+
+    /* svg_parse_bytes */
+    uint64_t svgB = folio_svg_parse_bytes(svgXml, (int32_t)strlen(svgXml));
+    ASSERT(svgB != 0, "svg_parse_bytes returns handle");
+    folio_svg_free(svgB);
+
+    /* ===== Stage 19: Flex container ===== */
+    printf("Testing flex container...\n");
+    doc = folio_document_new_letter();
+    helv = folio_font_helvetica();
+
+    uint64_t flex = folio_flex_new();
+    ASSERT(flex != 0, "flex_new returns handle");
+
+    rc = folio_flex_set_direction(flex, 0); /* row */
+    ASSERT(rc == 0, "flex_set_direction succeeds");
+
+    rc = folio_flex_set_justify_content(flex, 2); /* center */
+    ASSERT(rc == 0, "flex_set_justify_content succeeds");
+
+    rc = folio_flex_set_align_items(flex, 3); /* center */
+    ASSERT(rc == 0, "flex_set_align_items succeeds");
+
+    rc = folio_flex_set_wrap(flex, 1); /* wrap */
+    ASSERT(rc == 0, "flex_set_wrap succeeds");
+
+    rc = folio_flex_set_gap(flex, 10.0);
+    ASSERT(rc == 0, "flex_set_gap succeeds");
+
+    rc = folio_flex_set_row_gap(flex, 8.0);
+    ASSERT(rc == 0, "flex_set_row_gap succeeds");
+
+    rc = folio_flex_set_column_gap(flex, 12.0);
+    ASSERT(rc == 0, "flex_set_column_gap succeeds");
+
+    rc = folio_flex_set_padding(flex, 10.0);
+    ASSERT(rc == 0, "flex_set_padding succeeds");
+
+    rc = folio_flex_set_padding_all(flex, 10.0, 15.0, 10.0, 15.0);
+    ASSERT(rc == 0, "flex_set_padding_all succeeds");
+
+    rc = folio_flex_set_background(flex, 0.95, 0.95, 0.95);
+    ASSERT(rc == 0, "flex_set_background succeeds");
+
+    rc = folio_flex_set_border(flex, 1.0, 0.0, 0.0, 0.0);
+    ASSERT(rc == 0, "flex_set_border succeeds");
+
+    rc = folio_flex_set_space_before(flex, 12.0);
+    ASSERT(rc == 0, "flex_set_space_before succeeds");
+
+    rc = folio_flex_set_space_after(flex, 12.0);
+    ASSERT(rc == 0, "flex_set_space_after succeeds");
+
+    /* Add elements directly */
+    para = folio_paragraph_new("Flex child 1", helv, 12.0);
+    rc = folio_flex_add(flex, para);
+    ASSERT(rc == 0, "flex_add succeeds");
+
+    /* Add via flex item with properties */
+    uint64_t p2 = folio_paragraph_new("Flex child 2", helv, 12.0);
+    uint64_t item = folio_flex_item_new(p2);
+    ASSERT(item != 0, "flex_item_new returns handle");
+
+    rc = folio_flex_item_set_grow(item, 1.0);
+    ASSERT(rc == 0, "flex_item_set_grow succeeds");
+
+    rc = folio_flex_item_set_shrink(item, 0.0);
+    ASSERT(rc == 0, "flex_item_set_shrink succeeds");
+
+    rc = folio_flex_item_set_basis(item, 100.0);
+    ASSERT(rc == 0, "flex_item_set_basis succeeds");
+
+    rc = folio_flex_item_set_align_self(item, 1); /* start */
+    ASSERT(rc == 0, "flex_item_set_align_self succeeds");
+
+    rc = folio_flex_item_set_margins(item, 5.0, 5.0, 5.0, 5.0);
+    ASSERT(rc == 0, "flex_item_set_margins succeeds");
+
+    rc = folio_flex_add_item(flex, item);
+    ASSERT(rc == 0, "flex_add_item succeeds");
+
+    rc = folio_document_add(doc, flex);
+    ASSERT(rc == 0, "document_add flex succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_flex.pdf");
+    ASSERT(rc == 0, "flex document save succeeds");
+
+    folio_flex_item_free(item);
+    folio_flex_free(flex);
+    folio_document_free(doc);
+
+    /* ===== Stage 20: Grid container ===== */
+    printf("Testing grid container...\n");
+    doc = folio_document_new_letter();
+    helv = folio_font_helvetica();
+
+    uint64_t grid = folio_grid_new();
+    ASSERT(grid != 0, "grid_new returns handle");
+
+    /* 3 columns: 1fr, 2fr, 1fr */
+    int32_t colTypes[] = {2, 2, 2}; /* GridTrackFr */
+    double colValues[] = {1.0, 2.0, 1.0};
+    rc = folio_grid_set_template_columns(grid, colTypes, colValues, 3);
+    ASSERT(rc == 0, "grid_set_template_columns succeeds");
+
+    /* Auto rows with min 50pt */
+    int32_t rowTypes[] = {0}; /* GridTrackPx */
+    double rowValues[] = {50.0};
+    rc = folio_grid_set_auto_rows(grid, rowTypes, rowValues, 1);
+    ASSERT(rc == 0, "grid_set_auto_rows succeeds");
+
+    rc = folio_grid_set_gap(grid, 10.0, 10.0);
+    ASSERT(rc == 0, "grid_set_gap succeeds");
+
+    rc = folio_grid_set_padding(grid, 10.0);
+    ASSERT(rc == 0, "grid_set_padding succeeds");
+
+    rc = folio_grid_set_background(grid, 0.9, 0.95, 1.0);
+    ASSERT(rc == 0, "grid_set_background succeeds");
+
+    rc = folio_grid_set_justify_items(grid, 3); /* center */
+    ASSERT(rc == 0, "grid_set_justify_items succeeds");
+
+    rc = folio_grid_set_align_items(grid, 3); /* center */
+    ASSERT(rc == 0, "grid_set_align_items succeeds");
+
+    rc = folio_grid_set_space_before(grid, 12.0);
+    ASSERT(rc == 0, "grid_set_space_before succeeds");
+
+    /* Add children */
+    uint64_t gp1 = folio_paragraph_new("Cell A", helv, 12.0);
+    rc = folio_grid_add_child(grid, gp1);
+    ASSERT(rc == 0, "grid_add_child 1 succeeds");
+
+    uint64_t gp2 = folio_paragraph_new("Cell B (span 2 cols)", helv, 12.0);
+    rc = folio_grid_add_child(grid, gp2);
+    ASSERT(rc == 0, "grid_add_child 2 succeeds");
+
+    /* Place second child across columns 2-3 */
+    rc = folio_grid_set_placement(grid, 1, 2, 4, 0, 0);
+    ASSERT(rc == 0, "grid_set_placement succeeds");
+
+    rc = folio_document_add(doc, grid);
+    ASSERT(rc == 0, "document_add grid succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_grid.pdf");
+    ASSERT(rc == 0, "grid document save succeeds");
+
+    folio_grid_free(grid);
+    folio_document_free(doc);
+
+    /* ===== Stage 21: Columns layout ===== */
+    printf("Testing columns layout...\n");
+    doc = folio_document_new_letter();
+    helv = folio_font_helvetica();
+
+    uint64_t cols = folio_columns_new(3);
+    ASSERT(cols != 0, "columns_new returns handle");
+
+    rc = folio_columns_set_gap(cols, 20.0);
+    ASSERT(rc == 0, "columns_set_gap succeeds");
+
+    double widths[] = {0.25, 0.5, 0.25};
+    rc = folio_columns_set_widths(cols, widths, 3);
+    ASSERT(rc == 0, "columns_set_widths succeeds");
+
+    uint64_t cp1 = folio_paragraph_new("Left column text.", helv, 10.0);
+    rc = folio_columns_add(cols, 0, cp1);
+    ASSERT(rc == 0, "columns_add col 0 succeeds");
+
+    uint64_t cp2 = folio_paragraph_new("Center column with more text content.", helv, 10.0);
+    rc = folio_columns_add(cols, 1, cp2);
+    ASSERT(rc == 0, "columns_add col 1 succeeds");
+
+    uint64_t cp3 = folio_paragraph_new("Right column.", helv, 10.0);
+    rc = folio_columns_add(cols, 2, cp3);
+    ASSERT(rc == 0, "columns_add col 2 succeeds");
+
+    rc = folio_document_add(doc, cols);
+    ASSERT(rc == 0, "document_add columns succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_columns.pdf");
+    ASSERT(rc == 0, "columns document save succeeds");
+
+    folio_columns_free(cols);
+    folio_document_free(doc);
+
+    /* ===== Stage 22: Float layout ===== */
+    printf("Testing float layout...\n");
+    doc = folio_document_new_letter();
+    helv = folio_font_helvetica();
+
+    uint64_t floatContent = folio_paragraph_new("Floated left box", helv, 10.0);
+    uint64_t flt = folio_float_new(0, floatContent); /* FloatLeft */
+    ASSERT(flt != 0, "float_new returns handle");
+
+    rc = folio_float_set_margin(flt, 12.0);
+    ASSERT(rc == 0, "float_set_margin succeeds");
+
+    rc = folio_document_add(doc, flt);
+    ASSERT(rc == 0, "document_add float succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_float.pdf");
+    ASSERT(rc == 0, "float document save succeeds");
+
+    folio_float_free(flt);
+    folio_document_free(doc);
+
+    /* ===== Stage 23: TabbedLine ===== */
+    printf("Testing tabbed line...\n");
+    doc = folio_document_new_letter();
+    helv = folio_font_helvetica();
+
+    double positions[] = {400.0};
+    int32_t aligns[] = {1}; /* TabAlignRight */
+    int32_t leaders[] = {'.'}; /* dot leader */
+
+    uint64_t tl = folio_tabbed_line_new(helv, 12.0, positions, aligns, leaders, 1);
+    ASSERT(tl != 0, "tabbed_line_new returns handle");
+
+    const char* segments[] = {"Chapter 1", "15"};
+    rc = folio_tabbed_line_set_segments(tl, segments, 2);
+    ASSERT(rc == 0, "tabbed_line_set_segments succeeds");
+
+    rc = folio_tabbed_line_set_color(tl, 0.0, 0.0, 0.0);
+    ASSERT(rc == 0, "tabbed_line_set_color succeeds");
+
+    rc = folio_tabbed_line_set_leading(tl, 1.5);
+    ASSERT(rc == 0, "tabbed_line_set_leading succeeds");
+
+    rc = folio_document_add(doc, tl);
+    ASSERT(rc == 0, "document_add tabbed_line succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_tabs.pdf");
+    ASSERT(rc == 0, "tabbed_line document save succeeds");
+
+    folio_tabbed_line_free(tl);
+    folio_document_free(doc);
+
+    /* ===== Stage 24: Watermark & Outlines ===== */
+    printf("Testing watermark and outlines...\n");
+    doc = folio_document_new_letter();
+    helv = folio_font_helvetica();
+
+    rc = folio_document_set_watermark(doc, "DRAFT");
+    ASSERT(rc == 0, "document_set_watermark succeeds");
+
+    rc = folio_document_set_watermark_config(doc, "CONFIDENTIAL",
+        48.0, 0.8, 0.8, 0.8, 45.0, 0.2);
+    ASSERT(rc == 0, "document_set_watermark_config succeeds");
+
+    /* Add content for outlines to reference */
+    uint64_t oh1 = folio_heading_new("Chapter 1", 1);
+    rc = folio_document_add(doc, oh1);
+    ASSERT(rc == 0, "add heading for outline");
+
+    uint64_t outline = folio_document_add_outline(doc, "Chapter 1", 0);
+    ASSERT(outline != 0, "document_add_outline returns handle");
+
+    uint64_t child = folio_outline_add_child(outline, "Section 1.1", 0);
+    ASSERT(child != 0, "outline_add_child returns handle");
+
+    uint64_t outXyz = folio_document_add_outline_xyz(doc, "Precise", 0, 72.0, 500.0, 1.5);
+    ASSERT(outXyz != 0, "document_add_outline_xyz returns handle");
+
+    /* Named destination */
+    rc = folio_document_add_named_dest(doc, "ch1", 0, "Fit", 0.0, 0.0, 0.0);
+    ASSERT(rc == 0, "document_add_named_dest succeeds");
+
+    /* Viewer preferences */
+    rc = folio_document_set_viewer_preferences(doc, "SinglePage", "UseOutlines",
+        0, 0, 0, 1, 1, 1);
+    ASSERT(rc == 0, "document_set_viewer_preferences succeeds");
+
+    /* Page labels */
+    rc = folio_document_add_page_label(doc, 0, "r", "", 1); /* roman numerals */
+    ASSERT(rc == 0, "document_add_page_label succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_watermark.pdf");
+    ASSERT(rc == 0, "watermark document save succeeds");
+    folio_document_free(doc);
+
+    /* ===== Stage 25: Document extensions ===== */
+    printf("Testing document extensions...\n");
+    doc = folio_document_new_letter();
+
+    /* Page-specific margins */
+    rc = folio_document_set_first_margins(doc, 72, 72, 72, 72);
+    ASSERT(rc == 0, "document_set_first_margins succeeds");
+
+    rc = folio_document_set_left_margins(doc, 54, 72, 54, 54);
+    ASSERT(rc == 0, "document_set_left_margins succeeds");
+
+    rc = folio_document_set_right_margins(doc, 54, 54, 54, 72);
+    ASSERT(rc == 0, "document_set_right_margins succeeds");
+
+    /* Inline HTML */
+    rc = folio_document_add_html(doc, "<h2>HTML Section</h2><p>Inline HTML content.</p>");
+    ASSERT(rc == 0, "document_add_html succeeds");
+
+    rc = folio_document_add_html_with_options(doc,
+        "<p>With options</p>", 14.0, 612.0, 792.0, "", "");
+    ASSERT(rc == 0, "document_add_html_with_options succeeds");
+
+    /* File attachment */
+    const char* xmlData = "<?xml version=\"1.0\"?><invoice><total>100.00</total></invoice>";
+    rc = folio_document_attach_file(doc, xmlData, (int32_t)strlen(xmlData),
+        "invoice.xml", "application/xml", "Invoice data", "Alternative");
+    ASSERT(rc == 0, "document_attach_file succeeds");
+
+    /* Absolute positioning */
+    helv = folio_font_helvetica();
+    uint64_t absPara = folio_paragraph_new("Absolute positioned", helv, 10.0);
+    rc = folio_document_add_absolute(doc, absPara, 100.0, 200.0, 200.0);
+    ASSERT(rc == 0, "document_add_absolute succeeds");
+
+    /* Remove page */
+    folio_document_add_page(doc);
+    count = folio_document_page_count(doc);
+    rc = folio_document_remove_page(doc, count - 1);
+    ASSERT(rc == 0, "document_remove_page succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_docext.pdf");
+    ASSERT(rc == 0, "doc extensions save succeeds");
+    folio_document_free(doc);
+
+    /* ===== Stage 26: Page extensions ===== */
+    printf("Testing page extensions...\n");
+    doc = folio_document_new_letter();
+    page = folio_document_add_page(doc);
+    helv = folio_font_helvetica();
+
+    rc = folio_page_set_art_box(page, 36, 36, 576, 756);
+    ASSERT(rc == 0, "page_set_art_box succeeds");
+
+    rc = folio_page_set_size(page, 612.0, 792.0);
+    ASSERT(rc == 0, "page_set_size succeeds");
+
+    rc = folio_page_add_page_link(page, 72, 700, 200, 720, 0);
+    ASSERT(rc == 0, "page_add_page_link succeeds");
+
+    rc = folio_page_add_internal_link(page, 72, 670, 200, 690, "ch1");
+    ASSERT(rc == 0, "page_add_internal_link succeeds");
+
+    rc = folio_page_add_text_annotation(page, 72, 640, 90, 658, "A note", "Comment");
+    ASSERT(rc == 0, "page_add_text_annotation succeeds");
+
+    rc = folio_page_set_opacity_fill_stroke(page, 0.8, 1.0);
+    ASSERT(rc == 0, "page_set_opacity_fill_stroke succeeds");
+
+    rc = folio_page_set_crop_box(page, 0, 0, 612, 792);
+    ASSERT(rc == 0, "page_set_crop_box succeeds");
+
+    rc = folio_page_set_trim_box(page, 18, 18, 594, 774);
+    ASSERT(rc == 0, "page_set_trim_box succeeds");
+
+    rc = folio_page_set_bleed_box(page, 9, 9, 603, 783);
+    ASSERT(rc == 0, "page_set_bleed_box succeeds");
+
+    /* Text markup annotations — single quad point */
+    double quadPts[] = {72, 600, 200, 600, 200, 612, 72, 612};
+    rc = folio_page_add_highlight(page, 72, 600, 200, 612, 1.0, 1.0, 0.0, quadPts, 1);
+    ASSERT(rc == 0, "page_add_highlight succeeds");
+
+    rc = folio_page_add_underline_annotation(page, 72, 580, 200, 592, 0.0, 0.0, 1.0, quadPts, 1);
+    ASSERT(rc == 0, "page_add_underline_annotation succeeds");
+
+    rc = folio_page_add_squiggly(page, 72, 560, 200, 572, 1.0, 0.0, 0.0, quadPts, 1);
+    ASSERT(rc == 0, "page_add_squiggly succeeds");
+
+    rc = folio_page_add_strikeout(page, 72, 540, 200, 552, 0.5, 0.0, 0.0, quadPts, 1);
+    ASSERT(rc == 0, "page_add_strikeout succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_pageext.pdf");
+    ASSERT(rc == 0, "page extensions save succeeds");
+    folio_document_free(doc);
+
+    /* ===== Stage 27: Forms extensions ===== */
+    printf("Testing forms extensions...\n");
+    doc = folio_document_new_letter();
+    folio_document_add_page(doc);
+
+    form = folio_form_new();
+
+    /* Additional field types */
+    rc = folio_form_add_multiline_text_field(form, "notes", 72, 600, 300, 700, 0);
+    ASSERT(rc == 0, "form_add_multiline_text_field succeeds");
+
+    rc = folio_form_add_password_field(form, "pwd", 72, 560, 300, 580, 0);
+    ASSERT(rc == 0, "form_add_password_field succeeds");
+
+    const char* listOpts[] = {"Option A", "Option B", "Option C"};
+    rc = folio_form_add_listbox(form, "choices", 72, 400, 200, 540, 0, listOpts, 3);
+    ASSERT(rc == 0, "form_add_listbox succeeds");
+
+    /* Radio group */
+    const char* radioVals[] = {"yes", "no"};
+    double radioRects[] = {72, 350, 90, 368,  120, 350, 138, 368};
+    int32_t radioPages[] = {0, 0};
+    rc = folio_form_add_radio_group(form, "confirm", radioVals, radioRects, radioPages, 2);
+    ASSERT(rc == 0, "form_add_radio_group succeeds");
+
+    /* Field builder pattern */
+    uint64_t field = folio_form_create_text_field("email", 72, 300, 300, 320, 0);
+    ASSERT(field != 0, "form_create_text_field returns handle");
+
+    rc = folio_form_field_set_value(field, "user@example.com");
+    ASSERT(rc == 0, "form_field_set_value succeeds");
+
+    rc = folio_form_field_set_required(field);
+    ASSERT(rc == 0, "form_field_set_required succeeds");
+
+    rc = folio_form_field_set_background_color(field, 1.0, 1.0, 0.9);
+    ASSERT(rc == 0, "form_field_set_background_color succeeds");
+
+    rc = folio_form_field_set_border_color(field, 0.0, 0.0, 0.5);
+    ASSERT(rc == 0, "form_field_set_border_color succeeds");
+
+    rc = folio_form_add_field(form, field);
+    ASSERT(rc == 0, "form_add_field succeeds");
+
+    /* Read-only checkbox */
+    uint64_t roCheck = folio_form_create_checkbox("locked", 72, 260, 90, 278, 0, 1);
+    ASSERT(roCheck != 0, "form_create_checkbox returns handle");
+    rc = folio_form_field_set_read_only(roCheck);
+    ASSERT(rc == 0, "form_field_set_read_only succeeds");
+    rc = folio_form_add_field(form, roCheck);
+    ASSERT(rc == 0, "form_add_field (read-only checkbox) succeeds");
+
+    rc = folio_document_set_form(doc, form);
+    ASSERT(rc == 0, "document_set_form with extensions succeeds");
+
+    rc = folio_document_save(doc, "/tmp/folio_cabi_forms_ext.pdf");
+    ASSERT(rc == 0, "forms extension save succeeds");
+
+    folio_form_field_free(field);
+    folio_form_field_free(roCheck);
+    folio_form_free(form);
+    folio_document_free(doc);
+
+    /* ===== Stage 28: Form filling ===== */
+    printf("Testing form filling...\n");
+    /* Re-open the forms PDF we just saved */
+    uint64_t fillRdr = folio_reader_open("/tmp/folio_cabi_forms.pdf");
+    ASSERT(fillRdr != 0, "reader_open for form filling");
+
+    uint64_t filler = folio_form_filler_new(fillRdr);
+    ASSERT(filler != 0, "form_filler_new returns handle");
+
+    uint64_t namesBuf = folio_form_filler_field_names(filler);
+    ASSERT(namesBuf != 0, "form_filler_field_names returns buffer");
+    ASSERT(folio_buffer_len(namesBuf) > 0, "field names non-empty");
+    folio_buffer_free(namesBuf);
+
+    rc = folio_form_filler_set_value(filler, "name", "John Doe");
+    ASSERT(rc == 0, "form_filler_set_value succeeds");
+
+    uint64_t valBuf = folio_form_filler_get_value(filler, "name");
+    ASSERT(valBuf != 0, "form_filler_get_value returns buffer");
+    folio_buffer_free(valBuf);
+
+    rc = folio_form_filler_set_checkbox(filler, "agree", 0);
+    ASSERT(rc == 0, "form_filler_set_checkbox succeeds");
+
+    folio_form_filler_free(filler);
+    folio_reader_free(fillRdr);
+
+    /* ===== Stage 29: Image element extensions ===== */
+    printf("Testing image element align...\n");
+    /* We can't test actual image loading without a file, but we test
+       that the set_align function exists and handles bad handles */
+    rc = folio_image_element_set_align(99999, 1);
+    ASSERT(rc != 0, "image_element_set_align rejects bad handle");
+
+    /* ===== Stage 30: List extensions ===== */
+    printf("Testing list extensions...\n");
+    helv = folio_font_helvetica();
+    list = folio_list_new(helv, 12.0);
+
+    rc = folio_list_set_leading(list, 1.5);
+    ASSERT(rc == 0, "list_set_leading succeeds");
+
+    folio_list_add_item(list, "Parent item");
+    uint64_t subList = folio_list_add_nested_item(list, "Nested parent");
+    ASSERT(subList != 0, "list_add_nested_item returns sub-list handle");
+
+    folio_list_add_item(subList, "Sub-item A");
+    folio_list_add_item(subList, "Sub-item B");
+
+    folio_list_free(list);
+
     /* Summary */
     printf("\n%d passed, %d failed\n", passes, failures);
     return failures > 0 ? 1 : 0;

--- a/scripts/audit-cabi.sh
+++ b/scripts/audit-cabi.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# audit-cabi.sh — Compare Go exports, C header declarations, and built symbols.
+#
+# Usage:
+#   ./scripts/audit-cabi.sh          # audit only (no build)
+#   ./scripts/audit-cabi.sh --build  # build dylib and also verify symbols
+#
+# Exit codes:
+#   0  everything in sync
+#   1  drift detected
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ── 1. Extract Go //export directives ──────────────────────────────
+
+grep -rh '//export folio_' export/*.go \
+  | sed 's|.*//export ||' \
+  | sort -u \
+  > "$tmpdir/go_exports.txt"
+
+go_count=$(wc -l < "$tmpdir/go_exports.txt" | tr -d ' ')
+echo -e "${BOLD}Go //export directives:${NC} $go_count"
+
+# ── 2. Extract C header declarations ───────────────────────────────
+
+# Match function declarations: return_type folio_name(...)
+grep -oE 'folio_[a-zA-Z0-9_]+' export/folio.h \
+  | grep -v '^folio_page_decorator_fn$' \
+  | sort -u \
+  > "$tmpdir/header_funcs.txt"
+
+header_count=$(wc -l < "$tmpdir/header_funcs.txt" | tr -d ' ')
+echo -e "${BOLD}Header declarations:${NC}   $header_count"
+
+# ── 3. Compare Go exports vs header ───────────────────────────────
+
+in_go_not_header=$(comm -23 "$tmpdir/go_exports.txt" "$tmpdir/header_funcs.txt" || true)
+in_header_not_go=$(comm -13 "$tmpdir/go_exports.txt" "$tmpdir/header_funcs.txt" || true)
+
+drift=0
+
+if [ -n "$in_go_not_header" ]; then
+  echo ""
+  echo -e "${RED}Exported in Go but MISSING from folio.h:${NC}"
+  echo "$in_go_not_header" | sed 's/^/  - /'
+  drift=1
+fi
+
+if [ -n "$in_header_not_go" ]; then
+  echo ""
+  echo -e "${RED}Declared in folio.h but MISSING Go //export:${NC}"
+  echo "$in_header_not_go" | sed 's/^/  - /'
+  drift=1
+fi
+
+if [ "$drift" -eq 0 ]; then
+  echo -e "${GREEN}✓ Go exports and folio.h are in sync${NC}"
+fi
+
+# ── 4. Optionally verify built symbols ─────────────────────────────
+
+if [ "${1:-}" = "--build" ]; then
+  echo ""
+  echo -e "${BOLD}Building shared library...${NC}"
+  outlib="$tmpdir/libfolio_audit"
+
+  case "$(uname -s)" in
+    Darwin) outlib="$outlib.dylib" ;;
+    Linux)  outlib="$outlib.so" ;;
+    *)      outlib="$outlib.dll" ;;
+  esac
+
+  CGO_ENABLED=1 go build -o "$outlib" -buildmode=c-shared ./export/ 2>&1
+
+  # Extract symbols
+  case "$(uname -s)" in
+    Darwin) nm -gU "$outlib" | grep ' T _folio_' | sed 's/.* T _//' | sort -u > "$tmpdir/symbols.txt" ;;
+    *)      nm -D "$outlib" | grep ' T folio_' | sed 's/.* T //' | sort -u > "$tmpdir/symbols.txt" ;;
+  esac
+
+  sym_count=$(wc -l < "$tmpdir/symbols.txt" | tr -d ' ')
+  echo -e "${BOLD}Built symbols:${NC}         $sym_count"
+
+  in_go_not_sym=$(comm -23 "$tmpdir/go_exports.txt" "$tmpdir/symbols.txt" || true)
+  in_sym_not_go=$(comm -13 "$tmpdir/go_exports.txt" "$tmpdir/symbols.txt" || true)
+
+  if [ -n "$in_go_not_sym" ]; then
+    echo ""
+    echo -e "${RED}Go //export but NOT in built library:${NC}"
+    echo "$in_go_not_sym" | sed 's/^/  - /'
+    drift=1
+  fi
+
+  if [ -n "$in_sym_not_go" ]; then
+    echo ""
+    echo -e "${YELLOW}In built library but no Go //export (runtime/cgo internals):${NC}"
+    echo "$in_sym_not_go" | sed 's/^/  - /'
+  fi
+
+  if [ "$drift" -eq 0 ]; then
+    echo -e "${GREEN}✓ Built symbols match Go exports${NC}"
+  fi
+fi
+
+# ── 5. Summary ─────────────────────────────────────────────────────
+
+echo ""
+if [ "$drift" -ne 0 ]; then
+  echo -e "${RED}${BOLD}DRIFT DETECTED${NC} — header and Go exports are out of sync"
+  exit 1
+else
+  echo -e "${GREEN}${BOLD}ALL CLEAR${NC} — $go_count functions exported, header matches"
+  exit 0
+fi


### PR DESCRIPTION
## Description

New Go files:
- cabi_barcode.go — QR, Code128, EAN-13 + layout elements
- cabi_svg.go — SVG parse + layout elements
- cabi_link.go — hyperlink layout elements
- cabi_flex.go — flexbox container with items, direction, justify, align, wrap, gap
- cabi_document_ext.go — watermark, outlines, named destinations, viewer preferences, page labels, remove page, absolute positioning
- cabi_document_ext2.go — file attachments (PDF/A-3b), inline HTML, page-specific margins
- cabi_layout_ext.go — paragraph/table/cell/div/list/image/flex extensions, TIFF
- cabi_page_ext.go — art box, page size, page links, text markup annotations, opacity
- cabi_forms_ext.go — field builder, multiline/password/listbox/radio, form filling
- cabi_grid.go — CSS Grid with template columns/rows, auto-rows, placement, alignment
- cabi_columns.go — multi-column layout
- cabi_float.go — left/right floating elements
- cabi_tab.go — tabbed line with tab stops and leaders

Updated:
- cabi_font.go — all 14 standard font dedicated accessors
- folio.h — all 281 declarations with new enum constants
- test_cabi.c — 258 integration tests covering all new exports
- .gitignore — add cgo header and test binary
- ci.yml — add audit check, shared library build, C integration tests
- release.yml — build native libs for 5 platforms, ship with folio.h
- Makefile — add audit, cross-compilation targets

Added scripts/audit-cabi.sh to detect drift between Go exports and folio.h.

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
