### PR TITLE
Segment text runs by Unicode script per UAX #24

### DIFF
--- a/layout/bidi.go
+++ b/layout/bidi.go
@@ -208,13 +208,22 @@ func resolveLineBidi(words []Word, base Direction) ([]Word, Direction) {
 
 // splitMixedBidiWord checks if a word contains characters at different
 // bidi embedding levels (e.g. Hebrew letters mixed with digits or Latin
-// characters in a single whitespace-delimited token). If level transitions
-// are found, it splits the word into sub-words at the transition points.
-// Each sub-word inherits all styling from the original word; only Text and
-// Width differ. The caller must re-measure the sub-words' widths.
+// characters in a single whitespace-delimited token) OR characters from
+// different Unicode scripts per UAX #24 (e.g. Arabic mixed with
+// Devanagari). If either kind of transition is found, it splits the word
+// into sub-words at the transition points so each emitted sub-word is
+// uniform in both bidi bucket and script. Each sub-word inherits all
+// styling from the original word; only Text and Width differ. The caller
+// must re-measure the sub-words' widths.
 //
-// Returns nil if the word has uniform bidi level (no split needed) or if
-// it has no text content (inline block, empty).
+// Script inheritance follows the left-neighbour rule: Common and
+// Inherited runes (including digits, punctuation, combining marks) attach
+// to the preceding real script, matching how bidi-neutral runes attach
+// to the preceding strong bidi bucket. Leading Common runs attach to the
+// first following real script.
+//
+// Returns nil if the word has uniform bidi level AND uniform script (no
+// split needed) or if it has no text content (inline block, empty).
 func splitMixedBidiWord(w Word) []Word {
 	if w.Text == "" || w.InlineBlock != nil {
 		return nil
@@ -226,14 +235,14 @@ func splitMixedBidiWord(w Word) []Word {
 
 	// Classify each rune's bidi class quickly. We only care about the
 	// distinction between strong-RTL (R, AL, AN) and everything else.
-	// If all runes have the same "directionality bucket", no split.
+	// If all runes have the same "directionality bucket", no bidi split.
 	type bucket int
 	const (
 		bucketLTR bucket = iota
 		bucketRTL
 		bucketNeutral
 	)
-	classify := func(r rune) bucket {
+	classifyBidi := func(r rune) bucket {
 		props, _ := bidi.LookupRune(r)
 		switch props.Class() {
 		case bidi.R, bidi.AL, bidi.AN:
@@ -245,44 +254,79 @@ func splitMixedBidiWord(w Word) []Word {
 		}
 	}
 
-	// Walk runes, detect transitions between LTR and RTL (ignoring neutrals).
+	// Walk runes once to detect any transition that would force a split:
+	// a change in the strong bidi bucket, or a change in the resolved
+	// script. Neutrals / Common runes never trigger a transition on
+	// their own — they inherit from the left.
 	prevStrong := bucketNeutral
+	prevScript := ScriptCommon
 	hasTransition := false
 	for _, r := range runes {
-		b := classify(r)
-		if b == bucketNeutral {
-			continue
+		b := classifyBidi(r)
+		if b != bucketNeutral {
+			if prevStrong != bucketNeutral && b != prevStrong {
+				hasTransition = true
+				break
+			}
+			prevStrong = b
 		}
-		if prevStrong != bucketNeutral && b != prevStrong {
-			hasTransition = true
-			break
+		sc := ScriptOf(r)
+		if sc != ScriptCommon {
+			if prevScript != ScriptCommon && sc != prevScript {
+				hasTransition = true
+				break
+			}
+			prevScript = sc
 		}
-		prevStrong = b
 	}
 	if !hasTransition {
 		return nil
 	}
 
-	// Split at strong-direction transitions. Neutral characters attach to
-	// the preceding strong direction run (or the first strong run if they
-	// lead). This produces the smallest number of sub-words while keeping
-	// each sub-word directionally uniform.
+	// Split at strong-direction or script transitions. Neutral / Common
+	// characters attach to the preceding strong run (or the first strong
+	// run if they lead). This produces the smallest number of sub-words
+	// while keeping each sub-word uniform in both bidi and script.
 	var parts []string
 	start := 0
 	currentStrong := bucketNeutral
+	currentScript := ScriptCommon
 	for i, r := range runes {
-		b := classify(r)
-		if b == bucketNeutral {
-			continue
+		b := classifyBidi(r)
+		sc := ScriptOf(r)
+		bidiChange := false
+		scriptChange := false
+		if b != bucketNeutral {
+			if currentStrong == bucketNeutral {
+				currentStrong = b
+			} else if b != currentStrong {
+				bidiChange = true
+			}
 		}
-		if currentStrong == bucketNeutral {
-			currentStrong = b
-			continue
+		if sc != ScriptCommon {
+			if currentScript == ScriptCommon {
+				currentScript = sc
+			} else if sc != currentScript {
+				scriptChange = true
+			}
 		}
-		if b != currentStrong {
+		if bidiChange || scriptChange {
 			parts = append(parts, string(runes[start:i]))
 			start = i
-			currentStrong = b
+			// The current rune begins the next sub-word: reset the
+			// tracked strong direction and script to its values so the
+			// next iteration compares against this rune, not the old
+			// sub-word.
+			if b != bucketNeutral {
+				currentStrong = b
+			} else {
+				currentStrong = bucketNeutral
+			}
+			if sc != ScriptCommon {
+				currentScript = sc
+			} else {
+				currentScript = ScriptCommon
+			}
 		}
 	}
 	parts = append(parts, string(runes[start:]))

--- a/layout/bidi_test.go
+++ b/layout/bidi_test.go
@@ -247,6 +247,81 @@ func TestSplitMixedBidiWordInlineBlock(t *testing.T) {
 	}
 }
 
+// TestSplitMixedBidiWordScriptChange verifies that two characters from
+// different scripts at the same bidi level (e.g. Arabic alef + Devanagari
+// ka, both bidi-strong but mutually incompatible scripts) split into two
+// sub-words. This is the UAX #24 script-segmentation case and is the
+// behaviour introduced alongside the ScriptOf / SegmentByScript helpers.
+func TestSplitMixedBidiWordScriptChange(t *testing.T) {
+	// Arabic alef followed by Devanagari ka.
+	w := Word{Text: "\u0627\u0915", Width: 20, SpaceAfter: 4}
+	subs := splitMixedBidiWord(w)
+	if subs == nil {
+		t.Fatal("expected split on script transition, got nil")
+	}
+	if len(subs) != 2 {
+		t.Fatalf("expected 2 sub-words, got %d", len(subs))
+	}
+	if subs[0].Text != "\u0627" {
+		t.Errorf("sub[0]: got %q, want Arabic alef", subs[0].Text)
+	}
+	if subs[1].Text != "\u0915" {
+		t.Errorf("sub[1]: got %q, want Devanagari ka", subs[1].Text)
+	}
+	if subs[0].SpaceAfter != 0 {
+		t.Errorf("sub[0].SpaceAfter: got %v, want 0", subs[0].SpaceAfter)
+	}
+	if subs[1].SpaceAfter != 4 {
+		t.Errorf("sub[1].SpaceAfter: got %v, want 4", subs[1].SpaceAfter)
+	}
+}
+
+// TestSplitMixedBidiWordLatinDevanagari verifies a same-direction
+// (both LTR) script change also splits — Latin "test" + Devanagari ka.
+func TestSplitMixedBidiWordLatinDevanagari(t *testing.T) {
+	w := Word{Text: "test\u0915", Width: 30}
+	subs := splitMixedBidiWord(w)
+	if subs == nil {
+		t.Fatal("expected split, got nil")
+	}
+	if len(subs) != 2 {
+		t.Fatalf("expected 2 sub-words, got %d", len(subs))
+	}
+	if subs[0].Text != "test" {
+		t.Errorf("sub[0]: got %q, want 'test'", subs[0].Text)
+	}
+	if subs[1].Text != "\u0915" {
+		t.Errorf("sub[1]: got %q, want Devanagari ka", subs[1].Text)
+	}
+}
+
+// TestSplitMixedBidiWordPureCJK ensures pure Han text passes through
+// without splitting (script is uniform, bidi is uniform).
+func TestSplitMixedBidiWordPureCJK(t *testing.T) {
+	w := Word{Text: "\u4E2D\u6587", Width: 20} // 中文
+	if subs := splitMixedBidiWord(w); subs != nil {
+		t.Errorf("pure Han should not split, got %d sub-words", len(subs))
+	}
+}
+
+// TestSplitMixedBidiWordPureArabic ensures pure Arabic passes through
+// unchanged (no script transition, no bidi transition).
+func TestSplitMixedBidiWordPureArabic(t *testing.T) {
+	w := Word{Text: "\u0645\u0631\u062D\u0628\u0627", Width: 30} // مرحبا
+	if subs := splitMixedBidiWord(w); subs != nil {
+		t.Errorf("pure Arabic should not split, got %d sub-words", len(subs))
+	}
+}
+
+// TestSplitMixedBidiWordAccentedLatin ensures combining marks on Latin
+// text (Inherited script per UAX #24) attach to the Latin run.
+func TestSplitMixedBidiWordAccentedLatin(t *testing.T) {
+	w := Word{Text: "cafe\u0301", Width: 30}
+	if subs := splitMixedBidiWord(w); subs != nil {
+		t.Errorf("Latin with combining mark should not split, got %d sub-words", len(subs))
+	}
+}
+
 func TestBidiNumbersInRTL(t *testing.T) {
 	// "שלום 42 עולם" — numbers in an RTL paragraph stay LTR.
 	// Visual order (left-to-right): עולם 42 שלום

--- a/layout/script.go
+++ b/layout/script.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Script identifies a Unicode script per UAX #24. The set of values is
+// intentionally limited to the scripts the layout engine can currently
+// distinguish for shaping decisions. All other codepoints (including the
+// real UAX #24 Common and Inherited pseudo-scripts, plus any unrecognised
+// script) map to ScriptCommon and are resolved against their neighbours.
+type Script uint8
+
+const (
+	// ScriptCommon covers UAX #24 "Common" and "Inherited" codepoints, plus
+	// anything outside the recognised set. Runs of Common characters are
+	// promoted to a neighbouring real script during segmentation.
+	ScriptCommon Script = iota
+	ScriptLatin
+	ScriptArabic
+	ScriptHebrew
+	ScriptDevanagari
+	ScriptBengali
+	ScriptTamil
+	ScriptThai
+	ScriptHan
+	ScriptHiragana
+	ScriptKatakana
+	ScriptHangul
+	ScriptCyrillic
+	ScriptGreek
+)
+
+// ScriptOf returns the Script that r belongs to. ASCII letters take a fast
+// path; everything else falls through an ordered list of unicode.RangeTable
+// checks arranged roughly by real-world frequency so the common cases exit
+// early. Characters outside the recognised scripts (digits, punctuation,
+// symbols, combining marks, scripts we do not yet handle) return
+// ScriptCommon; callers are expected to resolve these against neighbours.
+func ScriptOf(r rune) Script {
+	// ASCII fast path: letters are Latin, everything else is Common.
+	if r < 0x80 {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			return ScriptLatin
+		}
+		return ScriptCommon
+	}
+	switch {
+	case unicode.Is(unicode.Latin, r):
+		return ScriptLatin
+	case unicode.Is(unicode.Han, r):
+		return ScriptHan
+	case unicode.Is(unicode.Hiragana, r):
+		return ScriptHiragana
+	case unicode.Is(unicode.Katakana, r):
+		return ScriptKatakana
+	case unicode.Is(unicode.Hangul, r):
+		return ScriptHangul
+	case unicode.Is(unicode.Arabic, r):
+		return ScriptArabic
+	case unicode.Is(unicode.Hebrew, r):
+		return ScriptHebrew
+	case unicode.Is(unicode.Cyrillic, r):
+		return ScriptCyrillic
+	case unicode.Is(unicode.Greek, r):
+		return ScriptGreek
+	case unicode.Is(unicode.Devanagari, r):
+		return ScriptDevanagari
+	case unicode.Is(unicode.Bengali, r):
+		return ScriptBengali
+	case unicode.Is(unicode.Tamil, r):
+		return ScriptTamil
+	case unicode.Is(unicode.Thai, r):
+		return ScriptThai
+	}
+	return ScriptCommon
+}
+
+// ScriptRun describes a contiguous byte range of a string whose characters
+// all resolve to the same Script per UAX #24 segmentation. Start and End
+// are byte offsets into the original string; End is exclusive.
+type ScriptRun struct {
+	Start  int
+	End    int
+	Script Script
+}
+
+// SegmentByScript partitions s into runs where each rune resolves to the
+// same Script. Common and Inherited runes inherit from their left
+// neighbour; leading Common runs fall back to the nearest real script on
+// the right, and a whole-Common input emits a single ScriptCommon run.
+//
+// This is a linear pass: one walk to collect raw rune segments, a
+// two-sweep resolution pass that promotes Commons against neighbours,
+// then a coalescing emit. It implements the "inherit-from-neighbour"
+// simplification of UAX #24; full Script_Extensions support can land in
+// a later change.
+func SegmentByScript(s string) []ScriptRun {
+	if s == "" {
+		return nil
+	}
+
+	// Phase 1: walk runes once, recording each rune's script and byte
+	// span. We keep per-script granularity here (adjacent runes of the
+	// same script are merged immediately) so the resolution pass below
+	// can promote whole Common groups in one step.
+	type rawRun struct {
+		start, end int
+		script     Script
+	}
+	raws := make([]rawRun, 0, 8)
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		sc := ScriptOf(r)
+		if n := len(raws); n > 0 && raws[n-1].script == sc {
+			raws[n-1].end = i + size
+		} else {
+			raws = append(raws, rawRun{start: i, end: i + size, script: sc})
+		}
+		i += size
+	}
+
+	// Phase 2: resolve Common runs.
+	// Left-neighbour wins: a Common group takes the script of the
+	// preceding real group. Leading Common groups have no left neighbour,
+	// so a reverse sweep promotes them from the first real script to
+	// their right. If no real script exists anywhere in s, every group
+	// stays ScriptCommon and the whole string emits as one Common run.
+	for idx := 0; idx < len(raws); idx++ {
+		if raws[idx].script != ScriptCommon {
+			continue
+		}
+		if idx > 0 && raws[idx-1].script != ScriptCommon {
+			raws[idx].script = raws[idx-1].script
+		}
+	}
+	for idx := len(raws) - 1; idx >= 0; idx-- {
+		if raws[idx].script != ScriptCommon {
+			continue
+		}
+		if idx+1 < len(raws) && raws[idx+1].script != ScriptCommon {
+			raws[idx].script = raws[idx+1].script
+		}
+	}
+
+	// Phase 3: coalesce adjacent groups that now share a script.
+	out := make([]ScriptRun, 0, len(raws))
+	for _, r := range raws {
+		if n := len(out); n > 0 && out[n-1].Script == r.script {
+			out[n-1].End = r.end
+			continue
+		}
+		out = append(out, ScriptRun{Start: r.start, End: r.end, Script: r.script})
+	}
+	return out
+}

--- a/layout/script_test.go
+++ b/layout/script_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import "testing"
+
+func TestScriptOfSamples(t *testing.T) {
+	cases := []struct {
+		name string
+		r    rune
+		want Script
+	}{
+		{"Latin ASCII", 'a', ScriptLatin},
+		{"Latin upper", 'Z', ScriptLatin},
+		{"Arabic alef", '\u0627', ScriptArabic},
+		{"Hebrew shin", '\u05E9', ScriptHebrew},
+		{"Devanagari ka", '\u0915', ScriptDevanagari},
+		{"Bengali ka", '\u0995', ScriptBengali},
+		{"Tamil ka", '\u0B95', ScriptTamil},
+		{"Thai ko kai", '\u0E01', ScriptThai},
+		{"Han Chinese", '\u4E2D', ScriptHan},
+		{"Hiragana a", '\u3042', ScriptHiragana},
+		{"Katakana a", '\u30A2', ScriptKatakana},
+		{"Hangul han", '\uD55C', ScriptHangul},
+		{"Cyrillic a", '\u0430', ScriptCyrillic},
+		{"Greek alpha", '\u03B1', ScriptGreek},
+		{"ASCII digit", '1', ScriptCommon},
+		{"ASCII space", ' ', ScriptCommon},
+		{"ASCII punct", '.', ScriptCommon},
+		{"combining acute", '\u0301', ScriptCommon},
+		{"Latin-1 e-acute precomposed", '\u00E9', ScriptLatin},
+	}
+	for _, tc := range cases {
+		if got := ScriptOf(tc.r); got != tc.want {
+			t.Errorf("%s: ScriptOf(%U) = %d, want %d", tc.name, tc.r, got, tc.want)
+		}
+	}
+}
+
+func TestSegmentByScriptEmpty(t *testing.T) {
+	if runs := SegmentByScript(""); len(runs) != 0 {
+		t.Errorf("empty input: got %d runs, want 0", len(runs))
+	}
+}
+
+func TestSegmentByScriptPureLatin(t *testing.T) {
+	runs := SegmentByScript("hello")
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if runs[0].Script != ScriptLatin {
+		t.Errorf("script: got %d, want ScriptLatin", runs[0].Script)
+	}
+	if runs[0].Start != 0 || runs[0].End != len("hello") {
+		t.Errorf("range: got [%d,%d), want [0,5)", runs[0].Start, runs[0].End)
+	}
+}
+
+func TestSegmentByScriptLatinThenArabic(t *testing.T) {
+	// "hello" followed directly by Arabic "مرحبا" (no space between).
+	s := "hello\u0645\u0631\u062D\u0628\u0627"
+	runs := SegmentByScript(s)
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d: %+v", len(runs), runs)
+	}
+	if runs[0].Script != ScriptLatin {
+		t.Errorf("run[0] script: got %d, want Latin", runs[0].Script)
+	}
+	if runs[1].Script != ScriptArabic {
+		t.Errorf("run[1] script: got %d, want Arabic", runs[1].Script)
+	}
+	if runs[0].End != 5 {
+		t.Errorf("run[0] end: got %d, want 5 (after 'hello')", runs[0].End)
+	}
+	if runs[1].Start != 5 {
+		t.Errorf("run[1] start: got %d, want 5", runs[1].Start)
+	}
+	if runs[1].End != len(s) {
+		t.Errorf("run[1] end: got %d, want %d", runs[1].End, len(s))
+	}
+}
+
+func TestSegmentByScriptLatinSpaceArabic(t *testing.T) {
+	// "hello مرحبا" — the space is Common and should inherit from its
+	// left neighbour (Latin), placing it inside the Latin run.
+	s := "hello \u0645\u0631\u062D\u0628\u0627"
+	runs := SegmentByScript(s)
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d: %+v", len(runs), runs)
+	}
+	if runs[0].Script != ScriptLatin {
+		t.Errorf("run[0] script: got %d, want Latin", runs[0].Script)
+	}
+	// Latin run includes the trailing space (offset 6, past the space).
+	if runs[0].End != 6 {
+		t.Errorf("run[0] end: got %d, want 6 (Latin absorbs the space)", runs[0].End)
+	}
+	if runs[1].Script != ScriptArabic || runs[1].Start != 6 {
+		t.Errorf("run[1]: got %+v, want Arabic starting at 6", runs[1])
+	}
+}
+
+func TestSegmentByScriptCombiningMark(t *testing.T) {
+	// "cafe\u0301" — combining acute is Inherited/Common and attaches
+	// to the preceding Latin 'e', yielding one Latin run.
+	s := "cafe\u0301"
+	runs := SegmentByScript(s)
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d: %+v", len(runs), runs)
+	}
+	if runs[0].Script != ScriptLatin {
+		t.Errorf("script: got %d, want Latin", runs[0].Script)
+	}
+	if runs[0].End != len(s) {
+		t.Errorf("end: got %d, want %d (full string)", runs[0].End, len(s))
+	}
+}
+
+func TestSegmentByScriptLeadingCommon(t *testing.T) {
+	// " hello" — leading space has no left neighbour, so it inherits
+	// from the first real script to the right (Latin).
+	s := " hello"
+	runs := SegmentByScript(s)
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d: %+v", len(runs), runs)
+	}
+	if runs[0].Script != ScriptLatin {
+		t.Errorf("script: got %d, want Latin", runs[0].Script)
+	}
+	if runs[0].Start != 0 || runs[0].End != len(s) {
+		t.Errorf("range: got [%d,%d), want full string", runs[0].Start, runs[0].End)
+	}
+}
+
+func TestSegmentByScriptAllCommon(t *testing.T) {
+	// A whole-Common string (digits + punctuation + spaces) has no real
+	// script anywhere, so it emits a single ScriptCommon run.
+	s := "123 ."
+	runs := SegmentByScript(s)
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d: %+v", len(runs), runs)
+	}
+	if runs[0].Script != ScriptCommon {
+		t.Errorf("script: got %d, want Common", runs[0].Script)
+	}
+	if runs[0].End != len(s) {
+		t.Errorf("end: got %d, want %d", runs[0].End, len(s))
+	}
+}
+
+func TestSegmentByScriptArabicDevanagari(t *testing.T) {
+	// Arabic alef followed directly by Devanagari ka. Two runs.
+	s := "\u0627\u0915"
+	runs := SegmentByScript(s)
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d: %+v", len(runs), runs)
+	}
+	if runs[0].Script != ScriptArabic {
+		t.Errorf("run[0]: got %d, want Arabic", runs[0].Script)
+	}
+	if runs[1].Script != ScriptDevanagari {
+		t.Errorf("run[1]: got %d, want Devanagari", runs[1].Script)
+	}
+}


### PR DESCRIPTION
## Summary

Adds UAX #24 script segmentation so bidi runs are further split by Unicode script, enabling per-script shaping decisions downstream.

- New `layout/script.go` with `Script`, `ScriptOf(r rune)`, `ScriptRun`, and `SegmentByScript(s string)`. Uses stdlib `unicode` range tables (`Latin`, `Han`, `Hiragana`, `Katakana`, `Hangul`, `Arabic`, `Hebrew`, `Cyrillic`, `Greek`, `Devanagari`, `Bengali`, `Tamil`, `Thai`) arranged roughly by real-world frequency, with an ASCII letter fast path.
- `splitMixedBidiWord` in `layout/bidi.go` now folds a script-transition check into its existing single-pass walk. The emitted sub-words are uniform in both bidi bucket and script.
- The two measurement call sites in `layout/paragraph.go` (around lines 303 and 1239) are unchanged; their existing per-sub-word shaping and re-measurement paths continue to run unmodified.

## Behavioural change

- A token containing characters from two different real scripts that share a bidi bucket (e.g. Latin `test` followed directly by Devanagari `क`, or Arabic `ا` followed directly by Devanagari `क`) now produces two `Word`s instead of one.
- Pure-Latin, pure-Arabic, pure-Hebrew, pure-CJK, Hebrew+digits, and Latin-with-combining-marks inputs produce the same `Word` slice as before.

## Common / Inherited inheritance rule

Left-neighbour wins: Common and Inherited runes (digits, punctuation, spaces, combining marks) attach to the preceding real script. Leading Common runs fall back to the first following real script, and a whole-Common input emits a single `ScriptCommon` run. This matches how the existing bidi classifier treats neutrals and keeps the implementation to one rune walk plus a two-sweep resolution pass.

This is the simplification of UAX #24 — full `Script_Extensions` (where e.g. an Arabic comma stays Arabic when surrounded by Arabic because its extension set includes Arabic) is a known gap and can land in a later change.

## Why stdlib `unicode` and not `x/text/unicode/script`

- No new dependency.
- Simpler code: the handful of scripts the layout engine currently cares about map to well-known `RangeTable`s that already ship with the standard library.
- `x/text/unicode/script` additionally exposes Script_Extensions; until the layout engine needs that data, the extra surface is wasted.

## Downstream code paths affected

The only existing downstream consumer of `splitMixedBidiWord`'s output is the measurement loop in `layout/paragraph.go`, which re-measures and re-shapes each sub-word. Arabic shaping, CJK breaking, and bidi reordering all operate per-`Word`, so they transparently benefit when mixed-script tokens are split.

## Performance

The splitter's complexity is unchanged: still one linear pass over the token's runes. `SegmentByScript` itself is three linear passes (raw walk, two-sweep resolution, coalesce) over a small `rawRun` slice. `ScriptOf` takes an ASCII fast path and then a short ordered chain of `unicode.Is` calls.

## Test plan

- [x] `go test ./layout/...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `layout/script_test.go` covers `ScriptOf` across all 14 scripts plus Common inputs, and `SegmentByScript` across empty, pure-Latin, Latin-then-Arabic, Latin + space + Arabic (left-neighbour), combining marks, leading Common, all-Common, and Arabic-then-Devanagari cases.
- [x] `layout/bidi_test.go` adds coverage for same-bidi-different-script splits (Arabic+Devanagari, Latin+Devanagari), plus regression tests for pure Arabic, pure Han, and combining-mark Latin.
- [x] Existing `TestSplitMixedBidiWord` (Hebrew+digits) still passes: digits are `ScriptCommon` and inherit Hebrew under the left-neighbour rule, so the script pass does not force an extra split — the bidi pass alone produces the same two sub-words.