### PR TITLE
Add PDF/UA accessibility: alt text, custom tags, structure tree reading

### DIFF
--- a/export/cabi_tagged.go
+++ b/export/cabi_tagged.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+/*
+#include <stdint.h>
+*/
+import "C"
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// ── Alt text for figure elements ───────────────────────────────────
+
+//export folio_image_element_set_alt_text
+func folio_image_element_set_alt_text(ieH C.uint64_t, text *C.char) C.int32_t {
+	v := ht.load(uint64(ieH))
+	if v == nil {
+		setLastError("invalid image element handle")
+		return errInvalidHandle
+	}
+	ie, ok := v.(*layout.ImageElement)
+	if !ok {
+		setLastError(fmt.Sprintf("handle %d is not an image element", uint64(ieH)))
+		return errTypeMismatch
+	}
+	ie.SetAltText(C.GoString(text))
+	return errOK
+}
+
+//export folio_barcode_element_set_alt_text
+func folio_barcode_element_set_alt_text(beH C.uint64_t, text *C.char) C.int32_t {
+	be, errCode := loadBarcodeElement(beH)
+	if errCode != errOK {
+		return errCode
+	}
+	be.SetAltText(C.GoString(text))
+	return errOK
+}
+
+//export folio_svg_element_set_alt_text
+func folio_svg_element_set_alt_text(seH C.uint64_t, text *C.char) C.int32_t {
+	se, errCode := loadSVGElement(seH)
+	if errCode != errOK {
+		return errCode
+	}
+	se.SetAltText(C.GoString(text))
+	return errOK
+}
+
+// ── Custom structure tags ──────────────────────────────────────────
+
+//export folio_div_set_tag
+func folio_div_set_tag(divH C.uint64_t, tag *C.char) C.int32_t {
+	div, errCode := loadDiv(divH)
+	if errCode != errOK {
+		return errCode
+	}
+	div.SetTag(C.GoString(tag))
+	return errOK
+}
+
+// ── Structure tree reading ─────────────────────────────────────────
+
+// folio_reader_structure_tree returns the document's structure tree as JSON.
+// Returns 0 if the document is not tagged.
+//
+//export folio_reader_structure_tree
+func folio_reader_structure_tree(rH C.uint64_t) C.uint64_t {
+	r, errCode := loadReader(rH)
+	if errCode != errOK {
+		return 0
+	}
+	tree := r.StructureTree()
+	if tree == nil {
+		setLastError("document is not tagged")
+		return 0
+	}
+	data, err := json.Marshal(tree)
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	return C.uint64_t(ht.store(newCBuffer(data)))
+}

--- a/export/folio.h
+++ b/export/folio.h
@@ -363,6 +363,7 @@ void     folio_image_free(uint64_t img);
 uint64_t folio_image_element_new(uint64_t img);
 int32_t  folio_image_element_set_size(uint64_t elem, double w, double h);
 int32_t  folio_image_element_set_align(uint64_t elem, int32_t align);
+int32_t  folio_image_element_set_alt_text(uint64_t elem, const char *text);
 void     folio_image_element_free(uint64_t elem);
 
 /* ── Div (container) ───────────────────────────────────────────────── */
@@ -383,6 +384,7 @@ int32_t  folio_div_set_space_after(uint64_t div, double pts);
 int32_t  folio_div_set_border_radius(uint64_t div, double radius);
 int32_t  folio_div_set_opacity(uint64_t div, double opacity);
 int32_t  folio_div_set_overflow(uint64_t div, const char *mode);
+int32_t  folio_div_set_tag(uint64_t div, const char *tag);  /* PDF/UA structure tag override */
 int32_t  folio_div_set_box_shadow(uint64_t div, double offset_x, double offset_y,
              double blur, double spread, double r, double g, double b);
 int32_t  folio_div_set_max_height(uint64_t div, double pts);
@@ -450,6 +452,7 @@ void     folio_barcode_free(uint64_t bc);
 uint64_t folio_barcode_element_new(uint64_t bc, double width);
 int32_t  folio_barcode_element_set_height(uint64_t elem, double height);
 int32_t  folio_barcode_element_set_align(uint64_t elem, int32_t align);
+int32_t  folio_barcode_element_set_alt_text(uint64_t elem, const char *text);
 void     folio_barcode_element_free(uint64_t elem);
 
 /* ── SVG ──────────────────────────────────────────────────────────── */
@@ -463,6 +466,7 @@ void     folio_svg_free(uint64_t svg);
 uint64_t folio_svg_element_new(uint64_t svg);
 int32_t  folio_svg_element_set_size(uint64_t elem, double w, double h);
 int32_t  folio_svg_element_set_align(uint64_t elem, int32_t align);
