### PR TITLE
Add forms example and fix radio button / checkbox appearance bugs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ examples/
 ├── hello/          # minimal one-page PDF
 ├── fonts/          # standard, custom, and Unicode fonts (CJK, Cyrillic)
 ├── links/          # hyperlinks, bookmarks, internal navigation
+├── forms/          # interactive AcroForm fields (text, checkbox, radio, dropdown)
 ├── zugferd/        # PDF/A-3B invoice with Factur-X XML attachment
 └── README.md
 ```

--- a/examples/forms/main.go
+++ b/examples/forms/main.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Forms demonstrates creating a PDF with interactive AcroForm fields:
+//
+//   - Text fields (single-line and multi-line)
+//   - Password field
+//   - Checkboxes
+//   - Radio button groups
+//   - Dropdown (combo box)
+//   - List box
+//   - Read-only and required fields
+//   - Styled fields (colors, borders)
+//
+// Open the generated PDF in Adobe Acrobat or another form-capable viewer
+// to interact with the fields. Note: macOS Preview has limited form support.
+//
+// Usage:
+//
+//	go run ./examples/forms
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/forms"
+)
+
+func main() {
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.Info.Title = "Folio Forms Showcase"
+	doc.Info.Author = "Folio"
+
+	// Page 1 handles the form fields.
+	p := doc.AddPage()
+
+	// --- Title ---
+	p.AddText("Folio Forms Showcase", font.HelveticaBold, 20, 72, 740)
+	p.AddText("Interactive AcroForm fields — open in Adobe Acrobat to edit.", font.Helvetica, 10, 72, 722)
+
+	// --- Text Fields ---
+	y := 690.0
+	p.AddText("Text Fields", font.HelveticaBold, 13, 72, y)
+
+	y -= 22
+	p.AddText("Full Name:", font.Helvetica, 10, 72, y+4)
+	nameField := forms.TextField("fullName", rect(180, y, 350, y+18), 0).
+		SetValue("Jane Smith").
+		SetRequired().
+		SetBorderColor(0.6, 0.6, 0.6).
+		SetBackgroundColor(1, 1, 0.95)
+
+	y -= 26
+	p.AddText("Email:", font.Helvetica, 10, 72, y+4)
+	emailField := forms.TextField("email", rect(180, y, 350, y+18), 0).
+		SetBorderColor(0.6, 0.6, 0.6)
+
+	y -= 26
+	p.AddText("Password:", font.Helvetica, 10, 72, y+4)
+	passwordField := forms.PasswordField("password", rect(180, y, 350, y+18), 0).
+		SetBorderColor(0.6, 0.6, 0.6)
+
+	y -= 26
+	p.AddText("Read-only:", font.Helvetica, 10, 72, y+4)
+	readonlyField := forms.TextField("readonly", rect(180, y, 350, y+18), 0).
+		SetValue("Cannot edit this").
+		SetReadOnly().
+		SetBackgroundColor(0.95, 0.95, 0.95)
+
+	// --- Multi-line Text ---
+	y -= 36
+	p.AddText("Multi-line Text", font.HelveticaBold, 13, 72, y)
+
+	y -= 22
+	p.AddText("Comments:", font.Helvetica, 10, 72, y+40)
+	commentsField := forms.MultilineTextField("comments", rect(180, y, 450, y+58), 0).
+		SetValue("Enter your comments here...\nMultiple lines supported.").
+		SetBorderColor(0.4, 0.4, 0.7)
+
+	// --- Checkboxes ---
+	y -= 36
+	p.AddText("Checkboxes", font.HelveticaBold, 13, 72, y)
+
+	y -= 22
+	p.AddText("Agree to terms:", font.Helvetica, 10, 72, y+4)
+	termsCheckbox := forms.Checkbox("agreeTerms", rect(180, y, 196, y+16), 0, true)
+
+	y -= 22
+	p.AddText("Subscribe:", font.Helvetica, 10, 72, y+4)
+	subCheckbox := forms.Checkbox("subscribe", rect(180, y, 196, y+16), 0, false)
+
+	// --- Radio Buttons ---
+	y -= 36
+	p.AddText("Radio Buttons", font.HelveticaBold, 13, 72, y)
+
+	y -= 22
+	p.AddText("Preference:", font.Helvetica, 10, 72, y+4)
+	p.AddText("Option A", font.Helvetica, 9, 198, y+4)
+	p.AddText("Option B", font.Helvetica, 9, 278, y+4)
+	p.AddText("Option C", font.Helvetica, 9, 358, y+4)
+	radioGroup := forms.RadioGroup("preference", []forms.RadioOption{
+		{Value: "A", Rect: rect(180, y, 196, y+16), PageIndex: 0},
+		{Value: "B", Rect: rect(260, y, 276, y+16), PageIndex: 0},
+		{Value: "C", Rect: rect(340, y, 356, y+16), PageIndex: 0},
+	})
+
+	// --- Dropdown ---
+	y -= 36
+	p.AddText("Dropdown", font.HelveticaBold, 13, 72, y)
+
+	y -= 22
+	p.AddText("Country:", font.Helvetica, 10, 72, y+4)
+	dropdown := forms.Dropdown("country", rect(180, y, 350, y+20), 0,
+		[]string{"United States", "Germany", "Japan", "Brazil", "Australia"}).
+		SetBorderColor(0.6, 0.6, 0.6)
+
+	// --- List Box ---
+	y -= 36
+	p.AddText("List Box", font.HelveticaBold, 13, 72, y)
+
+	y -= 70
+	p.AddText("Languages:", font.Helvetica, 10, 72, y+50)
+	listbox := forms.ListBox("languages", rect(180, y, 350, y+60), 0,
+		[]string{"Go", "Python", "Rust", "TypeScript", "Java", "C++", "Ruby"}).
+		SetBorderColor(0.4, 0.6, 0.4)
+
+	// --- Styled Fields ---
+	y -= 26
+	p.AddText("Styled Fields", font.HelveticaBold, 13, 72, y)
+
+	y -= 22
+	p.AddText("Blue border:", font.Helvetica, 10, 72, y+4)
+	blueField := forms.TextField("blue", rect(180, y, 350, y+18), 0).
+		SetBorderColor(0.2, 0.3, 0.8).
+		SetBackgroundColor(0.93, 0.95, 1.0)
+
+	y -= 26
+	p.AddText("Green border:", font.Helvetica, 10, 72, y+4)
+	greenField := forms.TextField("green", rect(180, y, 350, y+18), 0).
+		SetBorderColor(0.2, 0.6, 0.3).
+		SetBackgroundColor(0.93, 1.0, 0.95).
+		SetValue("Styled input")
+
+	// --- Signature Field ---
+	y -= 36
+	p.AddText("Signature Field", font.HelveticaBold, 13, 72, y)
+
+	y -= 22
+	p.AddText("Sign here:", font.Helvetica, 10, 72, y+4)
+	sigField := forms.SignatureField("signature", rect(180, y, 400, y+40), 0)
+
+	// --- Build the form ---
+	form := forms.NewAcroForm()
+	form.Add(nameField)
+	form.Add(emailField)
+	form.Add(passwordField)
+	form.Add(readonlyField)
+	form.Add(commentsField)
+	form.Add(termsCheckbox)
+	form.Add(subCheckbox)
+	form.Add(radioGroup)
+	form.Add(dropdown)
+	form.Add(listbox)
+	form.Add(sigField)
+	form.Add(blueField)
+	form.Add(greenField)
+
+	doc.SetAcroForm(form)
+
+	if err := doc.Save("forms.pdf"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("Created forms.pdf — open in Adobe Acrobat to interact with fields")
+}
+
+// rect creates a field rectangle [x1, y1, x2, y2].
+func rect(x1, y1, x2, y2 float64) [4]float64 {
+	return [4]float64{x1, y1, x2, y2}
+}

--- a/forms/appearance.go
+++ b/forms/appearance.go
@@ -33,9 +33,11 @@ func buildCheckboxAppearance(f *Field, addObject func(core.PdfObject) *core.PdfI
 	w := f.Rect[2] - f.Rect[0]
 	h := f.Rect[3] - f.Rect[1]
 
-	// "Yes" appearance: checkmark.
+	// "Yes" appearance: border + checkmark.
 	yesStream := core.NewPdfStream([]byte(
-		fmt.Sprintf("q\n0 0 0 rg\nBT\n/ZaDb %s Tf\n%s %s Td\n(4) Tj\nET\nQ",
+		fmt.Sprintf("q\n0.6 0.6 0.6 RG\n0.5 w\n0 0 %s %s re S\n"+
+			"0 0 0 rg\nBT\n/ZaDb %s Tf\n%s %s Td\n(4) Tj\nET\nQ",
+			fmtNum(w), fmtNum(h),
 			fmtNum(h*0.8), fmtNum(w*0.15), fmtNum(h*0.15)),
 	))
 	yesStream.Dict.Set("Type", core.NewPdfName("XObject"))
@@ -57,8 +59,10 @@ func buildCheckboxAppearance(f *Field, addObject func(core.PdfObject) *core.PdfI
 	yesStream.Dict.Set("Resources", resDict)
 	yesRef := addObject(yesStream)
 
-	// "Off" appearance: empty box.
-	offStream := core.NewPdfStream([]byte(""))
+	// "Off" appearance: border only.
+	offStream := core.NewPdfStream([]byte(
+		fmt.Sprintf("q\n0.6 0.6 0.6 RG\n0.5 w\n0 0 %s %s re S\nQ", fmtNum(w), fmtNum(h)),
+	))
 	offStream.Dict.Set("Type", core.NewPdfName("XObject"))
 	offStream.Dict.Set("Subtype", core.NewPdfName("Form"))
 	offStream.Dict.Set("BBox", core.NewPdfArray(
@@ -79,7 +83,7 @@ func buildCheckboxAppearance(f *Field, addObject func(core.PdfObject) *core.PdfI
 
 // buildWidgetDict creates a standalone widget annotation dictionary for a radio button child.
 // The widget is linked to its parent field and, when valid, to the target page.
-func buildWidgetDict(child *Field, parentRef *core.PdfIndirectReference, pageRefs []*core.PdfIndirectReference) *core.PdfDictionary {
+func buildWidgetDict(child *Field, parentRef *core.PdfIndirectReference, pageRefs []*core.PdfIndirectReference, addObject func(core.PdfObject) *core.PdfIndirectReference) *core.PdfDictionary {
 	w := core.NewPdfDictionary()
 	w.Set("Type", core.NewPdfName("Annot"))
 	w.Set("Subtype", core.NewPdfName("Widget"))
@@ -98,7 +102,66 @@ func buildWidgetDict(child *Field, parentRef *core.PdfIndirectReference, pageRef
 	// Appearance state.
 	w.Set("AS", core.NewPdfName("Off"))
 
+	// Radio button appearance: each widget needs its own /AP with a
+	// unique export value key so the viewer can select them independently.
+	exportVal := child.ExportValue
+	if exportVal == "" {
+		exportVal = "Yes"
+	}
+	rw := child.Rect[2] - child.Rect[0]
+	rh := child.Rect[3] - child.Rect[1]
+	ap := buildRadioAppearance(exportVal, rw, rh, addObject)
+	w.Set("AP", ap)
+
 	return w
+}
+
+// buildRadioAppearance creates an /AP dictionary for a radio button widget.
+// The /N sub-dictionary contains an appearance for the export value (filled
+// circle) and /Off (empty circle).
+func buildRadioAppearance(exportVal string, w, h float64, addObject func(core.PdfObject) *core.PdfIndirectReference) *core.PdfDictionary {
+	cx := w / 2
+	cy := h / 2
+	r := min(w, h) / 2 * 0.8
+
+	// "On" appearance: outlined box with a filled dot in the center.
+	dotR := r * 0.5
+	onContent := fmt.Sprintf(
+		"q\n0.6 0.6 0.6 RG\n0.5 w\n%s %s %s %s re S\n"+
+			"0 0 0 rg\n%s %s %s %s re f\nQ",
+		fmtNum(cx-r), fmtNum(cy-r), fmtNum(r*2), fmtNum(r*2),
+		fmtNum(cx-dotR), fmtNum(cy-dotR), fmtNum(dotR*2), fmtNum(dotR*2),
+	)
+	onStream := core.NewPdfStream([]byte(onContent))
+	onStream.Dict.Set("Type", core.NewPdfName("XObject"))
+	onStream.Dict.Set("Subtype", core.NewPdfName("Form"))
+	onStream.Dict.Set("BBox", core.NewPdfArray(
+		core.NewPdfInteger(0), core.NewPdfInteger(0),
+		core.NewPdfReal(w), core.NewPdfReal(h),
+	))
+	onRef := addObject(onStream)
+
+	// "Off" appearance: empty box.
+	offContent := fmt.Sprintf(
+		"q\n0.6 0.6 0.6 RG\n0.5 w\n%s %s %s %s re S\nQ",
+		fmtNum(cx-r), fmtNum(cy-r), fmtNum(r*2), fmtNum(r*2),
+	)
+	offStream := core.NewPdfStream([]byte(offContent))
+	offStream.Dict.Set("Type", core.NewPdfName("XObject"))
+	offStream.Dict.Set("Subtype", core.NewPdfName("Form"))
+	offStream.Dict.Set("BBox", core.NewPdfArray(
+		core.NewPdfInteger(0), core.NewPdfInteger(0),
+		core.NewPdfReal(w), core.NewPdfReal(h),
+	))
+	offRef := addObject(offStream)
+
+	nDict := core.NewPdfDictionary()
+	nDict.Set(exportVal, onRef)
+	nDict.Set("Off", offRef)
+
+	ap := core.NewPdfDictionary()
+	ap.Set("N", nDict)
+	return ap
 }
 
 // fmtNum formats a float64 as a compact string for PDF content streams.

--- a/forms/field.go
+++ b/forms/field.go
@@ -274,7 +274,7 @@ func (f *Field) ToDict(addObject func(core.PdfObject) *core.PdfIndirectReference
 	if f.Type == FieldRadio && len(f.children) > 0 {
 		kids := core.NewPdfArray()
 		for _, child := range f.children {
-			wDict := buildWidgetDict(child, fieldRef, pageRefs)
+			wDict := buildWidgetDict(child, fieldRef, pageRefs, addObject)
 			wRef := addObject(wDict)
 			kids.Add(wRef)
 			if child.PageIndex >= 0 && child.PageIndex < len(pageRefs) {

--- a/forms/forms_test.go
+++ b/forms/forms_test.go
@@ -102,6 +102,109 @@ func TestRadioGroupCreation(t *testing.T) {
 	}
 }
 
+// TestRadioGroupUniqueAppearances verifies that each radio widget gets its
+// own /AP with a unique export value. Without this, selecting one radio
+// button would visually select all of them.
+func TestRadioGroupUniqueAppearances(t *testing.T) {
+	form := NewAcroForm()
+	form.Add(RadioGroup("pref", []RadioOption{
+		{Value: "A", Rect: [4]float64{72, 580, 92, 600}, PageIndex: 0},
+		{Value: "B", Rect: [4]float64{102, 580, 122, 600}, PageIndex: 0},
+		{Value: "C", Rect: [4]float64{132, 580, 152, 600}, PageIndex: 0},
+	}))
+
+	data := generateFormPDF(t, form)
+	pdf := string(data)
+
+	// Each export value must appear as a Name key in an /N appearance dict.
+	for _, val := range []string{"/A ", "/B ", "/C "} {
+		if !strings.Contains(pdf, val) {
+			t.Errorf("expected radio export value %s in PDF", val)
+		}
+	}
+	// Every radio widget should have /AP.
+	apCount := strings.Count(pdf, "/AP")
+	if apCount < 3 {
+		t.Errorf("expected at least 3 /AP entries (one per radio), got %d", apCount)
+	}
+	// All widgets start as /Off.
+	offCount := strings.Count(pdf, "/AS /Off")
+	if offCount < 3 {
+		t.Errorf("expected 3 /AS /Off entries, got %d", offCount)
+	}
+}
+
+// TestCheckboxAppearancesHaveBorder verifies that checkbox appearance
+// streams draw visible borders (not empty content).
+func TestCheckboxAppearancesHaveBorder(t *testing.T) {
+	form := NewAcroForm()
+	form.Add(Checkbox("test", [4]float64{72, 680, 92, 700}, 0, false))
+
+	data := generateFormPDF(t, form)
+	pdf := string(data)
+
+	// Should have /AP dictionary.
+	if !strings.Contains(pdf, "/AP") {
+		t.Error("expected /AP dictionary on checkbox widget")
+	}
+	// The Off appearance should have content (border drawing).
+	// Before the fix, the Off stream was empty.
+	if strings.Count(pdf, "/AP") < 1 {
+		t.Error("checkbox missing appearance dictionary")
+	}
+	// The appearance streams should contain drawing operators.
+	// "re S" = rectangle stroke (the border).
+	if !strings.Contains(pdf, "re S") {
+		t.Error("expected border drawing (re S) in checkbox appearance")
+	}
+}
+
+// TestDropdownOptions verifies that the /Opt array contains all options.
+func TestDropdownOptions(t *testing.T) {
+	opts := []string{"USA", "Canada", "Mexico", "Brazil"}
+	form := NewAcroForm()
+	form.Add(Dropdown("country", [4]float64{72, 620, 250, 640}, 0, opts))
+
+	data := generateFormPDF(t, form)
+	pdf := string(data)
+
+	if !strings.Contains(pdf, "/Opt") {
+		t.Error("expected /Opt array in dropdown")
+	}
+	for _, opt := range opts {
+		if !strings.Contains(pdf, opt) {
+			t.Errorf("expected option %q in PDF", opt)
+		}
+	}
+}
+
+// TestListBoxOptions verifies that list box has /Opt array and is not
+// a combo box (no /Combo flag).
+func TestListBoxOptions(t *testing.T) {
+	opts := []string{"Go", "Rust", "Python"}
+	form := NewAcroForm()
+	form.Add(ListBox("lang", [4]float64{72, 400, 250, 500}, 0, opts))
+
+	data := generateFormPDF(t, form)
+	pdf := string(data)
+
+	if !strings.Contains(pdf, "/FT /Ch") {
+		t.Error("expected /FT /Ch for list box")
+	}
+	if !strings.Contains(pdf, "/Opt") {
+		t.Error("expected /Opt array")
+	}
+	for _, opt := range opts {
+		if !strings.Contains(pdf, opt) {
+			t.Errorf("expected option %q in PDF", opt)
+		}
+	}
+	// Combo box flag (bit 17 = 0x20000) should NOT be set for a list box.
+	if strings.Contains(pdf, "/Ff 131072") {
+		t.Error("list box should not have combo flag")
+	}
+}
+
 func TestMultilineTextField(t *testing.T) {
 	form := NewAcroForm()
 	f := MultilineTextField("comments", [4]float64{72, 500, 400, 600}, 0)


### PR DESCRIPTION
## Description

Example showcasing all AcroForm field types: text, password, multi-line, read-only, required, checkboxes, radio buttons, dropdown, list box, and styled fields with custom colors.

Bug fixes in forms/appearance.go:
- Radio buttons: each widget now gets its own /AP dictionary with a unique export-value key, so selecting one deselects the others. Previously all widgets shared no appearance, causing all to appear selected simultaneously.
- Checkboxes: both Yes and Off appearances now draw a visible border. Previously the Off state was an empty stream with no visible box.

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
