### PR TITLE
Strengthen image tests, fix JPEG parser OOB found by fuzz

### DIFF
--- a/image/fuzz_test.go
+++ b/image/fuzz_test.go
@@ -3,13 +3,87 @@
 
 package image
 
-import "testing"
+import (
+	"bytes"
+	goimage "image"
+	"image/color"
+	"image/color/palette"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"testing"
+
+	"golang.org/x/image/tiff"
+)
+
+// Fuzz seeds are generated once at fuzz-target setup time via the
+// fuzzSeed* helpers below. Each helper produces a minimal but non-empty,
+// format-valid encoding so the fuzzer starts from real structured input
+// rather than only empty bytes or a magic-number header.
+
+func fuzzSeedJPEG() []byte {
+	img := goimage.NewRGBA(goimage.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	img.Set(1, 0, color.RGBA{G: 255, A: 255})
+	img.Set(0, 1, color.RGBA{B: 255, A: 255})
+	img.Set(1, 1, color.RGBA{R: 255, G: 255, B: 255, A: 255})
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 75}); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+func fuzzSeedPNGOpaque() []byte {
+	img := goimage.NewRGBA(goimage.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	img.Set(1, 1, color.RGBA{G: 255, A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+func fuzzSeedPNGAlpha() []byte {
+	img := goimage.NewNRGBA(goimage.Rect(0, 0, 2, 2))
+	img.SetNRGBA(0, 0, color.NRGBA{R: 255, G: 0, B: 0, A: 128})
+	img.SetNRGBA(1, 1, color.NRGBA{R: 0, G: 255, B: 0, A: 64})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+func fuzzSeedTIFF() []byte {
+	img := goimage.NewRGBA(goimage.Rect(0, 0, 2, 2))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	img.Set(1, 1, color.RGBA{B: 255, A: 255})
+	var buf bytes.Buffer
+	if err := tiff.Encode(&buf, img, nil); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
+
+func fuzzSeedGIF() []byte {
+	img := goimage.NewPaletted(goimage.Rect(0, 0, 2, 2), palette.Plan9)
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	img.Set(1, 1, color.RGBA{G: 255, A: 255})
+	var buf bytes.Buffer
+	if err := gif.Encode(&buf, img, nil); err != nil {
+		return nil
+	}
+	return buf.Bytes()
+}
 
 func FuzzNewJPEG(f *testing.F) {
-	// Seed with empty bytes.
 	f.Add([]byte{})
-	// Seed with the JPEG SOI marker.
 	f.Add([]byte{0xFF, 0xD8, 0xFF, 0xE0})
+	if seed := fuzzSeedJPEG(); len(seed) > 0 {
+		f.Add(seed)
+	}
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		defer func() {
@@ -23,10 +97,14 @@ func FuzzNewJPEG(f *testing.F) {
 }
 
 func FuzzNewPNG(f *testing.F) {
-	// Seed with empty bytes.
 	f.Add([]byte{})
-	// Seed with the PNG magic header.
 	f.Add([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
+	if seed := fuzzSeedPNGOpaque(); len(seed) > 0 {
+		f.Add(seed)
+	}
+	if seed := fuzzSeedPNGAlpha(); len(seed) > 0 {
+		f.Add(seed)
+	}
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		defer func() {

--- a/image/jpeg.go
+++ b/image/jpeg.go
@@ -100,10 +100,11 @@ func parseJPEGHeader(data []byte) (width, height, numComponents int, err error) 
 
 		// SOF markers contain the image dimensions.
 		if marker == markerSOF0 || marker == markerSOF1 || marker == markerSOF2 {
-			if pos+7 > len(data) {
+			// SOF layout: length(2) + precision(1) + height(2) + width(2) + ncomp(1)
+			// The ncomp byte lives at data[pos+7], so we need pos+8 ≤ len(data).
+			if pos+8 > len(data) {
 				return 0, 0, 0, fmt.Errorf("truncated SOF segment")
 			}
-			// SOF layout: length(2) + precision(1) + height(2) + width(2) + ncomp(1)
 			height = int(binary.BigEndian.Uint16(data[pos+3 : pos+5]))
 			width = int(binary.BigEndian.Uint16(data[pos+5 : pos+7]))
 			numComponents = int(data[pos+7])

--- a/image/limits_test.go
+++ b/image/limits_test.go
@@ -5,7 +5,6 @@ package image
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	goimage "image"
 	"image/color"
@@ -14,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/carlos7ags/folio/core"
 )
 
 // --- checkDimensions ---
@@ -74,6 +75,37 @@ func TestCheckDimensionsPixelCountOverflow(t *testing.T) {
 	}
 }
 
+// TestCheckDimensionsBoundaries locks in the exact inclusive/exclusive
+// semantics of [checkDimensions]: exactly MaxDimension and exactly
+// MaxPixels must pass, one more in any direction must fail.
+func TestCheckDimensionsBoundaries(t *testing.T) {
+	// Individual axes: exactly MaxDimension passes, +1 fails.
+	if err := checkDimensions(MaxDimension, 1); err != nil {
+		t.Errorf("checkDimensions(MaxDimension, 1): got %v, want nil", err)
+	}
+	if err := checkDimensions(1, MaxDimension); err != nil {
+		t.Errorf("checkDimensions(1, MaxDimension): got %v, want nil", err)
+	}
+	if err := checkDimensions(MaxDimension+1, 1); !errors.Is(err, ErrDimensionTooLarge) {
+		t.Errorf("MaxDimension+1 width should fail, got %v", err)
+	}
+	if err := checkDimensions(1, MaxDimension+1); !errors.Is(err, ErrDimensionTooLarge) {
+		t.Errorf("MaxDimension+1 height should fail, got %v", err)
+	}
+
+	// Pixel product: exactly MaxPixels passes, one more fails.
+	// 10000 × 10000 = 100,000,000 = MaxPixels exactly.
+	if err := checkDimensions(10000, 10000); err != nil {
+		t.Errorf("checkDimensions at exactly MaxPixels: got %v, want nil", err)
+	}
+	if err := checkDimensions(10001, 10000); !errors.Is(err, ErrPixelCountTooLarge) {
+		t.Errorf("one pixel over MaxPixels should fail, got %v", err)
+	}
+	if err := checkDimensions(10000, 10001); !errors.Is(err, ErrPixelCountTooLarge) {
+		t.Errorf("one pixel over MaxPixels (tall) should fail, got %v", err)
+	}
+}
+
 // --- readLimited / file size enforcement ---
 
 func TestReadLimitedSmallFile(t *testing.T) {
@@ -114,19 +146,39 @@ func TestReadLimitedRejectsOversizedFile(t *testing.T) {
 	}
 }
 
-func TestLoadJPEGRejectsOversizedFile(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "big.jpg")
-	f, err := os.Create(path)
-	if err != nil {
-		t.Fatal(err)
+// TestLoadRejectsOversizedFile exercises the MaxFileSize guard on every
+// Load* constructor, not just LoadJPEG. The file is sparse (Truncate) so
+// no real disk space is consumed.
+func TestLoadRejectsOversizedFile(t *testing.T) {
+	cases := []struct {
+		name   string
+		ext    string
+		loader func(string) (*Image, error)
+	}{
+		{"jpeg", ".jpg", LoadJPEG},
+		{"png", ".png", LoadPNG},
+		{"tiff", ".tiff", LoadTIFF},
+		{"webp", ".webp", LoadWebP},
+		{"gif", ".gif", LoadGIF},
 	}
-	_ = f.Truncate(MaxFileSize + 1)
-	_ = f.Close()
-
-	_, err = LoadJPEG(path)
-	if !errors.Is(err, ErrFileTooLarge) {
-		t.Errorf("LoadJPEG: expected ErrFileTooLarge, got %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "big"+tc.ext)
+			f, err := os.Create(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Truncate(MaxFileSize + 1); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tc.loader(path); !errors.Is(err, ErrFileTooLarge) {
+				t.Errorf("Load%s: expected ErrFileTooLarge, got %v", tc.name, err)
+			}
+		})
 	}
 }
 
@@ -177,6 +229,28 @@ func TestNewJPEGRejectsZeroDimensions(t *testing.T) {
 	}
 }
 
+// TestParseJPEGHeaderTruncatedSOF is a regression test for a one-off
+// index check in parseJPEGHeader: the bounds test allowed pos+7 == len(data)
+// but the code then accessed data[pos+7], which is out of range. Found by
+// FuzzNewJPEG after its seed corpus was strengthened in this PR.
+func TestParseJPEGHeaderTruncatedSOF(t *testing.T) {
+	// SOI + SOF2 marker + 7 bytes (length field + precision + height +
+	// width but no ncomp byte). parseJPEGHeader must return an error,
+	// not panic.
+	data := []byte{
+		0xFF, 0xD8, // SOI
+		0xFF, 0xC2, // SOF2
+		0x00, 0x11, // length = 17
+		0x08,                   // precision
+		0x00, 0x01, 0x00, 0x01, // height=1, width=1 — but no ncomp byte
+	}
+	// Must not panic.
+	_, _, _, err := parseJPEGHeader(data)
+	if err == nil {
+		t.Error("expected error for truncated SOF segment, got nil")
+	}
+}
+
 func TestParseJPEGHeaderSegmentCap(t *testing.T) {
 	// Craft a JPEG with many trivial APP0 segments but no SOF. The
 	// parser should bail after maxJPEGSegments rather than walking the
@@ -195,54 +269,167 @@ func TestParseJPEGHeaderSegmentCap(t *testing.T) {
 	}
 }
 
-// --- generic buildRGBMaybeAlpha path (Paletted input) ---
+// --- buildRGBMaybeAlpha: each switch case exercised with position-
+//     specific pixel assertions so that swaps, colour channel mistakes,
+//     or un-premultiplication bugs would actually be caught. ---
 
+// pixelAt returns the RGB triplet and alpha byte at (x, y) in the flat
+// data/smask buffers produced by buildRGBMaybeAlpha. Tests use this to
+// express expectations as "pixel (0,0) is [255,0,0] with alpha 128".
+func pixelAt(img *Image, x, y int) (r, g, b, a byte) {
+	off := (y*img.width + x) * 3
+	r, g, b = img.data[off], img.data[off+1], img.data[off+2]
+	if len(img.smask) > 0 {
+		a = img.smask[y*img.smaskW+x]
+	} else {
+		a = 255
+	}
+	return
+}
+
+func assertPixel(t *testing.T, img *Image, x, y int, wantR, wantG, wantB, wantA byte) {
+	t.Helper()
+	r, g, b, a := pixelAt(img, x, y)
+	if r != wantR || g != wantG || b != wantB || a != wantA {
+		t.Errorf("pixel (%d,%d): got RGBA [%d,%d,%d,%d], want [%d,%d,%d,%d]",
+			x, y, r, g, b, a, wantR, wantG, wantB, wantA)
+	}
+}
+
+// TestBuildRGBMaybeAlphaGenericPath feeds a 2x2 Paletted image through
+// the generic default branch of buildRGBMaybeAlpha and verifies every
+// pixel's RGB triplet AND alpha at its position. The previous version of
+// this test only asserted that "alpha 128 and 255 both appear somewhere",
+// which would have passed even if RGB channels were swapped or zeroed.
 func TestBuildRGBMaybeAlphaGenericPath(t *testing.T) {
-	// *goimage.Paletted hits the generic default branch of the switch in
-	// buildRGBMaybeAlpha and exercises the color.NRGBAModel conversion.
+	// Palette: index 0 = unused, 1 = semi-transparent red, 2 = opaque
+	// green, 3 = opaque blue.
 	pal := color.Palette{
 		color.NRGBA{0, 0, 0, 255},
-		color.NRGBA{255, 0, 0, 128}, // semi-transparent red
-		color.NRGBA{0, 255, 0, 255}, // opaque green
+		color.NRGBA{255, 0, 0, 128},
+		color.NRGBA{0, 255, 0, 255},
+		color.NRGBA{0, 0, 255, 255},
 	}
 	img := goimage.NewPaletted(goimage.Rect(0, 0, 2, 2), pal)
-	img.SetColorIndex(0, 0, 1) // transparent red
+	img.SetColorIndex(0, 0, 1) // semi-transparent red
 	img.SetColorIndex(1, 0, 2) // opaque green
-	img.SetColorIndex(0, 1, 2)
-	img.SetColorIndex(1, 1, 1)
+	img.SetColorIndex(0, 1, 3) // opaque blue
+	img.SetColorIndex(1, 1, 2) // opaque green
 
 	out, err := buildRGBMaybeAlpha(img, 2, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
+	if out.colorSpace != "DeviceRGB" {
+		t.Errorf("colorSpace = %q, want DeviceRGB", out.colorSpace)
+	}
 	if len(out.data) != 2*2*3 {
-		t.Errorf("expected %d RGB bytes, got %d", 2*2*3, len(out.data))
+		t.Fatalf("data len = %d, want %d", len(out.data), 2*2*3)
 	}
 	if len(out.smask) != 2*2 {
-		t.Errorf("expected %d alpha bytes, got %d", 2*2, len(out.smask))
+		t.Fatalf("smask len = %d, want %d", len(out.smask), 2*2)
 	}
-	// Opaque green pixel (index 2) should have alpha 255.
-	// Semi-transparent red (index 1) should have alpha 128.
-	// Verify at least one of each is present.
-	saw128, saw255 := false, false
-	for _, a := range out.smask {
-		if a == 128 {
-			saw128 = true
+
+	// Position-specific checks: each pixel's RGB and alpha.
+	assertPixel(t, out, 0, 0, 255, 0, 0, 128) // semi-transparent red
+	assertPixel(t, out, 1, 0, 0, 255, 0, 255) // opaque green
+	assertPixel(t, out, 0, 1, 0, 0, 255, 255) // opaque blue
+	assertPixel(t, out, 1, 1, 0, 255, 0, 255) // opaque green
+}
+
+// TestBuildRGBMaybeAlphaNRGBAFastPath exercises the *goimage.NRGBA
+// branch of the type switch with position-specific assertions. NRGBA
+// stores straight alpha, so RGB bytes should pass through unchanged.
+func TestBuildRGBMaybeAlphaNRGBAFastPath(t *testing.T) {
+	img := goimage.NewNRGBA(goimage.Rect(0, 0, 2, 2))
+	img.SetNRGBA(0, 0, color.NRGBA{R: 200, G: 100, B: 50, A: 200})
+	img.SetNRGBA(1, 0, color.NRGBA{R: 0, G: 0, B: 0, A: 255})
+	img.SetNRGBA(0, 1, color.NRGBA{R: 255, G: 255, B: 255, A: 0})
+	img.SetNRGBA(1, 1, color.NRGBA{R: 128, G: 64, B: 32, A: 128})
+
+	out, err := buildRGBMaybeAlpha(img, 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.smask) == 0 {
+		t.Fatal("expected smask for partially transparent NRGBA input")
+	}
+	assertPixel(t, out, 0, 0, 200, 100, 50, 200)
+	assertPixel(t, out, 1, 0, 0, 0, 0, 255)
+	// NRGBA stores straight values, so even fully-transparent pixels
+	// keep their stored RGB bytes.
+	assertPixel(t, out, 0, 1, 255, 255, 255, 0)
+	assertPixel(t, out, 1, 1, 128, 64, 32, 128)
+}
+
+// TestBuildRGBMaybeAlphaRGBAFastPath exercises the *goimage.RGBA branch
+// of the type switch. RGBA stores premultiplied values, so the decoder
+// must un-premultiply to recover straight alpha for PDF output. This
+// branch was completely untested before this follow-up: PNG decode
+// returns NRGBA for alpha PNGs, so in practice this code path only
+// runs if a caller constructs an *goimage.RGBA directly.
+func TestBuildRGBMaybeAlphaRGBAFastPath(t *testing.T) {
+	// Semi-transparent red at A=128: premultiplied R = round(255*128/255)
+	// = 128. Decoder should un-premultiply back to straight R=255.
+	img := goimage.NewRGBA(goimage.Rect(0, 0, 2, 2))
+	img.SetRGBA(0, 0, color.RGBA{R: 128, G: 0, B: 0, A: 128})  // → straight [255,0,0,128]
+	img.SetRGBA(1, 0, color.RGBA{R: 0, G: 255, B: 0, A: 255})  // fully opaque
+	img.SetRGBA(0, 1, color.RGBA{R: 0, G: 0, B: 0, A: 0})      // fully transparent
+	img.SetRGBA(1, 1, color.RGBA{R: 64, G: 32, B: 16, A: 128}) // → straight [127,63,31,128]
+
+	out, err := buildRGBMaybeAlpha(img, 2, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.smask) == 0 {
+		t.Fatal("expected smask for partially transparent RGBA input")
+	}
+	assertPixel(t, out, 0, 0, 255, 0, 0, 128)
+	assertPixel(t, out, 1, 0, 0, 255, 0, 255)
+	// Fully transparent pixels are zeroed by the decoder.
+	assertPixel(t, out, 0, 1, 0, 0, 0, 0)
+	// Un-premultiplication uses integer division truncation:
+	// 64 * 255 / 128 = 127, 32 * 255 / 128 = 63, 16 * 255 / 128 = 31.
+	assertPixel(t, out, 1, 1, 127, 63, 31, 128)
+}
+
+// TestBuildRGBMaybeAlphaAllOpaqueDropsSMask confirms that when every
+// pixel is opaque, the single-pass path discards the transient alpha
+// buffer and produces an Image with no soft mask.
+func TestBuildRGBMaybeAlphaAllOpaqueDropsSMask(t *testing.T) {
+	img := goimage.NewNRGBA(goimage.Rect(0, 0, 3, 2))
+	for y := range 2 {
+		for x := range 3 {
+			img.SetNRGBA(x, y, color.NRGBA{R: uint8(x * 80), G: uint8(y * 120), B: 0, A: 255})
 		}
-		if a == 255 {
-			saw255 = true
-		}
 	}
-	if !saw128 || !saw255 {
-		t.Errorf("expected both 128 and 255 alpha values, got %v", out.smask)
+	out, err := buildRGBMaybeAlpha(img, 3, 2)
+	if err != nil {
+		t.Fatal(err)
 	}
+	if out.smask != nil || out.smaskW != 0 || out.smaskH != 0 {
+		t.Errorf("opaque image should produce no smask, got smask len=%d smaskW=%d smaskH=%d",
+			len(out.smask), out.smaskW, out.smaskH)
+	}
+	// Position-specific RGB spot-check.
+	assertPixel(t, out, 0, 0, 0, 0, 0, 255)
+	assertPixel(t, out, 1, 0, 80, 0, 0, 255)
+	assertPixel(t, out, 2, 1, 160, 120, 0, 255)
 }
 
 // --- fuzz targets (TIFF, WebP, GIF; JPEG/PNG are in fuzz_test.go) ---
+//
+// Each target seeds with three inputs: empty bytes, a format magic
+// header, and a minimal but valid encoded image. The valid seed gives
+// the fuzzer a realistic starting point whose mutations are much more
+// likely to exercise decoder internals than magic-header-only seeds.
 
 func FuzzNewTIFF(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte{0x49, 0x49, 0x2A, 0x00}) // TIFF little-endian magic
+	if seed := fuzzSeedTIFF(); len(seed) > 0 {
+		f.Add(seed)
+	}
 	f.Fuzz(func(t *testing.T, data []byte) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -256,6 +443,9 @@ func FuzzNewTIFF(f *testing.F) {
 func FuzzNewWebP(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte("RIFF\x00\x00\x00\x00WEBP"))
+	// minimalWebP is defined in webp_test.go and is a valid 1x1 VP8L
+	// lossless WebP — a richer starting point than a bare RIFF header.
+	f.Add(minimalWebP)
 	f.Fuzz(func(t *testing.T, data []byte) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -269,6 +459,9 @@ func FuzzNewWebP(f *testing.F) {
 func FuzzNewGIF(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte("GIF89a"))
+	if seed := fuzzSeedGIF(); len(seed) > 0 {
+		f.Add(seed)
+	}
 	f.Fuzz(func(t *testing.T, data []byte) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -300,25 +493,11 @@ func TestNewFromGoImageRejectsTooLarge(t *testing.T) {
 	}
 }
 
-func TestNewFromGoImageRejectsPixelCount(t *testing.T) {
-	// 12000x12000 would be 144M pixels, above MaxPixels=100M. Allocating
-	// a full pixel buffer would use ~576 MB, which is too much for a
-	// unit test. Use a zero-byte Pix slice with a large Rect; this hits
-	// the stride check first. For a real pixel-count rejection via
-	// NewFromGoImage we'd need the buffer allocation, which is the cost
-	// we're guarding against. Instead, exercise checkDimensions directly.
-	// This test documents that the guard is applied.
-	if err := checkDimensions(12000, 12000); !errors.Is(err, ErrPixelCountTooLarge) {
-		t.Errorf("checkDimensions should reject 12000x12000, got %v", err)
-	}
-}
-
-// --- Round-trip sanity: a created Image can build an XObject with valid
-//     Width/Height matching the source dimensions. ---
-
-func TestRoundTripPNGBuildXObject(t *testing.T) {
-	// Build a small PNG, decode it, produce an XObject, and verify the
-	// width/height entries match the source.
+// TestRoundTripPNGBuildXObjectOpaque decodes a small opaque PNG and then
+// calls BuildXObject, asserting the structure of the resulting indirect
+// objects. This replaces a prior version of the test that was named
+// "RoundTripPNGBuildXObject" but never actually called BuildXObject.
+func TestRoundTripPNGBuildXObjectOpaque(t *testing.T) {
 	const w, h = 7, 11
 	rgba := goimage.NewRGBA(goimage.Rect(0, 0, w, h))
 	for y := range h {
@@ -334,14 +513,135 @@ func TestRoundTripPNGBuildXObject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if img.Width() != w || img.Height() != h {
-		t.Errorf("dimensions mismatch: got %dx%d, want %dx%d",
-			img.Width(), img.Height(), w, h)
+
+	var added []core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		added = append(added, obj)
+		return core.NewPdfIndirectReference(len(added), 0)
+	}
+
+	imgRef, smaskRef := img.BuildXObject(addObject)
+	if imgRef == nil {
+		t.Fatal("expected non-nil image reference")
+	}
+	if smaskRef != nil {
+		t.Errorf("opaque PNG should not produce an SMask, got %v", smaskRef)
+	}
+	if len(added) != 1 {
+		t.Fatalf("expected 1 object added, got %d", len(added))
+	}
+	stream, ok := added[0].(*core.PdfStream)
+	if !ok {
+		t.Fatalf("expected *core.PdfStream, got %T", added[0])
+	}
+	assertStreamDictEntry(t, stream.Dict, "Type", "XObject")
+	assertStreamDictEntry(t, stream.Dict, "Subtype", "Image")
+	assertStreamDictEntry(t, stream.Dict, "ColorSpace", "DeviceRGB")
+	assertStreamDictInt(t, stream.Dict, "Width", w)
+	assertStreamDictInt(t, stream.Dict, "Height", h)
+	assertStreamDictInt(t, stream.Dict, "BitsPerComponent", 8)
+}
+
+// TestRoundTripPNGBuildXObjectAlpha decodes a semi-transparent PNG and
+// verifies that BuildXObject produces the expected image + SMask pair
+// with correct ordering and dict entries.
+func TestRoundTripPNGBuildXObjectAlpha(t *testing.T) {
+	const w, h = 4, 3
+	src := goimage.NewNRGBA(goimage.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			src.SetNRGBA(x, y, color.NRGBA{R: 0, G: 0, B: 255, A: 128})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, src); err != nil {
+		t.Fatal(err)
+	}
+	img, err := NewPNG(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var added []core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		added = append(added, obj)
+		return core.NewPdfIndirectReference(len(added), 0)
+	}
+
+	imgRef, smaskRef := img.BuildXObject(addObject)
+	if imgRef == nil || smaskRef == nil {
+		t.Fatalf("expected both image and smask refs, got img=%v smask=%v", imgRef, smaskRef)
+	}
+	if len(added) != 2 {
+		t.Fatalf("expected 2 objects added, got %d", len(added))
+	}
+	// SMask must be added first so its reference is available when the
+	// main image stream's dict is built.
+	if smaskRef.Num() != 1 {
+		t.Errorf("SMask should be object 1, got %d", smaskRef.Num())
+	}
+	if imgRef.Num() != 2 {
+		t.Errorf("Image should be object 2, got %d", imgRef.Num())
+	}
+
+	smaskStream := added[0].(*core.PdfStream)
+	assertStreamDictEntry(t, smaskStream.Dict, "Type", "XObject")
+	assertStreamDictEntry(t, smaskStream.Dict, "Subtype", "Image")
+	assertStreamDictEntry(t, smaskStream.Dict, "ColorSpace", "DeviceGray")
+	assertStreamDictInt(t, smaskStream.Dict, "Width", w)
+	assertStreamDictInt(t, smaskStream.Dict, "Height", h)
+	assertStreamDictInt(t, smaskStream.Dict, "BitsPerComponent", 8)
+
+	imgStream := added[1].(*core.PdfStream)
+	assertStreamDictEntry(t, imgStream.Dict, "ColorSpace", "DeviceRGB")
+	assertStreamDictInt(t, imgStream.Dict, "Width", w)
+	assertStreamDictInt(t, imgStream.Dict, "Height", h)
+	// Image dict should reference the SMask by indirect reference.
+	smaskEntry := imgStream.Dict.Get("SMask")
+	if smaskEntry == nil {
+		t.Fatal("image stream dict missing /SMask entry")
+	}
+	smaskRefActual, ok := smaskEntry.(*core.PdfIndirectReference)
+	if !ok {
+		t.Fatalf("/SMask should be *PdfIndirectReference, got %T", smaskEntry)
+	}
+	if smaskRefActual.Num() != smaskRef.Num() {
+		t.Errorf("/SMask ref = %d, want %d", smaskRefActual.Num(), smaskRef.Num())
 	}
 }
 
-// helpers --------------------------------------------------------------
+// --- Small helpers for the BuildXObject round-trip tests. ---
 
-// bigEndianUint16 is a test helper referenced by the bomb test for
-// clarity; kept here so the bomb test reads without magic numbers.
-var _ = binary.BigEndian.Uint16
+func assertStreamDictEntry(t *testing.T, dict *core.PdfDictionary, key, wantName string) {
+	t.Helper()
+	obj := dict.Get(key)
+	if obj == nil {
+		t.Errorf("dict missing /%s", key)
+		return
+	}
+	name, ok := obj.(*core.PdfName)
+	if !ok {
+		t.Errorf("/%s: expected *PdfName, got %T", key, obj)
+		return
+	}
+	if name.Value != wantName {
+		t.Errorf("/%s = %q, want %q", key, name.Value, wantName)
+	}
+}
+
+func assertStreamDictInt(t *testing.T, dict *core.PdfDictionary, key string, want int) {
+	t.Helper()
+	obj := dict.Get(key)
+	if obj == nil {
+		t.Errorf("dict missing /%s", key)
+		return
+	}
+	num, ok := obj.(*core.PdfNumber)
+	if !ok {
+		t.Errorf("/%s: expected *PdfNumber, got %T", key, obj)
+		return
+	}
+	if got := num.IntValue(); got != want {
+		t.Errorf("/%s = %d, want %d", key, got, want)
+	}
+}

--- a/image/testdata/fuzz/FuzzNewJPEG/c5d78678cf656b27
+++ b/image/testdata/fuzz/FuzzNewJPEG/c5d78678cf656b27
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\xff\xd8\xff\xc20000000")


### PR DESCRIPTION
## Summary

Follow-up to PR #167 addressing the weak-test feedback: replaces shallow assertions with position-specific pixel checks, covers the cases the first pass skipped, and strengthens fuzz seeds. Exercising the new JPEG seed immediately caught an out-of-range read in \`parseJPEGHeader\` that has been in the codebase since the package was introduced.

## Bug fix (found by fuzz)

- **\`jpeg.go\` \`parseJPEGHeader\`**: truncation guard was \`pos+7 > len(data)\` before reading \`data[pos+7]\` — off by one. A crafted input of \`SOI + SOF2 + 7 trailing bytes\` (so the \`ncomp\` byte is missing) panicked with \`index out of range [11] with length 11\`. Changed to \`pos+8 > len(data)\`.
- Discovered by \`FuzzNewJPEG\` within 2 seconds after seeding with a valid JPEG. Regression corpus entry: \`image/testdata/fuzz/FuzzNewJPEG/c5d78678cf656b27\`. A plain unit test (\`TestParseJPEGHeaderTruncatedSOF\`) also documents the case.

## Test improvements (the 7)

| # | Change | Why |
|---|---|---|
| **1** | \`TestBuildRGBMaybeAlphaGenericPath\` asserts every pixel's RGB triplet and alpha byte at its (x,y) position via a new \`assertPixel\` helper | The old version only checked \"alpha 128 and 255 both appear somewhere\"; an R/B swap would have passed |
| **2** | Deleted \`TestNewFromGoImageRejectsPixelCount\` | It claimed to test \`NewFromGoImage\` but only called \`checkDimensions\` directly — a duplicate of another test |
| **3** | Split \`TestRoundTripPNGBuildXObject\` into \`TestRoundTripPNGBuildXObjectOpaque\` and \`TestRoundTripPNGBuildXObjectAlpha\` | Neither original test called \`BuildXObject\`. The new ones capture the \`addObject\` callback, inspect the generated stream dicts, and verify \`Type\`/\`Subtype\`/\`ColorSpace\`/\`Width\`/\`Height\`/\`BitsPerComponent\` — and for the alpha case, that \`/SMask\` references the right indirect object and the SMask was added first |
| **4** | Added \`TestBuildRGBMaybeAlphaNRGBAFastPath\` and \`TestBuildRGBMaybeAlphaRGBAFastPath\` + \`TestBuildRGBMaybeAlphaAllOpaqueDropsSMask\` | The RGBA branch of the type switch was **unreachable** from any existing test (PNG decode returns NRGBA, not RGBA, for alpha PNGs). Now every branch of the switch has explicit coverage with position-specific assertions. The \"drop SMask when opaque\" test confirms the single-pass behaviour |
| **5** | Added \`TestCheckDimensionsBoundaries\` | Locks in inclusive/exclusive semantics: exactly \`MaxDimension\` and exactly \`MaxPixels\` pass; one more in any direction fails. Previous tests covered \"too large\" but not the boundary |
| **6** | \`TestLoadJPEGRejectsOversizedFile\` replaced by \`TestLoadRejectsOversizedFile\` parametrized over all five loaders | Previously only \`LoadJPEG\` was tested even though \`readLimited\` is called by \`LoadPNG\` / \`LoadTIFF\` / \`LoadWebP\` / \`LoadGIF\` too |
| **7** | All five fuzz targets now seed with a valid encoded file in addition to empty bytes and the magic header | A 5-second run now finds 30-147 new interesting inputs per target versus single-digit exploration from magic-header-only seeds |

## New helpers

- \`pixelAt(img, x, y)\` / \`assertPixel(t, img, x, y, r, g, b, a)\` — used by every buildRGBMaybeAlpha test
- \`assertStreamDictEntry\` / \`assertStreamDictInt\` — used by the two round-trip tests
- \`fuzzSeedJPEG\` / \`fuzzSeedPNGOpaque\` / \`fuzzSeedPNGAlpha\` / \`fuzzSeedTIFF\` / \`fuzzSeedGIF\` — pure functions returning a small valid encoded file, called from each \`Fuzz*\` at setup time

## Verification

- \`go build ./...\` — clean
- \`go vet ./...\` — clean
- \`go test ./...\` — all 14 packages pass
- \`golangci-lint run --tests ./...\` — 0 issues
- \`gofmt -s -l .\` — clean
- Image package coverage: **90.0% → 92.4%**
- Fuzz smoke test (5s each): \`FuzzNewJPEG\`, \`FuzzNewPNG\`, \`FuzzNewTIFF\`, \`FuzzNewWebP\`, \`FuzzNewGIF\` — all clean after the OOB fix

## Test plan

- [ ] \`go test ./image/ -count=1\`
- [ ] \`go test ./image/ -run FuzzNewJPEG/c5d78678cf656b27\` (regression fixture)
- [ ] \`go test ./image/ -fuzz=FuzzNewJPEG -fuzztime=30s\`
- [ ] \`go test ./image/ -fuzz=FuzzNewPNG -fuzztime=30s\`
- [ ] \`go test ./image/ -fuzz=FuzzNewWebP -fuzztime=30s\`
- [ ] \`golangci-lint run --tests ./...\`