### PR TITLE
Support \n as line break in Paragraph text, fix gofmt

### DIFF
--- a/examples/redact/main.go
+++ b/examples/redact/main.go
@@ -76,8 +76,8 @@ func main() {
 	r3, _ := reader.Parse(pdf)
 	emailPattern := regexp.MustCompile(`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
 	m2, err := reader.RedactPattern(r3, emailPattern, &reader.RedactOptions{
-		FillColor:   [3]float64{0.5, 0, 0},
-		OverlayText: "[EMAIL]",
+		FillColor:    [3]float64{0.5, 0, 0},
+		OverlayText:  "[EMAIL]",
 		OverlayColor: [3]float64{1, 1, 1},
 	})
 	if err != nil {

--- a/examples/report/main.go
+++ b/examples/report/main.go
@@ -70,12 +70,12 @@ func main() {
 	doc.Add(layout.NewAreaBreak())
 	doc.Add(layout.NewHeading("Executive Summary", layout.H1))
 	doc.Add(body(
-		"Fiscal year 2026 marked a transformational period for Apex Capital Partners. "+
-			"Revenue grew 22% year-over-year to $28.3M, driven by strong performance "+
+		"Fiscal year 2026 marked a transformational period for Apex Capital Partners. " +
+			"Revenue grew 22% year-over-year to $28.3M, driven by strong performance " +
 			"in advisory services and a strategic expansion into the Asia-Pacific region."))
 	doc.Add(body(
-		"Operating margin improved to 30%, reflecting disciplined cost management "+
-			"and technology-driven efficiency gains. Client retention remained strong "+
+		"Operating margin improved to 30%, reflecting disciplined cost management " +
+			"and technology-driven efficiency gains. Client retention remained strong " +
 			"at 97.2%, and we welcomed 23 new institutional clients during the year."))
 
 	// Callout box

--- a/layout/element.go
+++ b/layout/element.go
@@ -237,6 +237,10 @@ type Word struct {
 	WordSpacing   float64 // extra inter-word space added to SpaceAfter
 	BaselineShift float64 // vertical offset (positive = up, negative = down)
 
+	// LineBreak forces a new line before this word during word-wrapping.
+	// Used to honor explicit \n characters in paragraph text.
+	LineBreak bool
+
 	// LinkURI is the hyperlink target for this word. If non-empty, the
 	// renderer creates a link annotation covering this word's area.
 	LinkURI string

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -185,7 +185,12 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 		spaceW := measurer.MeasureString(" ", run.FontSize) + run.WordSpacing
 		words := splitWords(run.Text)
 
+		nextLineBreak := false
 		for _, w := range words {
+			if w == lineBreakMarker {
+				nextLineBreak = true
+				continue
+			}
 			wordW := measurer.MeasureString(w, run.FontSize)
 			// Account for letter-spacing: adds extra space after each character except last.
 			if run.LetterSpacing != 0 && len([]rune(w)) > 1 {
@@ -199,6 +204,7 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 				FontSize:        run.FontSize,
 				Color:           run.Color,
 				Decoration:      run.Decoration,
+				LineBreak:       nextLineBreak,
 				DecorationColor: run.DecorationColor,
 				DecorationStyle: run.DecorationStyle,
 				SpaceAfter:      spaceW,
@@ -207,6 +213,7 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 				BaselineShift:   run.BaselineShift,
 				LinkURI:         run.LinkURI,
 			})
+			nextLineBreak = false
 		}
 		if run.FontSize > maxFontSize {
 			maxFontSize = run.FontSize
@@ -247,6 +254,17 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 	}
 
 	for i := 1; i < len(measured); i++ {
+		// Forced line break from \n.
+		if measured[i].LineBreak {
+			lines = append(lines, Line{
+				Words: slices.Clone(measured[lineStart:i]),
+				Width: lineWidth, Height: lineHeight, SpaceW: measured[lineStart].SpaceAfter,
+			})
+			lineStart = i
+			lineWidth = measured[i].Width
+			effectiveMax = maxWidth
+			continue
+		}
 		spaceW := measured[i-1].SpaceAfter
 		candidate := lineWidth + spaceW + measured[i].Width
 		if candidate > effectiveMax && lineStart < i {
@@ -574,9 +592,24 @@ func (p *Paragraph) MaxWidth() float64 {
 
 // splitWords splits text on whitespace, collapsing consecutive whitespace.
 // Newlines are treated as word separators (same as HTML/CSS normal whitespace).
+// splitWords splits text into words, preserving \n as a lineBreakMarker
+// sentinel that forces a line break during word-wrapping.
 func splitWords(text string) []string {
-	return strings.Fields(text)
+	// Split on newlines first, then split each line into words.
+	lines := strings.Split(text, "\n")
+	var result []string
+	for i, line := range lines {
+		if i > 0 {
+			result = append(result, lineBreakMarker)
+		}
+		result = append(result, strings.Fields(line)...)
+	}
+	return result
 }
+
+// lineBreakMarker is a sentinel value in the word list that signals a
+// forced line break from a \n character in the source text.
+const lineBreakMarker = "\x00linebreak"
 
 // PlanLayout implements Element. It computes word-wrapped lines that fit
 // within the available area. If the paragraph doesn't fit entirely, it
@@ -794,7 +827,12 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 		}
 
 		words := splitWords(text)
+		nextLineBreak := false
 		for _, w := range words {
+			if w == lineBreakMarker {
+				nextLineBreak = true
+				continue
+			}
 			wordW := measurer.MeasureString(w, run.FontSize)
 			if run.LetterSpacing != 0 && len([]rune(w)) > 1 {
 				wordW += run.LetterSpacing * float64(len([]rune(w))-1)
@@ -814,7 +852,9 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 				WordSpacing:     run.WordSpacing,
 				BaselineShift:   run.BaselineShift,
 				LinkURI:         run.LinkURI,
+				LineBreak:       nextLineBreak,
 			})
+			nextLineBreak = false
 		}
 		if run.FontSize > maxFontSize {
 			maxFontSize = run.FontSize
@@ -881,13 +921,21 @@ func (p *Paragraph) wrapWords(words []Word, maxWidth float64) [][]Word {
 	lw := words[0].Width
 
 	for i := 1; i < len(words); i++ {
+		// Forced line break from \n in source text.
+		if words[i].LineBreak {
+			lines = append(lines, slices.Clone(words[lineStart:i]))
+			lineStart = i
+			lw = words[i].Width
+			effectiveWidth = maxWidth
+			continue
+		}
 		spaceW := words[i-1].SpaceAfter
 		candidate := lw + spaceW + words[i].Width
 		if candidate > effectiveWidth && lineStart < i {
 			lines = append(lines, slices.Clone(words[lineStart:i]))
 			lineStart = i
 			lw = words[i].Width
-			effectiveWidth = maxWidth // subsequent lines use full width
+			effectiveWidth = maxWidth
 		} else {
 			lw = candidate
 		}

--- a/layout/paragraph_test.go
+++ b/layout/paragraph_test.go
@@ -383,3 +383,65 @@ func TestParagraphZeroWidthLayout(t *testing.T) {
 		t.Error("expected at least 1 line even with 0 width")
 	}
 }
+
+// TestParagraphNewlineBreak verifies that \n in paragraph text creates
+// a forced line break, producing separate lines in the output.
+func TestParagraphNewlineBreak(t *testing.T) {
+	p := NewParagraph("Line one\nLine two\nLine three", font.Helvetica, 12)
+	plan := p.PlanLayout(LayoutArea{Width: 500, Height: 1000})
+	if plan.Status != LayoutFull {
+		t.Fatalf("expected LayoutFull, got %d", plan.Status)
+	}
+	// Should produce 3 lines (one per \n-separated segment).
+	if len(plan.Blocks) != 3 {
+		t.Errorf("expected 3 lines, got %d", len(plan.Blocks))
+	}
+}
+
+// TestParagraphNewlineInTable verifies the use case from issue #61:
+// multi-line address text in a table cell using \n.
+func TestParagraphNewlineInTable(t *testing.T) {
+	tbl := NewTable().SetColumnUnitWidths([]UnitValue{Pct(50), Pct(50)})
+	r := tbl.AddRow()
+	r.AddCell("Postcode", font.Helvetica, 10)
+
+	addr := NewParagraph("123 Main St\nSuite 456\nNew York, NY 10001", font.Helvetica, 10)
+	r.AddCellElement(addr)
+
+	plan := tbl.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != LayoutFull {
+		t.Fatalf("expected LayoutFull, got %d", plan.Status)
+	}
+	// The address cell should be taller than a single-line cell because
+	// it contains 3 lines.
+	if plan.Consumed <= 0 {
+		t.Error("expected positive consumed height")
+	}
+}
+
+// TestParagraphNewlineEmpty verifies that consecutive \n\n produces
+// a visual blank line (empty line between content lines).
+func TestParagraphNewlineEmpty(t *testing.T) {
+	p := NewParagraph("Before\n\nAfter", font.Helvetica, 12)
+	plan := p.PlanLayout(LayoutArea{Width: 500, Height: 1000})
+	// "Before" on line 1, empty line 2 (no words), "After" on line 3.
+	// Empty lines between \n\n may collapse since there are no words.
+	// At minimum we should get 2 lines (Before and After).
+	if len(plan.Blocks) < 2 {
+		t.Errorf("expected at least 2 lines, got %d", len(plan.Blocks))
+	}
+}
+
+// TestParagraphNewlineTrailing verifies that trailing \n doesn't
+// produce extra empty content.
+func TestParagraphNewlineTrailing(t *testing.T) {
+	p := NewParagraph("Hello\n", font.Helvetica, 12)
+	plan := p.PlanLayout(LayoutArea{Width: 500, Height: 1000})
+	if plan.Status != LayoutFull {
+		t.Fatalf("expected LayoutFull, got %d", plan.Status)
+	}
+	// Should have 1 line ("Hello"), trailing \n doesn't add a line.
+	if len(plan.Blocks) != 1 {
+		t.Errorf("expected 1 line, got %d", len(plan.Blocks))
+	}
+}

--- a/reader/redact_apply.go
+++ b/reader/redact_apply.go
@@ -84,7 +84,9 @@ func applyRedaction(m *Modifier, pageIdx int, rewritten []byte, overlay *core.Pd
 
 // ensureHelvFont adds a Helvetica font entry to the page's Resources
 // under the name "Helv" if not already present.
-func ensureHelvFont(pageDict *core.PdfDictionary, w interface{ AddObject(core.PdfObject) *core.PdfIndirectReference }) {
+func ensureHelvFont(pageDict *core.PdfDictionary, w interface {
+	AddObject(core.PdfObject) *core.PdfIndirectReference
+}) {
 	resources := pageDict.Get("Resources")
 	var resDict *core.PdfDictionary
 	if resources != nil {

--- a/reader/redact_rewrite.go
+++ b/reader/redact_rewrite.go
@@ -514,4 +514,3 @@ func (rs *rewriteState) charBounds(xOffset, charWidth float64) Box {
 func (rs *rewriteState) advanceTextPosition(textSpaceWidth float64) {
 	rs.tm[4] += textSpaceWidth * rs.fontSize
 }
-


### PR DESCRIPTION
## Description

Paragraph now respects \n characters as forced line breaks instead of collapsing them to whitespace. This makes multi-line text natural:

  layout.NewParagraph("Line 1\nLine 2\nLine 3", font.Helvetica, 12)

Previously \n was treated as a space by strings.Fields, producing a single wrapped line. Now splitWords splits on \n first and inserts a LineBreak marker that wrapWords honors as a forced line break.

Both Layout (legacy) and PlanLayout paths handle the marker. Works in table cells, divs, and anywhere Paragraph is used.

Also fixed gofmt -s formatting in files from recent PRs: examples/redact/main.go, examples/report/main.go,
reader/redact_apply.go, reader/redact_rewrite.go.

Brief description of the changes.

## Related issue

Closes #61

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
