### PR TITLE
Feat: Support per-run text highlight background color

### DIFF
--- a/html/converter_paragraph.go
+++ b/html/converter_paragraph.go
@@ -253,6 +253,7 @@ func (c *converter) collectRuns(n *html.Node, style computedStyle) []layout.Text
 				WordSpacing:     style.WordSpacing,
 				BaselineShift:   baselineShiftFromStyle(style),
 				TextShadow:      textShadowFromStyle(style),
+				BackgroundColor: style.BackgroundColor,
 			}
 			runs = append(runs, run)
 		case html.ElementNode:

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -79,6 +79,10 @@ func (c *converter) applyTagDefaults(n *html.Node, style *computedStyle) {
 		style.TextDecoration |= layout.DecorationUnderline
 	case atom.S, atom.Del:
 		style.TextDecoration |= layout.DecorationStrikethrough
+	case atom.Mark:
+		// Browser default: yellow highlight background.
+		bg := layout.RGB(1, 1, 0)
+		style.BackgroundColor = &bg
 	case atom.Small:
 		style.FontSize = style.FontSize * 0.833
 	case atom.Sub:

--- a/html/features_test.go
+++ b/html/features_test.go
@@ -1373,3 +1373,72 @@ func TestAbsoluteWithRightInContainingBlock(t *testing.T) {
 		t.Error("should render with positive height")
 	}
 }
+
+// --- Text highlight / background color ---
+
+func TestMarkElementRendersHighlight(t *testing.T) {
+	// <mark> should render with default yellow background.
+	src := `<p>This is <mark>highlighted</mark> text.</p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != layout.LayoutFull {
+		t.Errorf("expected LayoutFull, got %v", plan.Status)
+	}
+	if plan.Consumed <= 0 {
+		t.Error("expected positive consumed height")
+	}
+}
+
+func TestInlineBackgroundColorCSS(t *testing.T) {
+	// Explicit background-color on a span should produce a highlight.
+	src := `<p>Before <span style="background-color: #ff0;">highlight</span> after</p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != layout.LayoutFull {
+		t.Errorf("expected LayoutFull, got %v", plan.Status)
+	}
+}
+
+func TestMarkWithCustomColor(t *testing.T) {
+	// <mark> with CSS override should use the custom color.
+	src := `<style>mark { background-color: #90EE90; }</style>
+	<p>This is <mark>green highlight</mark> text.</p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != layout.LayoutFull {
+		t.Errorf("expected LayoutFull, got %v", plan.Status)
+	}
+}
+
+func TestMultipleHighlightsInParagraph(t *testing.T) {
+	src := `<p><mark>First</mark> gap <mark>Second</mark></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != layout.LayoutFull {
+		t.Errorf("expected LayoutFull, got %v", plan.Status)
+	}
+}

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -48,6 +48,63 @@ func drawTextLine(ctx DrawContext, words []Word, x, baselineY, maxWidth float64,
 		extraSpace = (maxWidth - totalWordWidth) / gaps
 	}
 
+	// First pass: draw highlight backgrounds behind words that have BackgroundColor.
+	// This must happen before text rendering so the background is behind the text.
+	{
+		bgX := x
+		for i, word := range words {
+			if word.InlineBlock != nil {
+				spaceW := words[0].SpaceAfter
+				if spaceW == 0 {
+					spaceW = 3
+				}
+				bgX += word.InlineWidth + spaceW
+				continue
+			}
+
+			if word.BackgroundColor != nil {
+				// Compute the highlight rectangle covering the word.
+				// Ascent ≈ 0.8 * FontSize, descent ≈ 0.2 * FontSize.
+				ascent := word.FontSize * 0.8
+				descent := word.FontSize * 0.2
+				rectH := ascent + descent
+				rectY := baselineY - descent // bottom of rect in PDF coordinates
+
+				// Extend through trailing space when the next word has the
+				// same background color (produces continuous highlight like browsers).
+				highlightW := word.Width
+				if i < len(words)-1 && words[i+1].BackgroundColor != nil &&
+					*words[i+1].BackgroundColor == *word.BackgroundColor {
+					if align == AlignJustify && !isLast {
+						highlightW += extraSpace
+					} else {
+						highlightW += word.SpaceAfter
+					}
+				}
+
+				ctx.Stream.SaveState()
+				setFillColor(ctx.Stream, *word.BackgroundColor)
+				ctx.Stream.Rectangle(bgX, rectY, highlightW, rectH)
+				ctx.Stream.Fill()
+				ctx.Stream.RestoreState()
+			}
+
+			var advance float64
+			if i < len(words)-1 {
+				if align == AlignJustify && !isLast {
+					advance = word.Width + extraSpace
+				} else {
+					spaceW := word.SpaceAfter
+					if spaceW == 0 && len(words) > 0 {
+						spaceW = words[0].SpaceAfter
+					}
+					advance = word.Width + spaceW
+				}
+			}
+			bgX += advance
+		}
+	}
+
 	curColor := Color{R: -1, G: -1, B: -1}
 	curX := x
 	for i, word := range words {

--- a/layout/element.go
+++ b/layout/element.go
@@ -116,6 +116,7 @@ type TextRun struct {
 	BaselineShift   float64     // vertical offset in points (positive = up for super, negative = down for sub)
 	LinkURI         string      // if non-empty, this run is part of a hyperlink
 	TextShadow      *TextShadow // if non-nil, draws a shadow behind the text
+	BackgroundColor *Color      // if non-nil, a highlight rectangle is drawn behind the text
 }
 
 // Run creates a TextRun with a standard font.
@@ -156,6 +157,13 @@ func (r TextRun) WithDecoration(d TextDecoration) TextRun {
 // Words from this run will produce a clickable annotation in the PDF.
 func (r TextRun) WithLinkURI(uri string) TextRun {
 	r.LinkURI = uri
+	return r
+}
+
+// WithBackgroundColor returns a copy of the run with a highlight background.
+// A filled rectangle of the given color is drawn behind the text.
+func (r TextRun) WithBackgroundColor(c Color) TextRun {
+	r.BackgroundColor = &c
 	return r
 }
 
@@ -255,6 +263,10 @@ type Word struct {
 	// LinkURI is the hyperlink target for this word. If non-empty, the
 	// renderer creates a link annotation covering this word's area.
 	LinkURI string
+
+	// BackgroundColor, if non-nil, draws a filled highlight rectangle
+	// behind this word before rendering the text.
+	BackgroundColor *Color
 
 	// InlineBlock fields: when set, this Word represents an inline-block
 	// element (e.g., a Div) that flows within a paragraph like a "big word".

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -213,6 +213,7 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 				BaselineShift:   run.BaselineShift,
 				LinkURI:         run.LinkURI,
 				TextShadow:      run.TextShadow,
+				BackgroundColor: run.BackgroundColor,
 			})
 			nextLineBreak = false
 		}
