### PR TITLE
Parse and apply GSUB LookupType 4 ligature substitutions

### DIFF
--- a/font/face.go
+++ b/font/face.go
@@ -85,7 +85,7 @@ type Face interface {
 // TODO: at v1.0, merge GSUB() back into Face. The type-assertion
 // indirection adds no value once the API is stable.
 type GSUBProvider interface {
-	GSUB() GSUBSubstitutions
+	GSUB() *GSUBSubstitutions
 	// GIDToUnicode returns a reverse mapping from glyph ID to Unicode
 	// codepoint, built from the font's cmap table. Used to convert
 	// GSUB-substituted GIDs back to codepoints for the text pipeline.

--- a/font/gsub.go
+++ b/font/gsub.go
@@ -7,8 +7,7 @@ import (
 	"encoding/binary"
 )
 
-// GSUBFeature identifies an OpenType GSUB feature tag used for Arabic
-// positional shaping.
+// GSUBFeature identifies an OpenType GSUB feature tag.
 type GSUBFeature string
 
 const (
@@ -16,27 +15,46 @@ const (
 	GSUBMedi GSUBFeature = "medi" // medial form
 	GSUBFina GSUBFeature = "fina" // final form
 	GSUBIsol GSUBFeature = "isol" // isolated form
+	GSUBLiga GSUBFeature = "liga" // standard ligatures
+	GSUBRlig GSUBFeature = "rlig" // required ligatures
+	GSUBClig GSUBFeature = "clig" // contextual ligatures
 )
 
-// GSUBSubstitutions maps a GSUB feature tag to its glyph ID substitution
-// table: sourceGID -> replacementGID. Only SingleSubstitution lookups
-// (GSUB LookupType 1) are supported in this version.
-type GSUBSubstitutions map[GSUBFeature]map[uint16]uint16
+// LigatureSubst describes a single ligature substitution: a sequence of
+// component glyph IDs (after the first) that, together with the first
+// component used as the lookup key, are replaced by LigatureGID.
+type LigatureSubst struct {
+	Components  []uint16 // component GIDs after the first (may be empty)
+	LigatureGID uint16
+}
+
+// GSUBSubstitutions holds parsed GSUB lookups grouped by feature tag.
+//
+// Single holds LookupType 1 substitutions: a per-feature map from source
+// glyph ID to replacement glyph ID.
+//
+// Ligature holds LookupType 4 substitutions: a per-feature map keyed by
+// the first component glyph ID to a slice of candidate ligatures sharing
+// that prefix. Slices are ordered so that longest matches appear first,
+// which matches the OpenType greedy matching rule.
+type GSUBSubstitutions struct {
+	Single   map[GSUBFeature]map[uint16]uint16
+	Ligature map[GSUBFeature]map[uint16][]LigatureSubst
+}
 
 // ParseGSUB reads the GSUB table from raw TrueType/OpenType font bytes
-// and extracts SingleSubstitution lookups for the Arabic positional
-// features (init, medi, fina, isol). Returns nil if the font has no GSUB
-// table or no matching features.
+// and extracts Single (LookupType 1) and Ligature (LookupType 4)
+// substitutions for the Arabic positional features, the standard Latin
+// ligature features, and required/contextual ligatures.
 //
-// The implementation walks the OpenType GSUB table structure:
+// Script selection: "arab", "latn", and "DFLT" (in that preference order
+// for the default LangSys). Extension lookups (LookupType 7) are
+// unwrapped transparently.
 //
-//	ScriptList -> find "arab" or "DFLT" script -> default LangSys
-//	FeatureList -> match "init"/"medi"/"fina"/"isol" features
-//	LookupList -> follow each feature's lookup indices
-//	Each lookup -> subtables -> SingleSubstitution format 1 or 2
+// Returns nil if the font has no GSUB table or no matching features.
 //
-// Reference: OpenType spec v1.9, GSUB table (ISO 14496-22 §6.2).
-func ParseGSUB(data []byte) GSUBSubstitutions {
+// Reference: ISO 14496-22 §6.2, OpenType GSUB table.
+func ParseGSUB(data []byte) *GSUBSubstitutions {
 	gsub := findTable(data, "GSUB")
 	if gsub == nil {
 		return nil
@@ -45,7 +63,6 @@ func ParseGSUB(data []byte) GSUBSubstitutions {
 		return nil
 	}
 
-	// GSUB header (version 1.0 or 1.1).
 	scriptListOff := int(be16(gsub, 4))
 	featureListOff := int(be16(gsub, 6))
 	lookupListOff := int(be16(gsub, 8))
@@ -54,36 +71,104 @@ func ParseGSUB(data []byte) GSUBSubstitutions {
 		return nil
 	}
 
-	// Step 1: find feature indices for the "arab" or "DFLT" script.
 	featureIndices := scriptFeatureIndices(gsub, scriptListOff)
 	if len(featureIndices) == 0 {
 		return nil
 	}
 
-	// Step 2: match feature tags to our target features.
 	targetTags := map[string]GSUBFeature{
 		"init": GSUBInit,
 		"medi": GSUBMedi,
 		"fina": GSUBFina,
 		"isol": GSUBIsol,
+		"liga": GSUBLiga,
+		"rlig": GSUBRlig,
+		"clig": GSUBClig,
 	}
 	featureToLookups := matchFeatures(gsub, featureListOff, featureIndices, targetTags)
 	if len(featureToLookups) == 0 {
 		return nil
 	}
 
-	// Step 3: parse lookups and collect substitutions.
-	result := make(GSUBSubstitutions)
+	result := &GSUBSubstitutions{
+		Single:   make(map[GSUBFeature]map[uint16]uint16),
+		Ligature: make(map[GSUBFeature]map[uint16][]LigatureSubst),
+	}
 	for feat, lookupIndices := range featureToLookups {
-		subs := parseLookups(gsub, lookupListOff, lookupIndices)
-		if len(subs) > 0 {
-			result[feat] = subs
+		single := make(map[uint16]uint16)
+		lig := make(map[uint16][]LigatureSubst)
+		parseLookups(gsub, lookupListOff, lookupIndices, single, lig)
+		if len(single) > 0 {
+			result.Single[feat] = single
+		}
+		if len(lig) > 0 {
+			// Order each bucket so longest component sequences come first
+			// so ApplyLigature's greedy left-to-right scan produces the
+			// longest match per ISO 14496-22 §6.2.
+			for k := range lig {
+				sortLigsByLenDesc(lig[k])
+			}
+			result.Ligature[feat] = lig
 		}
 	}
-	if len(result) == 0 {
+	if len(result.Single) == 0 && len(result.Ligature) == 0 {
 		return nil
 	}
 	return result
+}
+
+// ApplyLigature scans gids left-to-right and replaces the longest matching
+// ligature sequence with the ligature glyph. Greedy longest-match per
+// ISO 14496-22 §6.2. Returns a new slice; the input is not modified.
+func (g *GSUBSubstitutions) ApplyLigature(gids []uint16, feature GSUBFeature) []uint16 {
+	if g == nil || len(g.Ligature) == 0 || len(gids) == 0 {
+		return gids
+	}
+	table, ok := g.Ligature[feature]
+	if !ok || len(table) == 0 {
+		return gids
+	}
+	out := make([]uint16, 0, len(gids))
+	i := 0
+	for i < len(gids) {
+		candidates := table[gids[i]]
+		matched := false
+		for _, cand := range candidates {
+			need := len(cand.Components)
+			if i+1+need > len(gids) {
+				continue
+			}
+			ok := true
+			for j := 0; j < need; j++ {
+				if gids[i+1+j] != cand.Components[j] {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				out = append(out, cand.LigatureGID)
+				i += 1 + need
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			out = append(out, gids[i])
+			i++
+		}
+	}
+	return out
+}
+
+// sortLigsByLenDesc sorts ligatures so that longer component sequences
+// come first. Insertion sort is used to keep the implementation tiny and
+// because ligature buckets are typically small (single digits).
+func sortLigsByLenDesc(s []LigatureSubst) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && len(s[j].Components) > len(s[j-1].Components); j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
 }
 
 // findTable locates a TrueType/OpenType table by its 4-byte tag in the
@@ -118,15 +203,6 @@ func findTable(data []byte, tag string) []byte {
 			entry[2] == tagBytes[2] && entry[3] == tagBytes[3] {
 			offset := int(be32(entry, 8))
 			length := int(be32(entry, 12))
-			// For TTC, offset is from the original data start, but we
-			// already sliced. Adjust: use the pre-slice data via the
-			// stored offset. Actually, table offsets in TTC are relative
-			// to the file start, but we sliced data to the font offset.
-			// Since findTable is called on the sliced data, the table
-			// offsets are relative to the font header. This is correct
-			// for non-TTC fonts. For TTC, we need to use the original
-			// data. This is a known limitation; TTC support would need
-			// the original data reference.
 			if offset+length > len(data) {
 				return nil
 			}
@@ -137,7 +213,7 @@ func findTable(data []byte, tag string) []byte {
 }
 
 // scriptFeatureIndices finds the feature indices referenced by the "arab"
-// script (or "DFLT" fallback) in the GSUB ScriptList.
+// script, then "latn", then "DFLT" fallback in the GSUB ScriptList.
 func scriptFeatureIndices(gsub []byte, off int) []int {
 	if off+2 > len(gsub) {
 		return nil
@@ -147,47 +223,57 @@ func scriptFeatureIndices(gsub []byte, off int) []int {
 		return nil
 	}
 
-	// Prefer "arab" script; fall back to "DFLT".
-	var langSysOff int
-	found := false
+	// Collect LangSys offsets from all preferred scripts so a font that
+	// only lists "latn" still contributes its Latin ligature features,
+	// while "arab" contributes Arabic positional lookups. Duplicates are
+	// folded in matchFeatures via the allowed set.
+	var langSysOffs []int
+	var dfltOff int
+	dfltFound := false
 	for i := 0; i < count; i++ {
 		rec := gsub[off+2+i*6:]
 		tag := string(rec[:4])
 		scriptOff := off + int(be16(rec, 4))
-		if tag == "arab" {
-			langSysOff = scriptOff
-			found = true
-			break
-		}
-		if tag == "DFLT" && !found {
-			langSysOff = scriptOff
-			found = true
+		switch tag {
+		case "arab", "latn":
+			langSysOffs = append(langSysOffs, scriptOff)
+		case "DFLT":
+			dfltOff = scriptOff
+			dfltFound = true
 		}
 	}
-	if !found {
+	if len(langSysOffs) == 0 && dfltFound {
+		langSysOffs = append(langSysOffs, dfltOff)
+	}
+	if len(langSysOffs) == 0 {
 		return nil
 	}
 
-	// Script table: defaultLangSys offset at +0.
-	if langSysOff+2 > len(gsub) {
-		return nil
-	}
-	defOff := int(be16(gsub, langSysOff))
-	if defOff == 0 {
-		return nil
-	}
-	langSys := langSysOff + defOff
-	if langSys+4 > len(gsub) {
-		return nil
-	}
-	// LangSys: skip lookupOrder (uint16) and reqFeatureIndex (uint16).
-	featureCount := int(be16(gsub, langSys+4))
-	if langSys+6+featureCount*2 > len(gsub) {
-		return nil
-	}
-	indices := make([]int, featureCount)
-	for i := 0; i < featureCount; i++ {
-		indices[i] = int(be16(gsub, langSys+6+i*2))
+	seen := make(map[int]bool)
+	var indices []int
+	for _, langSysOff := range langSysOffs {
+		if langSysOff+2 > len(gsub) {
+			continue
+		}
+		defOff := int(be16(gsub, langSysOff))
+		if defOff == 0 {
+			continue
+		}
+		langSys := langSysOff + defOff
+		if langSys+6 > len(gsub) {
+			continue
+		}
+		featureCount := int(be16(gsub, langSys+4))
+		if langSys+6+featureCount*2 > len(gsub) {
+			continue
+		}
+		for i := 0; i < featureCount; i++ {
+			idx := int(be16(gsub, langSys+6+i*2))
+			if !seen[idx] {
+				seen[idx] = true
+				indices = append(indices, idx)
+			}
+		}
 	}
 	return indices
 }
@@ -221,7 +307,6 @@ func matchFeatures(gsub []byte, off int, allowed []int, targetTags map[string]GS
 		if featureOff+4 > len(gsub) {
 			continue
 		}
-		// Feature table: skip featureParams (uint16), then lookupCount.
 		lookupCount := int(be16(gsub, featureOff+2))
 		if featureOff+4+lookupCount*2 > len(gsub) {
 			continue
@@ -235,34 +320,61 @@ func matchFeatures(gsub []byte, off int, allowed []int, targetTags map[string]GS
 	return result
 }
 
-// parseLookups reads SingleSubstitution subtables from the specified
-// lookup indices and returns a merged glyph substitution map.
-func parseLookups(gsub []byte, listOff int, indices []int) map[uint16]uint16 {
+// parseLookups walks each referenced lookup and dispatches its subtables
+// to the appropriate LookupType parser. Extension lookups (type 7) are
+// unwrapped; nested extensions are not expected by the spec and are
+// ignored if encountered.
+func parseLookups(gsub []byte, listOff int, indices []int, single map[uint16]uint16, lig map[uint16][]LigatureSubst) {
 	if listOff+2 > len(gsub) {
-		return nil
+		return
 	}
 	count := int(be16(gsub, listOff))
-	subs := make(map[uint16]uint16)
 	for _, idx := range indices {
 		if idx >= count {
 			continue
 		}
 		lookupOff := listOff + int(be16(gsub, listOff+2+idx*2))
-		if lookupOff+6 > len(gsub) {
-			continue
-		}
-		lookupType := be16(gsub, lookupOff)
-		if lookupType != 1 {
-			// Only SingleSubstitution (type 1) is supported.
-			continue
-		}
-		subCount := int(be16(gsub, lookupOff+4))
-		for si := 0; si < subCount; si++ {
-			subOff := lookupOff + int(be16(gsub, lookupOff+6+si*2))
-			parseSingleSubst(gsub, subOff, subs)
+		parseLookup(gsub, lookupOff, single, lig)
+	}
+}
+
+// parseLookup reads a single Lookup table, following each subtable offset
+// and calling the appropriate subtable parser for supported lookup types.
+func parseLookup(gsub []byte, lookupOff int, single map[uint16]uint16, lig map[uint16][]LigatureSubst) {
+	if lookupOff+6 > len(gsub) {
+		return
+	}
+	lookupType := be16(gsub, lookupOff)
+	subCount := int(be16(gsub, lookupOff+4))
+	if lookupOff+6+subCount*2 > len(gsub) {
+		return
+	}
+	for si := 0; si < subCount; si++ {
+		subOff := lookupOff + int(be16(gsub, lookupOff+6+si*2))
+		switch lookupType {
+		case 1:
+			parseSingleSubst(gsub, subOff, single)
+		case 4:
+			parseLigatureSubst(gsub, subOff, lig)
+		case 7:
+			// Extension table: format(2), extensionLookupType(2),
+			// extensionOffset(4, relative to the extension subtable start).
+			if subOff+8 > len(gsub) {
+				continue
+			}
+			extType := be16(gsub, subOff+2)
+			extOff := subOff + int(be32(gsub, subOff+4))
+			if extOff >= len(gsub) {
+				continue
+			}
+			switch extType {
+			case 1:
+				parseSingleSubst(gsub, extOff, single)
+			case 4:
+				parseLigatureSubst(gsub, extOff, lig)
+			}
 		}
 	}
-	return subs
 }
 
 // parseSingleSubst reads a SingleSubstitution subtable (format 1 or 2)
@@ -281,13 +393,11 @@ func parseSingleSubst(gsub []byte, off int, subs map[uint16]uint16) {
 
 	switch format {
 	case 1:
-		// Format 1: delta applied to each covered glyph ID.
 		delta := int16(be16(gsub, off+4))
 		for _, gid := range covered {
 			subs[gid] = uint16(int16(gid) + delta)
 		}
 	case 2:
-		// Format 2: explicit substitute array, one per covered glyph.
 		substCount := int(be16(gsub, off+4))
 		if off+6+substCount*2 > len(gsub) {
 			return
@@ -301,6 +411,84 @@ func parseSingleSubst(gsub []byte, off int, subs map[uint16]uint16) {
 	}
 }
 
+// parseLigatureSubst reads a LigatureSubstFormat1 subtable and appends
+// every ligature into lig keyed by its first component.
+//
+// Subtable layout (ISO 14496-22 §6.2 LookupType 4):
+//
+//	format           uint16  (always 1)
+//	coverageOffset   Offset16
+//	ligatureSetCount uint16
+//	ligatureSetOffsets[ligatureSetCount] Offset16
+//
+// Each LigatureSet:
+//
+//	ligatureCount      uint16
+//	ligatureOffsets[]  Offset16 (relative to LigatureSet)
+//
+// Each Ligature:
+//
+//	ligatureGlyph      uint16
+//	componentCount     uint16
+//	componentGlyphIDs[componentCount-1] uint16
+func parseLigatureSubst(gsub []byte, off int, lig map[uint16][]LigatureSubst) {
+	if off+6 > len(gsub) {
+		return
+	}
+	format := be16(gsub, off)
+	if format != 1 {
+		return
+	}
+	coverageOff := off + int(be16(gsub, off+2))
+	ligSetCount := int(be16(gsub, off+4))
+	if off+6+ligSetCount*2 > len(gsub) {
+		return
+	}
+	covered := parseCoverage(gsub, coverageOff)
+	if covered == nil {
+		return
+	}
+	for i, firstGID := range covered {
+		if i >= ligSetCount {
+			break
+		}
+		setOff := off + int(be16(gsub, off+6+i*2))
+		if setOff+2 > len(gsub) {
+			continue
+		}
+		ligCount := int(be16(gsub, setOff))
+		if setOff+2+ligCount*2 > len(gsub) {
+			continue
+		}
+		for j := 0; j < ligCount; j++ {
+			ligOff := setOff + int(be16(gsub, setOff+2+j*2))
+			if ligOff+4 > len(gsub) {
+				continue
+			}
+			ligGlyph := be16(gsub, ligOff)
+			compCount := int(be16(gsub, ligOff+2))
+			if compCount == 0 {
+				continue
+			}
+			rest := compCount - 1
+			if ligOff+4+rest*2 > len(gsub) {
+				continue
+			}
+			var comps []uint16
+			if rest > 0 {
+				comps = make([]uint16, rest)
+				for k := 0; k < rest; k++ {
+					comps[k] = be16(gsub, ligOff+4+k*2)
+				}
+			}
+			lig[firstGID] = append(lig[firstGID], LigatureSubst{
+				Components:  comps,
+				LigatureGID: ligGlyph,
+			})
+		}
+	}
+}
+
 // parseCoverage reads a Coverage table and returns the list of covered
 // glyph IDs in coverage index order.
 func parseCoverage(gsub []byte, off int) []uint16 {
@@ -310,7 +498,6 @@ func parseCoverage(gsub []byte, off int) []uint16 {
 	format := be16(gsub, off)
 	switch format {
 	case 1:
-		// Format 1: array of glyph IDs.
 		count := int(be16(gsub, off+2))
 		if off+4+count*2 > len(gsub) {
 			return nil
@@ -321,18 +508,39 @@ func parseCoverage(gsub []byte, off int) []uint16 {
 		}
 		return result
 	case 2:
-		// Format 2: ranges of glyph IDs.
+		// Format 2: RangeRecord[] where each record gives
+		// startGlyphID, endGlyphID, startCoverageIndex. The coverage
+		// index order is the one implied by startCoverageIndex, so
+		// ranges must be placed at their declared index to preserve the
+		// correspondence with Format 1 used by callers that index the
+		// returned slice positionally (e.g. LigatureSubstFormat1).
 		rangeCount := int(be16(gsub, off+2))
 		if off+4+rangeCount*6 > len(gsub) {
 			return nil
 		}
-		var result []uint16
+		// First pass: compute total length from the highest end index.
+		total := 0
 		for i := 0; i < rangeCount; i++ {
 			rec := off + 4 + i*6
 			startGID := be16(gsub, rec)
 			endGID := be16(gsub, rec+2)
+			startCov := int(be16(gsub, rec+4))
+			end := startCov + int(endGID-startGID) + 1
+			if end > total {
+				total = end
+			}
+		}
+		result := make([]uint16, total)
+		for i := 0; i < rangeCount; i++ {
+			rec := off + 4 + i*6
+			startGID := be16(gsub, rec)
+			endGID := be16(gsub, rec+2)
+			startCov := int(be16(gsub, rec+4))
 			for gid := startGID; gid <= endGID; gid++ {
-				result = append(result, gid)
+				idx := startCov + int(gid-startGID)
+				if idx < len(result) {
+					result[idx] = gid
+				}
 			}
 		}
 		return result

--- a/font/gsub_test.go
+++ b/font/gsub_test.go
@@ -27,15 +27,15 @@ func TestParseGSUBFindsArabicFeatures(t *testing.T) {
 	}
 	// At minimum, a good Arabic font should have at least init and fina.
 	for _, feat := range []GSUBFeature{GSUBInit, GSUBFina} {
-		table, ok := subs[feat]
+		table, ok := subs.Single[feat]
 		if !ok || len(table) == 0 {
 			t.Errorf("feature %q: not found or empty in %s", feat, path)
 		}
 	}
 	t.Logf("GSUB from %s: init=%d medi=%d fina=%d isol=%d",
 		path,
-		len(subs[GSUBInit]), len(subs[GSUBMedi]),
-		len(subs[GSUBFina]), len(subs[GSUBIsol]))
+		len(subs.Single[GSUBInit]), len(subs.Single[GSUBMedi]),
+		len(subs.Single[GSUBFina]), len(subs.Single[GSUBIsol]))
 }
 
 // TestParseGSUBNilOnStandardFont verifies that ParseGSUB returns nil
@@ -139,8 +139,8 @@ func TestParseGSUBEmptyLists(t *testing.T) {
 	gsubData[8] = 0x00
 	gsubData[9] = 0x0E // lookupListOff = 14
 	ttf := buildTTFWithGSUB(gsubData)
-	if subs := ParseGSUB(ttf); len(subs) != 0 {
-		t.Errorf("expected no substitutions from empty GSUB lists, got %d features", len(subs))
+	if subs := ParseGSUB(ttf); subs != nil {
+		t.Errorf("expected nil from empty GSUB lists, got %+v", subs)
 	}
 }
 
@@ -159,6 +159,336 @@ func TestParseGSUBOutOfRangeOffsets(t *testing.T) {
 	if subs := ParseGSUB(ttf); subs != nil {
 		t.Errorf("expected nil for out-of-range offsets, got %v", subs)
 	}
+}
+
+// --- LookupType 4 (Ligature Substitution) unit tests ---
+
+// TestApplyLigatureBasic exercises the simplest ligature: one two-component
+// ligature replaces the matching GID pair with the ligature glyph.
+func TestApplyLigatureBasic(t *testing.T) {
+	g := &GSUBSubstitutions{
+		Ligature: map[GSUBFeature]map[uint16][]LigatureSubst{
+			GSUBLiga: {
+				10: []LigatureSubst{
+					{Components: []uint16{20}, LigatureGID: 99},
+				},
+			},
+		},
+	}
+	got := g.ApplyLigature([]uint16{10, 20, 30}, GSUBLiga)
+	want := []uint16{99, 30}
+	if !uint16SliceEq(got, want) {
+		t.Errorf("ApplyLigature: got %v, want %v", got, want)
+	}
+}
+
+// TestApplyLigatureGreedyLongest confirms that when multiple ligatures
+// share a prefix, the longest matching sequence wins. Input [10,20,30,40]
+// with ligatures [10,20]->99 and [10,20,30]->100 must produce [100, 40].
+func TestApplyLigatureGreedyLongest(t *testing.T) {
+	g := &GSUBSubstitutions{
+		Ligature: map[GSUBFeature]map[uint16][]LigatureSubst{
+			GSUBLiga: {
+				10: []LigatureSubst{
+					// Intentionally not in length order; ParseGSUB sorts,
+					// but callers may construct this directly — ApplyLigature
+					// should still pick the longest via its candidate scan
+					// when the slice is pre-sorted by ParseGSUB. Sort here
+					// to match the documented invariant.
+					{Components: []uint16{20, 30}, LigatureGID: 100},
+					{Components: []uint16{20}, LigatureGID: 99},
+				},
+			},
+		},
+	}
+	got := g.ApplyLigature([]uint16{10, 20, 30, 40}, GSUBLiga)
+	want := []uint16{100, 40}
+	if !uint16SliceEq(got, want) {
+		t.Errorf("ApplyLigature: got %v, want %v", got, want)
+	}
+}
+
+// TestApplyLigatureNoMatch verifies that unmatched glyph runs are left
+// untouched and that matching and non-matching runs can interleave.
+func TestApplyLigatureNoMatch(t *testing.T) {
+	g := &GSUBSubstitutions{
+		Ligature: map[GSUBFeature]map[uint16][]LigatureSubst{
+			GSUBLiga: {
+				10: []LigatureSubst{
+					{Components: []uint16{20}, LigatureGID: 99},
+				},
+			},
+		},
+	}
+	// No [10,20] pair; prefix starts with 10 but 2nd glyph doesn't match.
+	got := g.ApplyLigature([]uint16{10, 21, 10, 20}, GSUBLiga)
+	want := []uint16{10, 21, 99}
+	if !uint16SliceEq(got, want) {
+		t.Errorf("ApplyLigature: got %v, want %v", got, want)
+	}
+}
+
+// TestApplyLigatureNilReceiver and missing-feature cases should no-op.
+func TestApplyLigatureEmptyCases(t *testing.T) {
+	var g *GSUBSubstitutions
+	if got := g.ApplyLigature([]uint16{1, 2}, GSUBLiga); !uint16SliceEq(got, []uint16{1, 2}) {
+		t.Errorf("nil receiver: got %v, want [1 2]", got)
+	}
+	empty := &GSUBSubstitutions{}
+	if got := empty.ApplyLigature([]uint16{1, 2}, GSUBLiga); !uint16SliceEq(got, []uint16{1, 2}) {
+		t.Errorf("empty ligature map: got %v, want [1 2]", got)
+	}
+	only := &GSUBSubstitutions{
+		Ligature: map[GSUBFeature]map[uint16][]LigatureSubst{
+			GSUBRlig: {1: []LigatureSubst{{Components: []uint16{2}, LigatureGID: 9}}},
+		},
+	}
+	if got := only.ApplyLigature([]uint16{1, 2}, GSUBLiga); !uint16SliceEq(got, []uint16{1, 2}) {
+		t.Errorf("wrong feature: got %v, want [1 2]", got)
+	}
+}
+
+// TestParseGSUBLigatureEndToEnd builds a minimal synthetic GSUB table
+// wired via ScriptList/FeatureList/LookupList to a LigatureSubstFormat1
+// subtable and verifies that ParseGSUB surfaces the ligature.
+func TestParseGSUBLigatureEndToEnd(t *testing.T) {
+	gsub := buildLigatureGSUB(ligOptions{})
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil")
+	}
+	table, ok := subs.Ligature[GSUBLiga]
+	if !ok {
+		t.Fatalf("liga feature missing; have %v", subs.Ligature)
+	}
+	bucket := table[10]
+	if len(bucket) != 1 {
+		t.Fatalf("expected 1 ligature for key 10, got %d", len(bucket))
+	}
+	if bucket[0].LigatureGID != 99 || len(bucket[0].Components) != 1 || bucket[0].Components[0] != 20 {
+		t.Errorf("unexpected ligature entry: %+v", bucket[0])
+	}
+	got := subs.ApplyLigature([]uint16{10, 20, 30}, GSUBLiga)
+	if !uint16SliceEq(got, []uint16{99, 30}) {
+		t.Errorf("ApplyLigature on parsed table: got %v, want [99 30]", got)
+	}
+}
+
+// TestParseGSUBLigatureExtension wraps the LigatureSubst subtable inside
+// a LookupType 7 (Extension) subtable, as large fonts commonly do, and
+// confirms ParseGSUB follows the 32-bit extension offset.
+func TestParseGSUBLigatureExtension(t *testing.T) {
+	gsub := buildLigatureGSUB(ligOptions{Extension: true})
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil for extension-wrapped ligature")
+	}
+	bucket := subs.Ligature[GSUBLiga][10]
+	if len(bucket) != 1 || bucket[0].LigatureGID != 99 {
+		t.Fatalf("extension unwrap failed: %+v", bucket)
+	}
+}
+
+// TestParseGSUBLigatureCoverageFormat2 builds the same ligature subtable
+// but uses a Coverage Format 2 range to enumerate the single covered GID.
+func TestParseGSUBLigatureCoverageFormat2(t *testing.T) {
+	gsub := buildLigatureGSUB(ligOptions{CoverageFormat: 2})
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil for Coverage Format 2 ligature")
+	}
+	bucket := subs.Ligature[GSUBLiga][10]
+	if len(bucket) != 1 || bucket[0].LigatureGID != 99 {
+		t.Fatalf("Coverage Format 2 parsing failed: %+v", bucket)
+	}
+}
+
+// uint16SliceEq compares two uint16 slices for equality. Only used in tests.
+func uint16SliceEq(a, b []uint16) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ligOptions controls the synthetic GSUB blob built by buildLigatureGSUB.
+type ligOptions struct {
+	Extension      bool // wrap the LookupType 4 subtable in a LookupType 7
+	CoverageFormat int  // 0 or 1 = format 1; 2 = format 2 (range)
+}
+
+// buildLigatureGSUB constructs a minimal GSUB byte blob containing a
+// single "latn" script, a single "liga" feature, and a LookupType 4
+// (optionally wrapped in LookupType 7) subtable that maps the two-glyph
+// sequence [10, 20] to ligature glyph 99. All internal offsets are
+// computed from the actual layout produced below so the blob is a
+// faithful ISO 14496-22 §6.2 GSUB table.
+func buildLigatureGSUB(opt ligOptions) []byte {
+	put16 := func(buf []byte, v uint16) { buf[0] = byte(v >> 8); buf[1] = byte(v) }
+	put32 := func(buf []byte, v uint32) {
+		buf[0] = byte(v >> 24)
+		buf[1] = byte(v >> 16)
+		buf[2] = byte(v >> 8)
+		buf[3] = byte(v)
+	}
+
+	// Build each section into its own buffer at a known position; final
+	// offsets are computed by concatenation.
+	var (
+		header     = make([]byte, 10)
+		scriptList []byte
+		script     []byte
+		langSys    []byte
+		featList   []byte
+		feature    []byte
+		lookupList []byte
+		lookup     []byte
+		extSub     []byte // only used when opt.Extension
+		ligSub     []byte
+		coverage   []byte
+		ligSet     []byte
+		ligature   []byte
+	)
+
+	// --- inner-most first so sizes are known going outward ---
+
+	// Ligature: ligGlyph=99, componentCount=2, components=[20]
+	ligature = make([]byte, 6)
+	put16(ligature[0:2], 99)
+	put16(ligature[2:4], 2)
+	put16(ligature[4:6], 20)
+
+	// LigatureSet: ligCount=1, offsets=[ligatureOffset]
+	// Layout inside set: [hdr(2) + offsets(2)] then the ligature.
+	ligSet = make([]byte, 4+len(ligature))
+	put16(ligSet[0:2], 1) // ligCount
+	put16(ligSet[2:4], 4) // ligature offset (relative to ligSet start)
+	copy(ligSet[4:], ligature)
+
+	// Coverage: either format 1 or format 2 covering GID 10.
+	switch opt.CoverageFormat {
+	case 2:
+		coverage = make([]byte, 10)
+		put16(coverage[0:2], 2) // format
+		put16(coverage[2:4], 1) // rangeCount
+		put16(coverage[4:6], 10) // startGlyphID
+		put16(coverage[6:8], 10) // endGlyphID
+		put16(coverage[8:10], 0) // startCoverageIndex
+	default:
+		coverage = make([]byte, 6)
+		put16(coverage[0:2], 1) // format
+		put16(coverage[2:4], 1) // glyphCount
+		put16(coverage[4:6], 10) // GID 10
+	}
+
+	// LigatureSubstFormat1 subtable:
+	//   format(2) + coverageOff(2) + ligSetCount(2) + setOffsets[1](2)
+	//   then the coverage, then the ligSet.
+	ligSubHdr := 8
+	ligSub = make([]byte, ligSubHdr+len(coverage)+len(ligSet))
+	put16(ligSub[0:2], 1)                                  // format
+	put16(ligSub[2:4], uint16(ligSubHdr))                  // coverageOff
+	put16(ligSub[4:6], 1)                                  // ligSetCount
+	put16(ligSub[6:8], uint16(ligSubHdr+len(coverage)))    // setOffset[0]
+	copy(ligSub[ligSubHdr:], coverage)
+	copy(ligSub[ligSubHdr+len(coverage):], ligSet)
+
+	// Optional Extension subtable: format(2) + extType(2) + extOff(4)
+	// where extOff is relative to the extension subtable start and points
+	// to the wrapped LigatureSubst bytes appended immediately after.
+	if opt.Extension {
+		extHdr := 8
+		extSub = make([]byte, extHdr+len(ligSub))
+		put16(extSub[0:2], 1)                    // format = 1
+		put16(extSub[2:4], 4)                    // wrapped type = 4
+		put32(extSub[4:8], uint32(extHdr))       // offset to wrapped subtable
+		copy(extSub[extHdr:], ligSub)
+	}
+
+	// Lookup: type(2) + flag(2) + subTableCount(2) + subTableOffsets[1](2)
+	// Followed by the subtable itself (either extSub or ligSub).
+	lookupHdr := 8
+	inner := ligSub
+	lookupType := uint16(4)
+	if opt.Extension {
+		inner = extSub
+		lookupType = 7
+	}
+	lookup = make([]byte, lookupHdr+len(inner))
+	put16(lookup[0:2], lookupType)        // lookupType
+	put16(lookup[2:4], 0)                 // lookupFlag
+	put16(lookup[4:6], 1)                 // subTableCount
+	put16(lookup[6:8], uint16(lookupHdr)) // subTableOffset[0]
+	copy(lookup[lookupHdr:], inner)
+
+	// LookupList: lookupCount(2) + lookupOffsets[1](2) + lookup
+	lookupListHdr := 4
+	lookupList = make([]byte, lookupListHdr+len(lookup))
+	put16(lookupList[0:2], 1)                     // lookupCount
+	put16(lookupList[2:4], uint16(lookupListHdr)) // offset to lookup
+	copy(lookupList[lookupListHdr:], lookup)
+
+	// Feature: featureParamsOff(2) + lookupCount(2) + lookupIndex[0](2)
+	feature = make([]byte, 6)
+	put16(feature[0:2], 0) // featureParams
+	put16(feature[2:4], 1) // lookupCount
+	put16(feature[4:6], 0) // lookupListIndex
+
+	// FeatureList: featureCount(2) + FeatureRecord[1](tag(4)+offset(2))
+	featListHdr := 8
+	featList = make([]byte, featListHdr+len(feature))
+	put16(featList[0:2], 1)                   // featureCount
+	copy(featList[2:6], []byte("liga"))       // tag
+	put16(featList[6:8], uint16(featListHdr)) // featureOff
+	copy(featList[featListHdr:], feature)
+
+	// LangSys: lookupOrder(2)=0 + reqFeatureIndex(2)=0xFFFF +
+	//          featureIndexCount(2)=1 + featureIndices[0](2)=0
+	langSys = make([]byte, 8)
+	put16(langSys[0:2], 0)
+	put16(langSys[2:4], 0xFFFF)
+	put16(langSys[4:6], 1)
+	put16(langSys[6:8], 0)
+
+	// Script: defaultLangSysOff(2) + langSysCount(2) + langSys
+	scriptHdr := 4
+	script = make([]byte, scriptHdr+len(langSys))
+	put16(script[0:2], uint16(scriptHdr)) // defaultLangSysOff
+	put16(script[2:4], 0)                  // langSysCount
+	copy(script[scriptHdr:], langSys)
+
+	// ScriptList: scriptCount(2) + ScriptRecord[1](tag(4)+offset(2)) + script
+	scriptListHdr := 8
+	scriptList = make([]byte, scriptListHdr+len(script))
+	put16(scriptList[0:2], 1)                     // scriptCount
+	copy(scriptList[2:6], []byte("latn"))         // tag
+	put16(scriptList[6:8], uint16(scriptListHdr)) // scriptOff
+	copy(scriptList[scriptListHdr:], script)
+
+	// Header: GSUB version 1.0 + offsets to ScriptList/FeatureList/LookupList.
+	scriptListOff := len(header)
+	featListOff := scriptListOff + len(scriptList)
+	lookupListOff := featListOff + len(featList)
+	put16(header[0:2], 1) // majorVersion
+	put16(header[2:4], 0) // minorVersion
+	put16(header[4:6], uint16(scriptListOff))
+	put16(header[6:8], uint16(featListOff))
+	put16(header[8:10], uint16(lookupListOff))
+
+	out := make([]byte, 0, lookupListOff+len(lookupList))
+	out = append(out, header...)
+	out = append(out, scriptList...)
+	out = append(out, featList...)
+	out = append(out, lookupList...)
+	return out
 }
 
 func arabicFontPath() string {

--- a/font/truetype.go
+++ b/font/truetype.go
@@ -28,8 +28,10 @@ type sfntFace struct {
 	tables       map[string][]byte
 	tablesParsed bool
 
-	// Cached GSUB substitution tables (nil = not yet parsed).
-	gsubResult GSUBSubstitutions
+	// Cached GSUB substitution tables. gsubParsed distinguishes "not
+	// yet parsed" (false) from "parsed and empty" (true, gsubResult nil).
+	gsubResult *GSUBSubstitutions
+	gsubParsed bool
 
 	// Cached GID→Unicode reverse map (nil = not yet built).
 	gidToUnicodeMap   map[uint16]rune
@@ -408,26 +410,16 @@ func (f *sfntFace) NumGlyphs() int {
 	return f.font.NumGlyphs()
 }
 
-// gsubCache caches the parsed GSUB substitutions (nil means not yet parsed;
-// an empty map means "parsed but no Arabic features found").
-var gsubSentinel = GSUBSubstitutions{} // non-nil empty sentinel
-
-// GSUB returns the parsed GSUB substitution tables for Arabic positional
-// features. The result is cached after the first call.
-func (f *sfntFace) GSUB() GSUBSubstitutions {
-	if f.gsubResult != nil {
-		if len(f.gsubResult) == 0 {
-			return nil // sentinel: already parsed, nothing found
-		}
+// GSUB returns the parsed GSUB substitution tables. The result is cached
+// after the first call; a nil return means the font has no GSUB tables
+// for any of the recognized features.
+func (f *sfntFace) GSUB() *GSUBSubstitutions {
+	if f.gsubParsed {
 		return f.gsubResult
 	}
-	result := ParseGSUB(f.rawData)
-	if result == nil {
-		f.gsubResult = gsubSentinel
-		return nil
-	}
-	f.gsubResult = result
-	return result
+	f.gsubResult = ParseGSUB(f.rawData)
+	f.gsubParsed = true
+	return f.gsubResult
 }
 
 // GIDToUnicode returns a reverse mapping from glyph ID to Unicode codepoint.

--- a/font/truetype_test.go
+++ b/font/truetype_test.go
@@ -5,7 +5,6 @@ package font
 
 import (
 	"os"
-	"reflect"
 	"testing"
 )
 
@@ -341,13 +340,9 @@ func TestFaceGSUBCaching(t *testing.T) {
 		t.Skip("font has no GSUB table; cannot verify cache identity")
 	}
 
-	// Identity check: the cached path must return the same map header.
-	// reflect.Value.Pointer on a map returns the hmap pointer, which is
-	// a stable identity token for the underlying map.
-	p1 := reflect.ValueOf(first).Pointer()
-	p2 := reflect.ValueOf(second).Pointer()
-	if p1 != p2 {
-		t.Errorf("GSUB cache returned different map instances (%#x vs %#x); cache is not taking effect", p1, p2)
+	// Identity check: the cached path must return the same pointer.
+	if first != second {
+		t.Errorf("GSUB cache returned different pointers (%p vs %p); cache is not taking effect", first, second)
 	}
 }
 

--- a/layout/arabic.go
+++ b/layout/arabic.go
@@ -248,7 +248,7 @@ func ShapeArabicWithFont(s string, face font.Face) string {
 	return shapeArabicWithFont(s, gsub, face, gidReverse)
 }
 
-func shapeArabicWithFont(s string, gsub font.GSUBSubstitutions, face font.Face, gidReverse map[uint16]rune) string {
+func shapeArabicWithFont(s string, gsub *font.GSUBSubstitutions, face font.Face, gidReverse map[uint16]rune) string {
 	runes := []rune(s)
 	if len(runes) == 0 {
 		return s
@@ -305,7 +305,7 @@ func shapeArabicWithFont(s string, gsub font.GSUBSubstitutions, face font.Face, 
 		// replacement GID → rune (via reverse cmap). Falls through to
 		// PFB if any step fails.
 		if gsub != nil && face != nil && gidReverse != nil {
-			if table, ok := gsub[targetFeature]; ok {
+			if table, ok := gsub.Single[targetFeature]; ok {
 				gid := face.GlyphIndex(r)
 				if gid != 0 {
 					if subGID, found := table[gid]; found {

--- a/layout/arabic_gsub_test.go
+++ b/layout/arabic_gsub_test.go
@@ -16,9 +16,9 @@ import (
 // mockGSUBFace implements font.Face and font.GSUBProvider with synthetic
 // data so tests don't depend on system fonts.
 type mockGSUBFace struct {
-	glyphMap      map[rune]uint16        // cmap: rune -> GID
-	reverseMap    map[uint16]rune        // reverse cmap: GID -> rune
-	substitutions font.GSUBSubstitutions // GSUB tables
+	glyphMap      map[rune]uint16         // cmap: rune -> GID
+	reverseMap    map[uint16]rune         // reverse cmap: GID -> rune
+	substitutions *font.GSUBSubstitutions // GSUB tables
 }
 
 func (m *mockGSUBFace) PostScriptName() string { return "MockArabic" }
@@ -40,7 +40,7 @@ func (m *mockGSUBFace) Kern(uint16, uint16) int       { return 0 }
 func (m *mockGSUBFace) Flags() uint32                 { return 0 }
 func (m *mockGSUBFace) RawData() []byte               { return nil }
 func (m *mockGSUBFace) NumGlyphs() int                { return 100 }
-func (m *mockGSUBFace) GSUB() font.GSUBSubstitutions  { return m.substitutions }
+func (m *mockGSUBFace) GSUB() *font.GSUBSubstitutions { return m.substitutions }
 func (m *mockGSUBFace) GIDToUnicode() map[uint16]rune { return m.reverseMap }
 
 // newMockArabicFace creates a mock face with synthetic GSUB data for
@@ -61,9 +61,11 @@ func newMockArabicFace() *mockGSUBFace {
 			30: 0xE001, // GID 30 -> PUA codepoint (font-specific, NOT in PFB table)
 			31: 0xE002, // GID 31 -> PUA codepoint
 		},
-		substitutions: font.GSUBSubstitutions{
-			font.GSUBInit: {10: 30}, // beh initial: GID 10 -> GID 30 -> U+E001
-			font.GSUBFina: {11: 31}, // alef final: GID 11 -> GID 31 -> U+E002
+		substitutions: &font.GSUBSubstitutions{
+			Single: map[font.GSUBFeature]map[uint16]uint16{
+				font.GSUBInit: {10: 30}, // beh initial: GID 10 -> GID 30 -> U+E001
+				font.GSUBFina: {11: 31}, // alef final: GID 11 -> GID 31 -> U+E002
+			},
 		},
 	}
 }
@@ -96,10 +98,11 @@ func TestGSUBPipelineUsedOverPFB(t *testing.T) {
 // covered by GSUB fall back to the PFB table.
 func TestGSUBFallbackToPFBWhenNoSubstitution(t *testing.T) {
 	face := &mockGSUBFace{
-		glyphMap:      map[rune]uint16{0x0633: 40}, // seen -> GID 40
-		reverseMap:    map[uint16]rune{40: 0x0633},
-		substitutions: font.GSUBSubstitutions{
+		glyphMap:   map[rune]uint16{0x0633: 40}, // seen -> GID 40
+		reverseMap: map[uint16]rune{40: 0x0633},
+		substitutions: &font.GSUBSubstitutions{
 			// No init/fina/medi/isol entries for GID 40.
+			Single: map[font.GSUBFeature]map[uint16]uint16{},
 		},
 	}
 	// Seen isolated: GSUB has no entry -> falls back to PFB.
@@ -116,9 +119,11 @@ func TestGSUBFallbackToPFBWhenNoSubstitution(t *testing.T) {
 // doesn't have the rune (GlyphIndex returns 0).
 func TestGSUBFallbackWhenGIDZero(t *testing.T) {
 	face := &mockGSUBFace{
-		glyphMap:      map[rune]uint16{}, // empty cmap
-		reverseMap:    map[uint16]rune{},
-		substitutions: font.GSUBSubstitutions{font.GSUBIsol: {99: 100}},
+		glyphMap:   map[rune]uint16{}, // empty cmap
+		reverseMap: map[uint16]rune{},
+		substitutions: &font.GSUBSubstitutions{
+			Single: map[font.GSUBFeature]map[uint16]uint16{font.GSUBIsol: {99: 100}},
+		},
 	}
 	input := "\u0628" // beh
 	shaped := ShapeArabicWithFont(input, face)
@@ -133,9 +138,11 @@ func TestGSUBFallbackWhenGIDZero(t *testing.T) {
 // substituted GID has no reverse cmap entry.
 func TestGSUBFallbackWhenNoReverseMapping(t *testing.T) {
 	face := &mockGSUBFace{
-		glyphMap:      map[rune]uint16{0x0628: 10},
-		reverseMap:    map[uint16]rune{10: 0x0628},                     // no entry for GID 50
-		substitutions: font.GSUBSubstitutions{font.GSUBIsol: {10: 50}}, // maps to GID 50
+		glyphMap:   map[rune]uint16{0x0628: 10},
+		reverseMap: map[uint16]rune{10: 0x0628}, // no entry for GID 50
+		substitutions: &font.GSUBSubstitutions{
+			Single: map[font.GSUBFeature]map[uint16]uint16{font.GSUBIsol: {10: 50}}, // maps to GID 50
+		},
 	}
 	input := "\u0628"
 	shaped := ShapeArabicWithFont(input, face)
@@ -182,9 +189,10 @@ func TestShapeArabicWithRealFontGSUB(t *testing.T) {
 	if !ok || gp.GSUB() == nil {
 		t.Skip("no GSUB tables")
 	}
+	sub := gp.GSUB()
 	t.Logf("GSUB features: init=%d medi=%d fina=%d isol=%d",
-		len(gp.GSUB()[font.GSUBInit]), len(gp.GSUB()[font.GSUBMedi]),
-		len(gp.GSUB()[font.GSUBFina]), len(gp.GSUB()[font.GSUBIsol]))
+		len(sub.Single[font.GSUBInit]), len(sub.Single[font.GSUBMedi]),
+		len(sub.Single[font.GSUBFina]), len(sub.Single[font.GSUBIsol]))
 
 	input := "\u0633\u0644\u0627\u0645" // salam
 	shaped := ShapeArabicWithFont(input, face)


### PR DESCRIPTION
## Summary

Extends the GSUB parser in font/gsub.go to read LookupType 4 ligature
substitution subtables (ISO 14496-22 §6.2) and exposes a small
left-to-right greedy applier, so the shaper can compose many-to-one
glyph substitutions such as Arabic lam-alef and Latin fi/fl/ffi.

LookupType 7 (Extension) unwrap is added at the same time because large
fonts routinely place their ligature lookups behind 32-bit extension
offsets, and without it those lookups are silently missed.

## Public API change

GSUBSubstitutions used to be a map keyed by feature tag. It is now a
struct with two fields, returned by pointer:

    type LigatureSubst struct {
        Components  []uint16 // GIDs after the first; first GID is the lookup key
        LigatureGID uint16
    }

    type GSUBSubstitutions struct {
        Single   map[GSUBFeature]map[uint16]uint16
        Ligature map[GSUBFeature]map[uint16][]LigatureSubst
    }

ParseGSUB and the GSUBProvider interface now return *GSUBSubstitutions.
Callers that previously wrote `gsub[feature]` now write
`gsub.Single[feature]`. Internal callers in font and layout have been
updated accordingly.

## Feature and script changes

- New feature tags parsed: liga, rlig, clig. init/medi/fina/isol
  continue to work.
- Script selection now includes latn alongside arab and the DFLT
  fallback, so Latin ligature features are picked up in the same pass.

## ApplyLigature

A new method on *GSUBSubstitutions scans a glyph run left-to-right and
replaces the longest matching ligature sequence with the ligature
glyph, per the OpenType greedy matching rule. It is not yet wired into
the Arabic shaping pipeline; that is a follow-up.

## Other parser fixes

Coverage Format 2 now respects startCoverageIndex instead of assuming
ranges are listed in order and contiguous, which is required for
correct positional indexing into LigatureSet offsets.

## Standard reference

ISO 14496-22 §6.2, OpenType GSUB table, LookupType 4 (Ligature
Substitution Subtable) and LookupType 7 (Extension Substitution).

## Test plan

- [x] go test ./font/... ./layout/... passes
- [x] go vet ./... clean
- [x] Full suite go test ./... passes
- [x] New unit tests in font/gsub_test.go:
  - ApplyLigature basic case
  - ApplyLigature greedy longest match
  - ApplyLigature non-match pass-through
  - ApplyLigature nil receiver and empty cases
  - End-to-end ParseGSUB of a synthetic LookupType 4 blob
  - End-to-end ParseGSUB with LookupType 7 extension wrapping
  - End-to-end ParseGSUB with Coverage Format 2
- [x] Pre-existing LookupType 1 tests still pass
- [x] font package coverage 84.8% of statements