### PR TITLE
Fix punctuation at font boundaries to keep its own font

### DIFF
--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -1013,7 +1013,8 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 		// from absorbing "!" (normal) in "7<sup>th</sup>! works".
 		if len(measured) > 0 && len(text) > 0 && !isSpace(rune(text[0])) {
 			prev := &measured[len(measured)-1]
-			sameStyle := prev.FontSize == run.FontSize && prev.BaselineShift == run.BaselineShift
+			sameStyle := prev.Font == run.Font && prev.Embedded == run.Embedded &&
+				prev.FontSize == run.FontSize && prev.BaselineShift == run.BaselineShift
 			if sameStyle {
 				punct, rest := splitLeadingPunct(text)
 				if punct != "" {

--- a/layout/paragraph_test.go
+++ b/layout/paragraph_test.go
@@ -964,9 +964,13 @@ func TestSingleNewlineNoEmptyLine(t *testing.T) {
 func TestTrailingDoubleNewline(t *testing.T) {
 	p := NewParagraph("Text\n\n", font.Helvetica, 12)
 	lines := p.Layout(500)
-	// Should produce at least 2 lines: "Text" and an empty line.
-	if len(lines) < 2 {
-		t.Fatalf("expected at least 2 lines, got %d", len(lines))
+	// "Text\n\n" = "Text" line, then empty line from \n\n.
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	// Second line should be the blank word.
+	if len(lines[1].Words) != 1 || lines[1].Words[0].Text != "" {
+		t.Errorf("expected empty second line, got words: %v", lines[1].Words)
 	}
 }
 
@@ -985,8 +989,60 @@ func TestConsecutiveNewlinesPlanLayout(t *testing.T) {
 func TestPureNewlinesParagraph(t *testing.T) {
 	p := NewParagraph("\n\n", font.Helvetica, 12)
 	lines := p.Layout(500)
-	// "\n\n" = empty first line, empty second line.
-	if len(lines) < 1 {
-		t.Fatalf("expected at least 1 line for pure newlines, got %d", len(lines))
+	// "\n\n" with no surrounding text produces a blank word from the
+	// consecutive newlines. At minimum 1 line with a blank word.
+	if len(lines) == 0 {
+		t.Fatal("expected at least 1 line for pure newlines")
+	}
+	// The line should contain a blank word.
+	if lines[0].Words[0].Text != "" {
+		t.Errorf("expected blank word, got %q", lines[0].Words[0].Text)
+	}
+}
+
+func TestPunctuationKeepsOwnFont(t *testing.T) {
+	// <b>here</b>. — the period should render in regular font, not bold.
+	p := NewStyledParagraph(
+		NewRun("here", font.HelveticaBold, 12),
+		NewRun(".", font.Helvetica, 12),
+	)
+	plan := p.PlanLayout(LayoutArea{Width: 500, Height: 1000})
+	if plan.Status != LayoutFull {
+		t.Fatal("expected LayoutFull")
+	}
+	// Also verify via Layout which doesn't use splitLeadingPunct.
+	lines := p.Layout(500)
+	if len(lines) == 0 {
+		t.Fatal("expected at least one line")
+	}
+	for _, w := range lines[0].Words {
+		if w.Text == "." && w.Font != font.Helvetica {
+			t.Errorf("period should be Helvetica, got %v", w.Font)
+		}
+		if w.Text == "here" && w.Font != font.HelveticaBold {
+			t.Errorf("'here' should be Helvetica-Bold, got %v", w.Font)
+		}
+	}
+	// Period should be glued (SpaceAfter=0) but keep its own font.
+	for _, w := range lines[0].Words {
+		if w.Text == "here" && w.SpaceAfter != 0 {
+			t.Errorf("'here' SpaceAfter = %.2f, want 0 (glued to period)", w.SpaceAfter)
+		}
+	}
+}
+
+func TestCommaAfterBoldKeepsRegularFont(t *testing.T) {
+	// <b>word</b>, rest — comma should be regular.
+	p := NewStyledParagraph(
+		NewRun("word", font.HelveticaBold, 12),
+		NewRun(", rest", font.Helvetica, 12),
+	)
+	lines := p.Layout(500)
+	for _, w := range lines[0].Words {
+		if w.Text == "word," || w.Text == "," {
+			if w.Font == font.HelveticaBold {
+				t.Errorf("comma/word should not be bold, got %v", w.Font)
+			}
+		}
 	}
 }

--- a/layout/richtext_test.go
+++ b/layout/richtext_test.go
@@ -21,6 +21,12 @@ func TestStyledParagraphSingleRun(t *testing.T) {
 	if lines[0].Words[0].Text != "Hello" || lines[0].Words[1].Text != "World" {
 		t.Error("unexpected word text")
 	}
+	if lines[0].Words[0].Font != font.Helvetica {
+		t.Errorf("expected Helvetica font, got %v", lines[0].Words[0].Font)
+	}
+	if lines[0].Words[0].FontSize != 12 {
+		t.Errorf("expected fontSize 12, got %.1f", lines[0].Words[0].FontSize)
+	}
 }
 
 func TestStyledParagraphMixedFonts(t *testing.T) {
@@ -102,13 +108,13 @@ func TestStyledParagraphWordWrap(t *testing.T) {
 	if len(lines) < 2 {
 		t.Errorf("expected multiple lines, got %d", len(lines))
 	}
-	// Words should flow across runs — a bold word may end up on line 2.
+	// Count all words across lines — input has 11 words, all must survive.
 	allWords := 0
 	for _, l := range lines {
 		allWords += len(l.Words)
 	}
-	if allWords < 5 {
-		t.Errorf("expected at least 5 words total, got %d", allWords)
+	if allWords != 12 {
+		t.Errorf("expected 12 words total, got %d", allWords)
 	}
 }
 
@@ -158,9 +164,9 @@ func TestStyledParagraphSpaceAfterPerWord(t *testing.T) {
 	lines := p.Layout(500)
 	words := lines[0].Words
 	// Each word should have SpaceAfter from its own font/size.
+	// Helvetica space width at 24pt vs 8pt should differ.
 	if words[0].SpaceAfter == words[1].SpaceAfter {
-		t.Log("SpaceAfter differs by font size — expected different values for different sizes")
-		// Helvetica space width at 24pt vs 8pt should differ.
+		t.Errorf("SpaceAfter should differ by font size: 24pt=%.2f, 8pt=%.2f", words[0].SpaceAfter, words[1].SpaceAfter)
 	}
 	if words[0].SpaceAfter <= 0 {
 		t.Error("SpaceAfter should be positive")
@@ -210,35 +216,34 @@ func TestRGBConstructor(t *testing.T) {
 	}
 }
 
-// TestPunctuationMergedAcrossRuns verifies that a period at the start of
-// a new run is merged into the last word of the previous run, producing
-// "here." as one word instead of "here" + "." as two separate words.
-// Regression test for #25.
-func TestPunctuationMergedAcrossRuns(t *testing.T) {
+// TestPunctuationNotMergedAcrossFontBoundary verifies that punctuation at
+// a font boundary is NOT merged into the preceding word when the fonts
+// differ. The period should keep its own (regular) font, not inherit bold.
+// Regression test for #30, supersedes #25 behavior for cross-font cases.
+func TestPunctuationNotMergedAcrossFontBoundary(t *testing.T) {
 	p := NewStyledParagraph(
 		NewRun("click here", font.HelveticaBold, 12),
 		NewRun(". Then continue.", font.Helvetica, 12),
 	)
 	words, _ := p.measureWords(400)
-	// Expected words: ["click", "here.", "Then", "continue."]
-	// NOT: ["click", "here", ".", "Then", "continue."]
-	for _, w := range words {
-		if w.Text == "." {
-			t.Errorf("period should be merged into previous word, but found standalone '.' word")
-		}
-	}
-	foundHereDot := false
+	// "here" should be bold, "." should be regular (separate word).
 	for _, w := range words {
 		if w.Text == "here." {
-			foundHereDot = true
+			t.Error("period should NOT be merged into bold word across font boundary")
 		}
 	}
-	if !foundHereDot {
-		texts := make([]string, len(words))
-		for i, w := range words {
-			texts[i] = w.Text
+	// The period must exist as its own word with regular font.
+	foundPeriod := false
+	for _, w := range words {
+		if w.Text == "." {
+			foundPeriod = true
+			if w.Font != font.Helvetica {
+				t.Errorf("period should be Helvetica, got %v", w.Font)
+			}
 		}
-		t.Errorf("expected word 'here.' but got words: %v", texts)
+	}
+	if !foundPeriod {
+		t.Error("expected standalone '.' word in output")
 	}
 }
 
@@ -263,30 +268,38 @@ func TestPunctuationMergeMatchesSingleRun(t *testing.T) {
 	}
 }
 
-// TestPunctuationCommaAfterStyledRun verifies that a comma at a style
-// boundary merges into the preceding word.
-func TestPunctuationCommaAfterStyledRun(t *testing.T) {
+// TestPunctuationCommaKeepsOwnFontAcrossBoundary verifies that a comma
+// after a bold word keeps regular font when the fonts differ.
+func TestPunctuationCommaKeepsOwnFontAcrossBoundary(t *testing.T) {
 	p := NewStyledParagraph(
 		NewRun("see ", font.Helvetica, 12),
 		NewRun("this", font.HelveticaBold, 12),
 		NewRun(", that.", font.Helvetica, 12),
 	)
 	words, _ := p.measureWords(400)
-	foundThisComma := false
+	// "this" should be bold, comma should NOT be merged into it.
 	for _, w := range words {
 		if w.Text == "this," {
-			foundThisComma = true
-		}
-		if w.Text == "," {
-			t.Error("comma should be merged, not standalone")
+			t.Error("comma should NOT be merged into bold word across font boundary")
 		}
 	}
-	if !foundThisComma {
+	// Verify the comma exists as part of its own run's words with regular font.
+	// The run ", that." starts with comma, so after splitWords it becomes [",", "that."].
+	foundCommaWord := false
+	for _, w := range words {
+		if w.Text == "," || (len(w.Text) > 0 && w.Text[0] == ',') {
+			foundCommaWord = true
+			if w.Font == font.HelveticaBold {
+				t.Errorf("comma should be regular font, got bold")
+			}
+		}
+	}
+	if !foundCommaWord {
 		texts := make([]string, len(words))
 		for i, w := range words {
 			texts[i] = w.Text
 		}
-		t.Errorf("expected word 'this,' but got: %v", texts)
+		t.Errorf("expected word starting with comma, got: %v", texts)
 	}
 }
 


### PR DESCRIPTION
## Description

Punctuation at style boundaries was merged into the preceding word and inherited its font. For example, `<b>here</b>.` rendered the period in bold instead of regular weight.

### Root cause

`splitLeadingPunct` in `measureWords` checked `sameStyle` using only `FontSize` and `BaselineShift`. Two runs with the same size/shift but different fonts (e.g., Helvetica-Bold vs Helvetica) were considered "same style", causing the period to merge into the bold word.

### Fix

Add `Font` and `Embedded` pointer comparison to `sameStyle`:

```go
sameStyle := prev.Font == run.Font && prev.Embedded == run.Embedded &&
    prev.FontSize == run.FontSize && prev.BaselineShift == run.BaselineShift
```

When fonts differ, the punctuation stays as a separate word. `glueAdjacentRuns` (from PR #87) sets `SpaceAfter=0` so it renders flush — correct spacing without incorrect font inheritance.

Same-font merging is preserved (verified by `TestPunctuationMergeMatchesSingleRun`).

### Test improvements

Also fixes 5 weak/wrong tests in `richtext_test.go` identified during review:
- `TestStyledParagraphSpaceAfterPerWord`: `t.Log` → `t.Errorf` (was impossible to fail)
- `TestStyledParagraphSingleRun`: added font/size assertions
- `TestStyledParagraphWordWrap`: exact word count instead of trivially low floor
- `TestPunctuationNotMergedAcrossFontBoundary`: positive assertion that "." exists
- `TestPunctuationCommaKeepsOwnFontAcrossBoundary`: positive assertion comma has regular font

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`go test ./...`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)

Closes #30