### PR TITLE
Fix baseline calculation using CSS half-leading

### DIFF
--- a/layout/list.go
+++ b/layout/list.go
@@ -351,7 +351,7 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 				Tag:   "LI",
 				Links: linkSpans(wl),
 				Draw: func(ctx DrawContext, absX, absTopY float64) {
-					baselineY := absTopY - capturedHeight
+					baselineY := absTopY - computeBaseline(capturedWords, capturedHeight)
 					if len(capturedMarker) > 0 {
 						drawTextLine(ctx, capturedMarker, absX, baselineY, capturedIndent, AlignLeft, true)
 					}

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -395,6 +395,44 @@ func runMeasurer(run TextRun) font.TextMeasurer {
 	return run.Font
 }
 
+// computeBaseline returns the distance from the top of the line box to the
+// text baseline using CSS half-leading (CSS 2.1 §10.8.1):
+//
+//	leading = lineH - (ascent + descent)
+//	half-leading = leading / 2
+//	baseline from top = half-leading + ascent = (lineH + ascent - descent) / 2
+//
+// When a line has mixed font sizes, the largest baseline wins so that all
+// text on the line shares a common baseline position.
+func computeBaseline(words []Word, lineH float64) float64 {
+	baseline := 0.0
+	for _, w := range words {
+		if w.InlineBlock != nil {
+			continue
+		}
+		var ascent, descent float64
+		if w.Font != nil {
+			ascent = w.Font.Ascent(w.FontSize)
+			descent = w.Font.Descent(w.FontSize)
+		} else if w.Embedded != nil {
+			face := w.Embedded.Face()
+			upem := float64(face.UnitsPerEm())
+			ascent = float64(face.Ascent()) / upem * w.FontSize
+			descent = -float64(face.Descent()) / upem * w.FontSize
+		}
+		if ascent > 0 {
+			wb := (lineH + ascent - descent) / 2
+			if wb > baseline {
+				baseline = wb
+			}
+		}
+	}
+	if baseline == 0 {
+		baseline = lineH * 0.8
+	}
+	return baseline
+}
+
 // runsAdjacent returns true when run at index i directly abuts the previous
 // run with no whitespace between them. This happens with inline elements like
 // <sub>/<sup> where "C<sub>8</sub>" produces runs ["C", "8"] with no space.
@@ -886,7 +924,8 @@ func (p *Paragraph) PlanLayout(area LayoutArea) LayoutPlan {
 				if capturedBg != nil {
 					drawBackground(ctx, *capturedBg, absX, absTopY, capturedWidth, capturedLineH)
 				}
-				drawTextLine(ctx, capturedWords, absX, absTopY-capturedLineH, capturedWidth, capturedAlign, capturedIsLast)
+				baseline := computeBaseline(capturedWords, capturedLineH)
+				drawTextLine(ctx, capturedWords, absX, absTopY-baseline, capturedWidth, capturedAlign, capturedIsLast)
 			},
 			Children: inlineChildren,
 		}

--- a/layout/paragraph_test.go
+++ b/layout/paragraph_test.go
@@ -894,3 +894,40 @@ func TestAdjacentRunsWithSpacePreserved(t *testing.T) {
 		t.Error("expected non-zero SpaceAfter between 'Hello' and 'world'")
 	}
 }
+
+func TestComputeBaselineStandardFont(t *testing.T) {
+	words := []Word{{Font: font.Helvetica, FontSize: 12}}
+	lineH := 14.4
+	baseline := computeBaseline(words, lineH)
+	ascent := font.Helvetica.Ascent(12)
+	descent := font.Helvetica.Descent(12)
+	expected := (lineH + ascent - descent) / 2
+	if math.Abs(baseline-expected) > 0.01 {
+		t.Errorf("baseline = %.4f, want %.4f", baseline, expected)
+	}
+}
+
+func TestComputeBaselineFallback(t *testing.T) {
+	el := &fixedElement{width: 20, height: 16}
+	words := []Word{{InlineBlock: el, InlineWidth: 20, InlineHeight: 16}}
+	baseline := computeBaseline(words, 20)
+	expected := 20.0 * 0.8
+	if math.Abs(baseline-expected) > 0.01 {
+		t.Errorf("baseline = %.2f, want %.2f", baseline, expected)
+	}
+}
+
+func TestComputeBaselineMixedSizes(t *testing.T) {
+	words := []Word{
+		{Font: font.Helvetica, FontSize: 12},
+		{Font: font.Helvetica, FontSize: 24},
+	}
+	lineH := 28.8
+	baseline := computeBaseline(words, lineH)
+	ascent24 := font.Helvetica.Ascent(24)
+	descent24 := font.Helvetica.Descent(24)
+	expected := (lineH + ascent24 - descent24) / 2
+	if math.Abs(baseline-expected) > 0.01 {
+		t.Errorf("baseline = %.4f, want %.4f", baseline, expected)
+	}
+}

--- a/layout/tab.go
+++ b/layout/tab.go
@@ -276,7 +276,8 @@ func (tl *TabbedLine) PlanLayout(area LayoutArea) LayoutPlan {
 			Height: lineHeight,
 			Tag:    "P",
 			Draw: func(ctx DrawContext, absX, absTopY float64) {
-				drawTextLine(ctx, capturedWords, absX, absTopY-lineHeight, capturedWidth, AlignLeft, true)
+				baseline := computeBaseline(capturedWords, lineHeight)
+				drawTextLine(ctx, capturedWords, absX, absTopY-baseline, capturedWidth, AlignLeft, true)
 			},
 		}},
 	}


### PR DESCRIPTION
## Description

The paragraph baseline was computed as `absTopY - lineHeight`, placing it at the bottom of the line box. This caused:

- Text visually starting too low within the line box
- Background colors only covering the ascent area, not descent
- Descent area of one line overlapping the next paragraph

### Fix

Replace with CSS half-leading per CSS 2.1 §10.8.1:

```
leading = lineHeight - (ascent + descent)
half-leading = leading / 2
baseline from top = half-leading + ascent = (lineH + ascent - descent) / 2
```

Uses `Font.Ascent()`/`Descent()` for standard fonts (from PDF spec Appendix D metrics) and `Face().Ascent()`/`Descent()` scaled by `UnitsPerEm` for embedded TTF fonts.

### Scope

- `layout/paragraph.go` — new `computeBaseline()` function, updated Draw closure
- `layout/list.go` — updated list item Draw closure
- `layout/tab.go` — updated tabbed line Draw closure
- Table cells left unchanged (they use a different centering model)
- Headings go through `Paragraph.PlanLayout` so they get the fix automatically

### Visual impact

For Helvetica 12pt at 1.2 leading, the baseline moves up ~4pt within the line box. This is a global visual change affecting all paragraphs, headings, list items, and tabbed lines. All existing PDFs will look different — text is now correctly vertically centered within line boxes instead of sitting at the bottom.

### Verified

- Background colors cover full line height (ascent + descent)
- No overlap between consecutive paragraphs
- Highlight rectangles, underlines, strikethrough, and BaselineShift (sub/sup) all position relative to baselineY, so they remain consistent
- Mixed font sizes on the same line handled via max-wins logic

## Checklist

- [x] Code is formatted
- [x] Tests pass (`go test ./...`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
- [x] Reviewed against CSS 2.1 §10.8.1 spec
- [x] Reviewed against ARCHITECTURE.md

Closes #90