### PR TITLE
Add MarginBoxes/FirstMarginBoxes to ConvertResult for simpler API

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -101,22 +101,12 @@ func renderHTML(_ js.Value, args []js.Value) any {
 		}
 	}
 
-	// Apply margin boxes from @page rules.
-	if pc := result.PageConfig; pc != nil {
-		if len(pc.MarginBoxes) > 0 {
-			boxes := make(map[string]layout.MarginBox)
-			for name, mbc := range pc.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
-			}
-			doc.SetMarginBoxes(boxes)
-		}
-		if pc.First != nil && len(pc.First.MarginBoxes) > 0 {
-			boxes := make(map[string]layout.MarginBox)
-			for name, mbc := range pc.First.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
-			}
-			doc.SetFirstMarginBoxes(boxes)
-		}
+	// Apply margin boxes from @page rules (e.g. page numbers).
+	if result.MarginBoxes != nil {
+		doc.SetMarginBoxes(result.MarginBoxes)
+	}
+	if result.FirstMarginBoxes != nil {
+		doc.SetFirstMarginBoxes(result.FirstMarginBoxes)
 	}
 
 	// Apply metadata from HTML <title>/<meta> tags

--- a/examples/html-to-pdf/main.go
+++ b/examples/html-to-pdf/main.go
@@ -263,20 +263,12 @@ func main() {
 				Bottom: pc.MarginBottom, Left: pc.MarginLeft,
 			})
 		}
-		if len(pc.MarginBoxes) > 0 {
-			boxes := make(map[string]layout.MarginBox)
-			for name, mbc := range pc.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
-			}
-			doc.SetMarginBoxes(boxes)
-		}
-		if pc.First != nil && len(pc.First.MarginBoxes) > 0 {
-			boxes := make(map[string]layout.MarginBox)
-			for name, mbc := range pc.First.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
-			}
-			doc.SetFirstMarginBoxes(boxes)
-		}
+	}
+	if result.MarginBoxes != nil {
+		doc.SetMarginBoxes(result.MarginBoxes)
+	}
+	if result.FirstMarginBoxes != nil {
+		doc.SetFirstMarginBoxes(result.FirstMarginBoxes)
 	}
 
 	for _, e := range result.Elements {

--- a/export/cabi_html.go
+++ b/export/cabi_html.go
@@ -95,6 +95,14 @@ func htmlToDocument(htmlStr string, pageWidth, pageHeight float64) (*document.Do
 		})
 	}
 
+	// Apply @page margin boxes (page numbers, headers/footers).
+	if result.MarginBoxes != nil {
+		doc.SetMarginBoxes(result.MarginBoxes)
+	}
+	if result.FirstMarginBoxes != nil {
+		doc.SetFirstMarginBoxes(result.FirstMarginBoxes)
+	}
+
 	// Apply metadata.
 	if result.Metadata.Title != "" {
 		doc.Info.Title = result.Metadata.Title

--- a/html/converter.go
+++ b/html/converter.go
@@ -69,6 +69,15 @@ type ConvertResult struct {
 	Absolutes  []AbsoluteItem
 	PageConfig *PageConfig // page settings from @page rules (nil if none)
 	Metadata   DocMetadata // extracted from <title> and <meta> tags
+
+	// MarginBoxes are ready-to-use margin box definitions from @page rules
+	// (e.g. page numbers via @bottom-center). Pass directly to
+	// document.SetMarginBoxes. Nil if no margin boxes were declared.
+	MarginBoxes map[string]layout.MarginBox
+
+	// FirstMarginBoxes are margin boxes for @page :first only.
+	// Pass to document.SetFirstMarginBoxes. Nil if not declared.
+	FirstMarginBoxes map[string]layout.MarginBox
 }
 
 // DocMetadata holds document metadata extracted from HTML head elements.
@@ -117,6 +126,22 @@ type PageConfig struct {
 
 	// Default margin boxes (from @page with no pseudo-selector).
 	MarginBoxes map[string]MarginBoxContent // e.g. "top-center" → content
+}
+
+// convertMarginBoxes converts html.MarginBoxContent to layout.MarginBox.
+func convertMarginBoxes(src map[string]MarginBoxContent) map[string]layout.MarginBox {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make(map[string]layout.MarginBox, len(src))
+	for name, mbc := range src {
+		out[name] = layout.MarginBox{
+			Content:  mbc.Content,
+			FontSize: mbc.FontSize,
+			Color:    mbc.Color,
+		}
+	}
+	return out
 }
 
 // AbsoluteItem represents an element removed from normal flow via
@@ -176,6 +201,15 @@ func ConvertFull(htmlStr string, opts *Options) (*ConvertResult, error) {
 	elems := c.walkChildren(doc, style)
 	result := &ConvertResult{Elements: elems, Absolutes: c.absolutes, Metadata: c.metadata}
 	result.PageConfig = pageConfig
+
+	// Build ready-to-use margin box maps so callers can pass them
+	// directly to doc.SetMarginBoxes without type conversion.
+	if pageConfig != nil {
+		result.MarginBoxes = convertMarginBoxes(pageConfig.MarginBoxes)
+		if pageConfig.First != nil {
+			result.FirstMarginBoxes = convertMarginBoxes(pageConfig.First.MarginBoxes)
+		}
+	}
 
 	return result, nil
 }


### PR DESCRIPTION
## Description

ConvertResult now includes ready-to-use layout.MarginBox maps, so callers can wire @page margin boxes (page numbers, headers) with:

  doc.SetMarginBoxes(result.MarginBoxes)
  doc.SetFirstMarginBoxes(result.FirstMarginBoxes)

Instead of the previous 15-line manual conversion from html.MarginBoxContent to layout.MarginBox.

Updated cmd/wasm and examples/html-to-pdf to use the new fields.

## Related issue

Closes #52

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