@@ -856,6 +857,7 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 				BaselineShift:   run.BaselineShift,
 				LinkURI:         run.LinkURI,
 				TextShadow:      run.TextShadow,
+				BackgroundColor: run.BackgroundColor,
 				LineBreak:       nextLineBreak,
 			})
 			nextLineBreak = false

--- a/layout/paragraph_test.go
+++ b/layout/paragraph_test.go
@@ -445,3 +445,54 @@ func TestParagraphNewlineTrailing(t *testing.T) {
 		t.Errorf("expected 1 line, got %d", len(plan.Blocks))
 	}
 }
+
+// --- Text highlight / background color ---
+
+func TestWithBackgroundColor(t *testing.T) {
+	bg := RGB(1, 1, 0)
+	run := Run("highlight", font.Helvetica, 12).WithBackgroundColor(bg)
+	if run.BackgroundColor == nil {
+		t.Fatal("expected BackgroundColor to be set")
+	}
+	if *run.BackgroundColor != bg {
+		t.Errorf("BackgroundColor = %v, want %v", *run.BackgroundColor, bg)
+	}
+}
+
+func TestParagraphBackgroundColorPropagates(t *testing.T) {
+	bg := RGB(1, 1, 0)
+	p := NewStyledParagraph(
+		Run("Hello ", font.Helvetica, 12),
+		Run("World", font.Helvetica, 12).WithBackgroundColor(bg),
+	)
+	lines := p.Layout(500)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	// "World" should carry the background color.
+	found := false
+	for _, w := range lines[0].Words {
+		if w.BackgroundColor != nil && *w.BackgroundColor == bg {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a word with BackgroundColor set")
+	}
+}
+
+func TestParagraphHighlightRendersWithPlanLayout(t *testing.T) {
+	bg := RGB(1, 1, 0)
+	p := NewStyledParagraph(
+		Run("Normal ", font.Helvetica, 12),
+		Run("highlighted", font.Helvetica, 12).WithBackgroundColor(bg),
+		Run(" normal", font.Helvetica, 12),
+	)
+	plan := p.PlanLayout(LayoutArea{Width: 500, Height: 1000})
+	if plan.Status != LayoutFull {
+		t.Fatalf("expected LayoutFull, got %d", plan.Status)
+	}
+	if plan.Consumed <= 0 {
+		t.Error("expected positive consumed height")
+	}
+}


### PR DESCRIPTION
## Description
Add BackgroundColor field to TextRun and Word, enabling colored highlight rectangles behind individual words. The highlight is drawn before text rendering and extends through inter-word spaces when consecutive words share the same background color (matching browser behavior for <mark> and CSS background-color on inline elements).

Notable changes:
- layout/element.go: Add BackgroundColor to TextRun and Word, add WithBackgroundColor method
- layout/paragraph.go: Propagate BackgroundColor in measureWords and Layout
- layout/draw.go: Draw highlight rects in a first pass before text in drawTextLine
- html/converter_paragraph.go: Pass BackgroundColor from computedStyle to TextRun in collectRuns
- html/converter_style.go: Add default yellow background for <mark> element

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
