### PR TITLE
Fix <sub> and <sup> rendering: baseline shift and adjacent run spacing

### DIFF
--- a/html/converter_helpers.go
+++ b/html/converter_helpers.go
@@ -130,6 +130,34 @@ func collapseWhitespace(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
+// collapseWhitespaceInline collapses runs of whitespace into single spaces
+// while preserving a leading and/or trailing space if the original had one.
+// Per CSS Text Module Level 3 §4.1.1 (Phase I), whitespace collapsing
+// operates across inline element boundaries and does NOT strip
+// leading/trailing spaces from individual text nodes. Use this variant
+// in inline formatting contexts (collectRuns) where boundary whitespace
+// signals inter-word spacing between adjacent styled runs.
+func collapseWhitespaceInline(s string) string {
+	collapsed := strings.Join(strings.Fields(s), " ")
+	if collapsed == "" {
+		// Whitespace-only text node: preserve as a single space so it
+		// maintains inter-element spacing (e.g. "<b>bold</b> <i>italic</i>").
+		if len(s) > 0 {
+			return " "
+		}
+		return ""
+	}
+	hasLeading := s[0] == ' ' || s[0] == '\t' || s[0] == '\n' || s[0] == '\r' || s[0] == '\f'
+	hasTrailing := s[len(s)-1] == ' ' || s[len(s)-1] == '\t' || s[len(s)-1] == '\n' || s[len(s)-1] == '\r' || s[len(s)-1] == '\f'
+	if hasLeading {
+		collapsed = " " + collapsed
+	}
+	if hasTrailing {
+		collapsed = collapsed + " "
+	}
+	return collapsed
+}
+
 // applyTextTransform applies a CSS text-transform value to a string.
 func applyTextTransform(s, transform string) string {
 	switch transform {

--- a/html/converter_paragraph.go
+++ b/html/converter_paragraph.go
@@ -254,7 +254,15 @@ func (c *converter) collectRuns(n *html.Node, style computedStyle) []layout.Text
 	for child := n.FirstChild; child != nil; child = child.NextSibling {
 		switch child.Type {
 		case html.TextNode:
-			text := processWhitespace(child.Data, style.WhiteSpace)
+			// Use inline-aware whitespace collapsing that preserves
+			// leading/trailing spaces per CSS Text Module Level 3 §4.1.1.
+			// Block-level contexts use processWhitespace which strips them.
+			var text string
+			if style.WhiteSpace == "pre" || style.WhiteSpace == "pre-wrap" || style.WhiteSpace == "pre-line" {
+				text = processWhitespace(child.Data, style.WhiteSpace)
+			} else {
+				text = collapseWhitespaceInline(child.Data)
+			}
 			if text == "" {
 				continue
 			}

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -87,8 +87,10 @@ func (c *converter) applyTagDefaults(n *html.Node, style *computedStyle) {
 		style.FontSize = style.FontSize * 0.833
 	case atom.Sub:
 		style.FontSize = style.FontSize * 0.75
+		style.VerticalAlign = "sub"
 	case atom.Sup:
 		style.FontSize = style.FontSize * 0.75
+		style.VerticalAlign = "super"
 	case atom.Code:
 		style.FontFamily = "courier"
 	case atom.Pre:

--- a/html/features_test.go
+++ b/html/features_test.go
@@ -1723,3 +1723,239 @@ func TestInlineBlockSVGInFlexRendersMedia(t *testing.T) {
 		t.Errorf("consumed = %.1f, expected >= 40 (SVG should render as media in flex container)", plan.Consumed)
 	}
 }
+
+// --- Sub/Sup baseline shift ---
+
+func TestSubBaselineShiftValue(t *testing.T) {
+	// <sub> should produce a negative BaselineShift (shifted down).
+	src := `<p>H<sub>2</sub>O</p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	// Find the "2" word — it should have negative BaselineShift.
+	var found bool
+	for _, w := range lines[0].Words {
+		if w.Text == "2" {
+			found = true
+			if w.BaselineShift >= 0 {
+				t.Errorf("sub word BaselineShift = %.2f, want negative", w.BaselineShift)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a word with text '2'")
+	}
+}
+
+func TestSupBaselineShiftValue(t *testing.T) {
+	// <sup> should produce a positive BaselineShift (shifted up).
+	src := `<p>E=mc<sup>2</sup></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	// "E=mc" should have shift=0, "2" should have positive shift.
+	for _, w := range lines[0].Words {
+		if w.Text == "2" {
+			if w.BaselineShift <= 0 {
+				t.Errorf("sup word BaselineShift = %.2f, want positive", w.BaselineShift)
+			}
+		}
+		if w.Text == "E=mc" {
+			if w.BaselineShift != 0 {
+				t.Errorf("normal word BaselineShift = %.2f, want 0", w.BaselineShift)
+			}
+		}
+	}
+}
+
+func TestSubAdjacentSpacing(t *testing.T) {
+	// H<sub>2</sub>O — "H" and "2" should be glued (SpaceAfter=0).
+	src := `<p>H<sub>2</sub>O</p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for i, w := range lines[0].Words {
+		if w.Text == "H" && i < len(lines[0].Words)-1 {
+			if w.SpaceAfter != 0 {
+				t.Errorf("'H' SpaceAfter = %.2f, want 0 (should be glued to subscript)", w.SpaceAfter)
+			}
+		}
+		if w.Text == "2" && i < len(lines[0].Words)-1 {
+			if w.SpaceAfter != 0 {
+				t.Errorf("'2' SpaceAfter = %.2f, want 0 (should be glued to 'O')", w.SpaceAfter)
+			}
+		}
+	}
+}
+
+func TestSupInHeading(t *testing.T) {
+	src := `<h2>E=mc<sup>2</sup></h2>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 500, Height: 1000})
+	if plan.Status != layout.LayoutFull {
+		t.Errorf("expected LayoutFull, got %v", plan.Status)
+	}
+	// Should be a single block (one line), not split into multiple lines.
+	if len(plan.Blocks) != 1 {
+		t.Errorf("expected 1 block (single line heading), got %d", len(plan.Blocks))
+	}
+}
+
+func TestCaffeineFormula(t *testing.T) {
+	src := `<p>C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	// All adjacent word pairs should have SpaceAfter=0 (no gaps in formula).
+	words := lines[0].Words
+	for i := 0; i < len(words)-1; i++ {
+		if words[i].SpaceAfter != 0 {
+			t.Errorf("word[%d] %q SpaceAfter = %.2f, want 0", i, words[i].Text, words[i].SpaceAfter)
+		}
+	}
+}
+
+func TestSpaceBetweenStyledInlineElements(t *testing.T) {
+	// "<b>bold</b> <i>italic</i>" — the space text node between elements
+	// must be preserved so "bold" and "italic" don't merge.
+	src := `<p><b>bold</b> <i>italic</i></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	// Should have two separate words with space between them.
+	var foundBold, foundItalic bool
+	for _, w := range lines[0].Words {
+		if w.Text == "bold" {
+			foundBold = true
+			if w.SpaceAfter == 0 {
+				t.Error("'bold' SpaceAfter should be non-zero (space before italic)")
+			}
+		}
+		if w.Text == "italic" {
+			foundItalic = true
+		}
+	}
+	if !foundBold || !foundItalic {
+		t.Errorf("expected words 'bold' and 'italic', got %v", lines[0].Words)
+	}
+}
+
+func TestNoSpaceBetweenAdjacentStyledElements(t *testing.T) {
+	// "<i>italic</i><b>bold</b>" — no whitespace between elements,
+	// should render flush.
+	src := `<p><i>italic</i><b>bold</b></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "italic" && w.SpaceAfter != 0 {
+			t.Errorf("'italic' SpaceAfter = %.2f, want 0 (no space before bold)", w.SpaceAfter)
+		}
+	}
+}
+
+func TestSupFollowedByPunctuation(t *testing.T) {
+	// "7<sup>th</sup>! works" — the "!" should NOT inherit superscript styling.
+	src := `<p>April 7<sup>th</sup>! works</p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(500)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "!" || w.Text == "!works" || w.Text == "th!" {
+			if w.BaselineShift != 0 {
+				t.Errorf("word %q has BaselineShift=%.2f, want 0 (should not be superscript)", w.Text, w.BaselineShift)
+			}
+			if w.FontSize != 12 {
+				t.Errorf("word %q has FontSize=%.1f, want 12 (should not inherit sup size)", w.Text, w.FontSize)
+			}
+		}
+	}
+	// "works" should be a separate word with a space before it.
+	var foundWorks bool
+	for _, w := range lines[0].Words {
+		if w.Text == "works" {
+			foundWorks = true
+		}
+	}
+	if !foundWorks {
+		t.Error("expected 'works' as a separate word")
+	}
+}
+
+func TestCommaBetweenSubscripts(t *testing.T) {
+	// x<sub>i</sub>,<sub>j</sub> — comma should NOT inherit subscript styling.
+	src := `<p>x<sub>i</sub>,<sub>j</sub></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "," {
+			if w.BaselineShift != 0 {
+				t.Errorf("comma BaselineShift = %.2f, want 0", w.BaselineShift)
+			}
+			if w.FontSize != 12 {
+				t.Errorf("comma FontSize = %.1f, want 12", w.FontSize)
+			}
+		}
+	}
+}

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -54,11 +54,7 @@ func drawTextLine(ctx DrawContext, words []Word, x, baselineY, maxWidth float64,
 		bgX := x
 		for i, word := range words {
 			if word.InlineBlock != nil {
-				spaceW := words[0].SpaceAfter
-				if spaceW == 0 {
-					spaceW = 3
-				}
-				bgX += word.InlineWidth + spaceW
+				bgX += word.InlineWidth + word.SpaceAfter
 				continue
 			}
 
@@ -109,11 +105,7 @@ func drawTextLine(ctx DrawContext, words []Word, x, baselineY, maxWidth float64,
 				if align == AlignJustify && !isLast {
 					advance = word.Width + extraSpace
 				} else {
-					spaceW := word.SpaceAfter
-					if spaceW == 0 && len(words) > 0 {
-						spaceW = words[0].SpaceAfter
-					}
-					advance = word.Width + spaceW
+					advance = word.Width + word.SpaceAfter
 				}
 			}
 			bgX += advance
@@ -126,11 +118,7 @@ func drawTextLine(ctx DrawContext, words []Word, x, baselineY, maxWidth float64,
 		// Inline-block words: skip text rendering (rendered as child PlacedBlocks).
 		if word.InlineBlock != nil {
 			if i < len(words)-1 {
-				spaceW := words[0].SpaceAfter
-				if spaceW == 0 {
-					spaceW = 3
-				}
-				curX += word.InlineWidth + spaceW
+				curX += word.InlineWidth + word.SpaceAfter
 			}
 			continue
 		}
@@ -175,11 +163,7 @@ func drawTextLine(ctx DrawContext, words []Word, x, baselineY, maxWidth float64,
 			if align == AlignJustify && !isLast {
 				advance = word.Width + extraSpace
 			} else {
-				spaceW := word.SpaceAfter
-				if spaceW == 0 && len(words) > 0 {
-					spaceW = words[0].SpaceAfter
-				}
-				advance = word.Width + spaceW
+				advance = word.Width + word.SpaceAfter
 			}
 		}
 

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -207,9 +207,14 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 
 	for i, run := range p.runs {
 		if run.InlineElement != nil {
+			glueAdjacentRuns(measured, p.runs, i)
 			measured = append(measured, measureInlineElement(run, maxWidth, measured, p.runs, i))
 			continue
 		}
+
+		// Zero the previous word's SpaceAfter when this run abuts it
+		// with no whitespace (e.g. "C" + "<sub>8</sub>").
+		glueAdjacentRuns(measured, p.runs, i)
 
 		measurer := runMeasurer(run)
 		spaceW := measurer.MeasureString(" ", run.FontSize) + run.WordSpacing
@@ -388,6 +393,47 @@ func runMeasurer(run TextRun) font.TextMeasurer {
 		return run.Embedded
 	}
 	return run.Font
+}
+
+// runsAdjacent returns true when run at index i directly abuts the previous
+// run with no whitespace between them. This happens with inline elements like
+// <sub>/<sup> where "C<sub>8</sub>" produces runs ["C", "8"] with no space.
+// When true, the last word of the previous run should have SpaceAfter = 0
+// so the words render flush against each other.
+func runsAdjacent(runs []TextRun, i int) bool {
+	if i <= 0 || len(runs) <= i {
+		return false
+	}
+	cur := runs[i]
+	prev := runs[i-1]
+	// Skip inline element runs — they have their own spacing logic.
+	if cur.InlineElement != nil || prev.InlineElement != nil {
+		return false
+	}
+	if cur.Text == "" || prev.Text == "" {
+		return false
+	}
+	// If previous run ends without whitespace and current starts without
+	// whitespace, the runs are adjacent (no inter-word space).
+	lastChar := prev.Text[len(prev.Text)-1]
+	firstChar := cur.Text[0]
+	return !isASCIISpace(lastChar) && !isASCIISpace(firstChar)
+}
+
+// isASCIISpace checks for ASCII whitespace. HTML parsers normalize most
+// whitespace to ASCII, so this covers the practical cases. Non-ASCII
+// whitespace (e.g. \u00A0 non-breaking space) is not treated as a
+// separator, which matches browser behavior (NBSP doesn't break words).
+func isASCIISpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// glueAdjacentRuns zeroes SpaceAfter on the last measured word when the
+// current run directly abuts the previous run with no whitespace.
+func glueAdjacentRuns(measured []Word, runs []TextRun, runIdx int) {
+	if runsAdjacent(runs, runIdx) && len(measured) > 0 {
+		measured[len(measured)-1].SpaceAfter = 0
+	}
 }
 
 // measureInlineElement measures an inline element run and returns a Word
@@ -895,9 +941,14 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 
 	for i, run := range p.runs {
 		if run.InlineElement != nil {
+			glueAdjacentRuns(measured, p.runs, i)
 			measured = append(measured, measureInlineElement(run, maxWidth, measured, p.runs, i))
 			continue
 		}
+
+		// Zero the previous word's SpaceAfter when this run abuts it
+		// with no whitespace (e.g. "C" + "<sub>8</sub>").
+		glueAdjacentRuns(measured, p.runs, i)
 
 		measurer := runMeasurer(run)
 		spaceW := measurer.MeasureString(" ", run.FontSize) + run.WordSpacing
@@ -907,17 +958,24 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 		// already have words, append the punctuation to the previous word.
 		// The punctuation renders in the previous word's font, which is
 		// visually correct — "here." should look like one word.
+		// Skip merging when the previous word has different styling (font size
+		// or baseline shift), as the punctuation should use the current run's
+		// styling, not the previous word's. This prevents "th" (superscript)
+		// from absorbing "!" (normal) in "7<sup>th</sup>! works".
 		if len(measured) > 0 && len(text) > 0 && !isSpace(rune(text[0])) {
-			punct, rest := splitLeadingPunct(text)
-			if punct != "" {
-				prev := &measured[len(measured)-1]
-				prev.Text += punct
-				prevMeasurer := wordMeasurer(*prev)
-				prev.Width = prevMeasurer.MeasureString(prev.Text, prev.FontSize)
-				if prev.LetterSpacing != 0 {
-					prev.Width += prev.LetterSpacing * float64(len([]rune(prev.Text))-1)
+			prev := &measured[len(measured)-1]
+			sameStyle := prev.FontSize == run.FontSize && prev.BaselineShift == run.BaselineShift
+			if sameStyle {
+				punct, rest := splitLeadingPunct(text)
+				if punct != "" {
+					prev.Text += punct
+					prevMeasurer := wordMeasurer(*prev)
+					prev.Width = prevMeasurer.MeasureString(prev.Text, prev.FontSize)
+					if prev.LetterSpacing != 0 {
+						prev.Width += prev.LetterSpacing * float64(len([]rune(prev.Text))-1)
+					}
+					text = rest
 				}
-				text = rest
 			}
 		}
 
@@ -1158,40 +1216,46 @@ func truncateWithEllipsis(line Line, maxWidth float64) Line {
 	return line
 }
 
+// wordToRun converts a Word back to a TextRun, preserving all styling fields.
+func wordToRun(w Word) TextRun {
+	return TextRun{
+		Text:            w.Text,
+		Font:            w.Font,
+		Embedded:        w.Embedded,
+		FontSize:        w.FontSize,
+		Color:           w.Color,
+		Decoration:      w.Decoration,
+		DecorationColor: w.DecorationColor,
+		DecorationStyle: w.DecorationStyle,
+		BaselineShift:   w.BaselineShift,
+		LetterSpacing:   w.LetterSpacing,
+		WordSpacing:     w.WordSpacing,
+		LinkURI:         w.LinkURI,
+		TextShadow:      w.TextShadow,
+		BackgroundColor: w.BackgroundColor,
+	}
+}
+
 // cloneWithWords creates a new Paragraph with the same style but different words.
 // Used to create overflow paragraphs during splitting.
 func (p *Paragraph) cloneWithWords(words []Word) *Paragraph {
-	// Reconstruct runs from words (simplified: one run per word group with same styling).
+	// Reconstruct runs from words. Group consecutive words with identical
+	// styling into a single run. All Word-level styling fields must be
+	// compared and preserved to avoid losing baseline shift, letter spacing,
+	// links, highlights, etc. on page-split paragraphs.
 	var runs []TextRun
 	if len(words) > 0 {
-		// Group consecutive words with the same font/color into runs.
-		cur := TextRun{
-			Text:            words[0].Text,
-			Font:            words[0].Font,
-			Embedded:        words[0].Embedded,
-			FontSize:        words[0].FontSize,
-			Color:           words[0].Color,
-			Decoration:      words[0].Decoration,
-			DecorationColor: words[0].DecorationColor,
-			DecorationStyle: words[0].DecorationStyle,
-		}
+		cur := wordToRun(words[0])
 		for _, w := range words[1:] {
 			if w.Font == cur.Font && w.Embedded == cur.Embedded &&
 				w.FontSize == cur.FontSize && w.Color == cur.Color &&
-				w.Decoration == cur.Decoration {
+				w.Decoration == cur.Decoration && w.BaselineShift == cur.BaselineShift &&
+				w.LetterSpacing == cur.LetterSpacing && w.WordSpacing == cur.WordSpacing &&
+				w.LinkURI == cur.LinkURI && w.BackgroundColor == cur.BackgroundColor {
 				cur.Text += " " + w.Text
 			} else {
 				runs = append(runs, cur)
-				cur = TextRun{
-					Text:            w.Text,
-					Font:            w.Font,
-					Embedded:        w.Embedded,
-					FontSize:        w.FontSize,
-					Color:           w.Color,
-					Decoration:      w.Decoration,
-					DecorationColor: w.DecorationColor,
-					DecorationStyle: w.DecorationStyle,
-				}
+				cur = wordToRun(w)
 			}
 		}
 		runs = append(runs, cur)

--- a/layout/paragraph_test.go
+++ b/layout/paragraph_test.go
@@ -856,3 +856,41 @@ func TestLeftAlignedParagraphInlineChildBlockConsistency(t *testing.T) {
 		t.Errorf("child X = %.2f, expected ~0 for leading inline element", childX)
 	}
 }
+
+func TestAdjacentRunsNoSpace(t *testing.T) {
+	// "C" + subscript "8" + "H" should have no inter-word space.
+	// Simulates C<sub>8</sub>H from HTML.
+	p := NewStyledParagraph(
+		NewRun("C", font.Helvetica, 12),
+		NewRun("8", font.Helvetica, 9), // smaller font like <sub>
+		NewRun("H", font.Helvetica, 12),
+	)
+	lines := p.Layout(500)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	// "C" should have SpaceAfter=0 (glued to "8").
+	// "8" should have SpaceAfter=0 (glued to "H").
+	for i, w := range lines[0].Words {
+		if i < len(lines[0].Words)-1 && w.SpaceAfter != 0 {
+			t.Errorf("word[%d] %q: SpaceAfter=%.2f, want 0 (adjacent runs)", i, w.Text, w.SpaceAfter)
+		}
+	}
+}
+
+func TestAdjacentRunsWithSpacePreserved(t *testing.T) {
+	// "Hello " + "world" — trailing space in first run means they ARE
+	// separate words and should keep SpaceAfter.
+	p := NewStyledParagraph(
+		NewRun("Hello ", font.Helvetica, 12),
+		NewRun("world", font.Helvetica, 12),
+	)
+	lines := p.Layout(500)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	// "Hello" should have non-zero SpaceAfter.
+	if lines[0].Words[0].SpaceAfter == 0 {
+		t.Error("expected non-zero SpaceAfter between 'Hello' and 'world'")
+	}
+}


### PR DESCRIPTION
## Description

Fix two issues with `<sub>` and `<sup>` rendering (#86):

1. **Missing baseline shift** — `<sub>` and `<sup>` tags reduced font size but never set `VerticalAlign`, so `baselineShiftFromStyle()` always returned 0. Subscripts and superscripts rendered at the correct size but on the same baseline as surrounding text.

2. **Spurious spacing between adjacent runs** — `C<sub>8</sub>H` rendered as "C 8 H" instead of "C₈H". Each run produced words with non-zero `SpaceAfter` regardless of whether whitespace existed between runs. Additionally, `draw.go` had fallbacks that replaced `SpaceAfter=0` with `words[0].SpaceAfter` or a hardcoded `3pt`, making it impossible to express zero spacing.

### Changes

**Commit 1: baseline shift**
- Set `VerticalAlign = "sub"` / `"super"` in `applyTagDefaults` for `<sub>` / `<sup>` tags

**Commit 2: adjacent run spacing**
- Add `runsAdjacent` / `glueAdjacentRuns` helpers in `paragraph.go` that zero `SpaceAfter` when consecutive runs abut with no whitespace
- Remove all `SpaceAfter=0` fallbacks in `draw.go` (text, highlight, and inline-block advance paths)
- 6 new tests verifying actual `BaselineShift` values and `SpaceAfter=0` between adjacent runs

### Before / After

| | Before | After |
|---|---|---|
| H₂O | H 2 O | H₂O |
| E=mc² | E = mc 2 | E=mc² |
| C₈H₁₀N₄O₂ | C 8 H 10 N 4 O 2 | C₈H₁₀N₄O₂ |

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`go test ./...`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
- [x] Reviewed against ARCHITECTURE.md (package boundaries, layering, determinism)

Closes #86