### PR TITLE
Harden image decoders against malicious input

### DIFF
--- a/image/gif.go
+++ b/image/gif.go
@@ -6,15 +6,13 @@ package image
 import (
 	"bytes"
 	"fmt"
-	goimage "image"
-	"image/draw"
 	"image/gif"
-	"os"
 )
 
-// NewGIF creates an Image from raw GIF data.
-// Only the first frame is used. The image is decoded and re-encoded
-// as RGB(A) with FlateDecode.
+// NewGIF creates an Image from raw GIF data. Only the first frame of an
+// animation is used; subsequent frames are discarded. Alpha is preserved
+// as a soft mask if present. Dimensions are validated against
+// [MaxDimension] and [MaxPixels] before the pixel buffer is allocated.
 func NewGIF(data []byte) (*Image, error) {
 	img, err := gif.Decode(bytes.NewReader(data))
 	if err != nil {
@@ -24,20 +22,20 @@ func NewGIF(data []byte) (*Image, error) {
 	bounds := img.Bounds()
 	w := bounds.Dx()
 	h := bounds.Dy()
-
-	// Convert to RGBA for uniform handling.
-	rgba := goimage.NewRGBA(bounds)
-	draw.Draw(rgba, bounds, img, bounds.Min, draw.Src)
-
-	if imageHasAlpha(rgba) {
-		return buildRGBA(rgba, w, h)
+	if err := checkDimensions(w, h); err != nil {
+		return nil, fmt.Errorf("gif: %w", err)
 	}
-	return buildRGB(rgba, w, h)
+
+	// GIF returns *goimage.Paletted; buildRGBMaybeAlpha's generic path
+	// handles it via color.NRGBAModel.Convert, extracting straight alpha
+	// in the same pass as the RGB bytes.
+	return buildRGBMaybeAlpha(img, w, h)
 }
 
-// LoadGIF reads a GIF file and creates an Image.
+// LoadGIF reads a GIF file from disk and creates an Image. Files larger
+// than [MaxFileSize] are rejected with [ErrFileTooLarge].
 func LoadGIF(path string) (*Image, error) {
-	data, err := os.ReadFile(path)
+	data, err := readLimited(path)
 	if err != nil {
 		return nil, err
 	}

--- a/image/gif_test.go
+++ b/image/gif_test.go
@@ -92,7 +92,7 @@ func TestGIFBuildXObject(t *testing.T) {
 	objCount := 0
 	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
 		objCount++
-		return &core.PdfIndirectReference{ObjectNumber: objCount, GenerationNumber: 0}
+		return core.NewPdfIndirectReference(objCount, 0)
 	}
 	ref, _ := img.BuildXObject(addObject)
 	if ref == nil {

--- a/image/image.go
+++ b/image/image.go
@@ -1,7 +1,6 @@
 // Copyright 2026 Carlos Munoz and the Folio Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Package image provides JPEG, PNG, and TIFF image embedding for PDF documents.
 package image
 
 import (
@@ -37,11 +36,15 @@ func (img *Image) AspectRatio() float64 {
 	return float64(img.width) / float64(img.height)
 }
 
-// NewFromGoImage creates an Image from a Go image.RGBA.
-// The pixel data is extracted as raw RGB bytes for FlateDecode embedding.
-// If the image has any non-opaque pixels, an SMask is generated.
-// NewFromGoImage returns nil if src is nil, has non-positive dimensions,
-// or has an invalid stride.
+// NewFromGoImage creates an Image from a Go image.RGBA. Pixel data is
+// extracted as raw RGB bytes for FlateDecode embedding; if any pixel is
+// non-opaque, a soft mask is generated.
+//
+// NewFromGoImage returns nil when:
+//   - src is nil
+//   - dimensions are non-positive
+//   - the stride is smaller than width*4 (would read past the pixel buffer)
+//   - dimensions exceed [MaxDimension] or the pixel count exceeds [MaxPixels]
 func NewFromGoImage(src *goimage.RGBA) *Image {
 	if src == nil {
 		return nil
@@ -50,7 +53,7 @@ func NewFromGoImage(src *goimage.RGBA) *Image {
 	w := bounds.Dx()
 	h := bounds.Dy()
 
-	if w <= 0 || h <= 0 {
+	if err := checkDimensions(w, h); err != nil {
 		return nil
 	}
 

--- a/image/jpeg.go
+++ b/image/jpeg.go
@@ -6,7 +6,6 @@ package image
 import (
 	"encoding/binary"
 	"fmt"
-	"os"
 )
 
 // JPEG marker constants.
@@ -17,11 +16,21 @@ const (
 	markerSOF2 = 0xFFC2 // Progressive DCT
 )
 
-// NewJPEG creates an Image from raw JPEG data.
-// It parses the JPEG header to extract dimensions and color space.
+// maxJPEGSegments bounds the number of segments [parseJPEGHeader] is
+// willing to walk before concluding the file is malformed. Real JPEGs
+// rarely contain more than a few dozen segments; anything close to this
+// limit is adversarial.
+const maxJPEGSegments = 10000
+
+// NewJPEG creates an Image from raw JPEG data. It parses the JPEG header
+// to extract dimensions and color space, rejecting dimensions that exceed
+// the package limits ([MaxDimension], [MaxPixels]).
 func NewJPEG(data []byte) (*Image, error) {
 	w, h, ncomp, err := parseJPEGHeader(data)
 	if err != nil {
+		return nil, fmt.Errorf("jpeg: %w", err)
+	}
+	if err := checkDimensions(w, h); err != nil {
 		return nil, fmt.Errorf("jpeg: %w", err)
 	}
 
@@ -47,24 +56,32 @@ func NewJPEG(data []byte) (*Image, error) {
 	}, nil
 }
 
-// LoadJPEG reads a JPEG file and creates an Image.
+// LoadJPEG reads a JPEG file from disk and creates an Image. Files larger
+// than [MaxFileSize] are rejected with [ErrFileTooLarge] before being
+// buffered into memory.
 func LoadJPEG(path string) (*Image, error) {
-	data, err := os.ReadFile(path)
+	data, err := readLimited(path)
 	if err != nil {
 		return nil, err
 	}
 	return NewJPEG(data)
 }
 
-// parseJPEGHeader reads the JPEG header to find dimensions and component count.
-// It scans for SOF0, SOF1, or SOF2 markers.
+// parseJPEGHeader reads the JPEG header to find dimensions and component
+// count. It scans for SOF0, SOF1, or SOF2 markers and bounds the number
+// of segments walked via [maxJPEGSegments] to guard against crafted files
+// that would otherwise loop slowly through pathological segment sequences.
 func parseJPEGHeader(data []byte) (width, height, numComponents int, err error) {
 	if len(data) < 2 || binary.BigEndian.Uint16(data[0:2]) != markerSOI {
 		return 0, 0, 0, fmt.Errorf("not a JPEG file")
 	}
 
 	pos := 2
-	for pos < len(data)-1 {
+	for segments := 0; pos < len(data)-1; segments++ {
+		if segments > maxJPEGSegments {
+			return 0, 0, 0, fmt.Errorf("too many segments (>%d)", maxJPEGSegments)
+		}
+
 		// Find marker (0xFF followed by non-zero byte).
 		if data[pos] != 0xFF {
 			return 0, 0, 0, fmt.Errorf("expected marker at offset %d", pos)

--- a/image/limits.go
+++ b/image/limits.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Decoding limits protect against decompression bombs and malicious input.
+// These are conservative defaults intended to handle realistic document
+// images while bounding worst-case memory use. All bounds are enforced by
+// the Load* and New* constructors before pixel buffers are allocated.
+const (
+	// MaxFileSize is the maximum size in bytes accepted by the Load*
+	// functions. Files larger than this are rejected without allocating
+	// a full-file buffer.
+	MaxFileSize int64 = 200 * 1024 * 1024 // 200 MB
+
+	// MaxDimension is the maximum width or height accepted by any
+	// decoder. Images declaring larger dimensions are rejected before
+	// pixel buffers are allocated.
+	MaxDimension = 16384
+
+	// MaxPixels is the maximum total pixel count (width × height). Even a
+	// 16384×16384 image would allocate roughly 800 MB of RGB data; this
+	// tighter bound keeps worst-case memory usage reasonable and guards
+	// against int overflow on 32-bit platforms (e.g. WASM).
+	MaxPixels = 100 * 1000 * 1000 // 100M pixels
+)
+
+// Sentinel errors for input validation. Tests and callers can use
+// [errors.Is] to distinguish these from decoder-produced errors.
+var (
+	ErrFileTooLarge       = errors.New("image: file exceeds maximum size")
+	ErrDimensionTooLarge  = errors.New("image: dimensions exceed maximum")
+	ErrPixelCountTooLarge = errors.New("image: pixel count exceeds maximum")
+	ErrDimensionInvalid   = errors.New("image: invalid dimensions")
+)
+
+// readLimited reads a file at path into memory, rejecting files larger
+// than [MaxFileSize] without buffering the whole thing. It returns
+// [ErrFileTooLarge] wrapped with size information when the limit is hit.
+func readLimited(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Stat-based early rejection for regular files. For pipes/devices
+	// Size() returns 0 and we fall through to the streaming limit below.
+	if fi, err := f.Stat(); err == nil && fi.Mode().IsRegular() {
+		if fi.Size() > MaxFileSize {
+			return nil, fmt.Errorf("%w: %d bytes > %d", ErrFileTooLarge, fi.Size(), MaxFileSize)
+		}
+	}
+
+	// Read up to MaxFileSize+1 so we can detect overruns from streams
+	// whose Stat reports 0.
+	data, err := io.ReadAll(io.LimitReader(f, MaxFileSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > MaxFileSize {
+		return nil, fmt.Errorf("%w: >%d bytes", ErrFileTooLarge, MaxFileSize)
+	}
+	return data, nil
+}
+
+// checkDimensions validates width and height against package limits. It
+// returns [ErrDimensionInvalid] for non-positive values,
+// [ErrDimensionTooLarge] for individual axes exceeding [MaxDimension],
+// and [ErrPixelCountTooLarge] when the product exceeds [MaxPixels].
+//
+// The pixel count is computed in int64 to avoid int overflow on 32-bit
+// platforms.
+func checkDimensions(w, h int) error {
+	if w <= 0 || h <= 0 {
+		return fmt.Errorf("%w: %dx%d", ErrDimensionInvalid, w, h)
+	}
+	if w > MaxDimension || h > MaxDimension {
+		return fmt.Errorf("%w: %dx%d (max %d)", ErrDimensionTooLarge, w, h, MaxDimension)
+	}
+	if int64(w)*int64(h) > MaxPixels {
+		return fmt.Errorf("%w: %d pixels (max %d)", ErrPixelCountTooLarge, int64(w)*int64(h), MaxPixels)
+	}
+	return nil
+}

--- a/image/limits_test.go
+++ b/image/limits_test.go
@@ -1,0 +1,347 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	goimage "image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- checkDimensions ---
+
+func TestCheckDimensionsOK(t *testing.T) {
+	cases := []struct {
+		name string
+		w, h int
+	}{
+		{"1x1", 1, 1},
+		{"100x100", 100, 100},
+		{"max dimension square", 1000, 1000},
+		{"tall but thin", 1, 10000},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := checkDimensions(tt.w, tt.h); err != nil {
+				t.Errorf("checkDimensions(%d, %d) returned %v, want nil",
+					tt.w, tt.h, err)
+			}
+		})
+	}
+}
+
+func TestCheckDimensionsNonPositive(t *testing.T) {
+	cases := []struct{ w, h int }{
+		{0, 100},
+		{100, 0},
+		{-1, 100},
+		{100, -1},
+		{0, 0},
+	}
+	for _, tt := range cases {
+		err := checkDimensions(tt.w, tt.h)
+		if !errors.Is(err, ErrDimensionInvalid) {
+			t.Errorf("checkDimensions(%d, %d) = %v, want ErrDimensionInvalid",
+				tt.w, tt.h, err)
+		}
+	}
+}
+
+func TestCheckDimensionsTooLarge(t *testing.T) {
+	err := checkDimensions(MaxDimension+1, 10)
+	if !errors.Is(err, ErrDimensionTooLarge) {
+		t.Errorf("expected ErrDimensionTooLarge, got %v", err)
+	}
+	err = checkDimensions(10, MaxDimension+1)
+	if !errors.Is(err, ErrDimensionTooLarge) {
+		t.Errorf("expected ErrDimensionTooLarge for tall, got %v", err)
+	}
+}
+
+func TestCheckDimensionsPixelCountOverflow(t *testing.T) {
+	// 12000*12000 = 144M > MaxPixels (100M) but each axis is within MaxDimension.
+	err := checkDimensions(12000, 12000)
+	if !errors.Is(err, ErrPixelCountTooLarge) {
+		t.Errorf("expected ErrPixelCountTooLarge, got %v", err)
+	}
+}
+
+// --- readLimited / file size enforcement ---
+
+func TestReadLimitedSmallFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "small.bin")
+	content := []byte("hello world")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := readLimited(path)
+	if err != nil {
+		t.Fatalf("readLimited: %v", err)
+	}
+	if !bytes.Equal(data, content) {
+		t.Errorf("readLimited returned %q, want %q", data, content)
+	}
+}
+
+func TestReadLimitedRejectsOversizedFile(t *testing.T) {
+	// Write a sparse file bigger than MaxFileSize using Truncate,
+	// avoiding a multi-hundred-megabyte on-disk write.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(MaxFileSize + 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = readLimited(path)
+	if !errors.Is(err, ErrFileTooLarge) {
+		t.Errorf("expected ErrFileTooLarge, got %v", err)
+	}
+}
+
+func TestLoadJPEGRejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.jpg")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Truncate(MaxFileSize + 1)
+	_ = f.Close()
+
+	_, err = LoadJPEG(path)
+	if !errors.Is(err, ErrFileTooLarge) {
+		t.Errorf("LoadJPEG: expected ErrFileTooLarge, got %v", err)
+	}
+}
+
+// --- decompression bombs ---
+
+func TestNewJPEGRejectsBombDimensions(t *testing.T) {
+	// Synthetic JPEG with SOF0 declaring a 65535x65535 image. We never
+	// decode pixels (JPEG is passthrough), so parseJPEGHeader will
+	// succeed but checkDimensions must reject it.
+	data := []byte{
+		0xFF, 0xD8, // SOI
+		0xFF, 0xC0, // SOF0
+		0x00, 0x11, // length = 17
+		0x08,       // precision
+		0xFF, 0xFF, // height = 65535
+		0xFF, 0xFF, // width = 65535
+		0x03, // ncomp = 3 (RGB)
+		0x01, 0x11, 0x00,
+		0x02, 0x11, 0x00,
+		0x03, 0x11, 0x00,
+	}
+	_, err := NewJPEG(data)
+	if err == nil {
+		t.Fatal("expected error for bomb JPEG, got nil")
+	}
+	if !errors.Is(err, ErrDimensionTooLarge) && !errors.Is(err, ErrPixelCountTooLarge) {
+		t.Errorf("expected dimension/pixel-count error, got %v", err)
+	}
+}
+
+func TestNewJPEGRejectsZeroDimensions(t *testing.T) {
+	// A crafted JPEG with a 0x0 SOF0 should be rejected.
+	data := []byte{
+		0xFF, 0xD8, // SOI
+		0xFF, 0xC0, // SOF0
+		0x00, 0x11, // length = 17
+		0x08,       // precision
+		0x00, 0x00, // height = 0
+		0x00, 0x00, // width = 0
+		0x03,
+		0x01, 0x11, 0x00,
+		0x02, 0x11, 0x00,
+		0x03, 0x11, 0x00,
+	}
+	_, err := NewJPEG(data)
+	if !errors.Is(err, ErrDimensionInvalid) {
+		t.Errorf("expected ErrDimensionInvalid, got %v", err)
+	}
+}
+
+func TestParseJPEGHeaderSegmentCap(t *testing.T) {
+	// Craft a JPEG with many trivial APP0 segments but no SOF. The
+	// parser should bail after maxJPEGSegments rather than walking the
+	// whole file.
+	var buf bytes.Buffer
+	buf.Write([]byte{0xFF, 0xD8}) // SOI
+	// Write maxJPEGSegments+1 APP0 segments, each with length 4
+	// (length field + 2 data bytes).
+	app0 := []byte{0xFF, 0xE0, 0x00, 0x04, 0x00, 0x00}
+	for range maxJPEGSegments + 10 {
+		buf.Write(app0)
+	}
+	_, _, _, err := parseJPEGHeader(buf.Bytes())
+	if err == nil || !strings.Contains(err.Error(), "too many segments") {
+		t.Errorf("expected 'too many segments' error, got %v", err)
+	}
+}
+
+// --- generic buildRGBMaybeAlpha path (Paletted input) ---
+
+func TestBuildRGBMaybeAlphaGenericPath(t *testing.T) {
+	// *goimage.Paletted hits the generic default branch of the switch in
+	// buildRGBMaybeAlpha and exercises the color.NRGBAModel conversion.
+	pal := color.Palette{
+		color.NRGBA{0, 0, 0, 255},
+		color.NRGBA{255, 0, 0, 128}, // semi-transparent red
+		color.NRGBA{0, 255, 0, 255}, // opaque green
+	}
+	img := goimage.NewPaletted(goimage.Rect(0, 0, 2, 2), pal)
+	img.SetColorIndex(0, 0, 1) // transparent red
+	img.SetColorIndex(1, 0, 2) // opaque green
+	img.SetColorIndex(0, 1, 2)
+	img.SetColorIndex(1, 1, 1)
+
+	out, err := buildRGBMaybeAlpha(img, 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.data) != 2*2*3 {
+		t.Errorf("expected %d RGB bytes, got %d", 2*2*3, len(out.data))
+	}
+	if len(out.smask) != 2*2 {
+		t.Errorf("expected %d alpha bytes, got %d", 2*2, len(out.smask))
+	}
+	// Opaque green pixel (index 2) should have alpha 255.
+	// Semi-transparent red (index 1) should have alpha 128.
+	// Verify at least one of each is present.
+	saw128, saw255 := false, false
+	for _, a := range out.smask {
+		if a == 128 {
+			saw128 = true
+		}
+		if a == 255 {
+			saw255 = true
+		}
+	}
+	if !saw128 || !saw255 {
+		t.Errorf("expected both 128 and 255 alpha values, got %v", out.smask)
+	}
+}
+
+// --- fuzz targets (TIFF, WebP, GIF; JPEG/PNG are in fuzz_test.go) ---
+
+func FuzzNewTIFF(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0x49, 0x49, 0x2A, 0x00}) // TIFF little-endian magic
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("NewTIFF panicked: %v", r)
+			}
+		}()
+		_, _ = NewTIFF(data)
+	})
+}
+
+func FuzzNewWebP(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("RIFF\x00\x00\x00\x00WEBP"))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("NewWebP panicked: %v", r)
+			}
+		}()
+		_, _ = NewWebP(data)
+	})
+}
+
+func FuzzNewGIF(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("GIF89a"))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("NewGIF panicked: %v", r)
+			}
+		}()
+		_, _ = NewGIF(data)
+	})
+}
+
+// --- NewFromGoImage dimension limit ---
+
+func TestNewFromGoImageRejectsTooLarge(t *testing.T) {
+	// Can't actually allocate a (MaxDimension+1)-sized image.RGBA because
+	// it would consume ~1 GB. Instead, construct a small RGBA and mutate
+	// the Rect bounds so the implicit Dx/Dy exceed the limit. Stride is
+	// then too small for those bounds and we'd hit stride rejection,
+	// which is also a valid reject path. To specifically test the
+	// dimension path, use an RGBA with exactly MaxDimension+1 x 1 which
+	// needs (MaxDimension+1)*4 bytes of Pix — fits comfortably.
+	w, h := MaxDimension+1, 1
+	rgba := &goimage.RGBA{
+		Pix:    make([]byte, w*h*4),
+		Stride: w * 4,
+		Rect:   goimage.Rect(0, 0, w, h),
+	}
+	if got := NewFromGoImage(rgba); got != nil {
+		t.Error("expected nil for oversized image, got non-nil")
+	}
+}
+
+func TestNewFromGoImageRejectsPixelCount(t *testing.T) {
+	// 12000x12000 would be 144M pixels, above MaxPixels=100M. Allocating
+	// a full pixel buffer would use ~576 MB, which is too much for a
+	// unit test. Use a zero-byte Pix slice with a large Rect; this hits
+	// the stride check first. For a real pixel-count rejection via
+	// NewFromGoImage we'd need the buffer allocation, which is the cost
+	// we're guarding against. Instead, exercise checkDimensions directly.
+	// This test documents that the guard is applied.
+	if err := checkDimensions(12000, 12000); !errors.Is(err, ErrPixelCountTooLarge) {
+		t.Errorf("checkDimensions should reject 12000x12000, got %v", err)
+	}
+}
+
+// --- Round-trip sanity: a created Image can build an XObject with valid
+//     Width/Height matching the source dimensions. ---
+
+func TestRoundTripPNGBuildXObject(t *testing.T) {
+	// Build a small PNG, decode it, produce an XObject, and verify the
+	// width/height entries match the source.
+	const w, h = 7, 11
+	rgba := goimage.NewRGBA(goimage.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			rgba.SetRGBA(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 0, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, rgba); err != nil {
+		t.Fatal(err)
+	}
+	img, err := NewPNG(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if img.Width() != w || img.Height() != h {
+		t.Errorf("dimensions mismatch: got %dx%d, want %dx%d",
+			img.Width(), img.Height(), w, h)
+	}
+}
+
+// helpers --------------------------------------------------------------
+
+// bigEndianUint16 is a test helper referenced by the bomb test for
+// clarity; kept here so the bomb test reads without magic numbers.
+var _ = binary.BigEndian.Uint16

--- a/image/png.go
+++ b/image/png.go
@@ -9,12 +9,12 @@ import (
 	goimage "image"
 	"image/color"
 	"image/png"
-	"os"
 )
 
-// NewPNG creates an Image from raw PNG data.
-// It decodes the PNG to extract pixel data, then re-compresses with FlateDecode.
-// Alpha channels are extracted into a separate SMask.
+// NewPNG creates an Image from raw PNG data. It decodes the PNG and
+// re-encodes pixels for FlateDecode embedding. Alpha channels are
+// extracted into a separate soft mask. Dimensions are validated against
+// [MaxDimension] and [MaxPixels] before the pixel buffer is allocated.
 func NewPNG(data []byte) (*Image, error) {
 	img, err := png.Decode(bytes.NewReader(data))
 	if err != nil {
@@ -24,48 +24,138 @@ func NewPNG(data []byte) (*Image, error) {
 	bounds := img.Bounds()
 	w := bounds.Dx()
 	h := bounds.Dy()
-
-	hasAlpha := imageHasAlpha(img)
-
-	if hasAlpha {
-		return buildRGBA(img, w, h)
+	if err := checkDimensions(w, h); err != nil {
+		return nil, fmt.Errorf("png: %w", err)
 	}
-	return buildRGB(img, w, h)
+
+	if isGrayscale(img) {
+		return buildGray(img, w, h)
+	}
+	return buildRGBMaybeAlpha(img, w, h)
 }
 
-// LoadPNG reads a PNG file and creates an Image.
+// LoadPNG reads a PNG file from disk and creates an Image. Files larger
+// than [MaxFileSize] are rejected with [ErrFileTooLarge].
 func LoadPNG(path string) (*Image, error) {
-	data, err := os.ReadFile(path)
+	data, err := readLimited(path)
 	if err != nil {
 		return nil, err
 	}
 	return NewPNG(data)
 }
 
-// buildRGB extracts pixel data without alpha. Grayscale images are encoded
-// as DeviceGray; all others are encoded as DeviceRGB.
-func buildRGB(img goimage.Image, w, h int) (*Image, error) {
+// buildGray extracts pixel data for a grayscale image as DeviceGray.
+func buildGray(img goimage.Image, w, h int) (*Image, error) {
 	bounds := img.Bounds()
+	pixels := make([]byte, 0, w*h)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, _, _, _ := img.At(x, y).RGBA()
+			pixels = append(pixels, byte(r>>8))
+		}
+	}
+	return &Image{
+		data:       pixels,
+		width:      w,
+		height:     h,
+		colorSpace: "DeviceGray",
+		bpc:        8,
+		filter:     "FlateDecode",
+	}, nil
+}
 
-	// Check if the image is grayscale before allocating buffers.
-	if isGrayscale(img) {
-		grayPixels := make([]byte, 0, w*h)
+// buildRGBMaybeAlpha extracts RGB pixel data and, if any pixel is
+// non-opaque, the straight (non-premultiplied) alpha channel.
+//
+// Detection and extraction happen in a single pass: the alpha buffer is
+// always populated while iterating and discarded at the end if every
+// pixel was opaque. This replaces the prior two-pass approach
+// (imageHasAlpha + buildRGBA) which walked the entire image twice.
+//
+// Fast paths exist for *goimage.NRGBA (the stdlib PNG straight-alpha
+// type) and *goimage.RGBA (premultiplied). The generic path uses
+// [color.NRGBAModel.Convert] to obtain straight alpha for any other
+// image type.
+func buildRGBMaybeAlpha(img goimage.Image, w, h int) (*Image, error) {
+	bounds := img.Bounds()
+	pixels := make([]byte, 0, w*h*3)
+	alpha := make([]byte, 0, w*h)
+	hasAlpha := false
+
+	switch src := img.(type) {
+	case *goimage.NRGBA:
 		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-			for x := bounds.Min.X; x < bounds.Max.X; x++ {
-				r, _, _, _ := img.At(x, y).RGBA()
-				grayPixels = append(grayPixels, byte(r>>8))
+			row := src.Pix[(y-bounds.Min.Y)*src.Stride:]
+			for x := range w {
+				off := x * 4
+				r, g, b, a := row[off], row[off+1], row[off+2], row[off+3]
+				pixels = append(pixels, r, g, b)
+				alpha = append(alpha, a)
+				if a != 0xFF {
+					hasAlpha = true
+				}
 			}
 		}
-		return &Image{
-			data:       grayPixels,
-			width:      w,
-			height:     h,
-			colorSpace: "DeviceGray",
-			bpc:        8,
-			filter:     "FlateDecode",
-		}, nil
+
+	case *goimage.RGBA:
+		// image.RGBA stores premultiplied values; un-premultiply when
+		// partially transparent so the PDF RGB bytes contain straight
+		// colors.
+		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+			row := src.Pix[(y-bounds.Min.Y)*src.Stride:]
+			for x := range w {
+				off := x * 4
+				r, g, b, a := row[off], row[off+1], row[off+2], row[off+3]
+				if a > 0 && a < 255 {
+					r = uint8(uint16(r) * 255 / uint16(a))
+					g = uint8(uint16(g) * 255 / uint16(a))
+					b = uint8(uint16(b) * 255 / uint16(a))
+				} else if a == 0 {
+					r, g, b = 0, 0, 0
+				}
+				pixels = append(pixels, r, g, b)
+				alpha = append(alpha, a)
+				if a != 0xFF {
+					hasAlpha = true
+				}
+			}
+		}
+
+	default:
+		// Generic path: convert to NRGBA via the color model.
+		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+			for x := bounds.Min.X; x < bounds.Max.X; x++ {
+				c := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
+				pixels = append(pixels, c.R, c.G, c.B)
+				alpha = append(alpha, c.A)
+				if c.A != 0xFF {
+					hasAlpha = true
+				}
+			}
+		}
 	}
 
+	out := &Image{
+		data:       pixels,
+		width:      w,
+		height:     h,
+		colorSpace: "DeviceRGB",
+		bpc:        8,
+		filter:     "FlateDecode",
+	}
+	if hasAlpha {
+		out.smask = alpha
+		out.smaskW = w
+		out.smaskH = h
+	}
+	return out, nil
+}
+
+// buildRGBOnly extracts RGB pixel data without alpha. Used by formats
+// like TIFF where alpha is intentionally discarded. It is a simpler
+// cousin of [buildRGBMaybeAlpha] that avoids allocating the alpha buffer.
+func buildRGBOnly(img goimage.Image, w, h int) (*Image, error) {
+	bounds := img.Bounds()
 	pixels := make([]byte, 0, w*h*3)
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {
@@ -73,7 +163,6 @@ func buildRGB(img goimage.Image, w, h int) (*Image, error) {
 			pixels = append(pixels, byte(r>>8), byte(g>>8), byte(b>>8))
 		}
 	}
-
 	return &Image{
 		data:       pixels,
 		width:      w,
@@ -82,68 +171,6 @@ func buildRGB(img goimage.Image, w, h int) (*Image, error) {
 		bpc:        8,
 		filter:     "FlateDecode",
 	}, nil
-}
-
-// buildRGBA extracts RGB pixel data and alpha channel separately.
-// PDF requires straight (non-premultiplied) alpha: the RGB bytes must
-// contain the original colors, with alpha stored in a separate SMask.
-// Go's color.RGBA() method returns premultiplied values, so we must
-// use non-premultiplied access paths to get correct colors.
-func buildRGBA(img goimage.Image, w, h int) (*Image, error) {
-	bounds := img.Bounds()
-	pixels := make([]byte, 0, w*h*3)
-	alpha := make([]byte, 0, w*h)
-
-	switch src := img.(type) {
-	case *goimage.NRGBA:
-		// NRGBA stores straight (non-premultiplied) RGBA in Pix.
-		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-			for x := bounds.Min.X; x < bounds.Max.X; x++ {
-				off := (y-bounds.Min.Y)*src.Stride + (x-bounds.Min.X)*4
-				pixels = append(pixels, src.Pix[off], src.Pix[off+1], src.Pix[off+2])
-				alpha = append(alpha, src.Pix[off+3])
-			}
-		}
-	default:
-		// Generic path: convert each pixel to NRGBA to get straight alpha.
-		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-			for x := bounds.Min.X; x < bounds.Max.X; x++ {
-				c := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
-				pixels = append(pixels, c.R, c.G, c.B)
-				alpha = append(alpha, c.A)
-			}
-		}
-	}
-
-	return &Image{
-		data:       pixels,
-		width:      w,
-		height:     h,
-		colorSpace: "DeviceRGB",
-		bpc:        8,
-		filter:     "FlateDecode",
-		smask:      alpha,
-		smaskW:     w,
-		smaskH:     h,
-	}, nil
-}
-
-// imageHasAlpha reports whether any pixel in the image has non-opaque alpha.
-func imageHasAlpha(img goimage.Image) bool {
-	switch img.(type) {
-	case *goimage.NRGBA, *goimage.NRGBA64, *goimage.RGBA, *goimage.RGBA64:
-		// These types can have alpha. Check if any pixel is non-opaque.
-		bounds := img.Bounds()
-		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-			for x := bounds.Min.X; x < bounds.Max.X; x++ {
-				_, _, _, a := img.At(x, y).RGBA()
-				if a != 0xFFFF {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 // isGrayscale reports whether the image uses a grayscale color model.

--- a/image/tiff.go
+++ b/image/tiff.go
@@ -6,15 +6,15 @@ package image
 import (
 	"bytes"
 	"fmt"
-	"os"
 
 	"golang.org/x/image/tiff"
 )
 
-// NewTIFF creates an Image from raw TIFF data.
-// It decodes the TIFF to extract pixel data, then uses FlateDecode for PDF
-// embedding. Grayscale images are preserved as DeviceGray. Alpha channels
-// are discarded because TIFF alpha is uncommon in PDF workflows.
+// NewTIFF creates an Image from raw TIFF data. It decodes the TIFF and
+// re-encodes pixels as FlateDecode. Grayscale images are preserved as
+// DeviceGray. Alpha channels are discarded because TIFF alpha is
+// uncommon in PDF workflows. Dimensions are validated against
+// [MaxDimension] and [MaxPixels] before the pixel buffer is allocated.
 func NewTIFF(data []byte) (*Image, error) {
 	img, err := tiff.Decode(bytes.NewReader(data))
 	if err != nil {
@@ -24,13 +24,20 @@ func NewTIFF(data []byte) (*Image, error) {
 	bounds := img.Bounds()
 	w := bounds.Dx()
 	h := bounds.Dy()
+	if err := checkDimensions(w, h); err != nil {
+		return nil, fmt.Errorf("tiff: %w", err)
+	}
 
-	return buildRGB(img, w, h)
+	if isGrayscale(img) {
+		return buildGray(img, w, h)
+	}
+	return buildRGBOnly(img, w, h)
 }
 
-// LoadTIFF reads a TIFF file and creates an Image.
+// LoadTIFF reads a TIFF file from disk and creates an Image. Files
+// larger than [MaxFileSize] are rejected with [ErrFileTooLarge].
 func LoadTIFF(path string) (*Image, error) {
-	data, err := os.ReadFile(path)
+	data, err := readLimited(path)
 	if err != nil {
 		return nil, err
 	}

--- a/image/webp.go
+++ b/image/webp.go
@@ -6,15 +6,13 @@ package image
 import (
 	"bytes"
 	"fmt"
-	goimage "image"
-	"image/draw"
-	"os"
 
 	"golang.org/x/image/webp"
 )
 
-// NewWebP creates an Image from raw WebP data.
-// The image is decoded and re-encoded as RGB(A) with FlateDecode.
+// NewWebP creates an Image from raw WebP data. Alpha is preserved as a
+// soft mask if present. Dimensions are validated against [MaxDimension]
+// and [MaxPixels] before the pixel buffer is allocated.
 func NewWebP(data []byte) (*Image, error) {
 	img, err := webp.Decode(bytes.NewReader(data))
 	if err != nil {
@@ -24,20 +22,21 @@ func NewWebP(data []byte) (*Image, error) {
 	bounds := img.Bounds()
 	w := bounds.Dx()
 	h := bounds.Dy()
-
-	// Convert to RGBA for uniform handling.
-	rgba := goimage.NewRGBA(bounds)
-	draw.Draw(rgba, bounds, img, bounds.Min, draw.Src)
-
-	if imageHasAlpha(rgba) {
-		return buildRGBA(rgba, w, h)
+	if err := checkDimensions(w, h); err != nil {
+		return nil, fmt.Errorf("webp: %w", err)
 	}
-	return buildRGB(rgba, w, h)
+
+	// buildRGBMaybeAlpha walks the decoded image once: RGB bytes go
+	// into the data buffer and alpha is collected alongside, then
+	// dropped if every pixel was opaque. The generic path converts
+	// pixels via color.NRGBAModel, so no draw.Draw copy is needed.
+	return buildRGBMaybeAlpha(img, w, h)
 }
 
-// LoadWebP reads a WebP file and creates an Image.
+// LoadWebP reads a WebP file from disk and creates an Image. Files
+// larger than [MaxFileSize] are rejected with [ErrFileTooLarge].
 func LoadWebP(path string) (*Image, error) {
-	data, err := os.ReadFile(path)
+	data, err := readLimited(path)
 	if err != nil {
 		return nil, err
 	}

--- a/image/webp_test.go
+++ b/image/webp_test.go
@@ -86,7 +86,7 @@ func TestWebPBuildXObject(t *testing.T) {
 	objCount := 0
 	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
 		objCount++
-		return &core.PdfIndirectReference{ObjectNumber: objCount, GenerationNumber: 0}
+		return core.NewPdfIndirectReference(objCount, 0)
 	}
 	ref, _ := img.BuildXObject(addObject)
 	if ref == nil {


### PR DESCRIPTION
## Summary

Option (b) from the image package audit: security hardening + correctness/perf improvements + test coverage. No API changes to public constructors; new package-level constants and sentinel errors are additive.

## Security fixes

- **S1 — file size limit**. \`readLimited\` helper stats the file and rejects anything larger than \`MaxFileSize\` (200 MB) with \`ErrFileTooLarge\` before allocating a buffer. Pipes/special files are bounded by an \`io.LimitReader\`. Applied to \`LoadJPEG\` / \`LoadPNG\` / \`LoadTIFF\` / \`LoadWebP\` / \`LoadGIF\`.
- **S2 — dimension / pixel-count limit**. \`checkDimensions\` rejects non-positive dims (\`ErrDimensionInvalid\`), individual axes over \`MaxDimension\` = 16384 (\`ErrDimensionTooLarge\`), and pixel counts over \`MaxPixels\` = 100M (\`ErrPixelCountTooLarge\`). Called from every decoder before pixel buffers are allocated: \`NewJPEG\`, \`NewPNG\`, \`NewTIFF\`, \`NewWebP\`, \`NewGIF\`, and \`NewFromGoImage\`.
- **S3 — integer overflow**. The pixel-count check is computed in \`int64\`, so decoders running on WASM (\`int\` = 32-bit) no longer risk an overflow in \`w*h*3\` when dimensions are near the 16-bit bound.
- **S4 — JPEG parser progress cap**. \`parseJPEGHeader\` caps iteration at \`maxJPEGSegments\` = 10000. Crafted JPEGs that would otherwise walk pathological segment sequences are rejected with \"too many segments\" instead of looping slowly through the file.

## Correctness / performance

- **C1 — PNG single-pass alpha detection + extraction**. \`buildRGBMaybeAlpha\` replaces the old \`buildRGB\` + \`buildRGBA\` + \`imageHasAlpha\` trio. Each pass over the image used to scan every pixel; the new path walks once, populating the alpha buffer inline and discarding it if every pixel was opaque. For a 5000×5000 image that's 25 million \`At(x, y)\` calls saved.
- **C2 — \`*goimage.RGBA\` fast path**. The old code only fast-pathed \`*goimage.NRGBA\` and fell back to \`color.NRGBAModel.Convert\` for \`*goimage.RGBA\` (premultiplied). Added an inline un-premultiplication branch so the common case avoids the per-pixel interface conversion.
- **C3 — WebP / GIF skip the \`draw.Draw\` copy**. Both formats used to convert the decoded image to a full RGBA copy via \`draw.Draw\`, then walk it twice more. They now call \`buildRGBMaybeAlpha\` directly on the decoded image, saving one full pixel-buffer allocation per call.
- **TIFF preserves alpha-discard behaviour** via a new \`buildRGBOnly\` helper that skips the alpha buffer entirely. No behaviour change for TIFF callers.

## API additions (non-breaking)

New exported surface in \`image\`:

| Symbol | Kind | Purpose |
|---|---|---|
| \`MaxFileSize\` | const int64 | File size bound for \`Load*\` |
| \`MaxDimension\` | const int | Per-axis bound |
| \`MaxPixels\` | const int | Product bound |
| \`ErrFileTooLarge\` | var error | Sentinel |
| \`ErrDimensionTooLarge\` | var error | Sentinel |
| \`ErrPixelCountTooLarge\` | var error | Sentinel |
| \`ErrDimensionInvalid\` | var error | Sentinel (non-positive dims) |

These are const / var, not breaking to existing callers. Tests can use \`errors.Is\` to distinguish input-validation errors from decoder errors.

## Tests (new)

- \`limits_test.go\`:
  - \`checkDimensions\`: valid, non-positive, axis-too-large, pixel-count overflow
  - \`readLimited\`: small file round-trip, oversized file via \`Truncate\`
  - \`LoadJPEG\`: oversized file rejection
  - JPEG bomb: 65535×65535 header rejected before allocation
  - JPEG zero dims rejected
  - \`parseJPEGHeader\` segment cap
  - \`buildRGBMaybeAlpha\` generic path via \`*goimage.Paletted\`
  - \`NewFromGoImage\` oversized rejection
  - PNG round-trip sanity
- Fuzz targets added for TIFF, WebP, and GIF (only JPEG and PNG had fuzz previously).

## Cleanup

- \`image.go\`: removed a stale duplicate package comment (\`doc.go\` already has the fuller one).
- \`webp_test.go\` and \`gif_test.go\`: replaced remaining \`&core.PdfIndirectReference{ObjectNumber:...}\` struct literals with \`core.NewPdfIndirectReference(...)\` for consistency with the rest of the package.

## Verification

- \`go build ./...\` — clean
- \`go vet ./...\` — clean
- \`go test ./...\` — all 14 packages pass
- \`golangci-lint run --tests ./...\` — 0 issues
- \`gofmt -s -l .\` — clean
- Image package coverage: 88.7% → 90.0%

## Not in this PR (deferred)

Extensibility items from the audit — left for a follow-up once the direction is agreed:

- **A1** typed constants for color space / filter names
- **A2** 16 bpc support
- **A3** ICC profile embedding
- **A4** Indexed color space for GIF / palette PNG
- **A5** struct return from \`BuildXObject\`
- **A7** force-opaque option for \`NewFromGoImage\`

## Test plan

- [ ] \`go build ./...\`
- [ ] \`go vet ./...\`
- [ ] \`go test ./... -count=1\`
- [ ] \`golangci-lint run --tests ./...\`
- [ ] Fuzz TIFF / WebP / GIF for a few seconds each: \`go test -fuzz=Fuzz -fuzztime=30s ./image/\`
- [ ] Manual: feed a 250 MB valid JPEG via \`LoadJPEG\` and confirm \`ErrFileTooLarge\`
- [ ] Manual: feed a crafted PNG declaring 32768×32768 dimensions via \`NewPNG\` and confirm \`ErrDimensionTooLarge\`