### PR TITLE
Add AddHTMLTemplate for data-driven PDF generation

### DIFF
--- a/document/html.go
+++ b/document/html.go
@@ -4,6 +4,10 @@
 package document
 
 import (
+	"bytes"
+	"fmt"
+	"html/template"
+
 	foliohtml "github.com/carlos7ags/folio/html"
 	"github.com/carlos7ags/folio/layout"
 )
@@ -110,4 +114,48 @@ func (d *Document) AddHTML(htmlStr string, opts *foliohtml.Options) error {
 	}
 
 	return nil
+}
+
+// AddHTMLTemplate executes a Go [html/template] with the given data and
+// adds the resulting HTML to the document. This is a convenience for the
+// common workflow of rendering a template with dynamic data to produce a
+// PDF — e.g., invoices, reports, or letters.
+//
+// The template string is parsed with [html/template.New] and executed
+// with data. The result is passed to [Document.AddHTML]. Template
+// functions, CSS <style> blocks, and all HTML features supported by
+// [AddHTML] work as expected.
+//
+//	doc.AddHTMLTemplate(`
+//	  <h1>Invoice #{{.Number}}</h1>
+//	  <table>
+//	    {{range .Items}}
+//	    <tr><td>{{.Name}}</td><td>{{.Price}}</td></tr>
+//	    {{end}}
+//	  </table>
+//	`, invoiceData, nil)
+func (d *Document) AddHTMLTemplate(tmplStr string, data any, opts *foliohtml.Options) error {
+	t, err := template.New("folio").Parse(tmplStr)
+	if err != nil {
+		return fmt.Errorf("document: parse template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return fmt.Errorf("document: execute template: %w", err)
+	}
+	return d.AddHTML(buf.String(), opts)
+}
+
+// AddHTMLTemplateFuncs is like [AddHTMLTemplate] but accepts custom
+// template functions via a [template.FuncMap].
+func (d *Document) AddHTMLTemplateFuncs(tmplStr string, funcs template.FuncMap, data any, opts *foliohtml.Options) error {
+	t, err := template.New("folio").Funcs(funcs).Parse(tmplStr)
+	if err != nil {
+		return fmt.Errorf("document: parse template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return fmt.Errorf("document: execute template: %w", err)
+	}
+	return d.AddHTML(buf.String(), opts)
 }

--- a/document/html_test.go
+++ b/document/html_test.go
@@ -5,6 +5,7 @@ package document
 
 import (
 	"bytes"
+	"html/template"
 	"strings"
 	"testing"
 )
@@ -94,5 +95,112 @@ func TestAddHTMLProducesPDF(t *testing.T) {
 	}
 	if !strings.Contains(pdf, "Test PDF") {
 		t.Error("PDF does not contain title metadata")
+	}
+}
+
+func TestAddHTMLTemplate(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+
+	type Item struct {
+		Name  string
+		Price string
+	}
+	data := struct {
+		Title string
+		Items []Item
+	}{
+		Title: "Invoice #42",
+		Items: []Item{
+			{"Widget", "$10.00"},
+			{"Gadget", "$25.00"},
+		},
+	}
+
+	err := doc.AddHTMLTemplate(`
+		<h1>{{.Title}}</h1>
+		<table>
+		{{range .Items}}
+			<tr><td>{{.Name}}</td><td>{{.Price}}</td></tr>
+		{{end}}
+		</table>
+	`, data, nil)
+	if err != nil {
+		t.Fatalf("AddHTMLTemplate: %v", err)
+	}
+
+	var buf bytes.Buffer
+	n, err := doc.WriteTo(&buf)
+	if err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("produced zero bytes")
+	}
+	// Content is in compressed streams, so just verify non-trivial size.
+	if buf.Len() < 500 {
+		t.Errorf("PDF seems too small for template with table: %d bytes", buf.Len())
+	}
+}
+
+func TestAddHTMLTemplateInvalidTemplate(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	err := doc.AddHTMLTemplate(`{{.Unclosed`, nil, nil)
+	if err == nil {
+		t.Error("expected error for invalid template syntax")
+	}
+}
+
+func TestAddHTMLTemplateExecutionError(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	// Template calls a method on nil — should fail at execute time.
+	err := doc.AddHTMLTemplate(`<p>{{call .Fn}}</p>`, struct{ Fn func() string }{nil}, nil)
+	if err == nil {
+		t.Error("expected error for template execution failure")
+	}
+}
+
+func TestAddHTMLTemplateFuncs(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+
+	funcs := template.FuncMap{
+		"upper": strings.ToUpper,
+	}
+
+	err := doc.AddHTMLTemplateFuncs(`<p>{{upper .Name}}</p>`, funcs, struct{ Name string }{"hello"}, nil)
+	if err != nil {
+		t.Fatalf("AddHTMLTemplateFuncs: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	// Just verify it produces a valid PDF — content is compressed.
+	if !strings.HasPrefix(buf.String(), "%PDF-") {
+		t.Error("output does not start with %PDF-")
+	}
+}
+
+func TestAddHTMLTemplateWithCSS(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+
+	err := doc.AddHTMLTemplate(`
+		<style>
+			h1 { color: red; font-size: 24px; }
+			.item { font-weight: bold; }
+		</style>
+		<h1>{{.Title}}</h1>
+		<p class="item">{{.Body}}</p>
+	`, struct{ Title, Body string }{"Report", "Content here"}, nil)
+	if err != nil {
+		t.Fatalf("AddHTMLTemplate with CSS: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("produced empty PDF")
 	}
 }


### PR DESCRIPTION
## Summary

Adds two convenience methods to Document for the common "HTML template + data → PDF" workflow:

```go
// Simple template
doc.AddHTMLTemplate(`
  <h1>Invoice #{{.Number}}</h1>
  <table>
    {{range .Items}}
    <tr><td>{{.Name}}</td><td>{{.Price}}</td></tr>
    {{end}}
  </table>
`, invoiceData, nil)

// With custom functions
doc.AddHTMLTemplateFuncs(tmpl, template.FuncMap{"upper": strings.ToUpper}, data, nil)
```

Uses Go's `html/template` internally, delegates rendering to existing `AddHTML`. Zero new dependencies. Full CSS support via `<style>` blocks in templates.

## Test plan

- [x] `go test ./document/...` — all pass
- [x] `golangci-lint run ./document/...` — 0 issues
- [x] Template with range/table renders valid PDF
- [x] Invalid template syntax returns parse error
- [x] Template execution error returns error
- [x] Custom FuncMap works correctly
- [x] CSS `<style>` blocks work inside templates