### PR TITLE
Add tmpl package: Go html/template integration for PDF generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ node_modules/
 # OS
 .DS_Store
 Thumbs.db
+template

--- a/examples/template/main.go
+++ b/examples/template/main.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Example: render a Go html/template to PDF using the tmpl package.
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/carlos7ags/folio/tmpl"
+)
+
+const invoiceTemplate = `<!DOCTYPE html>
+<html>
+<head><style>
+  body { font-family: sans-serif; padding: 40px; font-size: 11px; }
+  h1 { font-size: 22px; margin-bottom: 8px; }
+  table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+  th, td { border: 1px solid #ccc; padding: 6px 10px; text-align: left; }
+  th { background: #f5f5f5; font-weight: bold; }
+  .total { text-align: right; font-size: 14px; font-weight: bold; margin-top: 16px; }
+</style></head>
+<body>
+  <h1>Invoice #{{.Number}}</h1>
+  <p>Date: {{.Date}}</p>
+  <p>Bill to: <strong>{{.Customer}}</strong></p>
+
+  <table>
+    <tr><th>Item</th><th>Qty</th><th>Unit Price</th><th>Amount</th></tr>
+    {{range .Items}}
+    <tr>
+      <td>{{.Name}}</td>
+      <td>{{.Qty}}</td>
+      <td>${{printf "%.2f" .Price}}</td>
+      <td>${{printf "%.2f" .Total}}</td>
+    </tr>
+    {{end}}
+  </table>
+
+  <p class="total">Total: ${{printf "%.2f" .Total}}</p>
+
+  {{if .Notes}}
+  <p><em>Notes: {{.Notes}}</em></p>
+  {{end}}
+</body>
+</html>`
+
+type LineItem struct {
+	Name  string
+	Qty   int
+	Price float64
+	Total float64
+}
+
+type Invoice struct {
+	Number   string
+	Date     string
+	Customer string
+	Items    []LineItem
+	Total    float64
+	Notes    string
+}
+
+func main() {
+	inv := Invoice{
+		Number:   "1042",
+		Date:     time.Now().Format("January 2, 2006"),
+		Customer: "Globex Corporation",
+		Items: []LineItem{
+			{"Consulting (40 hrs)", 1, 4800.00, 4800.00},
+			{"Platform license", 12, 99.00, 1188.00},
+			{"Support add-on", 1, 500.00, 500.00},
+		},
+		Total: 6488.00,
+		Notes: "Payment due within 30 days.",
+	}
+
+	doc, err := tmpl.RenderDocument(invoiceTemplate, inv, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := doc.Save("invoice.pdf"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Created invoice.pdf")
+}

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -1,0 +1,398 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package tmpl provides Go html/template integration for Folio.
+//
+// It bridges Go's standard html/template engine with Folio's HTML-to-PDF
+// converter, letting you define PDF templates as HTML files with Go
+// template directives ({{.Field}}, {{range}}, {{if}}, etc.) and render
+// them to layout elements or complete PDF documents with a single call.
+//
+// This is the "third input mode" alongside Folio's Go layout API and
+// raw HTML string input: templates live in separate files, designers
+// can preview them in a browser, and the rendering pipeline is
+// html/template → html.ConvertFull → layout.Element[].
+//
+// All functions in this package are safe for concurrent use.
+// User-provided Funcs override built-in helpers with the same name.
+//
+// Quick start:
+//
+//	// Render a template string to layout elements:
+//	data := map[string]any{"Title": "Invoice #1042", "Customer": "Acme"}
+//	elems, err := tmpl.Render(`<h1>{{.Title}}</h1><p>Bill to: {{.Customer}}</p>`, data, nil)
+//
+//	// Render a template file to a complete PDF:
+//	err := tmpl.RenderFile("invoice.html", data, nil, "invoice.pdf")
+//
+//	// Use custom template functions:
+//	opts := &tmpl.Options{
+//	    Funcs: template.FuncMap{"upper": strings.ToUpper},
+//	}
+//	elems, err := tmpl.Render(`<p>{{upper .Name}}</p>`, data, opts)
+package tmpl
+
+import (
+	"bytes"
+	"fmt"
+	htmltpl "html/template"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/carlos7ags/folio/document"
+	foliohtml "github.com/carlos7ags/folio/html"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// Options configures template rendering. All fields are optional.
+type Options struct {
+	// Funcs is an optional function map passed to html/template.
+	// Use this to register custom helpers (formatting, i18n, etc.)
+	// available inside {{call}} directives in the template.
+	// User-provided funcs override built-in helpers with the same
+	// name (e.g. a custom "dict" replaces the default one).
+	Funcs htmltpl.FuncMap
+
+	// BaseTemplate is an optional pre-parsed template tree that the
+	// template string is parsed into. Use this for shared partials:
+	//
+	//   base := template.Must(template.ParseGlob("partials/*.html"))
+	//   opts := &tmpl.Options{BaseTemplate: base}
+	//   elems, _ := tmpl.Render(`{{template "header" .}}...`, data, opts)
+	//
+	// When set, the template string is parsed into a clone of
+	// BaseTemplate (via t.Clone().Parse()), so all {{define}} blocks
+	// and {{template}} calls in BaseTemplate are available. The
+	// original BaseTemplate is never modified.
+	BaseTemplate *htmltpl.Template
+
+	// ConvertOpts is passed through to html.ConvertFull. Use it to
+	// set page dimensions, default font size, base path for assets,
+	// etc. RenderFile clones this before setting BasePath, so the
+	// caller's original value is never mutated.
+	ConvertOpts *foliohtml.Options
+
+	// PageSize sets the page size for RenderFile / RenderDocument.
+	// Defaults to US Letter (612x792 pt). Ignored by Render, which
+	// returns raw elements without page context. When the template
+	// contains @page CSS rules, the @page size takes precedence.
+	PageSize document.PageSize
+
+	// Margins sets the page margins for RenderFile / RenderDocument.
+	// Defaults to 36pt (0.5in) on all sides. Ignored by Render.
+	// When the template contains @page margin rules, those take
+	// precedence. Use a non-nil pointer to explicitly set zero
+	// margins: &layout.Margins{} produces a full-bleed document.
+	Margins *layout.Margins
+}
+
+func (o *Options) funcs() htmltpl.FuncMap {
+	if o != nil && o.Funcs != nil {
+		return o.Funcs
+	}
+	return nil
+}
+
+func (o *Options) convertOpts() *foliohtml.Options {
+	if o != nil && o.ConvertOpts != nil {
+		return o.ConvertOpts
+	}
+	return nil
+}
+
+func (o *Options) pageSize() document.PageSize {
+	if o != nil && o.PageSize.Width > 0 && o.PageSize.Height > 0 {
+		return o.PageSize
+	}
+	return document.PageSizeLetter
+}
+
+func (o *Options) margins() layout.Margins {
+	if o != nil && o.Margins != nil {
+		return *o.Margins
+	}
+	return layout.Margins{Top: 36, Right: 36, Bottom: 36, Left: 36}
+}
+
+func (o *Options) baseTemplate() *htmltpl.Template {
+	if o != nil {
+		return o.BaseTemplate
+	}
+	return nil
+}
+
+// cloneConvertOpts returns a shallow copy of the Options' ConvertOpts
+// (or a fresh instance if nil). This prevents RenderFile from mutating
+// the caller's original Options when setting BasePath.
+func (o *Options) cloneConvertOpts() *foliohtml.Options {
+	if o == nil || o.ConvertOpts == nil {
+		return &foliohtml.Options{}
+	}
+	cp := *o.ConvertOpts
+	return &cp
+}
+
+// Render executes a Go html/template string with the given data and
+// converts the resulting HTML to Folio layout elements. This is the
+// lowest-level entry point — use RenderDocument or RenderFile if you
+// want a complete PDF.
+func Render(templateStr string, data any, opts *Options) ([]layout.Element, error) {
+	htmlStr, err := execute(templateStr, "", data, opts)
+	if err != nil {
+		return nil, err
+	}
+	result, err := foliohtml.ConvertFull(htmlStr, opts.convertOpts())
+	if err != nil {
+		return nil, fmt.Errorf("tmpl: html conversion failed: %w", err)
+	}
+	return result.Elements, nil
+}
+
+// RenderDocument executes a template string and returns a fully laid-out
+// Document ready for Save(). The caller can add headers, footers, or
+// additional elements before saving.
+//
+// When the template contains @page CSS rules (size, margins, margin
+// boxes), they are applied to the document automatically.
+func RenderDocument(templateStr string, data any, opts *Options) (*document.Document, error) {
+	htmlStr, err := execute(templateStr, "", data, opts)
+	if err != nil {
+		return nil, err
+	}
+	result, err := foliohtml.ConvertFull(htmlStr, opts.convertOpts())
+	if err != nil {
+		return nil, fmt.Errorf("tmpl: html conversion failed: %w", err)
+	}
+	return buildDocumentFromResult(result, opts), nil
+}
+
+// RenderFile reads a template from disk, executes it with data, and
+// writes the resulting PDF to outPath. The template's directory is used
+// as the base path for resolving relative asset references (images,
+// fonts, stylesheets) in the HTML unless ConvertOpts.BasePath is
+// already set.
+//
+// RenderFile never mutates the caller's Options — it clones
+// ConvertOpts internally before setting BasePath.
+func RenderFile(templatePath string, data any, opts *Options, outPath string) error {
+	tmplBytes, err := os.ReadFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("tmpl: read template %q: %w", templatePath, err)
+	}
+
+	// Clone ConvertOpts so we don't mutate the caller's struct.
+	convOpts := opts.cloneConvertOpts()
+	if convOpts.BasePath == "" {
+		convOpts.BasePath = filepath.Dir(templatePath)
+	}
+
+	htmlStr, err := execute(string(tmplBytes), filepath.Base(templatePath), data, opts)
+	if err != nil {
+		return err
+	}
+
+	result, err := foliohtml.ConvertFull(htmlStr, convOpts)
+	if err != nil {
+		return fmt.Errorf("tmpl: html conversion failed: %w", err)
+	}
+
+	doc := buildDocumentFromResult(result, opts)
+	if err := doc.Save(outPath); err != nil {
+		return fmt.Errorf("tmpl: save %q: %w", outPath, err)
+	}
+	return nil
+}
+
+// RenderTo executes a template string and writes the resulting PDF to w.
+func RenderTo(w io.Writer, templateStr string, data any, opts *Options) error {
+	doc, err := RenderDocument(templateStr, data, opts)
+	if err != nil {
+		return err
+	}
+	_, err = doc.WriteTo(w)
+	if err != nil {
+		return fmt.Errorf("tmpl: write pdf: %w", err)
+	}
+	return nil
+}
+
+// RenderFileTo reads a template from disk, executes it with data, and
+// writes the resulting PDF to w. This is the natural entry point for
+// HTTP handlers that serve PDFs directly to the response writer.
+//
+// Like RenderFile, the template's directory is used as BasePath for
+// asset resolution unless ConvertOpts.BasePath is already set.
+// The caller's Options are never mutated.
+func RenderFileTo(w io.Writer, templatePath string, data any, opts *Options) error {
+	tmplBytes, err := os.ReadFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("tmpl: read template %q: %w", templatePath, err)
+	}
+
+	convOpts := opts.cloneConvertOpts()
+	if convOpts.BasePath == "" {
+		convOpts.BasePath = filepath.Dir(templatePath)
+	}
+
+	htmlStr, err := execute(string(tmplBytes), filepath.Base(templatePath), data, opts)
+	if err != nil {
+		return err
+	}
+
+	result, err := foliohtml.ConvertFull(htmlStr, convOpts)
+	if err != nil {
+		return fmt.Errorf("tmpl: html conversion failed: %w", err)
+	}
+
+	doc := buildDocumentFromResult(result, opts)
+	_, err = doc.WriteTo(w)
+	if err != nil {
+		return fmt.Errorf("tmpl: write pdf: %w", err)
+	}
+	return nil
+}
+
+// execute runs the Go html/template engine on the input string.
+// If opts.BaseTemplate is set, the template string is parsed into a
+// clone of it so that shared partials ({{define}}/{{template}}) are
+// available. The original BaseTemplate is never modified.
+func execute(templateStr, name string, data any, opts *Options) (string, error) {
+	if name == "" {
+		name = "folio"
+	}
+
+	var t *htmltpl.Template
+	if base := opts.baseTemplate(); base != nil {
+		// Clone the base so we don't modify the caller's template
+		// tree. Parse the template string into the clone, making all
+		// of the base's {{define}} blocks available via {{template}}.
+		clone, err := base.Clone()
+		if err != nil {
+			return "", fmt.Errorf("tmpl: clone base template: %w", err)
+		}
+		clone.Funcs(defaultFuncs())
+		if fns := opts.funcs(); fns != nil {
+			clone.Funcs(fns)
+		}
+		t, err = clone.New(name).Parse(templateStr)
+		if err != nil {
+			return "", fmt.Errorf("tmpl: parse template %q: %w", name, err)
+		}
+	} else {
+		t = htmltpl.New(name).Funcs(defaultFuncs())
+		if fns := opts.funcs(); fns != nil {
+			t.Funcs(fns)
+		}
+		var err error
+		t, err = t.Parse(templateStr)
+		if err != nil {
+			return "", fmt.Errorf("tmpl: parse template %q: %w", name, err)
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("tmpl: execute template %q: %w", name, err)
+	}
+	return buf.String(), nil
+}
+
+// buildDocumentFromResult creates a Document from a ConvertResult,
+// applying @page config (size, margins, margin boxes) when present.
+func buildDocumentFromResult(result *foliohtml.ConvertResult, opts *Options) *document.Document {
+	ps := opts.pageSize()
+	margins := opts.margins()
+
+	// @page rules from the template override Options.
+	if pc := result.PageConfig; pc != nil {
+		if pc.Width > 0 && pc.Height > 0 {
+			ps = document.PageSize{Width: pc.Width, Height: pc.Height}
+		}
+		if pc.HasMargins {
+			margins = layout.Margins{
+				Top:    pc.MarginTop,
+				Right:  pc.MarginRight,
+				Bottom: pc.MarginBottom,
+				Left:   pc.MarginLeft,
+			}
+		}
+	}
+
+	doc := document.NewDocument(ps)
+	doc.SetMargins(margins)
+
+	// Apply @page margin boxes (e.g. page numbers via @bottom-center).
+	if len(result.MarginBoxes) > 0 {
+		doc.SetMarginBoxes(result.MarginBoxes)
+	}
+	if len(result.FirstMarginBoxes) > 0 {
+		doc.SetFirstMarginBoxes(result.FirstMarginBoxes)
+	}
+
+	// Apply @page :first / :left / :right margin overrides.
+	if pc := result.PageConfig; pc != nil {
+		if pc.First != nil && pc.First.HasMargins {
+			doc.SetFirstMargins(layout.Margins{
+				Top: pc.First.Top, Right: pc.First.Right,
+				Bottom: pc.First.Bottom, Left: pc.First.Left,
+			})
+		}
+	}
+
+	// Apply document metadata from <title> and <meta> tags.
+	if result.Metadata.Title != "" {
+		doc.Info.Title = result.Metadata.Title
+	}
+	if result.Metadata.Author != "" {
+		doc.Info.Author = result.Metadata.Author
+	}
+	if result.Metadata.Subject != "" {
+		doc.Info.Subject = result.Metadata.Subject
+	}
+	if result.Metadata.Keywords != "" {
+		doc.Info.Keywords = result.Metadata.Keywords
+	}
+
+	for _, e := range result.Elements {
+		doc.Add(e)
+	}
+
+	// Add absolutely positioned elements.
+	for _, abs := range result.Absolutes {
+		if abs.RightAligned {
+			doc.AddAbsoluteRight(abs.Element, abs.X, abs.Y, abs.Width)
+		} else {
+			doc.AddAbsolute(abs.Element, abs.X, abs.Y, abs.Width)
+		}
+	}
+
+	return doc
+}
+
+// defaultFuncs returns built-in template helpers.
+func defaultFuncs() htmltpl.FuncMap {
+	return htmltpl.FuncMap{
+		// dict builds a map from alternating key-value pairs, useful for
+		// passing multiple values to a nested template:
+		//   {{template "header" dict "title" .Title "date" .Date}}
+		//
+		// Returns an error if called with an odd number of arguments or
+		// if any key is not a string. html/template surfaces the error
+		// as a template execution failure.
+		"dict": func(pairs ...any) (map[string]any, error) {
+			if len(pairs)%2 != 0 {
+				return nil, fmt.Errorf("dict: odd number of arguments (%d)", len(pairs))
+			}
+			m := make(map[string]any, len(pairs)/2)
+			for i := 0; i+1 < len(pairs); i += 2 {
+				k, ok := pairs[i].(string)
+				if !ok {
+					return nil, fmt.Errorf("dict: key at position %d is %T, want string", i, pairs[i])
+				}
+				m[k] = pairs[i+1]
+			}
+			return m, nil
+		},
+	}
+}

--- a/tmpl/tmpl_test.go
+++ b/tmpl/tmpl_test.go
@@ -1,0 +1,536 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tmpl
+
+import (
+	"bytes"
+	"fmt"
+	htmltpl "html/template"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/document"
+	foliohtml "github.com/carlos7ags/folio/html"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// executeHTML is a test helper that runs the template engine and returns
+// the intermediate HTML string. This lets tests verify that template
+// substitution actually happened, not just that elements were produced.
+func executeHTML(t *testing.T, templateStr string, data any, opts *Options) string {
+	t.Helper()
+	html, err := execute(templateStr, "", data, opts)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	return html
+}
+
+// --- Render tests ---
+
+func TestRenderBasic(t *testing.T) {
+	data := map[string]string{"Name": "Acme Corp"}
+	html := executeHTML(t, `<p>Hello, {{.Name}}!</p>`, data, nil)
+	if !strings.Contains(html, "Acme Corp") {
+		t.Errorf("expected 'Acme Corp' in output, got: %s", html)
+	}
+	elems, err := Render(`<p>Hello, {{.Name}}!</p>`, data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected at least one element")
+	}
+}
+
+func TestRenderMultipleFields(t *testing.T) {
+	data := struct {
+		Title    string
+		Customer string
+		Amount   float64
+	}{"Invoice #1042", "Acme Corp", 1200.50}
+
+	html := executeHTML(t, `
+		<h1>{{.Title}}</h1>
+		<p>Bill to: <strong>{{.Customer}}</strong></p>
+		<p>Total: ${{printf "%.2f" .Amount}}</p>
+	`, data, nil)
+	for _, want := range []string{"Invoice #1042", "Acme Corp", "1200.50"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("expected %q in output", want)
+		}
+	}
+}
+
+func TestRenderRange(t *testing.T) {
+	data := struct{ Items []string }{Items: []string{"Widget A", "Widget B", "Widget C"}}
+	html := executeHTML(t, `<ul>{{range .Items}}<li>{{.}}</li>{{end}}</ul>`, data, nil)
+	for _, item := range data.Items {
+		if !strings.Contains(html, item) {
+			t.Errorf("expected %q in output", item)
+		}
+	}
+}
+
+func TestRenderConditional(t *testing.T) {
+	t.Run("true branch", func(t *testing.T) {
+		html := executeHTML(t, `{{if .Paid}}<p>PAID</p>{{else}}<p>UNPAID</p>{{end}}`,
+			struct{ Paid bool }{true}, nil)
+		if !strings.Contains(html, "PAID") || strings.Contains(html, "UNPAID") {
+			t.Errorf("expected PAID branch, got: %s", html)
+		}
+	})
+	t.Run("false branch", func(t *testing.T) {
+		html := executeHTML(t, `{{if .Paid}}<p>PAID</p>{{else}}<p>UNPAID</p>{{end}}`,
+			struct{ Paid bool }{false}, nil)
+		if !strings.Contains(html, "UNPAID") {
+			t.Errorf("expected UNPAID branch, got: %s", html)
+		}
+	})
+}
+
+func TestRenderCustomFuncs(t *testing.T) {
+	data := map[string]string{"Name": "acme"}
+	opts := &Options{
+		Funcs: htmltpl.FuncMap{"upper": strings.ToUpper},
+	}
+	html := executeHTML(t, `<p>{{upper .Name}}</p>`, data, opts)
+	if !strings.Contains(html, "ACME") {
+		t.Errorf("expected 'ACME' from upper func, got: %s", html)
+	}
+}
+
+func TestRenderCustomFuncOverridesBuiltin(t *testing.T) {
+	// User-provided "dict" should override the built-in.
+	opts := &Options{
+		Funcs: htmltpl.FuncMap{
+			"dict": func() string { return "custom" },
+		},
+	}
+	html := executeHTML(t, `<p>{{dict}}</p>`, map[string]string{}, opts)
+	if !strings.Contains(html, "custom") {
+		t.Errorf("expected 'custom' from overridden dict, got: %s", html)
+	}
+}
+
+func TestRenderDictHelper(t *testing.T) {
+	html := executeHTML(t, `{{$d := dict "a" "1" "b" "2"}}<p>{{$d.a}}-{{$d.b}}</p>`,
+		map[string]string{}, nil)
+	if !strings.Contains(html, "1-2") {
+		t.Errorf("expected '1-2' from dict, got: %s", html)
+	}
+}
+
+func TestRenderDictOddArgs(t *testing.T) {
+	_, err := Render(`{{$d := dict "a" "1" "orphan"}}<p>ok</p>`, map[string]string{}, nil)
+	if err == nil {
+		t.Fatal("expected error for odd dict argument count")
+	}
+}
+
+func TestRenderDictNonStringKey(t *testing.T) {
+	_, err := Render(`{{$d := dict 42 "v"}}<p>ok</p>`, map[string]string{}, nil)
+	if err == nil {
+		t.Fatal("expected error for non-string dict key")
+	}
+}
+
+// --- RenderDocument tests ---
+
+func TestRenderDocument(t *testing.T) {
+	data := map[string]string{"Title": "Hello"}
+	doc, err := RenderDocument(`<h1>{{.Title}}</h1>`, data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil document")
+	}
+}
+
+func TestRenderDocumentCustomPageSize(t *testing.T) {
+	m := layout.Margins{Top: 72, Right: 72, Bottom: 72, Left: 72}
+	doc, err := RenderDocument(`<p>ok</p>`, map[string]string{}, &Options{
+		PageSize: document.PageSizeA4,
+		Margins:  &m,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil document")
+	}
+}
+
+func TestRenderDocumentPageRulesOverrideOptions(t *testing.T) {
+	// A template with @page { size: 200pt 300pt; } should override
+	// the default page size even when Options.PageSize is set.
+	tpl := `<html><head><style>@page { size: 200pt 300pt; }</style></head>
+		<body><p>ok</p></body></html>`
+	doc, err := RenderDocument(tpl, nil, &Options{
+		PageSize: document.PageSizeLetter,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil document")
+	}
+}
+
+// --- RenderFile tests ---
+
+func TestRenderFile(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, "test.html")
+	outPath := filepath.Join(dir, "test.pdf")
+
+	if err := os.WriteFile(tmplPath, []byte(`
+		<!DOCTYPE html>
+		<html><body>
+			<h1>{{.Title}}</h1>
+			<p>Generated from a template file.</p>
+		</body></html>
+	`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	data := map[string]string{"Title": "File Template Test"}
+	if err := RenderFile(tmplPath, data, nil, outPath); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() < 100 {
+		t.Errorf("PDF too small: %d bytes", info.Size())
+	}
+}
+
+func TestRenderFileDoesNotMutateOpts(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, "tpl.html")
+	outPath := filepath.Join(dir, "out.pdf")
+
+	if err := os.WriteFile(tmplPath, []byte(`<p>{{.V}}</p>`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := &Options{}
+	if err := RenderFile(tmplPath, map[string]string{"V": "test"}, opts, outPath); err != nil {
+		t.Fatal(err)
+	}
+	// The caller's Options must NOT have been mutated.
+	if opts.ConvertOpts != nil {
+		t.Error("RenderFile mutated opts.ConvertOpts — should clone internally")
+	}
+}
+
+func TestRenderFilePreservesExplicitBasePath(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, "tpl.html")
+	outPath := filepath.Join(dir, "out.pdf")
+
+	if err := os.WriteFile(tmplPath, []byte(`<p>ok</p>`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	customBase := "/custom/base/path"
+	opts := &Options{ConvertOpts: &foliohtml.Options{BasePath: customBase}}
+	if err := RenderFile(tmplPath, map[string]string{}, opts, outPath); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-set BasePath must be preserved, not overwritten.
+	if opts.ConvertOpts.BasePath != customBase {
+		t.Errorf("BasePath mutated: got %q, want %q", opts.ConvertOpts.BasePath, customBase)
+	}
+}
+
+func TestRenderFileNotFound(t *testing.T) {
+	err := RenderFile("/nonexistent/path.html", nil, nil, "/tmp/out.pdf")
+	if err == nil {
+		t.Fatal("expected error for missing template file")
+	}
+	if !strings.Contains(err.Error(), "tmpl:") {
+		t.Errorf("expected wrapped error with 'tmpl:' prefix, got: %v", err)
+	}
+}
+
+func TestRenderFileUnwritableOutput(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, "t.html")
+	if err := os.WriteFile(tmplPath, []byte(`<p>ok</p>`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := RenderFile(tmplPath, map[string]string{}, nil, "/nonexistent-dir/out.pdf")
+	if err == nil {
+		t.Fatal("expected error for non-writable output path")
+	}
+}
+
+// --- RenderTo tests ---
+
+func TestRenderTo(t *testing.T) {
+	var buf bytes.Buffer
+	err := RenderTo(&buf, `<p>{{.Msg}}</p>`, map[string]string{"Msg": "Hello PDF"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() < 100 {
+		t.Errorf("PDF too small: %d bytes", buf.Len())
+	}
+	if !bytes.HasPrefix(buf.Bytes(), []byte("%PDF-")) {
+		t.Error("output does not start with %PDF- header")
+	}
+}
+
+// --- Error handling tests ---
+
+func TestRenderTemplateError(t *testing.T) {
+	_, err := Render(`{{.Missing`, nil, nil)
+	if err == nil {
+		t.Fatal("expected template parse error")
+	}
+	if !strings.Contains(err.Error(), "tmpl:") {
+		t.Errorf("expected wrapped error, got: %v", err)
+	}
+}
+
+func TestRenderExecutionError(t *testing.T) {
+	_, err := Render(`<p>{{.Explode}}</p>`, 42, nil)
+	if err == nil {
+		t.Fatal("expected template execution error")
+	}
+	if !strings.Contains(err.Error(), "tmpl:") {
+		t.Errorf("expected wrapped error, got: %v", err)
+	}
+}
+
+func TestRenderEmptyTemplate(t *testing.T) {
+	elems, err := Render(``, map[string]string{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) != 0 {
+		t.Errorf("expected 0 elements from empty template, got %d", len(elems))
+	}
+}
+
+func TestRenderNilOptions(t *testing.T) {
+	elems, err := Render(`<p>ok</p>`, map[string]string{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected element")
+	}
+}
+
+func TestRenderHTMLEscaping(t *testing.T) {
+	data := map[string]string{"Name": "<script>alert('xss')</script>"}
+	html := executeHTML(t, `<p>{{.Name}}</p>`, data, nil)
+	if strings.Contains(html, "<script>") {
+		t.Error("raw <script> found in output — html/template should escape it")
+	}
+	if !strings.Contains(html, "&lt;script&gt;") {
+		t.Errorf("expected escaped &lt;script&gt;, got: %s", html)
+	}
+}
+
+func TestRenderBothFuncsAndConvertOpts(t *testing.T) {
+	opts := &Options{
+		Funcs:       htmltpl.FuncMap{"shout": strings.ToUpper},
+		ConvertOpts: &foliohtml.Options{DefaultFontSize: 16},
+	}
+	elems, err := Render(`<p>{{shout .X}}</p>`, map[string]string{"X": "hello"}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected element")
+	}
+}
+
+// --- Concurrency test ---
+
+func TestRenderConcurrent(t *testing.T) {
+	const n = 50
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			data := map[string]int{"I": i}
+			elems, err := Render(`<p>{{.I}}</p>`, data, nil)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if len(elems) == 0 {
+				errs <- fmt.Errorf("goroutine %d: no elements", i)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// --- Large output test ---
+
+func TestRenderLargeOutput(t *testing.T) {
+	items := make([]string, 200)
+	for i := range items {
+		items[i] = fmt.Sprintf("Item %d", i)
+	}
+	data := map[string]any{"Items": items}
+	elems, err := Render(`{{range .Items}}<p>{{.}}</p>{{end}}`, data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) < 100 {
+		t.Errorf("expected many elements from 200 items, got %d", len(elems))
+	}
+}
+
+// --- Template define/template nesting ---
+
+func TestRenderDefineAndTemplate(t *testing.T) {
+	tpl := `{{define "header"}}<h1>{{.Title}}</h1>{{end}}{{template "header" .}}<p>body</p>`
+	html := executeHTML(t, tpl, map[string]string{"Title": "Invoice"}, nil)
+	if !strings.Contains(html, "Invoice") {
+		t.Errorf("expected 'Invoice' from nested template, got: %s", html)
+	}
+}
+
+// --- Template partials via BaseTemplate ---
+
+func TestRenderWithBaseTemplate(t *testing.T) {
+	// Pre-parse shared partials into a base template tree.
+	base := htmltpl.Must(htmltpl.New("base").Funcs(defaultFuncs()).Parse(
+		`{{define "header"}}<header><h1>{{.Title}}</h1></header>{{end}}` +
+			`{{define "footer"}}<footer>Page {{.Page}}</footer>{{end}}`))
+
+	opts := &Options{BaseTemplate: base}
+	data := map[string]any{"Title": "Invoice #1042", "Page": 1}
+	html := executeHTML(t,
+		`{{template "header" .}}<p>Body content</p>{{template "footer" .}}`,
+		data, opts)
+
+	for _, want := range []string{"Invoice #1042", "Body content", "Page 1"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("expected %q in output, got: %s", want, html)
+		}
+	}
+}
+
+func TestRenderWithBaseTemplateDoesNotMutateBase(t *testing.T) {
+	base := htmltpl.Must(htmltpl.New("base").Parse(
+		`{{define "shared"}}<p>shared</p>{{end}}`))
+
+	// First render adds a "page" define to the clone.
+	opts := &Options{BaseTemplate: base}
+	_, err := Render(
+		`{{define "page"}}<p>page1</p>{{end}}{{template "shared" .}}{{template "page" .}}`,
+		map[string]string{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second render with a different "page" define should not see the
+	// first render's definition — the base must be untouched.
+	html := executeHTML(t,
+		`{{define "page"}}<p>page2</p>{{end}}{{template "shared" .}}{{template "page" .}}`,
+		map[string]string{}, opts)
+	if !strings.Contains(html, "page2") {
+		t.Errorf("expected 'page2' from fresh clone, got: %s", html)
+	}
+	if strings.Contains(html, "page1") {
+		t.Error("base template was mutated by previous render — clone failed")
+	}
+}
+
+func TestRenderWithBaseTemplateAndCustomFuncs(t *testing.T) {
+	base := htmltpl.Must(htmltpl.New("base").Funcs(htmltpl.FuncMap{
+		"shout": strings.ToUpper,
+	}).Parse(`{{define "name"}}<b>{{shout .Name}}</b>{{end}}`))
+
+	opts := &Options{BaseTemplate: base}
+	html := executeHTML(t,
+		`<p>Hello {{template "name" .}}</p>`,
+		map[string]string{"Name": "acme"}, opts)
+	if !strings.Contains(html, "ACME") {
+		t.Errorf("expected 'ACME' from base template's shout func, got: %s", html)
+	}
+}
+
+// --- RenderFileTo ---
+
+func TestRenderFileTo(t *testing.T) {
+	dir := t.TempDir()
+	tmplPath := filepath.Join(dir, "tpl.html")
+	if err := os.WriteFile(tmplPath, []byte(`<h1>{{.Title}}</h1>`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err := RenderFileTo(&buf, tmplPath, map[string]string{"Title": "Hello"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() < 100 {
+		t.Errorf("PDF too small: %d bytes", buf.Len())
+	}
+	if !bytes.HasPrefix(buf.Bytes(), []byte("%PDF-")) {
+		t.Error("output does not start with %PDF- header")
+	}
+}
+
+func TestRenderFileToNotFound(t *testing.T) {
+	var buf bytes.Buffer
+	err := RenderFileTo(&buf, "/nonexistent/path.html", nil, nil)
+	if err == nil {
+		t.Fatal("expected error for missing template file")
+	}
+}
+
+// --- Zero margins ---
+
+func TestRenderDocumentZeroMargins(t *testing.T) {
+	// A non-nil pointer to zero-valued Margins should produce a
+	// full-bleed document, not fall back to 36pt defaults.
+	zeroMargins := &layout.Margins{}
+	opts := &Options{Margins: zeroMargins}
+	m := opts.margins()
+	if m.Top != 0 || m.Right != 0 || m.Bottom != 0 || m.Left != 0 {
+		t.Errorf("expected zero margins, got %+v", m)
+	}
+}
+
+func TestRenderDocumentNilMarginsUsesDefaults(t *testing.T) {
+	opts := &Options{}
+	m := opts.margins()
+	if m.Top != 36 || m.Right != 36 || m.Bottom != 36 || m.Left != 36 {
+		t.Errorf("expected 36pt default margins, got %+v", m)
+	}
+}
+
+func TestRenderDocumentPartialMargins(t *testing.T) {
+	// A Margins with only Top set should be used as-is (other fields
+	// stay zero), not trigger the default.
+	partial := &layout.Margins{Top: 10}
+	opts := &Options{Margins: partial}
+	m := opts.margins()
+	if m.Top != 10 || m.Right != 0 || m.Bottom != 0 || m.Left != 0 {
+		t.Errorf("expected {10,0,0,0}, got %+v", m)
+	}
+}


### PR DESCRIPTION
## Summary

New \`tmpl/\` package that bridges Go's standard \`html/template\` engine with Folio's HTML-to-PDF converter. This is Folio's **third input mode** alongside the Go layout API and raw HTML string input.

Define PDF templates as HTML files with Go template directives (\`{{.Field}}\`, \`{{range}}\`, \`{{if}}\`, etc.) and render them to layout elements or complete PDFs with a single call.

## Motivation

- Directly addresses the competitive gap identified in the gpdf comparison: gpdf offers three input modes (builder API, JSON schema, Go templates); Folio had only two.
- Server-side Go teams already know \`html/template\` — this meets them where they are.
- Most users building letter/invoice templates are already doing \`html/template.Execute → string → html.Convert\` manually; this packages that workflow as a first-class API.

## API

\`\`\`go
// Lowest level: template string → layout elements
elems, err := tmpl.Render(tplStr, data, opts)

// Template string → complete Document ready for Save()
doc, err := tmpl.RenderDocument(tplStr, data, opts)

// Template file → PDF file (auto-resolves asset paths)
err := tmpl.RenderFile("invoice.html", data, opts, "invoice.pdf")

// Template string → io.Writer
err := tmpl.RenderTo(w, tplStr, data, opts)
\`\`\`

**Options:**
- \`Funcs\`: custom \`template.FuncMap\` (formatting, i18n helpers)
- \`ConvertOpts\`: passed through to \`html.Convert\` (page dimensions, default font, base path)
- \`PageSize\` / \`Margins\`: for the document-level entry points

**Built-in helpers:**
- \`dict\`: builds a map from key-value pairs — \`{{template "header" dict "title" .Title "date" .Date}}\`

**Security:** Uses \`html/template\` (not \`text/template\`) for automatic HTML escaping of user-supplied data.

## Example

\`\`\`go
inv := Invoice{Number: "1042", Customer: "Acme", Items: items}
doc, _ := tmpl.RenderDocument(invoiceTemplate, inv, nil)
doc.Save("invoice.pdf")
\`\`\`

See \`examples/template/main.go\` for the complete invoice demo.

## Test plan

- [x] 16 tests covering: basic rendering, struct/map data, range/if directives, custom functions, dict helper, file-based rendering with auto BasePath, io.Writer output, template parse errors, execution errors, empty templates, nil options, HTML escaping
- [x] \`go test ./...\` — all packages green
- [x] \`golangci-lint run\` — 0 issues
- [x] Example produces a valid PDF