### PR TITLE
Audit core package: correctness fixes, tests, and gradual API cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ node_modules/
 *.swo
 *~
 
+# Local Claude Code state (worktrees, session artifacts)
+.claude/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/core/array.go
+++ b/core/array.go
@@ -4,17 +4,31 @@
 package core
 
 import (
+	"fmt"
 	"io"
+	"iter"
 )
 
 // PdfArray represents a PDF array object (ISO 32000 §7.3.6).
 // An array is a one-dimensional collection of objects.
 type PdfArray struct {
+	// Elements is the underlying slice of array elements.
+	//
+	// Deprecated: direct field access is retained for backward compatibility.
+	// Prefer [PdfArray.All], [PdfArray.At], [PdfArray.Len], and [PdfArray.Add]
+	// for new code so that internal representation changes remain invisible
+	// to callers.
 	Elements []PdfObject
 }
 
 // NewPdfArray creates a new PdfArray containing the given elements.
+// It panics if any element is nil, matching the contract of [PdfArray.Add].
 func NewPdfArray(elements ...PdfObject) *PdfArray {
+	for i, e := range elements {
+		if e == nil {
+			panic(fmt.Sprintf("core.NewPdfArray: nil element at index %d", i))
+		}
+	}
 	return &PdfArray{Elements: elements}
 }
 
@@ -32,6 +46,52 @@ func (a *PdfArray) Add(obj PdfObject) {
 // Len returns the number of elements.
 func (a *PdfArray) Len() int {
 	return len(a.Elements)
+}
+
+// At returns the element at index i. It panics if i is out of range.
+func (a *PdfArray) At(i int) PdfObject {
+	return a.Elements[i]
+}
+
+// Set replaces the element at index i with obj. It panics if i is out of
+// range or if obj is nil, matching the contract of [PdfArray.Add].
+func (a *PdfArray) Set(i int, obj PdfObject) {
+	if obj == nil {
+		panic("core.PdfArray.Set: nil object")
+	}
+	a.Elements[i] = obj
+}
+
+// RemoveAt removes and returns the element at index i, shifting later
+// elements down. It panics if i is out of range.
+func (a *PdfArray) RemoveAt(i int) PdfObject {
+	removed := a.Elements[i]
+	a.Elements = append(a.Elements[:i], a.Elements[i+1:]...)
+	return removed
+}
+
+// Replace discards all current elements and sets the array content to the
+// given sequence. It panics if any element is nil.
+func (a *PdfArray) Replace(elements ...PdfObject) {
+	for i, e := range elements {
+		if e == nil {
+			panic(fmt.Sprintf("core.PdfArray.Replace: nil element at index %d", i))
+		}
+	}
+	a.Elements = elements
+}
+
+// All returns an iterator over (index, element) pairs in insertion order.
+// Using this iterator insulates callers from the underlying representation
+// of [PdfArray.Elements].
+func (a *PdfArray) All() iter.Seq2[int, PdfObject] {
+	return func(yield func(int, PdfObject) bool) {
+		for i, e := range a.Elements {
+			if !yield(i, e) {
+				return
+			}
+		}
+	}
 }
 
 // WriteTo serializes the array in PDF syntax to w.

--- a/core/array_test.go
+++ b/core/array_test.go
@@ -14,3 +14,73 @@ func TestArrayAddPanicsOnNil(t *testing.T) {
 	a := NewPdfArray()
 	a.Add(nil)
 }
+
+func TestNewPdfArrayPanicsOnNilElement(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when constructing PdfArray with nil element")
+		}
+	}()
+	NewPdfArray(NewPdfInteger(1), nil, NewPdfInteger(3))
+}
+
+func TestArrayAtAndAll(t *testing.T) {
+	a := NewPdfArray(
+		NewPdfInteger(10),
+		NewPdfInteger(20),
+		NewPdfInteger(30),
+	)
+	if a.At(1).(*PdfNumber).IntValue() != 20 {
+		t.Errorf("At(1): expected 20")
+	}
+
+	var collected []int
+	for i, e := range a.All() {
+		_ = i
+		collected = append(collected, e.(*PdfNumber).IntValue())
+	}
+	want := []int{10, 20, 30}
+	for i, v := range want {
+		if collected[i] != v {
+			t.Errorf("All()[%d]: expected %d, got %d", i, v, collected[i])
+		}
+	}
+}
+
+func TestArraySet(t *testing.T) {
+	a := NewPdfArray(
+		NewPdfInteger(10),
+		NewPdfInteger(20),
+		NewPdfInteger(30),
+	)
+	a.Set(1, NewPdfInteger(99))
+	if a.At(1).(*PdfNumber).IntValue() != 99 {
+		t.Errorf("after Set(1, 99): expected 99 at index 1")
+	}
+	if a.At(0).(*PdfNumber).IntValue() != 10 {
+		t.Errorf("Set should not affect other indices")
+	}
+	if a.Len() != 3 {
+		t.Errorf("Set should not change length")
+	}
+}
+
+func TestArraySetPanicsOnNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when Set receives nil")
+		}
+	}()
+	a := NewPdfArray(NewPdfInteger(1))
+	a.Set(0, nil)
+}
+
+func TestArraySetPanicsOutOfRange(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when Set index out of range")
+		}
+	}()
+	a := NewPdfArray(NewPdfInteger(1))
+	a.Set(5, NewPdfInteger(2))
+}

--- a/core/boolean.go
+++ b/core/boolean.go
@@ -9,14 +9,29 @@ import (
 )
 
 // PdfBoolean represents a PDF boolean value (ISO 32000 §7.3.2).
+// The underlying value is immutable after construction; use [NewPdfBoolean]
+// to create new instances and [PdfBoolean.Bool] to read them.
 type PdfBoolean struct {
-	Value bool
+	value bool
 }
 
-// NewPdfBoolean creates a new PdfBoolean with the given value.
+// Shared singletons for the two possible PdfBoolean values.
+var (
+	pdfBooleanTrue  = &PdfBoolean{value: true}
+	pdfBooleanFalse = &PdfBoolean{value: false}
+)
+
+// NewPdfBoolean returns the shared PdfBoolean instance for the given value.
+// Because PdfBoolean is immutable, singletons are safe and avoid allocation.
 func NewPdfBoolean(v bool) *PdfBoolean {
-	return &PdfBoolean{Value: v}
+	if v {
+		return pdfBooleanTrue
+	}
+	return pdfBooleanFalse
 }
+
+// Bool returns the underlying boolean value.
+func (b *PdfBoolean) Bool() bool { return b.value }
 
 // Type returns ObjectTypeBoolean.
 func (b *PdfBoolean) Type() ObjectType { return ObjectTypeBoolean }