+int32_t  folio_svg_element_set_alt_text(uint64_t elem, const char *text);
 void     folio_svg_element_free(uint64_t elem);
 
 /* ── Flex (container) ─────────────────────────────────────────────── */
@@ -516,6 +520,7 @@ double   folio_reader_page_width(uint64_t reader, int32_t page_index);
 double   folio_reader_page_height(uint64_t reader, int32_t page_index);
 
 /* Structured content extraction (returns JSON buffer handles) */
+uint64_t folio_reader_structure_tree(uint64_t reader);               /* JSON buffer, 0 if not tagged */
 uint64_t folio_reader_text_spans(uint64_t reader, int32_t page_index);
 uint64_t folio_reader_images(uint64_t reader, int32_t page_index);
 uint64_t folio_reader_paths(uint64_t reader, int32_t page_index);

--- a/export/testdata/test_cabi.c
+++ b/export/testdata/test_cabi.c
@@ -1258,6 +1258,18 @@ int main(void) {
     void* signedData = folio_buffer_data(signedBuf);
     ASSERT(memcmp(signedData, "%PDF", 4) == 0, "signed output is valid PDF");
 
+    /* Verify signed PDF contains signature markers */
+    char* signedStr = (char*)signedData;
+    int32_t signedLen2 = folio_buffer_len(signedBuf);
+    int hasSigField = 0;
+    for (int32_t i = 0; i < signedLen2 - 4; i++) {
+        if (signedStr[i] == '/' && signedStr[i+1] == 'S' && signedStr[i+2] == 'i' && signedStr[i+3] == 'g') {
+            hasSigField = 1;
+            break;
+        }
+    }
+    ASSERT(hasSigField, "signed PDF contains /Sig field");
+
     folio_buffer_free(signedBuf);
     folio_buffer_free(buf);
     folio_sign_opts_free(signOpts);
@@ -1316,6 +1328,24 @@ int main(void) {
 
     rc = folio_merge_save(merged, "/tmp/folio_manipulated.pdf");
     ASSERT(rc == 0, "manipulated document save succeeds");
+
+    /* Verify manipulated PDF via write-to-buffer */
+    uint64_t manipBuf = folio_merge_write_to_buffer(merged);
+    ASSERT(manipBuf != 0, "manipulated write_to_buffer");
+    ASSERT(memcmp(folio_buffer_data(manipBuf), "%PDF", 4) == 0, "manipulated output is PDF");
+    /* Check /Rotate is present in the output (page 0 was rotated 90) */
+    char* manipStr = (char*)folio_buffer_data(manipBuf);
+    int32_t manipLen2 = folio_buffer_len(manipBuf);
+    int hasRotate = 0;
+    for (int32_t i = 0; i < manipLen2 - 7; i++) {
+        if (manipStr[i] == '/' && manipStr[i+1] == 'R' && manipStr[i+2] == 'o' &&
+            manipStr[i+3] == 't' && manipStr[i+4] == 'a' && manipStr[i+5] == 't' && manipStr[i+6] == 'e') {
+            hasRotate = 1;
+            break;
+        }
+    }
+    ASSERT(hasRotate, "manipulated PDF contains /Rotate");
+    folio_buffer_free(manipBuf);
     folio_merge_free(merged);
 
     /* ===== Stage 35: Structured content extraction ===== */
@@ -1372,16 +1402,72 @@ int main(void) {
     rc = folio_merge_save(flatMerged, "/tmp/folio_flattened.pdf");
     ASSERT(rc == 0, "flattened document save succeeds");
 
-    folio_merge_free(flatMerged);
-    folio_reader_free(flatRdr);
+    /* Verify the flattened PDF has no AcroForm */
+    uint64_t flatBuf = folio_merge_write_to_buffer(flatMerged);
+    ASSERT(flatBuf != 0, "flattened write_to_buffer");
+    char* flatStr = (char*)folio_buffer_data(flatBuf);
+    int32_t flatLen2 = folio_buffer_len(flatBuf);
+    int hasAcroForm = 0;
+    for (int32_t i = 0; i < flatLen2 - 9; i++) {
+        if (flatStr[i] == '/' && flatStr[i+1] == 'A' && flatStr[i+2] == 'c' &&
+            flatStr[i+3] == 'r' && flatStr[i+4] == 'o' && flatStr[i+5] == 'F') {
+            hasAcroForm = 1;
+            break;
+        }
+    }
+    ASSERT(!hasAcroForm, "flattened PDF has no /AcroForm");
+    folio_buffer_free(flatBuf);
 
-    /* Verify the flattened PDF has no form fields */
     uint64_t flatCheck = folio_reader_open("/tmp/folio_flattened.pdf");
     ASSERT(flatCheck != 0, "re-open flattened PDF");
     ASSERT(folio_reader_page_count(flatCheck) >= 1, "flattened PDF has pages");
     folio_reader_free(flatCheck);
 
-    /* ===== Stage 37: Encryption with permissions ===== */
+    folio_merge_free(flatMerged);
+    folio_reader_free(flatRdr);
+
+    /* ===== Stage 37: PDF/UA tagged PDF ===== */
+    printf("Testing PDF/UA tagged PDF...\n");
+    doc = folio_document_new_letter();
+    helv = folio_font_helvetica();
+
+    rc = folio_document_set_tagged(doc, 1);
+    ASSERT(rc == 0, "set_tagged succeeds");
+
+    /* Image with alt text */
+    uint64_t tagQr = folio_barcode_qr("https://folio.dev");
+    uint64_t tagQrElem = folio_barcode_element_new(tagQr, 100.0);
+    rc = folio_barcode_element_set_alt_text(tagQrElem, "QR code linking to folio.dev");
+    ASSERT(rc == 0, "barcode_element_set_alt_text succeeds");
+    folio_document_add(doc, tagQrElem);
+
+    /* Div with custom tag */
+    div = folio_div_new();
+    rc = folio_div_set_tag(div, "Sect");
+    ASSERT(rc == 0, "div_set_tag succeeds");
+    para = folio_paragraph_new("Section content", helv, 12.0);
+    folio_div_add(div, para);
+    folio_document_add(doc, div);
+
+    buf = folio_document_write_to_buffer(doc);
+    ASSERT(buf != 0, "tagged doc write to buffer");
+    folio_document_free(doc);
+
+    /* Read back and check structure tree */
+    uint64_t tagRdr = folio_reader_parse(folio_buffer_data(buf), folio_buffer_len(buf));
+    ASSERT(tagRdr != 0, "reader_parse tagged doc");
+
+    uint64_t treeBuf = folio_reader_structure_tree(tagRdr);
+    ASSERT(treeBuf != 0, "reader_structure_tree returns buffer");
+    ASSERT(folio_buffer_len(treeBuf) > 10, "structure tree JSON non-trivial");
+    char* treeJson = (char*)folio_buffer_data(treeBuf);
+    ASSERT(treeJson[0] == '{', "structure tree JSON starts with {");
+    folio_buffer_free(treeBuf);
+
+    folio_reader_free(tagRdr);
+    folio_buffer_free(buf);
+
+    /* ===== Stage 38: Encryption with permissions ===== */
     printf("Testing encryption with permissions...\n");
     doc = folio_document_new_letter();
     folio_document_set_title(doc, "Encrypted");
@@ -1394,8 +1480,23 @@ int main(void) {
         (1 << 2) | (1 << 4) /* PRINT | EXTRACT */);
     ASSERT(rc == 0, "set_encryption_with_permissions succeeds");
 
-    rc = folio_document_save(doc, "/tmp/folio_cabi_encrypted.pdf");
-    ASSERT(rc == 0, "encrypted document save succeeds");
+    buf = folio_document_write_to_buffer(doc);
+    ASSERT(buf != 0, "encrypted doc write to buffer");
+    ASSERT(memcmp(folio_buffer_data(buf), "%PDF", 4) == 0, "encrypted output is PDF");
+    /* Verify /Encrypt dict present */
+    char* encStr = (char*)folio_buffer_data(buf);
+    int32_t encLen = folio_buffer_len(buf);
+    int hasEncrypt = 0;
+    for (int32_t i = 0; i < encLen - 8; i++) {
+        if (encStr[i] == '/' && encStr[i+1] == 'E' && encStr[i+2] == 'n' &&
+            encStr[i+3] == 'c' && encStr[i+4] == 'r' && encStr[i+5] == 'y' &&
+            encStr[i+6] == 'p' && encStr[i+7] == 't') {
+            hasEncrypt = 1;
+            break;
+        }
+    }
+    ASSERT(hasEncrypt, "encrypted PDF contains /Encrypt dictionary");
+    folio_buffer_free(buf);
     folio_document_free(doc);
 
     /* Summary */

--- a/layout/barcode_element.go
+++ b/layout/barcode_element.go
@@ -7,10 +7,11 @@ import "github.com/carlos7ags/folio/barcode"
 
 // BarcodeElement is a layout element that renders a barcode in the document flow.
 type BarcodeElement struct {
-	bc     *barcode.Barcode
-	width  float64 // display width in points
-	height float64 // display height in points (0 = auto from aspect ratio)
-	align  Align
+	bc      *barcode.Barcode
+	width   float64 // display width in points
+	height  float64 // display height in points (0 = auto from aspect ratio)
+	align   Align
+	altText string // alternative text for accessibility (PDF/UA)
 }
 
 // NewBarcodeElement creates a layout element from a generated barcode.
@@ -34,6 +35,12 @@ func (be *BarcodeElement) SetHeight(h float64) *BarcodeElement {
 // SetAlign sets horizontal alignment.
 func (be *BarcodeElement) SetAlign(a Align) *BarcodeElement {
 	be.align = a
+	return be
+}
+
+// SetAltText sets alternative text for accessibility (PDF/UA).
+func (be *BarcodeElement) SetAltText(text string) *BarcodeElement {
+	be.altText = text
 	return be
 }
 
@@ -89,7 +96,8 @@ func (be *BarcodeElement) PlanLayout(area LayoutArea) LayoutPlan {
 		Consumed: h,
 		Blocks: []PlacedBlock{{
 			X: x, Y: 0, Width: w, Height: h,
-			Tag: "Figure",
+			Tag:     "Figure",
+			AltText: be.altText,
 			Draw: func(ctx DrawContext, absX, absTopY float64) {
 				capturedBC.Draw(ctx.Stream, absX, absTopY-capturedH, capturedW, capturedH)
 			},

--- a/layout/div.go
+++ b/layout/div.go
@@ -72,6 +72,7 @@ type Div struct {
 	outlineOffset float64
 	bgImage       *BackgroundImage
 	clear         string // CSS clear: "left", "right", "both"
+	structTag     string // custom structure tag for PDF/UA (empty = default "Div")
 
 	// CSS position:relative offsets (visual only, don't affect layout flow).
 	relOffsetX float64
@@ -314,6 +315,22 @@ func (d *Div) SetOpacity(o float64) *Div {
 func (d *Div) SetOverflow(v string) *Div {
 	d.overflow = v
 	return d
+}
+
+// SetTag sets a custom PDF structure tag for accessibility (PDF/UA).
+// Common tags: "Sect", "Art", "BlockQuote", "Caption", "Part".
+// If empty, the default "Div" tag is used.
+func (d *Div) SetTag(tag string) *Div {
+	d.structTag = tag
+	return d
+}
+
+// resolveTag returns the structure tag for this Div.
+func (d *Div) resolveTag() string {
+	if d.structTag != "" {
+		return d.structTag
+	}
+	return "Div"
 }
 
 // SetBoxShadow sets a box-shadow effect on the Div.
@@ -572,7 +589,7 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 
 	containerBlock := PlacedBlock{
 		X: xPos, Y: d.spaceBefore + d.relOffsetY, Width: effectiveWidth, Height: totalH,
-		Tag: "Div",
+		Tag: d.resolveTag(),
 		Draw: func(ctx DrawContext, absX, absTopY float64) {
 			bottomY := absTopY - capturedTotalH
 			r := capturedDiv.borderRadius

--- a/layout/image.go
+++ b/layout/image.go
@@ -11,10 +11,11 @@ import (
 
 // ImageElement is a layout element that places an image in the document flow.
 type ImageElement struct {
-	img    *folioimage.Image
-	width  float64 // explicit width (0 = auto)
-	height float64 // explicit height (0 = auto)
-	align  Align
+	img     *folioimage.Image
+	width   float64 // explicit width (0 = auto)
+	height  float64 // explicit height (0 = auto)
+	align   Align
+	altText string // alternative text for accessibility (PDF/UA)
 }
 
 // NewImageElement creates a layout element from an Image.
@@ -38,6 +39,13 @@ func (ie *ImageElement) SetSize(width, height float64) *ImageElement {
 // SetAlign sets horizontal alignment of the image.
 func (ie *ImageElement) SetAlign(a Align) *ImageElement {
 	ie.align = a
+	return ie
+}
+
+// SetAltText sets alternative text for accessibility (PDF/UA).
+// Screen readers use this to describe the image to visually impaired users.
+func (ie *ImageElement) SetAltText(text string) *ImageElement {
+	ie.altText = text
 	return ie
 }
 
@@ -141,11 +149,12 @@ func (ie *ImageElement) PlanLayout(area LayoutArea) LayoutPlan {
 		Status:   LayoutFull,
 		Consumed: h,
 		Blocks: []PlacedBlock{{
-			X:      x,
-			Y:      0,
-			Width:  w,
-			Height: h,
-			Tag:    "Figure",
+			X:       x,
+			Y:       0,
+			Width:   w,
+			Height:  h,
+			Tag:     "Figure",
+			AltText: ie.altText,
 			Draw: func(ctx DrawContext, absX, absTopY float64) {
 				resName := registerImage(ctx.Page, capturedImg)
 				bottomY := absTopY - capturedH

--- a/layout/svg_element.go
+++ b/layout/svg_element.go
@@ -12,10 +12,11 @@ import (
 
 // SVGElement is a layout element that renders an SVG graphic in the document flow.
 type SVGElement struct {
-	svg    *svg.SVG
-	width  float64 // explicit width in points (0 = auto from SVG/viewBox)
-	height float64 // explicit height in points (0 = auto)
-	align  Align
+	svg     *svg.SVG
+	width   float64 // explicit width in points (0 = auto from SVG/viewBox)
+	height  float64 // explicit height in points (0 = auto)
+	align   Align
+	altText string // alternative text for accessibility (PDF/UA)
 }
 
 // NewSVGElement creates a layout element from a parsed SVG.
@@ -38,6 +39,12 @@ func (se *SVGElement) SetSize(width, height float64) *SVGElement {
 // SetAlign sets horizontal alignment.
 func (se *SVGElement) SetAlign(a Align) *SVGElement {
 	se.align = a
+	return se
+}
+
+// SetAltText sets alternative text for accessibility (PDF/UA).
+func (se *SVGElement) SetAltText(text string) *SVGElement {
+	se.altText = text
 	return se
 }
 
@@ -114,7 +121,8 @@ func (se *SVGElement) PlanLayout(area LayoutArea) LayoutPlan {
 		Consumed: h,
 		Blocks: []PlacedBlock{{
 			X: x, Y: 0, Width: w, Height: h,
-			Tag: "Figure",
+			Tag:     "Figure",
+			AltText: se.altText,
 			Draw: func(ctx DrawContext, absX, absTopY float64) {
 				opts := svg.RenderOptions{
 					RegisterOpacity: func(opacity float64) string {

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -348,6 +348,12 @@ func (r *PdfReader) Catalog() *core.PdfDictionary {
 	return r.catalog
 }
 
+// StructureTree parses and returns the document's structure tree.
+// Returns nil if the document is not tagged.
+func (r *PdfReader) StructureTree() *StructureTree {
+	return ParseStructureTree(r.catalog, r.resolver)
+}
+
 // ResolveObject resolves an indirect reference to its target object.
 func (r *PdfReader) ResolveObject(obj core.PdfObject) (core.PdfObject, error) {
 	return r.resolver.ResolveDeep(obj)

--- a/reader/structtree.go
+++ b/reader/structtree.go
@@ -7,15 +7,15 @@ import "github.com/carlos7ags/folio/core"
 
 // StructNode represents a node in the PDF structure tree.
 type StructNode struct {
-	Tag        string        // structure type (e.g. "P", "H1", "Table", "Span")
-	MCID       int           // marked content identifier (-1 if not a leaf)
-	PageObjNum int           // page object number for this MCID
-	Children   []*StructNode // child nodes
+	Tag        string        `json:"tag"`                    // structure type (e.g. "P", "H1", "Table", "Span")
+	MCID       int           `json:"mcid"`                   // marked content identifier (-1 if not a leaf)
+	PageObjNum int           `json:"page_obj_num,omitempty"` // page object number for this MCID
+	Children   []*StructNode `json:"children,omitempty"`     // child nodes
 }
 
 // StructureTree represents the parsed PDF structure tree.
 type StructureTree struct {
-	Root *StructNode
+	Root *StructNode `json:"root"`
 }
 
 // ParseStructureTree extracts the structure tree from a PDF catalog.


### PR DESCRIPTION
## Description

Go changes:
- ImageElement, BarcodeElement, SVGElement: add SetAltText() method and wire altText through PlanLayout → PlacedBlock.AltText
- Div: add SetTag() for custom PDF structure tags (Sect, Art, etc.)
- PdfReader: add StructureTree() public method
- StructNode: add JSON struct tags for C ABI serialization

C ABI (5 new exports, 330 total):
- folio_image_element_set_alt_text
- folio_barcode_element_set_alt_text
- folio_svg_element_set_alt_text
- folio_div_set_tag
- folio_reader_structure_tree (returns JSON buffer)

Tests strengthened with content verification:
- Signing: verify /Sig field present in signed output
- Page manipulation: verify /Rotate present after rotation
- Form flattening: verify no /AcroForm in flattened output
- Encryption: verify /Encrypt dictionary present

327 C integration tests passing, all Go tests passing.

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
