### PR TITLE
Fix nil font panic in paragraph measureWords (#98)

### DIFF
--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -402,7 +402,11 @@ func runMeasurer(run TextRun) font.TextMeasurer {
 	if run.Embedded != nil {
 		return run.Embedded
 	}
-	return run.Font
+	if run.Font != nil {
+		return run.Font
+	}
+	// Fallback: use Helvetica if no font is set (defensive).
+	return font.Helvetica
 }
 
 // computeBaseline returns the distance from the top of the line box to the


### PR DESCRIPTION
## Summary

Fixes #98. `runMeasurer()` returned nil when a `TextRun` had neither `Font` nor `Embedded` set, causing a nil pointer dereference in `MeasureString`. This crashes the WASM playground with "Go program has already exited" on templates with `<h3>` headings nested inside styled divs.

## Fix

Fall back to `font.Helvetica` when both font fields are nil. This is a defensive measure — the root cause is that certain converter code paths create runs without assigning a font.

## Test plan

- [x] `go test ./layout/... ./html/... ./document/...` — all pass
- [x] Flyer template renders without panic