@@ -24,7 +39,7 @@ func (b *PdfBoolean) Type() ObjectType { return ObjectTypeBoolean }
 // WriteTo serializes the boolean as "true" or "false" to w.
 func (b *PdfBoolean) WriteTo(w io.Writer) (int64, error) {
 	s := "false"
-	if b.Value {
+	if b.value {
 		s = "true"
 	}
 	n, err := fmt.Fprint(w, s)

--- a/core/dictionary.go
+++ b/core/dictionary.go
@@ -5,6 +5,8 @@ package core
 
 import (
 	"io"
+	"iter"
+	"slices"
 )
 
 // DictEntry is a key-value pair in a PdfDictionary.
@@ -18,8 +20,22 @@ type DictEntry struct {
 
 // PdfDictionary represents a PDF dictionary object (ISO 32000 §7.3.7).
 // Keys are PdfName objects; values can be any PdfObject.
+//
+// Insertion order is preserved to produce deterministic PDF output.
+// A lazily-built map index accelerates key lookups from O(n) to O(1).
 type PdfDictionary struct {
+	// Entries is the ordered list of key-value pairs.
+	//
+	// Deprecated: direct field access is retained for backward compatibility.
+	// Prefer [PdfDictionary.All] or [PdfDictionary.Get] in new code so that
+	// the internal index stays consistent with any mutations.
 	Entries []DictEntry
+
+	// index maps key name → position in Entries. It is lazily built on
+	// first use and rebuilt after any operation that reorders or removes
+	// entries. A nil index means "not yet built" and is safe to use —
+	// ensureIndex populates it on demand.
+	index map[string]int
 }
 
 // NewPdfDictionary creates a new empty PdfDictionary.
@@ -30,18 +46,36 @@ func NewPdfDictionary() *PdfDictionary {
 // Type returns ObjectTypeDictionary.
 func (d *PdfDictionary) Type() ObjectType { return ObjectTypeDictionary }
 
+// ensureIndex lazily populates the key→position map. Called by every
+// mutator and accessor so the index is always consistent with Entries.
+//
+// The index is rebuilt if its length disagrees with Entries, which
+// catches the common case where external code assigns to Entries
+// directly (e.g., slicing it to remove an element). Same-length
+// mutations are not detected — direct Entries access is deprecated
+// for this reason.
+func (d *PdfDictionary) ensureIndex() {
+	if d.index != nil && len(d.index) == len(d.Entries) {
+		return
+	}
+	d.index = make(map[string]int, len(d.Entries))
+	for i, e := range d.Entries {
+		d.index[e.Key.Value] = i
+	}
+}
+
 // Set adds or updates an entry. If the key already exists, its value is replaced.
 // Panics if value is nil.
 func (d *PdfDictionary) Set(key string, value PdfObject) {
 	if value == nil {
 		panic("core.PdfDictionary.Set: nil value for key " + key)
 	}
-	for i, e := range d.Entries {
-		if e.Key.Value == key {
-			d.Entries[i].Value = value
-			return
-		}
+	d.ensureIndex()
+	if i, ok := d.index[key]; ok {
+		d.Entries[i].Value = value
+		return
 	}
+	d.index[key] = len(d.Entries)
 	d.Entries = append(d.Entries, DictEntry{
 		Key:   NewPdfName(key),
 		Value: value,
@@ -50,20 +84,42 @@ func (d *PdfDictionary) Set(key string, value PdfObject) {
 
 // Get retrieves a value by key name. Returns nil if not found.
 func (d *PdfDictionary) Get(key string) PdfObject {
-	for _, e := range d.Entries {
-		if e.Key.Value == key {
-			return e.Value
-		}
+	d.ensureIndex()
+	if i, ok := d.index[key]; ok {
+		return d.Entries[i].Value
 	}
 	return nil
 }
 
 // Remove deletes an entry by key name. Does nothing if the key does not exist.
 func (d *PdfDictionary) Remove(key string) {
-	for i, e := range d.Entries {
-		if e.Key.Value == key {
-			d.Entries = append(d.Entries[:i], d.Entries[i+1:]...)
-			return
+	d.ensureIndex()
+	i, ok := d.index[key]
+	if !ok {
+		return
+	}
+	d.Entries = slices.Delete(d.Entries, i, i+1)
+	delete(d.index, key)
+	// Indexes for entries after the removed one have shifted down by one.
+	for j := i; j < len(d.Entries); j++ {
+		d.index[d.Entries[j].Key.Value] = j
+	}
+}
+
+// Len returns the number of entries.
+func (d *PdfDictionary) Len() int {
+	return len(d.Entries)
+}
+
+// All returns an iterator over (key, value) pairs in insertion order.
+// Using this iterator insulates callers from the underlying representation
+// of [PdfDictionary.Entries].
+func (d *PdfDictionary) All() iter.Seq2[string, PdfObject] {
+	return func(yield func(string, PdfObject) bool) {
+		for _, e := range d.Entries {
+			if !yield(e.Key.Value, e.Value) {
+				return
+			}
 		}
 	}
 }

--- a/core/dictionary_test.go
+++ b/core/dictionary_test.go
@@ -14,3 +14,82 @@ func TestDictionarySetPanicsOnNilValue(t *testing.T) {
 	d := NewPdfDictionary()
 	d.Set("Key", nil)
 }
+
+func TestDictionaryRemoveExisting(t *testing.T) {
+	d := NewPdfDictionary()
+	d.Set("A", NewPdfInteger(1))
+	d.Set("B", NewPdfInteger(2))
+	d.Set("C", NewPdfInteger(3))
+	d.Remove("B")
+	if d.Get("B") != nil {
+		t.Error("B should be gone after Remove")
+	}
+	if d.Get("A") == nil || d.Get("C") == nil {
+		t.Error("A and C should still be present")
+	}
+	got := serialize(t, d)
+	if got != "<< /A 1 /C 3 >>" {
+		t.Errorf("expected %q, got %q", "<< /A 1 /C 3 >>", got)
+	}
+}
+
+func TestDictionaryRemoveMissing(t *testing.T) {
+	d := NewPdfDictionary()
+	d.Set("A", NewPdfInteger(1))
+	d.Remove("NotThere") // should be a no-op, not panic
+	if d.Get("A") == nil {
+		t.Error("existing entry should not be affected by removing missing key")
+	}
+}
+
+func TestDictionaryRemoveOnly(t *testing.T) {
+	d := NewPdfDictionary()
+	d.Set("X", NewPdfInteger(42))
+	d.Remove("X")
+	if d.Len() != 0 {
+		t.Errorf("expected empty dictionary, got %d entries", d.Len())
+	}
+	got := serialize(t, d)
+	if got != "<< >>" {
+		t.Errorf("expected %q, got %q", "<< >>", got)
+	}
+}
+
+func TestDictionaryAllIterator(t *testing.T) {
+	d := NewPdfDictionary()
+	d.Set("B", NewPdfInteger(2))
+	d.Set("A", NewPdfInteger(1))
+	d.Set("C", NewPdfInteger(3))
+
+	var keys []string
+	for k, v := range d.All() {
+		_ = v
+		keys = append(keys, k)
+	}
+	// Must preserve insertion order.
+	want := []string{"B", "A", "C"}
+	if len(keys) != len(want) {
+		t.Fatalf("expected %d keys, got %d", len(want), len(keys))
+	}
+	for i, k := range want {
+		if keys[i] != k {
+			t.Errorf("key[%d]: expected %q, got %q", i, k, keys[i])
+		}
+	}
+}
+
+func TestDictionaryIndexAfterRemove(t *testing.T) {
+	d := NewPdfDictionary()
+	d.Set("A", NewPdfInteger(1))
+	d.Set("B", NewPdfInteger(2))
+	d.Set("C", NewPdfInteger(3))
+	d.Remove("A")
+	// Both B and C should still be findable via the index after Remove
+	// shifted their positions down.
+	if b := d.Get("B"); b == nil || b.(*PdfNumber).IntValue() != 2 {
+		t.Errorf("B lookup broken after Remove: %v", b)
+	}
+	if c := d.Get("C"); c == nil || c.(*PdfNumber).IntValue() != 3 {
+		t.Errorf("C lookup broken after Remove: %v", c)
+	}
+}

--- a/core/encrypt.go
+++ b/core/encrypt.go
@@ -13,6 +13,9 @@ import (
 	"crypto/sha512"
 	"encoding/binary"
 	"fmt"
+	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // Permission flags for PDF document encryption (ISO 32000 Table 22).
@@ -44,7 +47,11 @@ func permBits(p Permission) int32 {
 type EncryptionRevision int
 
 const (
-	RevisionRC4128 EncryptionRevision = 3 // RC4 128-bit (V=2, R=3)
+	// RevisionRC4128 selects the RC4-128 Standard Security Handler (V=2, R=3).
+	//
+	// Deprecated: RC4 is cryptographically broken and kept only for backward
+	// compatibility with legacy readers. Use [RevisionAES256] for new documents.
+	RevisionRC4128 EncryptionRevision = 3
 	RevisionAES128 EncryptionRevision = 4 // AES-128-CBC (V=4, R=4)
 	RevisionAES256 EncryptionRevision = 6 // AES-256-CBC (V=5, R=6)
 )
@@ -134,12 +141,12 @@ func (e *Encryptor) EncryptObject(obj PdfObject, objNum, genNum int) error {
 func (e *Encryptor) walkEncrypt(obj PdfObject, objNum, genNum int) error {
 	switch o := obj.(type) {
 	case *PdfString:
-		enc, err := e.EncryptBytes(objNum, genNum, []byte(o.Value))
+		enc, err := e.EncryptBytes(objNum, genNum, []byte(o.value))
 		if err != nil {
 			return fmt.Errorf("encrypt string (obj %d): %w", objNum, err)
 		}
-		o.Value = string(enc)
-		o.Encoding = StringHexadecimal // binary data must be hex-encoded
+		o.value = string(enc)
+		o.encoding = StringHexadecimal // binary data must be hex-encoded
 	case *PdfDictionary:
 		for _, entry := range o.Entries {
 			if err := e.walkEncrypt(entry.Value, objNum, genNum); err != nil {
@@ -162,10 +169,12 @@ func (e *Encryptor) walkEncrypt(obj PdfObject, objNum, genNum int) error {
 		// Compress data first (if applicable), then encrypt.
 		data := o.Data
 		if o.compress {
-			if compressed, err := deflate(data); err == nil {
-				data = compressed
-				o.Dict.Set("Filter", NewPdfName("FlateDecode"))
+			compressed, err := deflate(data)
+			if err != nil {
+				return fmt.Errorf("compress stream (obj %d): %w", objNum, err)
 			}
+			data = compressed
+			o.Dict.Set("Filter", NewPdfName("FlateDecode"))
 			o.compress = false
 		}
 		enc, err := e.EncryptBytes(objNum, genNum, data)
@@ -256,7 +265,7 @@ func computeOwnerHashR3(userPwd, ownerPwd string, keyLen int) []byte {
 	// Step a-d: hash the owner password.
 	padded := padPassword([]byte(ownerPwd))
 	h := md5.Sum(padded[:])
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		h = md5.Sum(h[:])
 	}
 	key := h[:keyLen]
@@ -284,7 +293,7 @@ func computeFileKeyR3(userPwd string, o []byte, p int32, fileID []byte, keyLen i
 	h.Write(pbuf[:])
 	h.Write(fileID)
 	sum := h.Sum(nil)
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		tmp := md5.Sum(sum[:keyLen])
 		sum = tmp[:]
 	}
@@ -321,10 +330,7 @@ func (e *Encryptor) objectKeyRC4(objNum, genNum int) []byte {
 	buf[4] = byte(genNum >> 8)
 	h.Write(buf[:])
 	sum := h.Sum(nil)
-	n := e.keyLen + 5
-	if n > 16 {
-		n = 16
-	}
+	n := min(e.keyLen+5, 16)
 	return sum[:n]
 }
 
@@ -363,9 +369,9 @@ func (e *Encryptor) objectKeyAES(objNum, genNum int) []byte {
 
 // newEncryptorR6 creates an Encryptor using AES-256-CBC (Revision 6, PDF 2.0).
 func newEncryptorR6(userPwd, ownerPwd string, p int32, fileID []byte) (*Encryptor, error) {
-	// Truncate passwords to 127 bytes (UTF-8).
-	uPwd := truncatePassword(userPwd)
-	oPwd := truncatePassword(ownerPwd)
+	// SASLprep (NFKC normalize + truncate to 127 bytes at rune boundary).
+	uPwd := saslPrepPassword(userPwd)
+	oPwd := saslPrepPassword(ownerPwd)
 
 	// Random 32-byte file encryption key.
 	fileKey, err := randomBytes(32)
@@ -422,7 +428,10 @@ func newEncryptorR6(userPwd, ownerPwd string, p int32, fileID []byte) (*Encrypto
 	}
 
 	// Perms: AES-256-ECB encrypt 16-byte permissions block.
-	perms := buildPermsBlock(p)
+	perms, err := buildPermsBlock(p)
+	if err != nil {
+		return nil, err
+	}
 	encPerms := aesECBEncryptBlock(fileKey, perms)
 
 	return &Encryptor{
@@ -454,7 +463,13 @@ func algorithmR6Hash(password, salt, userKey []byte) []byte {
 		}
 
 		// E = AES-128-CBC(key=K[0:16], iv=K[16:32], data=K1).
-		block, _ := aes.NewCipher(k[0:16])
+		// K[0:16] always comes from a hash output, so NewCipher cannot fail
+		// for a standards-compliant AES implementation; panic instead of
+		// silently discarding the error.
+		block, err := aes.NewCipher(k[0:16])
+		if err != nil {
+			panic("core: aes.NewCipher on hash-derived key failed: " + err.Error())
+		}
 		cbc := cipher.NewCBCEncrypter(block, k[16:32])
 		e := make([]byte, len(k1))
 		cbc.CryptBlocks(e, k1)
@@ -487,7 +502,7 @@ func algorithmR6Hash(password, salt, userKey []byte) []byte {
 }
 
 // buildPermsBlock creates the 16-byte permissions plaintext for R=6.
-func buildPermsBlock(p int32) []byte {
+func buildPermsBlock(p int32) ([]byte, error) {
 	buf := make([]byte, 16)
 	binary.LittleEndian.PutUint32(buf[0:4], uint32(p))
 	// Bytes 4-7: 0xFFFFFFFF.
@@ -497,8 +512,10 @@ func buildPermsBlock(p int32) []byte {
 	// Bytes 9-11: 'adb' (per spec).
 	buf[9], buf[10], buf[11] = 'a', 'd', 'b'
 	// Bytes 12-15: random.
-	_, _ = rand.Read(buf[12:16])
-	return buf
+	if _, err := rand.Read(buf[12:16]); err != nil {
+		return nil, fmt.Errorf("encrypt: random bytes for perms block: %w", err)
+	}
+	return buf, nil
 }
 
 // --- Cryptographic helpers ---
@@ -515,13 +532,32 @@ func padPassword(pwd []byte) [32]byte {
 }
 
 // truncatePassword truncates a UTF-8 password to at most 127 bytes, as
-// required by ISO 32000-2 §7.6.4.3.3.
+// required by ISO 32000-2 §7.6.4.3.3. Truncation respects rune boundaries:
+// if byte 127 falls inside a multi-byte sequence, it is cut at the preceding
+// rune start so the result is always valid UTF-8.
 func truncatePassword(pwd string) []byte {
 	b := []byte(pwd)
-	if len(b) > 127 {
-		b = b[:127]
+	if len(b) <= 127 {
+		return b
 	}
-	return b
+	// Walk backward from byte 127 until we find a valid rune start.
+	i := 127
+	for i > 0 && !utf8.RuneStart(b[i]) {
+		i--
+	}
+	return b[:i]
+}
+
+// saslPrepPassword applies a simplified SASLprep (RFC 4013) profile to a
+// PDF password, as required by ISO 32000-2 §7.6.4.3.3 for revision 6.
+// The full SASLprep specification includes character mapping, prohibited
+// character checks, and bidirectional string validation. This implementation
+// performs NFKC normalization — the most impactful step, which ensures that
+// canonically equivalent Unicode strings (e.g., precomposed "é" vs. "e" +
+// combining acute) produce the same encryption key — then truncates to
+// 127 bytes at a rune boundary.
+func saslPrepPassword(pwd string) []byte {
+	return truncatePassword(norm.NFKC.String(pwd))
 }
 
 // rc4Encrypt encrypts (or decrypts) data using RC4 with the given key.

--- a/core/encrypt_test.go
+++ b/core/encrypt_test.go
@@ -278,10 +278,10 @@ func TestEncryptObjectString(t *testing.T) {
 		t.Fatal(err)
 	}
 	// After encryption: encoding must be hex, value must differ.
-	if s.Encoding != StringHexadecimal {
+	if !s.IsHex() {
 		t.Error("encrypted string not hex-encoded")
 	}
-	if s.Value == "Hello" {
+	if s.Text() == "Hello" {
 		t.Error("string not encrypted")
 	}
 }
@@ -293,7 +293,7 @@ func TestEncryptObjectSkipsEncryptDict(t *testing.T) {
 	if err := enc.EncryptObject(s, 5, 0); err != nil {
 		t.Fatal(err)
 	}
-	if s.Value != "Secret" {
+	if s.Text() != "Secret" {
 		t.Error("encrypt dict object should not be encrypted")
 	}
 }
@@ -308,7 +308,7 @@ func TestEncryptObjectDict(t *testing.T) {
 	}
 	// String should be encrypted; integer should be unchanged.
 	title := d.Get("Title").(*PdfString)
-	if title.Value == "Test" {
+	if title.Text() == "Test" {
 		t.Error("string in dict not encrypted")
 	}
 	count := d.Get("Count").(*PdfNumber)
@@ -394,5 +394,151 @@ func TestBuildEncryptDictAuthEvent(t *testing.T) {
 		if em == nil {
 			t.Errorf("R=%d: missing /EncryptMetadata", rev)
 		}
+	}
+}
+
+func TestNewEncryptorInvalidRevision(t *testing.T) {
+	_, err := NewEncryptor(EncryptionRevision(99), "user", "owner", PermAll)
+	if err == nil {
+		t.Error("expected error for invalid revision, got nil")
+	}
+}
+
+func TestEncryptBytesEmpty(t *testing.T) {
+	enc, _ := NewEncryptor(RevisionAES256, "pass", "pass", PermAll)
+	out, err := enc.EncryptBytes(1, 0, []byte{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty output for empty input, got %d bytes", len(out))
+	}
+}
+
+func TestEncryptBytesRC4Direct(t *testing.T) {
+	enc, err := NewEncryptor(RevisionRC4128, "pass", "pass", PermAll)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plaintext := []byte("some plaintext")
+	encrypted, err := enc.EncryptBytes(1, 0, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(encrypted, plaintext) {
+		t.Error("RC4 encryption did not change data")
+	}
+	if len(encrypted) != len(plaintext) {
+		t.Errorf("RC4 should not change length: got %d, want %d",
+			len(encrypted), len(plaintext))
+	}
+}
+
+func TestEncryptBytesRC4RoundTrip(t *testing.T) {
+	enc, err := NewEncryptor(RevisionRC4128, "pass", "pass", PermAll)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("Hello, PDF encryption!")
+	encrypted, err := enc.EncryptBytes(1, 0, original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// RC4 is symmetric: encrypting with the same per-object key decrypts.
+	decrypted, err := enc.EncryptBytes(1, 0, encrypted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(decrypted, original) {
+		t.Errorf("RC4 round-trip failed: got %q, want %q", decrypted, original)
+	}
+}
+
+func TestEncryptBytesAES128Direct(t *testing.T) {
+	enc, err := NewEncryptor(RevisionAES128, "pass", "pass", PermAll)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plaintext := []byte("some AES-128 plaintext")
+	encrypted, err := enc.EncryptBytes(1, 0, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(encrypted, plaintext) {
+		t.Error("AES-128 encryption did not change data")
+	}
+	// Output must have a 16-byte IV prefix plus PKCS7-padded ciphertext.
+	if len(encrypted) < len(plaintext)+16 {
+		t.Errorf("AES-128 output too short: got %d, want >= %d",
+			len(encrypted), len(plaintext)+16)
+	}
+}
+
+func TestEncryptObjectArray(t *testing.T) {
+	enc, _ := NewEncryptor(RevisionAES256, "pass", "pass", PermAll)
+	arr := NewPdfArray(
+		NewPdfLiteralString("secret"),
+		NewPdfInteger(42),
+	)
+	if err := enc.EncryptObject(arr, 2, 0); err != nil {
+		t.Fatal(err)
+	}
+	s := arr.Elements[0].(*PdfString)
+	if s.Text() == "secret" {
+		t.Error("string in array not encrypted")
+	}
+	n := arr.Elements[1].(*PdfNumber)
+	if n.IntValue() != 42 {
+		t.Error("integer in array modified during encryption")
+	}
+}
+
+func TestSaslPrepNormalization(t *testing.T) {
+	// U+00E9 (precomposed e-acute) vs U+0065 U+0301 (e + combining acute).
+	precomposed := "caf\u00e9"
+	decomposed := "cafe\u0301"
+
+	p1 := saslPrepPassword(precomposed)
+	p2 := saslPrepPassword(decomposed)
+	if !bytes.Equal(p1, p2) {
+		t.Errorf("SASLprep should normalize equivalent Unicode: %x vs %x", p1, p2)
+	}
+}
+
+func TestTruncatePasswordRuneBoundary(t *testing.T) {
+	// Build a password whose byte 127 falls inside a multi-byte rune.
+	// The é character (U+00E9) is 2 bytes in UTF-8: 0xC3 0xA9.
+	// 63 × "ab" (126 bytes) + "é" (2 bytes) = 128 bytes. Byte 127 is
+	// the continuation byte of é.
+	pwd := ""
+	for range 63 {
+		pwd += "ab"
+	}
+	pwd += "é" // 0xC3 0xA9
+	if len(pwd) != 128 {
+		t.Fatalf("setup: pwd length = %d, want 128", len(pwd))
+	}
+	truncated := truncatePassword(pwd)
+	if len(truncated) > 127 {
+		t.Errorf("truncated length = %d, want <= 127", len(truncated))
+	}
+	// The result must be valid UTF-8 (no lone continuation byte).
+	if last := truncated[len(truncated)-1]; last&0xC0 == 0x80 {
+		t.Errorf("truncated password ends with continuation byte 0x%02X", last)
+	}
+}
+
+func TestEncryptR6EquivalentUnicodePasswords(t *testing.T) {
+	// Two R6 encryptors created with canonically equivalent passwords
+	// should accept each other's encryption under the same file key.
+	// Since each NewEncryptor randomizes the file key, we can't compare
+	// file keys directly; instead verify that saslPrepPassword produces
+	// the same bytes, which is what feeds the key derivation.
+	p1 := saslPrepPassword("Angstr\u00f6m")  // precomposed Å, single ö
+	p2 := saslPrepPassword("Angstro\u0308m") // o + combining diaeresis = ö
+	// Note: "Angstr" stays the same, difference is just in ö.
+	// Without NFKC these would differ; with NFKC they should match.
+	if !bytes.Equal(p1, p2) {
+		t.Errorf("canonically-equivalent passwords produced different bytes: %x vs %x", p1, p2)
 	}
 }

--- a/core/null.go
+++ b/core/null.go
@@ -9,11 +9,16 @@ import (
 )
 
 // PdfNull represents the PDF null object (ISO 32000 §7.3.9).
+// PdfNull is stateless; all instances are equivalent.
 type PdfNull struct{}
 
-// NewPdfNull creates a new PdfNull instance.
+// pdfNullSingleton is the single shared PdfNull instance returned by NewPdfNull.
+var pdfNullSingleton = &PdfNull{}
+
+// NewPdfNull returns the shared PdfNull instance. Because PdfNull has no
+// fields, a singleton is safe and avoids allocating on every call.
 func NewPdfNull() *PdfNull {
-	return &PdfNull{}
+	return pdfNullSingleton
 }
 
 // Type returns ObjectTypeNull.

--- a/core/number.go
+++ b/core/number.go
@@ -30,10 +30,43 @@ func NewPdfReal(v float64) *PdfNumber {
 // Type returns ObjectTypeNumber.
 func (n *PdfNumber) Type() ObjectType { return ObjectTypeNumber }
 
-// IntValue returns the integer value. It truncates reals.
+// IntValue returns the integer value, truncating reals toward zero.
+// NaN and infinite values return 0 so malformed PDFs cannot propagate
+// undefined conversions into the rest of the pipeline.
+//
+// Note: this method silently truncates real values and can overflow on
+// 32-bit platforms for very large reals. Use [PdfNumber.IntValueChecked]
+// when you need to distinguish between an integer, a truncated real,
+// and an out-of-range value.
 func (n *PdfNumber) IntValue() int {
+	if math.IsNaN(n.value) || math.IsInf(n.value, 0) {
+		return 0
+	}
 	return int(n.value)
 }
+
+// IntValueChecked returns the integer value and a boolean indicating whether
+// the conversion was exact. ok is false if the underlying value is a real
+// with a fractional part, is NaN or Inf, or overflows the platform int range.
+func (n *PdfNumber) IntValueChecked() (value int, ok bool) {
+	v := n.value
+	if v != v { // NaN
+		return 0, false
+	}
+	if v > float64(maxInt) || v < float64(minInt) {
+		return 0, false
+	}
+	if !n.isInteger && v != float64(int64(v)) {
+		return int(v), false
+	}
+	return int(v), true
+}
+
+// Platform int bounds for IntValueChecked overflow detection.
+const (
+	maxInt = int(^uint(0) >> 1)
+	minInt = -maxInt - 1
+)
 
 // FloatValue returns the float64 value.
 func (n *PdfNumber) FloatValue() float64 {

--- a/core/number_test.go
+++ b/core/number_test.go
@@ -28,3 +28,21 @@ func TestFormatRealNegInf(t *testing.T) {
 		t.Errorf("expected %q for -Inf, got %q", "0.0", got)
 	}
 }
+
+func TestIntValueNaN(t *testing.T) {
+	if got := NewPdfReal(math.NaN()).IntValue(); got != 0 {
+		t.Errorf("IntValue on NaN = %d, want 0", got)
+	}
+}
+
+func TestIntValuePosInf(t *testing.T) {
+	if got := NewPdfReal(math.Inf(1)).IntValue(); got != 0 {
+		t.Errorf("IntValue on +Inf = %d, want 0", got)
+	}
+}
+
+func TestIntValueNegInf(t *testing.T) {
+	if got := NewPdfReal(math.Inf(-1)).IntValue(); got != 0 {
+		t.Errorf("IntValue on -Inf = %d, want 0", got)
+	}
+}

--- a/core/object_test.go
+++ b/core/object_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"io"
+	"math"
 	"strings"
 	"testing"
 )
@@ -495,6 +496,65 @@ func TestReferenceHighNumbers(t *testing.T) {
 func TestReferenceType(t *testing.T) {
 	if NewPdfIndirectReference(1, 0).Type() != ObjectTypeReference {
 		t.Error("expected ObjectTypeReference")
+	}
+}
+
+func TestReferenceNumGen(t *testing.T) {
+	r := NewPdfIndirectReference(7, 2)
+	if r.Num() != 7 {
+		t.Errorf("Num() = %d, want 7", r.Num())
+	}
+	if r.Gen() != 2 {
+		t.Errorf("Gen() = %d, want 2", r.Gen())
+	}
+}
+
+func TestNumberIntValueChecked(t *testing.T) {
+	tests := []struct {
+		name    string
+		num     *PdfNumber
+		wantVal int
+		wantOK  bool
+	}{
+		{"integer zero", NewPdfInteger(0), 0, true},
+		{"integer positive", NewPdfInteger(42), 42, true},
+		{"integer negative", NewPdfInteger(-100), -100, true},
+		{"real whole", NewPdfReal(5.0), 5, true},
+		{"real fractional", NewPdfReal(3.14), 3, false},
+		{"real negative fractional", NewPdfReal(-0.5), 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, ok := tt.num.IntValueChecked()
+			if v != tt.wantVal || ok != tt.wantOK {
+				t.Errorf("IntValueChecked() = (%d, %v), want (%d, %v)",
+					v, ok, tt.wantVal, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestNumberIntValueCheckedNaN(t *testing.T) {
+	n := NewPdfReal(math.NaN())
+	_, ok := n.IntValueChecked()
+	if ok {
+		t.Error("IntValueChecked on NaN should return ok=false")
+	}
+}
+
+func TestNumberIntValueCheckedInf(t *testing.T) {
+	n := NewPdfReal(math.Inf(1))
+	_, ok := n.IntValueChecked()
+	if ok {
+		t.Error("IntValueChecked on +Inf should return ok=false")
+	}
+}
+
+func TestNullSingleton(t *testing.T) {
+	a := NewPdfNull()
+	b := NewPdfNull()
+	if a != b {
+		t.Error("NewPdfNull should return the same pointer (singleton)")
 	}
 }
 

--- a/core/reference.go
+++ b/core/reference.go
@@ -12,7 +12,16 @@ import (
 // Written as "objNum genNum R" (e.g., "1 0 R").
 // Generation numbers are almost always 0 in modern PDFs.
 type PdfIndirectReference struct {
-	ObjectNumber     int
+	// ObjectNumber is the object number of the referenced indirect object.
+	//
+	// Deprecated: direct field access is retained for backward compatibility.
+	// Prefer [PdfIndirectReference.Num] in new code.
+	ObjectNumber int
+
+	// GenerationNumber is the generation number of the referenced object.
+	//
+	// Deprecated: direct field access is retained for backward compatibility.
+	// Prefer [PdfIndirectReference.Gen] in new code.
 	GenerationNumber int
 }
 
@@ -26,6 +35,12 @@ func NewPdfIndirectReference(objNum, genNum int) *PdfIndirectReference {
 
 // Type returns ObjectTypeReference.
 func (r *PdfIndirectReference) Type() ObjectType { return ObjectTypeReference }
+
+// Num returns the object number of the referenced indirect object.
+func (r *PdfIndirectReference) Num() int { return r.ObjectNumber }
+
+// Gen returns the generation number of the referenced object.
+func (r *PdfIndirectReference) Gen() int { return r.GenerationNumber }
 
 // WriteTo serializes the indirect reference as "objNum genNum R" to w.
 func (r *PdfIndirectReference) WriteTo(w io.Writer) (int64, error) {

--- a/core/string.go
+++ b/core/string.go
@@ -20,32 +20,46 @@ const (
 // PdfString represents a PDF string object (ISO 32000 §7.3.4).
 // PDF supports two notations: literal strings in parentheses and
 // hexadecimal strings in angle brackets.
+//
+// Use [NewPdfLiteralString] or [NewPdfHexString] to construct, and
+// [PdfString.Text] / [PdfString.IsHex] to read. The underlying fields
+// are unexported; encryption mutates them in-place from within the
+// core package.
 type PdfString struct {
-	Value    string
-	Encoding StringEncoding
+	value    string
+	encoding StringEncoding
 }
 
 // NewPdfLiteralString creates a literal string: (value).
 func NewPdfLiteralString(v string) *PdfString {
-	return &PdfString{Value: v, Encoding: StringLiteral}
+	return &PdfString{value: v, encoding: StringLiteral}
 }
 
 // NewPdfHexString creates a hexadecimal string: <hex>.
 func NewPdfHexString(v string) *PdfString {
-	return &PdfString{Value: v, Encoding: StringHexadecimal}
+	return &PdfString{value: v, encoding: StringHexadecimal}
 }
 
 // Type returns ObjectTypeString.
 func (s *PdfString) Type() ObjectType { return ObjectTypeString }
 
+// Text returns the raw string value, without PDF escaping.
+// For literal strings this is the unescaped content; for hex strings
+// it is the decoded bytes interpreted as a string.
+func (s *PdfString) Text() string { return s.value }
+
+// IsHex reports whether the string will be serialized in hexadecimal
+// notation (<hex>) rather than literal notation ((text)).
+func (s *PdfString) IsHex() bool { return s.encoding == StringHexadecimal }
+
 // WriteTo serializes the string in literal or hexadecimal notation to w.
 func (s *PdfString) WriteTo(w io.Writer) (int64, error) {
 	var out string
-	switch s.Encoding {
+	switch s.encoding {
 	case StringHexadecimal:
-		out = "<" + fmt.Sprintf("%X", []byte(s.Value)) + ">"
+		out = "<" + fmt.Sprintf("%X", []byte(s.value)) + ">"
 	default:
-		out = "(" + EscapeLiteralString(s.Value) + ")"
+		out = "(" + EscapeLiteralString(s.value) + ")"
 	}
 	n, err := fmt.Fprint(w, out)
 	return int64(n), err
@@ -57,7 +71,7 @@ func (s *PdfString) WriteTo(w io.Writer) (int64, error) {
 func EscapeLiteralString(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		switch {
 		case c == '\\':

--- a/document/document.go
+++ b/document/document.go
@@ -935,12 +935,12 @@ func (d *Document) WriteTo(w io.Writer) (int64, error) {
 // a fully direct object tree that may contain font programs and other
 // streams as direct values.
 func hoistStreams(dict *core.PdfDictionary, addObj func(core.PdfObject) *core.PdfIndirectReference) {
-	for i, entry := range dict.Entries {
-		switch v := entry.Value.(type) {
+	for key, value := range dict.All() {
+		switch v := value.(type) {
 		case *core.PdfStream:
 			// Recursively hoist any streams nested in this stream's dict.
 			hoistStreams(v.Dict, addObj)
-			dict.Entries[i].Value = addObj(v)
+			dict.Set(key, addObj(v))
 		case *core.PdfDictionary:
 			hoistStreams(v, addObj)
 		case *core.PdfArray:
@@ -952,11 +952,11 @@ func hoistStreams(dict *core.PdfDictionary, addObj func(core.PdfObject) *core.Pd
 // hoistStreamArray walks a PdfArray and replaces any PdfStream elements
 // with indirect references.
 func hoistStreamArray(arr *core.PdfArray, addObj func(core.PdfObject) *core.PdfIndirectReference) {
-	for i, elem := range arr.Elements {
+	for i, elem := range arr.All() {
 		switch v := elem.(type) {
 		case *core.PdfStream:
 			hoistStreams(v.Dict, addObj)
-			arr.Elements[i] = addObj(v)
+			arr.Set(i, addObj(v))
 		case *core.PdfDictionary:
 			hoistStreams(v, addObj)
 		case *core.PdfArray:

--- a/document/encryption.go
+++ b/document/encryption.go
@@ -45,7 +45,14 @@ func revisionFromAlgorithm(alg EncryptionAlgorithm) core.EncryptionRevision {
 		return core.RevisionAES128
 	case EncryptAES256:
 		return core.RevisionAES256
+	case EncryptRC4128:
+		// Intentional: the public EncryptRC4128 option exists for PDF 1.4
+		// compatibility. The deprecation on core.RevisionRC4128 targets new
+		// callers, not this explicit mapping.
+		return core.RevisionRC4128 //nolint:staticcheck // SA1019
 	default:
-		return core.RevisionRC4128
+		// Unknown enum value — fall back to the recommended minimum
+		// instead of silently selecting broken RC4.
+		return core.RevisionAES128
 	}
 }

--- a/document/structtree.go
+++ b/document/structtree.go
@@ -156,7 +156,7 @@ func (st *structTree) buildPdfObjects(
 	kids := st.buildChildren(st.root, docElemRef, pageRefs, addObject, &parentEntries)
 
 	if kids.Len() == 1 {
-		docElem.Set("K", kids.Elements[0])
+		docElem.Set("K", kids.At(0))
 	} else if kids.Len() > 0 {
 		docElem.Set("K", kids)
 	}
@@ -220,12 +220,12 @@ func (st *structTree) buildChildren(
 
 		// Recurse into child structure elements.
 		childKids := st.buildChildren(child, elemRef, pageRefs, addObject, parentEntries)
-		for _, ck := range childKids.Elements {
+		for _, ck := range childKids.All() {
 			elemKids.Add(ck)
 		}
 
 		if elemKids.Len() == 1 {
-			elemDict.Set("K", elemKids.Elements[0])
+			elemDict.Set("K", elemKids.At(0))
 		} else if elemKids.Len() > 0 {
 			elemDict.Set("K", elemKids)
 		}

--- a/document/writer.go
+++ b/document/writer.go
@@ -86,7 +86,7 @@ func (w *Writer) SetEncryption(enc *core.Encryptor) {
 	w.encryptor = enc
 	encDict := enc.BuildEncryptDict()
 	w.encryptRef = w.AddObject(encDict)
-	enc.SetEncryptDictObjNum(w.encryptRef.ObjectNumber)
+	enc.SetEncryptDictObjNum(w.encryptRef.Num())
 }
 
 // WriteTo writes the complete PDF file to the given writer.

--- a/forms/fill.go
+++ b/forms/fill.go
@@ -32,7 +32,7 @@ func (ff *FormFiller) FieldNames() ([]string, error) {
 	for _, fd := range fields {
 		if t := fd.Get("T"); t != nil {
 			if s, ok := t.(*core.PdfString); ok {
-				names = append(names, s.Value)
+				names = append(names, s.Text())
 			}
 		}
 	}
@@ -86,9 +86,9 @@ func (ff *FormFiller) SetCheckbox(fieldName string, checked bool) error {
 					if apDict, ok := ap.(*core.PdfDictionary); ok {
 						if n := apDict.Get("N"); n != nil {
 							if nDict, ok := n.(*core.PdfDictionary); ok {
-								for _, entry := range nDict.Entries {
-									if entry.Key.Value != "Off" {
-										exportVal = entry.Key.Value
+								for key := range nDict.All() {
+									if key != "Off" {
+										exportVal = key
 										break
 									}
 								}
@@ -140,7 +140,7 @@ func (ff *FormFiller) getFieldDicts() ([]*core.PdfDictionary, error) {
 	}
 
 	var result []*core.PdfDictionary
-	for _, fieldRef := range fieldsArr.Elements {
+	for _, fieldRef := range fieldsArr.All() {
 		fieldObj, err := ff.reader.ResolveObject(fieldRef)
 		if err != nil {
 			continue
@@ -152,7 +152,7 @@ func (ff *FormFiller) getFieldDicts() ([]*core.PdfDictionary, error) {
 				kidsResolved, err := ff.reader.ResolveObject(kids)
 				if err == nil {
 					if kidsArr, ok := kidsResolved.(*core.PdfArray); ok {
-						for _, kidRef := range kidsArr.Elements {
+						for _, kidRef := range kidsArr.All() {
 							kidObj, err := ff.reader.ResolveObject(kidRef)
 							if err == nil {
 								if kd, ok := kidObj.(*core.PdfDictionary); ok {
@@ -176,7 +176,7 @@ func nameMatch(fd *core.PdfDictionary, name string) bool {
 		return false
 	}
 	if s, ok := t.(*core.PdfString); ok {
-		return s.Value == name
+		return s.Text() == name
 	}
 	return false
 }
@@ -189,7 +189,7 @@ func fieldValue(fd *core.PdfDictionary) string {
 	}
 	switch val := v.(type) {
 	case *core.PdfString:
-		return val.Value
+		return val.Text()
 	case *core.PdfName:
 		return val.Value
 	default:

--- a/image/jpeg_test.go
+++ b/image/jpeg_test.go
@@ -153,15 +153,15 @@ func TestJPEGBuildXObject(t *testing.T) {
 	objCount := 0
 	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
 		objCount++
-		return &core.PdfIndirectReference{ObjectNumber: objCount, GenerationNumber: 0}
+		return core.NewPdfIndirectReference(objCount, 0)
 	}
 
 	imgRef, smaskRef := img.BuildXObject(addObject)
 	if imgRef == nil {
 		t.Fatal("expected non-nil image reference")
 	}
-	if imgRef.ObjectNumber != 1 {
-		t.Errorf("expected object number 1, got %d", imgRef.ObjectNumber)
+	if imgRef.Num() != 1 {
+		t.Errorf("expected object number 1, got %d", imgRef.Num())
 	}
 	if smaskRef != nil {
 		t.Error("expected nil SMask reference for JPEG")
@@ -193,7 +193,7 @@ func TestJPEGBuildXObjectColorSpace(t *testing.T) {
 	}
 
 	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
-		return &core.PdfIndirectReference{ObjectNumber: 1, GenerationNumber: 0}
+		return core.NewPdfIndirectReference(1, 0)
 	}
 
 	imgRef, smaskRef := img.BuildXObject(addObject)

--- a/image/png_test.go
+++ b/image/png_test.go
@@ -199,7 +199,7 @@ func TestPNGBuildXObject(t *testing.T) {
 	objCount := 0
 	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
 		objCount++
-		return &core.PdfIndirectReference{ObjectNumber: objCount, GenerationNumber: 0}
+		return core.NewPdfIndirectReference(objCount, 0)
 	}
 
 	imgRef, smaskRef := img.BuildXObject(addObject)
@@ -224,7 +224,7 @@ func TestPNGBuildXObjectWithAlpha(t *testing.T) {
 	objCount := 0
 	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
 		objCount++
-		return &core.PdfIndirectReference{ObjectNumber: objCount, GenerationNumber: 0}
+		return core.NewPdfIndirectReference(objCount, 0)
 	}
 
 	imgRef, smaskRef := img.BuildXObject(addObject)
@@ -235,11 +235,11 @@ func TestPNGBuildXObjectWithAlpha(t *testing.T) {
 		t.Fatal("expected non-nil SMask reference for PNG with alpha")
 	}
 	// SMask should be added first (object 1), then the image (object 2).
-	if smaskRef.ObjectNumber != 1 {
-		t.Errorf("expected SMask object number 1, got %d", smaskRef.ObjectNumber)
+	if smaskRef.Num() != 1 {
+		t.Errorf("expected SMask object number 1, got %d", smaskRef.Num())
 	}
-	if imgRef.ObjectNumber != 2 {
-		t.Errorf("expected image object number 2, got %d", imgRef.ObjectNumber)
+	if imgRef.Num() != 2 {
+		t.Errorf("expected image object number 2, got %d", imgRef.Num())
 	}
 	if objCount != 2 {
 		t.Errorf("expected 2 objects added, got %d", objCount)
@@ -338,7 +338,7 @@ func TestPNGBuildXObjectGrayscale(t *testing.T) {
 	}
 
 	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
-		return &core.PdfIndirectReference{ObjectNumber: 1, GenerationNumber: 0}
+		return core.NewPdfIndirectReference(1, 0)
 	}
 
 	imgRef, smaskRef := img.BuildXObject(addObject)

--- a/reader/copier.go
+++ b/reader/copier.go
@@ -89,12 +89,12 @@ func (c *Copier) copyDeep(obj core.PdfObject) (core.PdfObject, error) {
 // placeholder to handle circular references.
 func (c *Copier) copyIndirectRef(ref *core.PdfIndirectReference) (core.PdfObject, error) {
 	// Check if already copied.
-	if newRef, ok := c.refMap[ref.ObjectNumber]; ok {
+	if newRef, ok := c.refMap[ref.Num()]; ok {
 		return newRef, nil
 	}
 
 	// Resolve the original object.
-	resolved, err := c.reader.resolver.Resolve(ref.ObjectNumber)
+	resolved, err := c.reader.resolver.Resolve(ref.Num())
 	if err != nil {
 		// Intentional tolerance: return null for references that cannot be
 		// resolved (broken xref, missing object, etc.). This is acceptable
@@ -109,7 +109,7 @@ func (c *Copier) copyIndirectRef(ref *core.PdfIndirectReference) (core.PdfObject
 
 	// Allocate a placeholder reference first (handles circular refs).
 	placeholder := c.addObj(core.NewPdfNull())
-	c.refMap[ref.ObjectNumber] = placeholder
+	c.refMap[ref.Num()] = placeholder
 
 	// Deep-copy the resolved object.
 	copied, err := c.copyDeep(resolved)
@@ -122,7 +122,7 @@ func (c *Copier) copyIndirectRef(ref *core.PdfIndirectReference) (core.PdfObject
 	// and update the refMap. The placeholder ref is now orphaned but
 	// harmless (it points to null).
 	newRef := c.addObj(copied)
-	c.refMap[ref.ObjectNumber] = newRef
+	c.refMap[ref.Num()] = newRef
 
 	return newRef, nil
 }
@@ -130,12 +130,12 @@ func (c *Copier) copyIndirectRef(ref *core.PdfIndirectReference) (core.PdfObject
 // copyDict deep-copies a PDF dictionary, recursively copying all values.
 func (c *Copier) copyDict(dict *core.PdfDictionary) (*core.PdfDictionary, error) {
 	newDict := core.NewPdfDictionary()
-	for _, entry := range dict.Entries {
-		copied, err := c.copyDeep(entry.Value)
+	for key, value := range dict.All() {
+		copied, err := c.copyDeep(value)
 		if err != nil {
 			return nil, err
 		}
-		newDict.Set(entry.Key.Value, copied)
+		newDict.Set(key, copied)
 	}
 	return newDict, nil
 }
@@ -143,7 +143,7 @@ func (c *Copier) copyDict(dict *core.PdfDictionary) (*core.PdfDictionary, error)
 // copyArray deep-copies a PDF array, recursively copying all elements.
 func (c *Copier) copyArray(arr *core.PdfArray) (*core.PdfArray, error) {
 	newArr := core.NewPdfArray()
-	for _, elem := range arr.Elements {
+	for _, elem := range arr.All() {
 		copied, err := c.copyDeep(elem)
 		if err != nil {
 			return nil, err
@@ -164,40 +164,26 @@ func (c *Copier) copyStream(stream *core.PdfStream) (*core.PdfStream, error) {
 	if hasFilter {
 		// Unknown filter — preserve raw data and dict entries as-is.
 		newStream = core.NewPdfStream(stream.Data)
-		for _, entry := range stream.Dict.Entries {
-			if entry.Key.Value == "Length" {
-				continue
-			}
-			copied, err := c.copyDeep(entry.Value)
-			if err != nil {
-				return nil, err
-			}
-			newStream.Dict.Set(entry.Key.Value, copied)
-		}
 	} else {
 		// Decompressed stream — re-compress with FlateDecode on write.
 		newStream = core.NewPdfStreamCompressed(stream.Data)
-		for _, entry := range stream.Dict.Entries {
-			if entry.Key.Value == "Length" {
-				continue
-			}
-			copied, err := c.copyDeep(entry.Value)
-			if err != nil {
-				return nil, err
-			}
-			newStream.Dict.Set(entry.Key.Value, copied)
+	}
+	for key, value := range stream.Dict.All() {
+		if key == "Length" {
+			continue
 		}
+		copied, err := c.copyDeep(value)
+		if err != nil {
+			return nil, err
+		}
+		newStream.Dict.Set(key, copied)
 	}
 	return newStream, nil
 }
 
-// removeEntry removes a key from a dictionary.
+// removeEntry removes a key from a dictionary. It delegates to
+// [core.PdfDictionary.Remove] so the dictionary's internal index
+// stays in sync.
 func removeEntry(dict *core.PdfDictionary, key string) {
-	var kept []core.DictEntry
-	for _, e := range dict.Entries {
-		if e.Key.Value != key {
-			kept = append(kept, e)
-		}
-	}
-	dict.Entries = kept
+	dict.Remove(key)
 }

--- a/reader/flatten.go
+++ b/reader/flatten.go
@@ -50,7 +50,7 @@ func (m *Modifier) flattenPage(pageDict *core.PdfDictionary, pageIndex int) erro
 	xobjCount := 0
 	var keepAnnots []core.PdfObject
 
-	for _, annotObj := range annots.Elements {
+	for _, annotObj := range annots.All() {
 		annotDict, ok := annotObj.(*core.PdfDictionary)
 		if !ok {
 			// Could be an indirect ref — try to use as-is.
@@ -103,9 +103,9 @@ func (m *Modifier) flattenPage(pageDict *core.PdfDictionary, pageIndex int) erro
 			}
 			// If no AS or AS key not found, try "Yes" or first non-Off key.
 			if apStream == nil {
-				for _, entry := range n.Entries {
-					if entry.Key.Value != "Off" {
-						apStream = entry.Value
+				for key, value := range n.All() {
+					if key != "Off" {
+						apStream = value
 						break
 					}
 				}
@@ -122,14 +122,14 @@ func (m *Modifier) flattenPage(pageDict *core.PdfDictionary, pageIndex int) erro
 			continue
 		}
 		rectArr, ok := rectObj.(*core.PdfArray)
-		if !ok || len(rectArr.Elements) < 4 {
+		if !ok || rectArr.Len() < 4 {
 			continue
 		}
 
-		x1 := pdfFloat(rectArr.Elements[0])
-		y1 := pdfFloat(rectArr.Elements[1])
-		x2 := pdfFloat(rectArr.Elements[2])
-		y2 := pdfFloat(rectArr.Elements[3])
+		x1 := pdfFloat(rectArr.At(0))
+		y1 := pdfFloat(rectArr.At(1))
+		x2 := pdfFloat(rectArr.At(2))
+		y2 := pdfFloat(rectArr.At(3))
 		w := x2 - x1
 		h := y2 - y1
 
@@ -151,11 +151,11 @@ func (m *Modifier) flattenPage(pageDict *core.PdfDictionary, pageIndex int) erro
 
 	if xobjCount == 0 {
 		// No widgets flattened — just clean up annotations if any were removed.
-		if len(keepAnnots) != len(annots.Elements) {
+		if len(keepAnnots) != annots.Len() {
 			if len(keepAnnots) == 0 {
 				removeEntry(pageDict, "Annots")
 			} else {
-				pageDict.Set("Annots", &core.PdfArray{Elements: keepAnnots})
+				pageDict.Set("Annots", core.NewPdfArray(keepAnnots...))
 			}
 		}
 		return nil
@@ -175,8 +175,8 @@ func (m *Modifier) flattenPage(pageDict *core.PdfDictionary, pageIndex int) erro
 	existingXObj := resDict.Get("XObject")
 	if existingXObj != nil {
 		if existingDict, ok := existingXObj.(*core.PdfDictionary); ok {
-			for _, entry := range xobjects.Entries {
-				existingDict.Set(entry.Key.Value, entry.Value)
+			for key, value := range xobjects.All() {
+				existingDict.Set(key, value)
 			}
 		}
 	} else {

--- a/reader/fontcache.go
+++ b/reader/fontcache.go
@@ -127,15 +127,13 @@ func buildFontCacheWithShared(resources *core.PdfDictionary, res *resolver, shar
 	}
 
 	cache := make(FontCache)
-	for _, entry := range fontDict.Entries {
-		name := entry.Key.Value
-
+	for name, value := range fontDict.All() {
 		// Check if the font value is an indirect reference so we can
 		// look it up in the shared cache by object number.
 		var objNum int
 		var hasObjNum bool
-		if ref, ok := entry.Value.(*core.PdfIndirectReference); ok {
-			objNum = ref.ObjectNumber
+		if ref, ok := value.(*core.PdfIndirectReference); ok {
+			objNum = ref.Num()
 			hasObjNum = true
 		}
 
@@ -147,7 +145,7 @@ func buildFontCacheWithShared(resources *core.PdfDictionary, res *resolver, shar
 			}
 		}
 
-		fontVal := resolveWith(res, entry.Value)
+		fontVal := resolveWith(res, value)
 		fd, ok := fontVal.(*core.PdfDictionary)
 		if !ok {
 			continue
@@ -272,7 +270,7 @@ func parseEncodingDict(d *core.PdfDictionary, res *resolver) *Encoding {
 	}
 
 	code := 0
-	for _, elem := range arr.Elements {
+	for _, elem := range arr.All() {
 		switch v := elem.(type) {
 		case *core.PdfNumber:
 			code = int(v.IntValue())
@@ -300,7 +298,7 @@ func parseFontWidths(fd *core.PdfDictionary, fe *FontEntry, res *resolver) {
 		if !ok || dfArr.Len() == 0 {
 			return
 		}
-		cidFontObj := resolveWith(res, dfArr.Elements[0])
+		cidFontObj := resolveWith(res, dfArr.At(0))
 		cidFont, ok := cidFontObj.(*core.PdfDictionary)
 		if !ok {
 			return
@@ -347,34 +345,40 @@ func parseFontWidths(fd *core.PdfDictionary, fe *FontEntry, res *resolver) {
 	}
 
 	fe.widths = make([]int, wArr.Len())
-	for i, elem := range wArr.Elements {
+	for i, elem := range wArr.All() {
 		if num, ok := elem.(*core.PdfNumber); ok {
 			fe.widths[i] = num.IntValue()
 		}
 	}
 }
 
+// maxCIDRangeSize bounds how many CIDs a single "first last width" entry in
+// a /W array may materialize. The CID namespace is 16-bit (up to 65535), so
+// any range larger than this must come from a malformed or adversarial PDF
+// and would otherwise let the font dictionary allocate an unbounded map.
+const maxCIDRangeSize = 65536
+
 // parseCIDWidths parses a CIDFont /W array into a CID → width map.
 func parseCIDWidths(arr *core.PdfArray) map[int]int {
 	widths := make(map[int]int)
-	elems := arr.Elements
+	n := arr.Len()
 	i := 0
 
-	for i < len(elems) {
-		cidNum, ok := elems[i].(*core.PdfNumber)
+	for i < n {
+		cidNum, ok := arr.At(i).(*core.PdfNumber)
 		if !ok {
 			i++
 			continue
 		}
 		startCID := cidNum.IntValue()
 		i++
-		if i >= len(elems) {
+		if i >= n {
 			break
 		}
 
-		switch next := elems[i].(type) {
+		switch next := arr.At(i).(type) {
 		case *core.PdfArray:
-			for j, wElem := range next.Elements {
+			for j, wElem := range next.All() {
 				if wNum, ok := wElem.(*core.PdfNumber); ok {
 					widths[startCID+j] = wNum.IntValue()
 				}
@@ -383,11 +387,16 @@ func parseCIDWidths(arr *core.PdfArray) map[int]int {
 		case *core.PdfNumber:
 			endCID := next.IntValue()
 			i++
-			if i < len(elems) {
-				if wNum, ok := elems[i].(*core.PdfNumber); ok {
+			if i < n {
+				if wNum, ok := arr.At(i).(*core.PdfNumber); ok {
 					w := wNum.IntValue()
-					for cid := startCID; cid <= endCID; cid++ {
-						widths[cid] = w
+					// Reject ranges that would allocate an unbounded number
+					// of map entries. A legitimate CIDFont never spans more
+					// than the 16-bit CID namespace in one entry.
+					if endCID >= startCID && endCID-startCID < maxCIDRangeSize {
+						for cid := startCID; cid <= endCID; cid++ {
+							widths[cid] = w
+						}
 					}
 				}
 				i++
@@ -424,7 +433,7 @@ func extractEmbeddedFontCMap(fd *core.PdfDictionary, res *resolver) *CMap {
 	if !ok || dfArr.Len() == 0 {
 		return nil
 	}
-	cidFontObj := resolveWith(res, dfArr.Elements[0])
+	cidFontObj := resolveWith(res, dfArr.At(0))
 	cidFont, ok := cidFontObj.(*core.PdfDictionary)
 	if !ok {
 		return nil

--- a/reader/import.go
+++ b/reader/import.go
@@ -91,38 +91,38 @@ func resolveDeepVisited(obj core.PdfObject, res *resolver, visited map[int]core.
 	// Resolve indirect references.
 	if ref, ok := obj.(*core.PdfIndirectReference); ok {
 		// Check for cycles.
-		if cached, ok := visited[ref.ObjectNumber]; ok {
+		if cached, ok := visited[ref.Num()]; ok {
 			return cached, nil
 		}
-		resolved, err := res.Resolve(ref.ObjectNumber)
+		resolved, err := res.Resolve(ref.Num())
 		if err != nil {
 			return obj, nil // return unresolved on error
 		}
 		// Mark as visited before recursing (handles cycles).
-		visited[ref.ObjectNumber] = nil
+		visited[ref.Num()] = nil
 		result, err := resolveDeepVisited(resolved, res, visited)
 		if err != nil {
 			return resolved, nil
 		}
-		visited[ref.ObjectNumber] = result
+		visited[ref.Num()] = result
 		return result, nil
 	}
 
 	switch o := obj.(type) {
 	case *core.PdfDictionary:
 		newDict := core.NewPdfDictionary()
-		for _, entry := range o.Entries {
-			resolved, err := resolveDeepVisited(entry.Value, res, visited)
+		for key, value := range o.All() {
+			resolved, err := resolveDeepVisited(value, res, visited)
 			if err != nil {
 				return nil, err
 			}
-			newDict.Set(entry.Key.Value, resolved)
+			newDict.Set(key, resolved)
 		}
 		return newDict, nil
 
 	case *core.PdfArray:
 		newArr := core.NewPdfArray()
-		for _, elem := range o.Elements {
+		for _, elem := range o.All() {
 			resolved, err := resolveDeepVisited(elem, res, visited)
 			if err != nil {
 				return nil, err
@@ -134,12 +134,12 @@ func resolveDeepVisited(obj core.PdfObject, res *resolver, visited map[int]core.
 	case *core.PdfStream:
 		// Copy the stream data and resolve dict entries.
 		newStream := core.NewPdfStream(o.Data)
-		for _, entry := range o.Dict.Entries {
-			resolved, err := resolveDeepVisited(entry.Value, res, visited)
+		for key, value := range o.Dict.All() {
+			resolved, err := resolveDeepVisited(value, res, visited)
 			if err != nil {
 				return nil, err
 			}
-			newStream.Dict.Set(entry.Key.Value, resolved)
+			newStream.Dict.Set(key, resolved)
 		}
 		return newStream, nil
 

--- a/reader/merge.go
+++ b/reader/merge.go
@@ -195,7 +195,7 @@ func (m *Modifier) RemovePage(index int) error {
 	if index < 0 || index >= m.pageCount {
 		return fmt.Errorf("page index %d out of range [0, %d)", index, m.pageCount)
 	}
-	m.kids.Elements = append(m.kids.Elements[:index], m.kids.Elements[index+1:]...)
+	m.kids.RemoveAt(index)
 	m.pageDicts = append(m.pageDicts[:index], m.pageDicts[index+1:]...)
 	m.pageCount--
 	return nil
@@ -236,10 +236,10 @@ func (m *Modifier) ReorderPages(order []int) error {
 	newKids := make([]core.PdfObject, m.pageCount)
 	newDicts := make([]*core.PdfDictionary, m.pageCount)
 	for i, idx := range order {
-		newKids[i] = m.kids.Elements[idx]
+		newKids[i] = m.kids.At(idx)
 		newDicts[i] = m.pageDicts[idx]
 	}
-	m.kids.Elements = newKids
+	m.kids.Replace(newKids...)
 	m.pageDicts = newDicts
 	return nil
 }

--- a/reader/parser.go
+++ b/reader/parser.go
@@ -178,8 +178,8 @@ func (p *Parser) parseStream(dict *core.PdfDictionary) (core.PdfObject, error) {
 
 	// Build PdfStream — data will be read from the file by the resolver.
 	stream := core.NewPdfStream(nil)
-	for _, entry := range dict.Entries {
-		stream.Dict.Set(entry.Key.Value, entry.Value)
+	for key, value := range dict.All() {
+		stream.Dict.Set(key, value)
 	}
 
 	return stream, nil

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -335,7 +335,7 @@ func (r *PdfReader) Info() (title, author, subject, creator, producer string) {
 			return ""
 		}
 		if s, ok := obj.(*core.PdfString); ok {
-			return s.Value
+			return s.Text()
 		}
 		return ""
 	}
@@ -439,7 +439,7 @@ func (r *PdfReader) collectPages(node *core.PdfDictionary, inh inherited) error 
 		return fmt.Errorf("reader: /Kids is not an array")
 	}
 
-	for _, kidRef := range kids.Elements {
+	for _, kidRef := range kids.All() {
 		kidObj, err := r.resolver.ResolveDeep(kidRef)
 		if err != nil {
 			return fmt.Errorf("reader: resolve page kid: %w", err)
@@ -519,10 +519,10 @@ func arrayToBox(arr *core.PdfArray) Box {
 		return Box{}
 	}
 	return Box{
-		X1: pdfNumValue(arr.Elements[0]),
-		Y1: pdfNumValue(arr.Elements[1]),
-		X2: pdfNumValue(arr.Elements[2]),
-		Y2: pdfNumValue(arr.Elements[3]),
+		X1: pdfNumValue(arr.At(0)),
+		Y1: pdfNumValue(arr.At(1)),
+		X2: pdfNumValue(arr.At(2)),
+		Y2: pdfNumValue(arr.At(3)),
 	}
 }
 
@@ -584,7 +584,7 @@ func (p *PageInfo) ContentStream() ([]byte, error) {
 	case *core.PdfArray:
 		// Multiple content streams — concatenate.
 		var result []byte
-		for _, elem := range v.Elements {
+		for _, elem := range v.All() {
 			streamObj, err := p.reader.resolver.ResolveDeep(elem)
 			if err != nil {
 				continue

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -222,8 +222,8 @@ func TestParserIndirectReference(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected PdfIndirectReference, got %T", obj)
 	}
-	if ref.ObjectNumber != 5 {
-		t.Errorf("objNum = %d, want 5", ref.ObjectNumber)
+	if ref.Num() != 5 {
+		t.Errorf("objNum = %d, want 5", ref.Num())
 	}
 }
 

--- a/reader/resolver.go
+++ b/reader/resolver.go
@@ -221,14 +221,14 @@ func (r *resolver) resolveCompressed(objNum, objStreamNum, indexInStream int) (c
 
 // ResolveRef resolves a PdfIndirectReference to its target object.
 func (r *resolver) ResolveRef(ref *core.PdfIndirectReference) (core.PdfObject, error) {
-	return r.Resolve(ref.ObjectNumber)
+	return r.Resolve(ref.Num())
 }
 
 // ResolveDeep resolves an object, following indirect references.
 // If obj is a PdfIndirectReference, it resolves it. Otherwise returns obj as-is.
 func (r *resolver) ResolveDeep(obj core.PdfObject) (core.PdfObject, error) {
 	if ref, ok := obj.(*core.PdfIndirectReference); ok {
-		return r.Resolve(ref.ObjectNumber)
+		return r.Resolve(ref.Num())
 	}
 	return obj, nil
 }
@@ -331,22 +331,22 @@ func (r *resolver) resolveStream(stream *core.PdfStream, objOffset int64) (*core
 			var result *core.PdfStream
 			if decompressed {
 				result = core.NewPdfStreamCompressed(data)
-				for _, entry := range stream.Dict.Entries {
-					switch entry.Key.Value {
+				for key, value := range stream.Dict.All() {
+					switch key {
 					case "Filter", "DecodeParms", "Length":
 						continue
 					default:
-						result.Dict.Set(entry.Key.Value, entry.Value)
+						result.Dict.Set(key, value)
 					}
 				}
 			} else {
 				// Unknown filter — preserve raw data and original dict.
 				result = core.NewPdfStream(rawData)
-				for _, entry := range stream.Dict.Entries {
-					if entry.Key.Value == "Length" {
+				for key, value := range stream.Dict.All() {
+					if key == "Length" {
 						continue // WriteTo recalculates Length
 					}
-					result.Dict.Set(entry.Key.Value, entry.Value)
+					result.Dict.Set(key, value)
 				}
 			}
 			return result, nil
@@ -565,7 +565,7 @@ func extractFilters(obj core.PdfObject) []string {
 	}
 	if arr, ok := obj.(*core.PdfArray); ok {
 		var filters []string
-		for _, elem := range arr.Elements {
+		for _, elem := range arr.All() {
 			if name, ok := elem.(*core.PdfName); ok {
 				filters = append(filters, name.Value)
 			}

--- a/reader/structtree.go
+++ b/reader/structtree.go
@@ -34,7 +34,7 @@ func parseStructureTree(catalog *core.PdfDictionary, res *resolver) *StructureTr
 				markedObj := markDict.Get("Marked")
 				if markedObj != nil {
 					if boolVal, ok := markedObj.(*core.PdfBoolean); ok {
-						if !boolVal.Value {
+						if !boolVal.Bool() {
 							return nil
 						}
 					}
@@ -92,7 +92,7 @@ func parseStructKids(kObj core.PdfObject, parent *StructNode, res *resolver) {
 		parseStructElement(v, parent, res)
 
 	case *core.PdfArray:
-		for _, elem := range v.Elements {
+		for _, elem := range v.All() {
 			parseStructKids(elem, parent, res)
 		}
 	}
@@ -112,7 +112,7 @@ func parseStructElement(dict *core.PdfDictionary, parent *StructNode, res *resol
 					pgObj := dict.Get("Pg")
 					if pgObj != nil {
 						if ref, ok := pgObj.(*core.PdfIndirectReference); ok {
-							pageObjNum = ref.ObjectNumber
+							pageObjNum = ref.Num()
 						}
 					}
 					// MCR is a leaf — attach MCID to parent directly.
@@ -149,7 +149,7 @@ func parseStructElement(dict *core.PdfDictionary, parent *StructNode, res *resol
 	pgObj := dict.Get("Pg")
 	if pgObj != nil {
 		if ref, ok := pgObj.(*core.PdfIndirectReference); ok {
-			pageObjNum = ref.ObjectNumber
+			pageObjNum = ref.Num()
 		}
 	}
 
@@ -171,7 +171,7 @@ func parseStructElement(dict *core.PdfDictionary, parent *StructNode, res *resol
 			case *core.PdfDictionary:
 				parseStructElement(kv, child, res)
 			case *core.PdfArray:
-				for _, elem := range kv.Elements {
+				for _, elem := range kv.All() {
 					parseStructKids(elem, child, res)
 				}
 			}

--- a/reader/xref.go
+++ b/reader/xref.go
@@ -170,9 +170,9 @@ func parseXrefStream(data []byte, offset int, table *xrefTable) (*core.PdfDictio
 		return nil, -1, fmt.Errorf("reader: xref stream /W must be array of 3 integers")
 	}
 	w := [3]int{
-		pdfIntValue(wArr.Elements[0]),
-		pdfIntValue(wArr.Elements[1]),
-		pdfIntValue(wArr.Elements[2]),
+		pdfIntValue(wArr.At(0)),
+		pdfIntValue(wArr.At(1)),
+		pdfIntValue(wArr.At(2)),
 	}
 	entrySize := w[0] + w[1] + w[2]
 	if entrySize == 0 {
@@ -190,8 +190,8 @@ func parseXrefStream(data []byte, offset int, table *xrefTable) (*core.PdfDictio
 	if indexObj := dict.Get("Index"); indexObj != nil {
 		if indexArr, ok := indexObj.(*core.PdfArray); ok {
 			for i := 0; i+1 < indexArr.Len(); i += 2 {
-				start := pdfIntValue(indexArr.Elements[i])
-				count := pdfIntValue(indexArr.Elements[i+1])
+				start := pdfIntValue(indexArr.At(i))
+				count := pdfIntValue(indexArr.At(i + 1))
 				subsections = append(subsections, [2]int{start, count})
 			}
 		}

--- a/sign/doctimestamp.go
+++ b/sign/doctimestamp.go
@@ -186,7 +186,9 @@ func buildAcroFormWithExisting(catalog *core.PdfDictionary, newFieldObjNum int) 
 		if acroFormDict, ok := acroFormObj.(*core.PdfDictionary); ok {
 			if fieldsObj := acroFormDict.Get("Fields"); fieldsObj != nil {
 				if fieldsArr, ok := fieldsObj.(*core.PdfArray); ok {
-					existingFields = fieldsArr.Elements
+					for _, f := range fieldsArr.All() {
+						existingFields = append(existingFields, f)
+					}
 				}
 			}
 		} else if acroFormRef, ok := acroFormObj.(*core.PdfIndirectReference); ok {
@@ -206,11 +208,11 @@ func buildAcroFormWithExisting(catalog *core.PdfDictionary, newFieldObjNum int) 
 // cloneCatalogWithAcroForm clones catalog entries and sets /AcroForm.
 func cloneCatalogWithAcroForm(catalog *core.PdfDictionary, acroFormObjNum int) *core.PdfDictionary {
 	d := core.NewPdfDictionary()
-	for _, e := range catalog.Entries {
-		if e.Key.Value == "AcroForm" {
+	for key, value := range catalog.All() {
+		if key == "AcroForm" {
 			continue
 		}
-		d.Set(e.Key.Value, e.Value)
+		d.Set(key, value)
 	}
 	d.Set("AcroForm", core.NewPdfIndirectReference(acroFormObjNum, 0))
 	return d
@@ -263,11 +265,11 @@ func AddDSS(pdfBytes []byte, dss *DSS) ([]byte, error) {
 
 	// Update catalog to include /DSS.
 	updatedCatalog := core.NewPdfDictionary()
-	for _, e := range catalog.Entries {
-		if e.Key.Value == "DSS" {
+	for key, value := range catalog.All() {
+		if key == "DSS" {
 			continue // Replace existing DSS.
 		}
-		updatedCatalog.Set(e.Key.Value, e.Value)
+		updatedCatalog.Set(key, value)
 	}
 	updatedCatalog.Set("DSS", dssRef)
 

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -265,7 +265,7 @@ func buildAcroForm(r *reader.PdfReader, sigFieldObjNum int) *core.PdfDictionary 
 		if af := catalog.Get("AcroForm"); af != nil {
 			if afDict, ok := af.(*core.PdfDictionary); ok {
 				if existingFields, ok := afDict.Get("Fields").(*core.PdfArray); ok {
-					for _, f := range existingFields.Elements {
+					for _, f := range existingFields.All() {
 						fields.Add(f)
 					}
 				}
@@ -275,7 +275,7 @@ func buildAcroForm(r *reader.PdfReader, sigFieldObjNum int) *core.PdfDictionary 
 				if resolved, err := r.ResolveObject(afRef); err == nil {
 					if afDict, ok := resolved.(*core.PdfDictionary); ok {
 						if existingFields, ok := afDict.Get("Fields").(*core.PdfArray); ok {
-							for _, f := range existingFields.Elements {
+							for _, f := range existingFields.All() {
 								fields.Add(f)
 							}
 						}
@@ -300,7 +300,7 @@ func getCatalogObjNum(trailer *core.PdfDictionary) (int, error) {
 	if !ok {
 		return 0, errors.New("sign: trailer /Root is not an indirect reference")
 	}
-	return ref.ObjectNumber, nil
+	return ref.Num(), nil
 }
 
 // buildCatalogWithAcroForm clones the original catalog and adds /AcroForm.
@@ -311,11 +311,11 @@ func buildCatalogWithAcroForm(r *reader.PdfReader, acroFormObjNum int) (*core.Pd
 	}
 
 	d := core.NewPdfDictionary()
-	for _, e := range catalog.Entries {
-		if e.Key.Value == "AcroForm" {
+	for key, value := range catalog.All() {
+		if key == "AcroForm" {
 			continue // Replace with our own.
 		}
-		d.Set(e.Key.Value, e.Value)
+		d.Set(key, value)
 	}
 	d.Set("AcroForm", core.NewPdfIndirectReference(acroFormObjNum, 0))
 	return d, nil


### PR DESCRIPTION
## Summary

First pass of a package-by-package audit of folio. This PR covers the `core` package (ISO 32000 §7.3 object primitives + Standard Security Handler encryption). Scope: correctness fixes, new tests, a lazy O(1) dictionary index, range-over-func iterators, and a deprecation-first API cleanup.

**All 14 packages build, vet, and test clean.** Core statement coverage 86.9% → 90.8%.

## Correctness fixes

- **Compression errors propagated** in \`Encryptor.EncryptObject\`. Previously a failed \`deflate\` silently produced an unencrypted, uncompressed stream.
- **Password truncation respects UTF-8 rune boundaries.** A 128-byte password whose 127-byte cut lands inside a multi-byte rune is now trimmed back to the last valid rune start. Uses \`unicode/utf8.RuneStart\`.
- **R6 (AES-256) passwords are NFKC-normalized** per ISO 32000-2 §7.6.4.3.3 (simplified SASLprep via \`golang.org/x/text/unicode/norm\`). Canonically equivalent Unicode strings (e.g. precomposed "é" vs. "e + combining acute") now derive the same encryption key.
- **\`aes.NewCipher\` error handled** in \`algorithmR6Hash\`. The key is always hash-derived so the call cannot fail on a standards-compliant AES, but panicking with a descriptive message beats silently discarding the error.
- **\`rand.Read\` error propagated** from \`buildPermsBlock\` through \`newEncryptorR6\`, so a CSPRNG failure surfaces instead of leaving 4 bytes zero.
- **\`NewPdfArray\` panics on nil elements**, matching the existing contract of \`PdfArray.Add\`. Previously the constructor silently accepted nil while \`Add\` panicked.

## Performance

- **\`PdfDictionary\` gains a lazy key→position map index**, turning Set/Get/Remove from O(n) to O(1). The index is built on first access and length-mismatch detection catches stale indexes when external code assigns to \`Entries\` directly.
- **\`PdfNull\` and \`PdfBoolean\` are singletons** — both are immutable, so zero-allocation constructors are safe. \`NewPdfBoolean(true)\`/\`NewPdfBoolean(false)\` return shared pointers; \`NewPdfNull()\` returns a single shared pointer.

## New API (non-breaking additions)

| Type | New method | Purpose |
|------|------------|---------|
| \`PdfArray\` | \`All() iter.Seq2[int, PdfObject]\` | Range-over-func iterator |
| \`PdfArray\` | \`At(i int)\`, \`Len()\` | Indexed / counted access |
| \`PdfDictionary\` | \`All() iter.Seq2[string, PdfObject]\` | Range-over-func iterator |
| \`PdfDictionary\` | \`Len()\` | Entry count |
| \`PdfIndirectReference\` | \`Num()\`, \`Gen()\` | Accessors |
| \`PdfNumber\` | \`IntValueChecked() (int, bool)\` | Overflow/fractional-safe conversion |
| \`PdfString\` | \`Text()\`, \`IsHex()\` | Value/encoding accessors |
| \`PdfBoolean\` | \`Bool()\` | Value accessor |

## Deprecations (old API still works)

Marked \`// Deprecated:\` so \`gopls\`/\`staticcheck\` flag them in new code. **No caller changes required to upgrade** — migrate at leisure.

- \`PdfArray.Elements\` → \`arr.All()\` / \`arr.At(i)\` / \`arr.Len()\`
- \`PdfDictionary.Entries\` → \`dict.All()\` / \`dict.Get(key)\` / \`dict.Len()\`
- \`PdfIndirectReference.ObjectNumber\` → \`ref.Num()\`
- \`PdfIndirectReference.GenerationNumber\` → \`ref.Gen()\`
- \`PdfNumber.IntValue()\` → \`num.IntValueChecked() (int, bool)\`
- \`RevisionRC4128\` → \`RevisionAES256\` (RC4 is broken, retained for legacy readers)

## Breaking changes (small blast radius, updated in this PR)

Three fields unexported. Updated every caller in-repo as part of the commit.

| Field | Replacement | Affected files |
|-------|-------------|----------------|
| \`PdfBoolean.Value\` | \`Bool()\` | \`reader/structtree.go\` (1 site) |
| \`PdfString.Value\` | \`Text()\` | \`reader/reader.go\`, \`forms/fill.go\` (3 sites) |
| \`PdfString.Encoding\` | \`IsHex()\` | internal only |

A count of call sites for **hard-breaking** the remaining exported fields (\`PdfArray.Elements\`, \`PdfDictionary.Entries\`, \`PdfIndirectReference.ObjectNumber\`, \`PdfNumber.IntValue\`) put the blast radius at 200+ production sites and 1,400+ test sites — too much churn for the safety benefit. The deprecation-plus-alternative strategy above was chosen instead.

## Tests

New test functions (net +14), targeted at previously-uncovered paths:

- **Dictionary**: \`Remove\` (existing / missing / only entry / index integrity after remove), \`All()\` iterator
- **Array**: \`NewPdfArray\` nil panic, \`At\` / \`All\` iterator
- **Encryption**: \`EncryptBytes\` on empty data, direct RC4-128 / AES-128, RC4 round-trip, \`EncryptObject\` on arrays, \`NewEncryptor\` with invalid revision, SASLprep Unicode normalization, \`truncatePassword\` rune boundary
- **Number**: \`IntValueChecked\` (integers / reals / fractional / NaN / Inf)
- **Null**: singleton identity
- **Reference**: \`Num()\` / \`Gen()\` accessors

Coverage: **86.9% → 90.8%**.

## Documentation

The v0.7.0 migration guide in \`MIGRATING.md\` is **not** included in this PR — it will land once the package tags are cut.

## Test plan

- [ ] \`go build ./...\`
- [ ] \`go vet ./...\`
- [ ] \`go test ./... -count=1\` passes across all 14 packages
- [ ] \`go test ./core/ -cover\` reports ≥90.8%
- [ ] Manual: generate a signed PDF with \`RevisionAES256\` using a Unicode password in both precomposed and decomposed forms; verify both open with the same logical password
- [ ] Manual: open an existing PDF that uses direct \`Entries\` slice mutation (if any in downstream code) and verify the dictionary lookup still works