### PR TITLE
Support baseline-shift CSS property and vertical-align lengths

### DIFF
--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -12,8 +12,6 @@ import (
 	"golang.org/x/net/html/atom"
 )
 
-// baselineShiftFromStyle computes the vertical baseline offset for
-// CSS vertical-align values like "super", "sub", "text-top", "text-bottom".
 // textShadowFromStyle converts a CSS text-shadow to a layout.TextShadow.
 func textShadowFromStyle(style computedStyle) *layout.TextShadow {
 	if style.TextShadow == nil {
@@ -27,7 +25,15 @@ func textShadowFromStyle(style computedStyle) *layout.TextShadow {
 	}
 }
 
+// baselineShiftFromStyle computes the vertical baseline offset in points.
+// An explicit numeric value (from CSS baseline-shift or vertical-align with
+// a length) takes precedence over keyword values like "super" and "sub".
 func baselineShiftFromStyle(style computedStyle) float64 {
+	// Explicit baseline-shift value (from CSS baseline-shift property)
+	// takes precedence over vertical-align keywords.
+	if style.BaselineShiftSet {
+		return style.BaselineShiftValue
+	}
 	switch style.VerticalAlign {
 	case "super":
 		return style.FontSize * 0.35 // raise by ~35% of font size

--- a/html/converter_paragraph.go
+++ b/html/converter_paragraph.go
@@ -72,14 +72,10 @@ func splitRunsAtBr(runs []layout.TextRun) [][]layout.TextRun {
 
 // buildParagraphFromRuns creates a styled paragraph from a slice of TextRuns.
 func (c *converter) buildParagraphFromRuns(runs []layout.TextRun, style computedStyle) *layout.Paragraph {
-	var p *layout.Paragraph
-	if len(runs) == 1 && runs[0].InlineElement == nil && runs[0].Embedded == nil && runs[0].Color == (layout.Color{}) {
-		// Simple case: single run, standard font, default color.
-		p = layout.NewParagraph(runs[0].Text, runs[0].Font, runs[0].FontSize)
-	} else {
-		// Styled: multiple runs, embedded font, or custom color.
-		p = layout.NewStyledParagraph(runs...)
-	}
+	// Always use NewStyledParagraph to preserve all TextRun fields
+	// (BaselineShift, BackgroundColor, Decoration, etc.). The NewParagraph
+	// fast path was a premature optimization that discarded per-run styling.
+	p := layout.NewStyledParagraph(runs...)
 
 	p.SetAlign(style.TextAlign)
 	if style.TextAlignLastSet {

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -569,6 +569,35 @@ func (c *converter) applyProperty(prop, val string, style *computedStyle) {
 		v := strings.TrimSpace(strings.ToLower(val))
 		if v == "top" || v == "middle" || v == "bottom" || v == "super" || v == "sub" || v == "baseline" || v == "text-top" || v == "text-bottom" {
 			style.VerticalAlign = v
+			style.BaselineShiftSet = false // keyword overrides any prior numeric shift
+		} else if l := parseCSSLengthWithUnit(v); l != nil {
+			// CSS 2.1 §10.8.1: vertical-align accepts lengths and percentages.
+			// Percentages resolve against line-height per spec.
+			// toPoints(relativeTo, fontSize): relativeTo for %, fontSize for em.
+			lineH := style.FontSize * style.LineHeight
+			style.BaselineShiftValue = l.toPoints(lineH, style.FontSize)
+			style.BaselineShiftSet = true
+		}
+	case "baseline-shift":
+		v := strings.TrimSpace(strings.ToLower(val))
+		switch v {
+		case "super":
+			style.VerticalAlign = "super"
+			style.BaselineShiftSet = false
+		case "sub":
+			style.VerticalAlign = "sub"
+			style.BaselineShiftSet = false
+		case "baseline":
+			style.VerticalAlign = ""
+			style.BaselineShiftSet = false
+		default:
+			// Length or percentage value. Percentages resolve against
+			// line-height per CSS Inline Layout Module Level 3 §4.3.
+			if l := parseCSSLengthWithUnit(v); l != nil {
+				lineH := style.FontSize * style.LineHeight
+				style.BaselineShiftValue = l.toPoints(lineH, style.FontSize)
+				style.BaselineShiftSet = true
+			}
 		}
 	case "border-top":
 		w, s, clr := parseBorderFull(val, style.FontSize)

--- a/html/features_test.go
+++ b/html/features_test.go
@@ -642,28 +642,74 @@ func TestHeadingColor(t *testing.T) {
 // --- vertical-align on inline elements ---
 
 func TestVerticalAlignSuper(t *testing.T) {
-	html := `<p>Normal <span style="vertical-align: super; font-size: 8pt">TM</span> text</p>`
-	elems, err := Convert(html, nil)
+	src := `<p>Normal <span style="vertical-align: super; font-size: 8pt">TM</span> text</p>`
+	elems, err := Convert(src, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(elems) == 0 {
 		t.Fatal("expected elements")
 	}
-	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
-	if plan.Consumed <= 0 {
-		t.Error("vertical-align:super should render text")
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	var foundTM, foundNormal bool
+	for _, w := range lines[0].Words {
+		if w.Text == "TM" {
+			foundTM = true
+			if w.BaselineShift <= 0 {
+				t.Errorf("'TM' BaselineShift = %.2f, want positive (super)", w.BaselineShift)
+			}
+			if w.FontSize != 8 {
+				t.Errorf("'TM' FontSize = %.1f, want 8", w.FontSize)
+			}
+		}
+		if w.Text == "Normal" {
+			foundNormal = true
+			if w.BaselineShift != 0 {
+				t.Errorf("'Normal' BaselineShift = %.2f, want 0", w.BaselineShift)
+			}
+		}
+	}
+	if !foundTM {
+		t.Error("expected word 'TM'")
+	}
+	if !foundNormal {
+		t.Error("expected word 'Normal'")
 	}
 }
 
 func TestVerticalAlignSub(t *testing.T) {
-	html := `<p>H<sub style="vertical-align: sub">2</sub>O</p>`
-	elems, err := Convert(html, nil)
+	src := `<p>H<sub style="vertical-align: sub">2</sub>O</p>`
+	elems, err := Convert(src, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(elems) == 0 {
 		t.Fatal("expected elements")
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "2" {
+			if w.BaselineShift >= 0 {
+				t.Errorf("'2' BaselineShift = %.2f, want negative (sub)", w.BaselineShift)
+			}
+			if w.FontSize >= 12 {
+				t.Errorf("'2' FontSize = %.1f, want smaller than 12 (sub reduces size)", w.FontSize)
+			}
+		}
+		if w.Text == "H" && w.BaselineShift != 0 {
+			t.Errorf("'H' BaselineShift = %.2f, want 0", w.BaselineShift)
+		}
+		if w.Text == "O" && w.BaselineShift != 0 {
+			t.Errorf("'O' BaselineShift = %.2f, want 0", w.BaselineShift)
+		}
 	}
 }
 
@@ -1955,6 +2001,188 @@ func TestCommaBetweenSubscripts(t *testing.T) {
 			}
 			if w.FontSize != 12 {
 				t.Errorf("comma FontSize = %.1f, want 12", w.FontSize)
+			}
+		}
+	}
+}
+
+func TestBaselineShiftCSSSuper(t *testing.T) {
+	src := `<p>normal<span style="baseline-shift: super; font-size: 75%">super</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "super" && w.BaselineShift <= 0 {
+			t.Errorf("baseline-shift:super word shift = %.2f, want positive", w.BaselineShift)
+		}
+	}
+}
+
+func TestBaselineShiftCSSLength(t *testing.T) {
+	src := `<p>normal<span style="baseline-shift: 5pt; font-size: 75%">shifted</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "shifted" {
+			if w.BaselineShift < 4.9 || w.BaselineShift > 5.1 {
+				t.Errorf("baseline-shift:5pt word shift = %.2f, want ~5.0", w.BaselineShift)
+			}
+		}
+	}
+}
+
+func TestBaselineShiftCSSNegative(t *testing.T) {
+	src := `<p>normal<span style="baseline-shift: -3pt">dropped</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "dropped" {
+			if w.BaselineShift > -2.9 || w.BaselineShift < -3.1 {
+				t.Errorf("baseline-shift:-3pt word shift = %.2f, want ~-3.0", w.BaselineShift)
+			}
+		}
+	}
+}
+
+func TestVerticalAlignLength(t *testing.T) {
+	src := `<p>normal<span style="vertical-align: 4pt; font-size: 75%">raised</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "raised" {
+			if w.BaselineShift < 3.9 || w.BaselineShift > 4.1 {
+				t.Errorf("vertical-align:4pt shift = %.2f, want ~4.0", w.BaselineShift)
+			}
+		}
+	}
+}
+
+func TestVerticalAlignOverridesBaselineShift(t *testing.T) {
+	src := `<p>normal<span style="baseline-shift: 10pt; vertical-align: sub">text</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "text" {
+			if w.BaselineShift >= 0 {
+				t.Errorf("vertical-align:sub should override baseline-shift:10pt, got shift=%.2f", w.BaselineShift)
+			}
+		}
+	}
+}
+
+func TestBaselineShiftCSSSub(t *testing.T) {
+	src := `<p>normal<span style="baseline-shift: sub; font-size: 75%">sub</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	for _, w := range lines[0].Words {
+		if w.Text == "sub" && w.BaselineShift >= 0 {
+			t.Errorf("baseline-shift:sub shift = %.2f, want negative", w.BaselineShift)
+		}
+	}
+}
+
+func TestBaselineShiftZero(t *testing.T) {
+	// Explicit zero should override a tag default like <sup>.
+	src := `<p>normal<sup style="baseline-shift: 0">flat</sup></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	for _, w := range lines[0].Words {
+		if w.Text == "flat" && w.BaselineShift != 0 {
+			t.Errorf("baseline-shift:0 on <sup> shift = %.2f, want 0", w.BaselineShift)
+		}
+	}
+}
+
+func TestBaselineShiftEmUnit(t *testing.T) {
+	src := `<p>normal<span style="baseline-shift: 0.5em">half</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	for _, w := range lines[0].Words {
+		if w.Text == "half" {
+			// 0.5em at 12pt = 6pt
+			if w.BaselineShift < 5.9 || w.BaselineShift > 6.1 {
+				t.Errorf("baseline-shift:0.5em shift = %.2f, want ~6.0", w.BaselineShift)
+			}
+		}
+	}
+}
+
+func TestBaselineShiftInvalid(t *testing.T) {
+	src := `<p>normal<span style="baseline-shift: garbage">text</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	for _, w := range lines[0].Words {
+		if w.Text == "text" && w.BaselineShift != 0 {
+			t.Errorf("invalid baseline-shift should produce 0, got %.2f", w.BaselineShift)
+		}
+	}
+}
+
+func TestBaselineShiftThenVerticalAlign(t *testing.T) {
+	// Reverse order: numeric then keyword — keyword should win.
+	src := `<p><span style="vertical-align: sub; baseline-shift: 5pt">text</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := elems[0].(*layout.Paragraph)
+	lines := p.Layout(400)
+	for _, w := range lines[0].Words {
+		if w.Text == "text" {
+			// baseline-shift: 5pt is declared AFTER vertical-align: sub,
+			// so the numeric 5pt should win.
+			if w.BaselineShift < 4.9 || w.BaselineShift > 5.1 {
+				t.Errorf("baseline-shift after vertical-align: shift = %.2f, want ~5.0", w.BaselineShift)
 			}
 		}
 	}

--- a/html/style.go
+++ b/html/style.go
@@ -136,10 +136,12 @@ type computedStyle struct {
 	BookmarkLabel    string // bookmark-label override (empty = use heading text)
 
 	// Table
-	BorderCollapse string  // "separate", "collapse"
-	BorderSpacingH float64 // horizontal border-spacing (points)
-	BorderSpacingV float64 // vertical border-spacing (points)
-	VerticalAlign  string  // "top", "middle", "bottom" (for table cells)
+	BorderCollapse     string  // "separate", "collapse"
+	BorderSpacingH     float64 // horizontal border-spacing (points)
+	BorderSpacingV     float64 // vertical border-spacing (points)
+	VerticalAlign      string  // "top", "middle", "bottom", "super", "sub" (for table cells and inline)
+	BaselineShiftValue float64 // explicit baseline-shift in points (from CSS baseline-shift property)
+	BaselineShiftSet   bool    // true if baseline-shift was explicitly set via CSS
 
 	// Visual effects
 	BorderRadius   float64 // uniform corner radius (points, 0 = sharp)


### PR DESCRIPTION
Re-targets #89 to main (was merged into fix/sup-sub-baseline which is now on main).

Adds `baseline-shift` CSS property and extends `vertical-align` to accept length/percentage values. See #89 for full description.

Closes #88