### PR TITLE
Phase 2 audit follow-ups: composite glyph tests and Adobe CMYK JPEGs

### DIFF
--- a/font/subset.go
+++ b/font/subset.go
@@ -205,9 +205,14 @@ func resolveComposites(glyfData []byte, offsets []uint32, glyphSet map[uint16]bo
 			if numContours >= 0 {
 				continue // simple glyph
 			}
-			// Composite glyph — parse components.
+			// Composite glyph — parse components. Filter component GIDs
+			// that point past numGlyphs; a malformed composite referring
+			// to a non-existent glyph must not pollute the glyph set.
 			components := parseCompositeComponents(data)
 			for _, cid := range components {
+				if int(cid) >= numGlyphs {
+					continue
+				}
 				if !glyphSet[cid] {
 					glyphSet[cid] = true
 					added = true

--- a/font/subset_test.go
+++ b/font/subset_test.go
@@ -6,8 +6,10 @@ package font
 import (
 	"encoding/binary"
 	"os"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/carlos7ags/folio/core"
 )
@@ -268,5 +270,366 @@ func TestSubsetTag(t *testing.T) {
 	tag2 := subsetTag(glyphs)
 	if tag != tag2 {
 		t.Errorf("tag not deterministic: %q vs %q", tag, tag2)
+	}
+}
+
+// --- parseCompositeComponents ---
+//
+// These tests cover the composite-glyph record walker directly with
+// hand-built bytes, so we can exercise each flag combination in the
+// transform encoding and confirm the bounds checks terminate safely
+// on malformed input.
+//
+// Composite glyph layout (OpenType spec, glyf table):
+//
+//	int16 numberOfContours (negative for composite)
+//	int16 xMin, yMin, xMax, yMax
+//	repeat until MORE_COMPONENTS (0x0020) is clear:
+//	    uint16 flags
+//	    uint16 glyphIndex
+//	    int8/int16 argument1, argument2   (words if 0x0001 set)
+//	    optional transform:
+//	        WE_HAVE_A_SCALE          (0x0008): F2Dot14       (2 bytes)
+//	        WE_HAVE_AN_X_AND_Y_SCALE (0x0040): 2 × F2Dot14   (4 bytes)
+//	        WE_HAVE_A_TWO_BY_TWO     (0x0080): 4 × F2Dot14   (8 bytes)
+
+const (
+	compArgsAreWords = 0x0001
+	compMoreComps    = 0x0020
+	compScale        = 0x0008
+	compXYScale      = 0x0040
+	compTwoByTwo     = 0x0080
+)
+
+// compositeHeader is the 10-byte header shared by every composite glyph
+// record in the tests below.
+var compositeHeader = []byte{
+	0xFF, 0xFF, // numberOfContours = -1 (composite)
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // bbox (zeros)
+}
+
+func appendComponent(buf []byte, flags, gid uint16, argSize, transformSize int) []byte {
+	buf = binary.BigEndian.AppendUint16(buf, flags)
+	buf = binary.BigEndian.AppendUint16(buf, gid)
+	buf = append(buf, make([]byte, argSize)...)
+	buf = append(buf, make([]byte, transformSize)...)
+	return buf
+}
+
+func equalUint16(a, b []uint16) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestParseCompositeComponentsSingle(t *testing.T) {
+	data := slices.Clone(compositeHeader)
+	// Single component, no MORE_COMPONENTS, 1-byte args, no transform.
+	data = appendComponent(data, 0, 42, 2, 0)
+
+	got := parseCompositeComponents(data)
+	want := []uint16{42}
+	if !equalUint16(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseCompositeComponentsMultiple(t *testing.T) {
+	data := slices.Clone(compositeHeader)
+	data = appendComponent(data, compMoreComps, 7, 2, 0)
+	data = appendComponent(data, compMoreComps, 19, 2, 0)
+	data = appendComponent(data, 0, 123, 2, 0) // last, no MORE_COMPONENTS
+
+	got := parseCompositeComponents(data)
+	want := []uint16{7, 19, 123}
+	if !equalUint16(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseCompositeComponentsArgsAsWords(t *testing.T) {
+	data := slices.Clone(compositeHeader)
+	// ARG_1_AND_2_ARE_WORDS -> args take 4 bytes instead of 2.
+	data = appendComponent(data, compArgsAreWords, 55, 4, 0)
+
+	got := parseCompositeComponents(data)
+	if !equalUint16(got, []uint16{55}) {
+		t.Errorf("got %v, want [55]", got)
+	}
+}
+
+func TestParseCompositeComponentsTransformVariants(t *testing.T) {
+	cases := []struct {
+		name      string
+		flags     uint16
+		transform int
+	}{
+		{"scale", compScale, 2},
+		{"xy_scale", compXYScale, 4},
+		{"two_by_two", compTwoByTwo, 8},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Two components: first has the transform flag + MORE_COMPONENTS,
+			// second has no transform and no MORE_COMPONENTS. This also
+			// verifies that pos is advanced past the transform block.
+			data := slices.Clone(compositeHeader)
+			data = appendComponent(data, tc.flags|compMoreComps, 100, 2, tc.transform)
+			data = appendComponent(data, 0, 200, 2, 0)
+
+			got := parseCompositeComponents(data)
+			want := []uint16{100, 200}
+			if !equalUint16(got, want) {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestParseCompositeComponentsTruncatedHeader(t *testing.T) {
+	// Anything shorter than the 10-byte header must return nil.
+	for n := range 12 {
+		got := parseCompositeComponents(make([]byte, n))
+		if got != nil {
+			t.Errorf("len=%d: expected nil, got %v", n, got)
+		}
+	}
+}
+
+func TestParseCompositeComponentsTruncatedTransform(t *testing.T) {
+	// Declare WE_HAVE_A_TWO_BY_TWO (needs 8 transform bytes) but only
+	// provide 3. The walker must stop without reading out of bounds.
+	data := slices.Clone(compositeHeader)
+	data = appendComponent(data, compTwoByTwo, 42, 2, 3) // short matrix
+
+	got := parseCompositeComponents(data)
+	// The first component header was read successfully, so GID 42 is
+	// reported before the walker notices the truncated transform.
+	if !equalUint16(got, []uint16{42}) {
+		t.Errorf("got %v, want [42]", got)
+	}
+}
+
+func TestParseCompositeComponentsTruncatedRecord(t *testing.T) {
+	// Header + only 3 bytes of the next component record. The loop
+	// condition (pos+4 <= len) must reject the short record.
+	data := slices.Clone(compositeHeader)
+	data = append(data, 0x00, 0x20, 0x00) // partial flags+gid
+
+	got := parseCompositeComponents(data)
+	if got != nil {
+		t.Errorf("expected nil on truncated record, got %v", got)
+	}
+}
+
+// --- resolveComposites ---
+
+// buildGlyfEntries concatenates glyph records and returns the glyf bytes
+// and the loca offsets array (length numGlyphs+1).
+func buildGlyfEntries(records [][]byte) ([]byte, []uint32) {
+	var glyf []byte
+	offsets := make([]uint32, len(records)+1)
+	for i, rec := range records {
+		offsets[i] = uint32(len(glyf))
+		glyf = append(glyf, rec...)
+	}
+	offsets[len(records)] = uint32(len(glyf))
+	return glyf, offsets
+}
+
+func TestResolveCompositesTransitiveClosure(t *testing.T) {
+	// Glyph 0: simple (.notdef), dummy contents.
+	// Glyph 1: simple.
+	// Glyph 2: composite referencing glyph 3 (not yet in the set).
+	// Glyph 3: composite referencing glyph 1 (already in the set via closure).
+	simple := []byte{0x00, 0x01, 0, 0, 0, 0, 0, 0, 0, 0} // numContours=1
+	comp := func(gid uint16) []byte {
+		b := slices.Clone(compositeHeader)
+		return appendComponent(b, 0, gid, 2, 0)
+	}
+	glyf, offsets := buildGlyfEntries([][]byte{
+		simple,      // gid 0
+		simple,      // gid 1
+		comp(3),     // gid 2 -> 3
+		comp(1),     // gid 3 -> 1
+	})
+
+	glyphSet := map[uint16]bool{0: true, 2: true}
+	resolveComposites(glyf, offsets, glyphSet, 4)
+
+	for _, gid := range []uint16{0, 1, 2, 3} {
+		if !glyphSet[gid] {
+			t.Errorf("gid %d missing from set after closure", gid)
+		}
+	}
+}
+
+func TestResolveCompositesCycleTerminates(t *testing.T) {
+	// Glyph 0 simple; glyph 1 and glyph 2 reference each other.
+	// The fixed-point loop must terminate because the set stops growing.
+	simple := []byte{0x00, 0x01, 0, 0, 0, 0, 0, 0, 0, 0}
+	comp := func(gid uint16) []byte {
+		b := slices.Clone(compositeHeader)
+		return appendComponent(b, 0, gid, 2, 0)
+	}
+	glyf, offsets := buildGlyfEntries([][]byte{
+		simple,  // gid 0
+		comp(2), // gid 1 -> 2
+		comp(1), // gid 2 -> 1
+	})
+
+	glyphSet := map[uint16]bool{0: true, 1: true}
+	done := make(chan struct{})
+	go func() {
+		resolveComposites(glyf, offsets, glyphSet, 3)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("resolveComposites did not terminate on cyclic references")
+	}
+	if !glyphSet[2] {
+		t.Error("cyclic target gid 2 should have been added to set")
+	}
+}
+
+func TestParseCompositeComponentsCombinedFlags(t *testing.T) {
+	// A single component can carry multiple flags simultaneously:
+	// ARG_1_AND_2_ARE_WORDS (4-byte args) together with WE_HAVE_A_TWO_BY_TWO
+	// (8-byte matrix) produces the longest-possible component record. The
+	// walker must advance past both blocks before it reads the next
+	// component header.
+	data := slices.Clone(compositeHeader)
+	data = appendComponent(data, compArgsAreWords|compTwoByTwo|compMoreComps, 77, 4, 8)
+	data = appendComponent(data, compArgsAreWords, 88, 4, 0)
+
+	got := parseCompositeComponents(data)
+	want := []uint16{77, 88}
+	if !equalUint16(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseCompositeComponentsInstructionsFlagIgnored(t *testing.T) {
+	// WE_HAVE_INSTRUCTIONS (0x0100) means a uint16 instruction-length
+	// field and its payload follow the last component. parseCompositeComponents
+	// has no business walking past the last record, so any trailing
+	// instruction bytes must be ignored without affecting the result.
+	const weHaveInstructions uint16 = 0x0100
+	data := slices.Clone(compositeHeader)
+	data = appendComponent(data, weHaveInstructions, 33, 2, 0)
+	// Trailing bytes that a naive reader might interpret as another
+	// component header — they must not pollute the returned list.
+	data = append(data, 0x00, 0x03, 0xFF, 0xFF, 0xFF)
+
+	got := parseCompositeComponents(data)
+	if !equalUint16(got, []uint16{33}) {
+		t.Errorf("got %v, want [33]", got)
+	}
+}
+
+func TestResolveCompositesWithRealFont(t *testing.T) {
+	raw := loadTestFont(t)
+	face := loadTestFace(t)
+
+	tables, err := parseTTFTables(raw)
+	if err != nil {
+		t.Fatalf("parseTTFTables: %v", err)
+	}
+	maxpData := tables["maxp"]
+	numGlyphs := int(binary.BigEndian.Uint16(maxpData[4:6]))
+	headData := tables["head"]
+	locaFormat := int16(binary.BigEndian.Uint16(headData[50:52]))
+	offsets, err := parseLoca(tables["loca"], locaFormat, numGlyphs)
+	if err != nil {
+		t.Fatalf("parseLoca: %v", err)
+	}
+	glyfData := tables["glyf"]
+
+	// Accented Latin letters are usually stored as composite glyphs
+	// (base + accent). Scan candidates until we find one that is
+	// actually composite in the installed font; skip if none are.
+	candidates := []rune{'Á', 'É', 'Í', 'Ó', 'Ú', 'Ñ', 'Ö', 'Ü', 'Ç', 'Å'}
+	var compositeGID uint16
+	var compositeRune rune
+	for _, r := range candidates {
+		gid := face.GlyphIndex(r)
+		if gid == 0 || int(gid) >= numGlyphs {
+			continue
+		}
+		start := offsets[gid]
+		end := offsets[gid+1]
+		if start >= end || int(end) > len(glyfData) || end-start < 2 {
+			continue
+		}
+		numContours := int16(binary.BigEndian.Uint16(glyfData[start : start+2]))
+		if numContours < 0 {
+			compositeGID = gid
+			compositeRune = r
+			break
+		}
+	}
+	if compositeGID == 0 {
+		t.Skip("no composite glyphs among candidates in installed test font")
+	}
+
+	glyphSet := map[uint16]bool{0: true, compositeGID: true}
+	resolveComposites(glyfData, offsets, glyphSet, numGlyphs)
+
+	if len(glyphSet) < 3 {
+		t.Errorf("closure for %q (gid %d) produced %d glyphs, expected at least 3 (notdef + composite + >=1 component)",
+			compositeRune, compositeGID, len(glyphSet))
+	}
+	// Every glyph in the closed set must be a valid GID.
+	for gid := range glyphSet {
+		if int(gid) >= numGlyphs {
+			t.Errorf("closed set contains out-of-range gid %d (numGlyphs=%d)", gid, numGlyphs)
+		}
+	}
+	// Subsetting the font with just the accented rune must succeed and
+	// must preserve the composite glyph's data (non-zero-length glyf entry).
+	subset, err := Subset(raw, map[uint16]rune{0: 0, compositeGID: compositeRune})
+	if err != nil {
+		t.Fatalf("Subset: %v", err)
+	}
+	subTables, err := parseTTFTables(subset)
+	if err != nil {
+		t.Fatalf("parseTTFTables(subset): %v", err)
+	}
+	subOffsets, err := parseLoca(subTables["loca"],
+		int16(binary.BigEndian.Uint16(subTables["head"][50:52])),
+		numGlyphs)
+	if err != nil {
+		t.Fatalf("parseLoca(subset): %v", err)
+	}
+	if subOffsets[compositeGID] >= subOffsets[compositeGID+1] {
+		t.Errorf("composite glyph %d was zeroed out of the subset", compositeGID)
+	}
+}
+
+func TestResolveCompositesIgnoresOutOfRangeComponents(t *testing.T) {
+	// Glyph 1 references gid 999, which is past numGlyphs. The outer
+	// loop (resolveComposites) filters gids >= numGlyphs, so the call
+	// must return without adding bogus entries or panicking.
+	simple := []byte{0x00, 0x01, 0, 0, 0, 0, 0, 0, 0, 0}
+	b := slices.Clone(compositeHeader)
+	b = appendComponent(b, 0, 999, 2, 0)
+	glyf, offsets := buildGlyfEntries([][]byte{simple, b})
+
+	glyphSet := map[uint16]bool{0: true, 1: true}
+	resolveComposites(glyf, offsets, glyphSet, 2)
+
+	if _, ok := glyphSet[999]; ok {
+		t.Error("out-of-range component gid 999 should not be in set")
+	}
+	if len(glyphSet) != 2 {
+		t.Errorf("glyphSet size = %d, want 2", len(glyphSet))
 	}
 }

--- a/font/subset_test.go
+++ b/font/subset_test.go
@@ -454,10 +454,10 @@ func TestResolveCompositesTransitiveClosure(t *testing.T) {
 		return appendComponent(b, 0, gid, 2, 0)
 	}
 	glyf, offsets := buildGlyfEntries([][]byte{
-		simple,      // gid 0
-		simple,      // gid 1
-		comp(3),     // gid 2 -> 3
-		comp(1),     // gid 3 -> 1
+		simple,  // gid 0
+		simple,  // gid 1
+		comp(3), // gid 2 -> 3
+		comp(1), // gid 3 -> 1
 	})
 
 	glyphSet := map[uint16]bool{0: true, 2: true}

--- a/image/image.go
+++ b/image/image.go
@@ -20,6 +20,7 @@ type Image struct {
 	smask      []byte // soft mask (alpha channel) for PNG with transparency
 	smaskW     int    // smask width (same as image width for alpha)
 	smaskH     int    // smask height
+	adobeCMYK  bool   // Adobe-style inverted CMYK (APP14 marker, ncomp==4)
 }
 
 // Width returns the image width in pixels.
@@ -129,6 +130,18 @@ func (img *Image) BuildXObject(addObject func(core.PdfObject) *core.PdfIndirectR
 	stream.Dict.Set("Height", core.NewPdfInteger(img.height))
 	stream.Dict.Set("ColorSpace", core.NewPdfName(img.colorSpace))
 	stream.Dict.Set("BitsPerComponent", core.NewPdfInteger(img.bpc))
+
+	// Adobe-written CMYK JPEGs store components in inverted form relative
+	// to the PDF default DeviceCMYK decode range. Flip every channel via
+	// the Decode array so viewers render the intended colors.
+	if img.adobeCMYK {
+		stream.Dict.Set("Decode", core.NewPdfArray(
+			core.NewPdfInteger(1), core.NewPdfInteger(0),
+			core.NewPdfInteger(1), core.NewPdfInteger(0),
+			core.NewPdfInteger(1), core.NewPdfInteger(0),
+			core.NewPdfInteger(1), core.NewPdfInteger(0),
+		))
+	}
 
 	// Handle SMask (alpha channel).
 	var smaskRef *core.PdfIndirectReference

--- a/image/jpeg.go
+++ b/image/jpeg.go
@@ -10,10 +10,11 @@ import (
 
 // JPEG marker constants.
 const (
-	markerSOI  = 0xFFD8 // Start of Image
-	markerSOF0 = 0xFFC0 // Baseline DCT
-	markerSOF1 = 0xFFC1 // Extended sequential DCT
-	markerSOF2 = 0xFFC2 // Progressive DCT
+	markerSOI   = 0xFFD8 // Start of Image
+	markerSOF0  = 0xFFC0 // Baseline DCT
+	markerSOF1  = 0xFFC1 // Extended sequential DCT
+	markerSOF2  = 0xFFC2 // Progressive DCT
+	markerAPP14 = 0xFFEE // Application segment 14 (Adobe)
 )
 
 // maxJPEGSegments bounds the number of segments [parseJPEGHeader] is
@@ -25,8 +26,14 @@ const maxJPEGSegments = 10000
 // NewJPEG creates an Image from raw JPEG data. It parses the JPEG header
 // to extract dimensions and color space, rejecting dimensions that exceed
 // the package limits ([MaxDimension], [MaxPixels]).
+//
+// When the JPEG is 4-component CMYK with an Adobe APP14 marker, the image
+// is flagged for inverted-CMYK decoding: Photoshop-exported CMYK JPEGs
+// store values in a convention opposite to what PDF viewers expect, so the
+// resulting XObject is emitted with a /Decode array that flips every
+// channel. This matches the behavior of poppler, mupdf, and Chrome.
 func NewJPEG(data []byte) (*Image, error) {
-	w, h, ncomp, err := parseJPEGHeader(data)
+	w, h, ncomp, hasAdobe, err := parseJPEGHeader(data)
 	if err != nil {
 		return nil, fmt.Errorf("jpeg: %w", err)
 	}
@@ -53,6 +60,7 @@ func NewJPEG(data []byte) (*Image, error) {
 		colorSpace: cs,
 		bpc:        8,
 		filter:     "DCTDecode",
+		adobeCMYK:  ncomp == 4 && hasAdobe,
 	}, nil
 }
 
@@ -67,24 +75,30 @@ func LoadJPEG(path string) (*Image, error) {
 	return NewJPEG(data)
 }
 
-// parseJPEGHeader reads the JPEG header to find dimensions and component
-// count. It scans for SOF0, SOF1, or SOF2 markers and bounds the number
-// of segments walked via [maxJPEGSegments] to guard against crafted files
-// that would otherwise loop slowly through pathological segment sequences.
-func parseJPEGHeader(data []byte) (width, height, numComponents int, err error) {
+// parseJPEGHeader reads the JPEG header to find dimensions, component
+// count, and whether an Adobe APP14 marker is present. It scans for SOF0,
+// SOF1, or SOF2 markers and bounds the number of segments walked via
+// [maxJPEGSegments] to guard against crafted files that would otherwise
+// loop slowly through pathological segment sequences.
+//
+// hasAdobe is true when the stream contains an APP14 segment (marker
+// 0xFFEE) whose payload starts with the "Adobe" identifier. Photoshop
+// always emits this marker when writing CMYK, so callers use it to detect
+// the inverted-CMYK convention and emit a PDF /Decode array accordingly.
+func parseJPEGHeader(data []byte) (width, height, numComponents int, hasAdobe bool, err error) {
 	if len(data) < 2 || binary.BigEndian.Uint16(data[0:2]) != markerSOI {
-		return 0, 0, 0, fmt.Errorf("not a JPEG file")
+		return 0, 0, 0, false, fmt.Errorf("not a JPEG file")
 	}
 
 	pos := 2
 	for segments := 0; pos < len(data)-1; segments++ {
 		if segments > maxJPEGSegments {
-			return 0, 0, 0, fmt.Errorf("too many segments (>%d)", maxJPEGSegments)
+			return 0, 0, 0, false, fmt.Errorf("too many segments (>%d)", maxJPEGSegments)
 		}
 
 		// Find marker (0xFF followed by non-zero byte).
 		if data[pos] != 0xFF {
-			return 0, 0, 0, fmt.Errorf("expected marker at offset %d", pos)
+			return 0, 0, 0, false, fmt.Errorf("expected marker at offset %d", pos)
 		}
 
 		// Skip padding 0xFF bytes.
@@ -103,12 +117,12 @@ func parseJPEGHeader(data []byte) (width, height, numComponents int, err error) 
 			// SOF layout: length(2) + precision(1) + height(2) + width(2) + ncomp(1)
 			// The ncomp byte lives at data[pos+7], so we need pos+8 ≤ len(data).
 			if pos+8 > len(data) {
-				return 0, 0, 0, fmt.Errorf("truncated SOF segment")
+				return 0, 0, 0, false, fmt.Errorf("truncated SOF segment")
 			}
 			height = int(binary.BigEndian.Uint16(data[pos+3 : pos+5]))
 			width = int(binary.BigEndian.Uint16(data[pos+5 : pos+7]))
 			numComponents = int(data[pos+7])
-			return width, height, numComponents, nil
+			return width, height, numComponents, hasAdobe, nil
 		}
 
 		// Skip non-SOF segments.
@@ -123,10 +137,22 @@ func parseJPEGHeader(data []byte) (width, height, numComponents int, err error) 
 		}
 		segLen := int(binary.BigEndian.Uint16(data[pos : pos+2]))
 		if segLen < 2 {
-			return 0, 0, 0, fmt.Errorf("invalid segment length %d at offset %d", segLen, pos)
+			return 0, 0, 0, false, fmt.Errorf("invalid segment length %d at offset %d", segLen, pos)
 		}
+
+		// APP14 Adobe marker: 2-byte length, then "Adobe" + 7-byte body.
+		// Only the identifier string is required to flag the file; the
+		// DCTEncodeVersion / flags / ColorTransform fields aren't used by
+		// the inversion heuristic.
+		if marker == markerAPP14 && segLen >= 7 && pos+segLen <= len(data) {
+			payload := data[pos+2 : pos+segLen]
+			if len(payload) >= 5 && string(payload[0:5]) == "Adobe" {
+				hasAdobe = true
+			}
+		}
+
 		pos += segLen
 	}
 
-	return 0, 0, 0, fmt.Errorf("no SOF marker found")
+	return 0, 0, 0, false, fmt.Errorf("no SOF marker found")
 }

--- a/image/jpeg_test.go
+++ b/image/jpeg_test.go
@@ -10,6 +10,7 @@ import (
 	"image/jpeg"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/carlos7ags/folio/core"
@@ -232,5 +233,278 @@ func TestNewJPEGCMYK(t *testing.T) {
 	}
 	if img.Width() != 1 || img.Height() != 1 {
 		t.Errorf("expected 1x1, got %dx%d", img.Width(), img.Height())
+	}
+	// No APP14 marker => no Adobe-inverted-CMYK flag.
+	if img.adobeCMYK {
+		t.Error("CMYK without APP14 should not set adobeCMYK")
+	}
+}
+
+// app14AdobeSegment returns a complete APP14 Adobe marker segment with
+// the given ColorTransform byte. The segment is 16 bytes total: marker
+// (2) + length (2) + "Adobe" (5) + DCTEncodeVersion (2) + Flags0 (2) +
+// Flags1 (2) + ColorTransform (1).
+func app14AdobeSegment(colorTransform byte) []byte {
+	return []byte{
+		0xFF, 0xEE, // APP14 marker
+		0x00, 0x0E, // segment length = 14 (includes length field)
+		'A', 'd', 'o', 'b', 'e',
+		0x00, 0x64, // DCTEncodeVersion = 100
+		0x80, 0x00, // APP14Flags0 = 0x8000
+		0x00, 0x00, // APP14Flags1
+		colorTransform,
+	}
+}
+
+// cmykSOF0 returns a minimal 1x1 CMYK SOF0 segment (SOF marker through
+// the four component records).
+func cmykSOF0() []byte {
+	return []byte{
+		0xFF, 0xC0, // SOF0
+		0x00, 0x11, // length = 17
+		0x08,       // precision
+		0x00, 0x01, // height
+		0x00, 0x01, // width
+		0x04, // ncomp = 4
+		0x01, 0x11, 0x00,
+		0x02, 0x11, 0x00,
+		0x03, 0x11, 0x00,
+		0x04, 0x11, 0x00,
+	}
+}
+
+func TestNewJPEGAdobeCMYK(t *testing.T) {
+	// SOI + APP14 (Adobe) + CMYK SOF0. The APP14 marker flips the
+	// adobeCMYK flag on the resulting Image.
+	data := []byte{0xFF, 0xD8} // SOI
+	data = append(data, app14AdobeSegment(0)...)
+	data = append(data, cmykSOF0()...)
+
+	img, err := NewJPEG(data)
+	if err != nil {
+		t.Fatalf("NewJPEG: %v", err)
+	}
+	if img.colorSpace != "DeviceCMYK" {
+		t.Errorf("expected DeviceCMYK, got %s", img.colorSpace)
+	}
+	if !img.adobeCMYK {
+		t.Error("APP14 + 4 components should set adobeCMYK")
+	}
+}
+
+func TestNewJPEGAdobeRGBNotFlagged(t *testing.T) {
+	// APP14 marker on a 3-component (RGB/YCbCr) JPEG must NOT flip the
+	// adobeCMYK flag — the inversion hack only applies to 4-component
+	// streams.
+	rgbSOF := []byte{
+		0xFF, 0xC0, // SOF0
+		0x00, 0x11, // length = 17 (header + 3*3 + pad)
+		0x08,
+		0x00, 0x01,
+		0x00, 0x01,
+		0x03, // ncomp = 3
+		0x01, 0x11, 0x00,
+		0x02, 0x11, 0x01,
+		0x03, 0x11, 0x01,
+		0x00, 0x00, // padding to match length (length includes itself)
+	}
+	data := []byte{0xFF, 0xD8}
+	data = append(data, app14AdobeSegment(1)...)
+	data = append(data, rgbSOF...)
+
+	img, err := NewJPEG(data)
+	if err != nil {
+		t.Fatalf("NewJPEG: %v", err)
+	}
+	if img.adobeCMYK {
+		t.Error("3-component JPEG with APP14 should not set adobeCMYK")
+	}
+}
+
+func TestJPEGBuildXObjectAdobeCMYKEmitsDecode(t *testing.T) {
+	data := []byte{0xFF, 0xD8}
+	data = append(data, app14AdobeSegment(0)...)
+	data = append(data, cmykSOF0()...)
+
+	img, err := NewJPEG(data)
+	if err != nil {
+		t.Fatalf("NewJPEG: %v", err)
+	}
+
+	var captured core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		captured = obj
+		return core.NewPdfIndirectReference(1, 0)
+	}
+	img.BuildXObject(addObject)
+
+	stream, ok := captured.(*core.PdfStream)
+	if !ok {
+		t.Fatalf("expected PdfStream, got %T", captured)
+	}
+	decode := stream.Dict.Get("Decode")
+	if decode == nil {
+		t.Fatal("expected Decode entry for Adobe CMYK JPEG")
+	}
+	arr, ok := decode.(*core.PdfArray)
+	if !ok {
+		t.Fatalf("Decode should be a PdfArray, got %T", decode)
+	}
+	// Decode array for inverted CMYK: [1 0 1 0 1 0 1 0] — eight integers.
+	if arr.Len() != 8 {
+		t.Fatalf("Decode array length = %d, want 8", arr.Len())
+	}
+	want := []int{1, 0, 1, 0, 1, 0, 1, 0}
+	for i, w := range want {
+		n, ok := arr.At(i).(*core.PdfNumber)
+		if !ok {
+			t.Errorf("Decode[%d] not a PdfNumber: %T", i, arr.At(i))
+			continue
+		}
+		if n.IntValue() != w {
+			t.Errorf("Decode[%d] = %d, want %d", i, n.IntValue(), w)
+		}
+	}
+}
+
+func TestJPEGBuildXObjectPlainRGBNoDecode(t *testing.T) {
+	data := createTestJPEG(t, 4, 4)
+	img, err := NewJPEG(data)
+	if err != nil {
+		t.Fatalf("NewJPEG: %v", err)
+	}
+
+	var captured core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		captured = obj
+		return core.NewPdfIndirectReference(1, 0)
+	}
+	img.BuildXObject(addObject)
+
+	stream, ok := captured.(*core.PdfStream)
+	if !ok {
+		t.Fatalf("expected PdfStream, got %T", captured)
+	}
+	if stream.Dict.Get("Decode") != nil {
+		t.Error("plain RGB JPEG must not emit a Decode array")
+	}
+}
+
+// TestNewJPEGAdobeCMYKWithIntermediateSegments covers the realistic
+// marker order used by Photoshop: SOI, APP14, DQT, SOF0. The parser must
+// remember the APP14 observation across intermediate segments and still
+// return the correct dimensions from the later SOF.
+func TestNewJPEGAdobeCMYKWithIntermediateSegments(t *testing.T) {
+	// DQT (0xFFDB) with a 65-byte quantization table (length 67 incl. length).
+	dqt := []byte{0xFF, 0xDB, 0x00, 0x43, 0x00}
+	dqt = append(dqt, make([]byte, 64)...)
+
+	data := []byte{0xFF, 0xD8}
+	data = append(data, app14AdobeSegment(2)...) // ColorTransform = YCCK
+	data = append(data, dqt...)
+	data = append(data, cmykSOF0()...)
+
+	img, err := NewJPEG(data)
+	if err != nil {
+		t.Fatalf("NewJPEG: %v", err)
+	}
+	if !img.adobeCMYK {
+		t.Error("APP14 before DQT+SOF must still set adobeCMYK")
+	}
+	if img.Width() != 1 || img.Height() != 1 {
+		t.Errorf("dimensions lost: got %dx%d, want 1x1", img.Width(), img.Height())
+	}
+	if img.colorSpace != "DeviceCMYK" {
+		t.Errorf("got %s, want DeviceCMYK", img.colorSpace)
+	}
+}
+
+// TestNewJPEGBogusAPP14NotFlagged verifies that APP markers at 0xFFEE
+// whose payload does not start with "Adobe" are ignored. Some encoders
+// use APP14 for their own purposes and we must not mis-flag those.
+func TestNewJPEGBogusAPP14NotFlagged(t *testing.T) {
+	// APP14 length 14, but identifier is "Appli" instead of "Adobe".
+	bogus := []byte{
+		0xFF, 0xEE,
+		0x00, 0x0E,
+		'A', 'p', 'p', 'l', 'i',
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+	data := []byte{0xFF, 0xD8}
+	data = append(data, bogus...)
+	data = append(data, cmykSOF0()...)
+
+	img, err := NewJPEG(data)
+	if err != nil {
+		t.Fatalf("NewJPEG: %v", err)
+	}
+	if img.adobeCMYK {
+		t.Error("APP14 with non-Adobe identifier must not set adobeCMYK")
+	}
+}
+
+// TestNewJPEGTruncatedAPP14NotFlagged covers a short APP14 segment
+// whose payload can't hold the full "Adobe" identifier. Parsing must
+// continue to SOF without panicking and without setting the flag.
+func TestNewJPEGTruncatedAPP14NotFlagged(t *testing.T) {
+	// APP14 with length 5: identifier field is only 3 bytes.
+	trunc := []byte{
+		0xFF, 0xEE,
+		0x00, 0x05,
+		'A', 'd', 'o',
+	}
+	data := []byte{0xFF, 0xD8}
+	data = append(data, trunc...)
+	data = append(data, cmykSOF0()...)
+
+	img, err := NewJPEG(data)
+	if err != nil {
+		t.Fatalf("NewJPEG: %v", err)
+	}
+	if img.adobeCMYK {
+		t.Error("truncated APP14 must not set adobeCMYK")
+	}
+}
+
+// TestJPEGBuildXObjectAdobeCMYKSerialization confirms that the Decode
+// array survives round-trip through PdfStream serialization — i.e. the
+// bytes emitted to a PDF reader actually contain the /Decode entry.
+func TestJPEGBuildXObjectAdobeCMYKSerialization(t *testing.T) {
+	data := []byte{0xFF, 0xD8}
+	data = append(data, app14AdobeSegment(0)...)
+	data = append(data, cmykSOF0()...)
+
+	img, err := NewJPEG(data)
+	if err != nil {
+		t.Fatalf("NewJPEG: %v", err)
+	}
+
+	var captured *core.PdfStream
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		if s, ok := obj.(*core.PdfStream); ok {
+			captured = s
+		}
+		return core.NewPdfIndirectReference(1, 0)
+	}
+	img.BuildXObject(addObject)
+	if captured == nil {
+		t.Fatal("no stream captured")
+	}
+
+	var buf bytes.Buffer
+	if _, err := captured.WriteTo(&buf); err != nil {
+		t.Fatalf("stream.WriteTo: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "/Decode") {
+		t.Errorf("serialized stream missing /Decode entry:\n%s", out)
+	}
+	if !strings.Contains(out, "[1 0 1 0 1 0 1 0]") {
+		t.Errorf("serialized stream missing expected Decode array:\n%s", out)
+	}
+	// The raw JPEG bytes (including the APP14 marker) must pass through
+	// unchanged — we do not re-encode, only flag.
+	if !bytes.Contains(buf.Bytes(), []byte("Adobe")) {
+		t.Error("serialized stream should contain the original APP14 Adobe payload")
 	}
 }

--- a/image/limits_test.go
+++ b/image/limits_test.go
@@ -245,7 +245,7 @@ func TestParseJPEGHeaderTruncatedSOF(t *testing.T) {
 		0x00, 0x01, 0x00, 0x01, // height=1, width=1 — but no ncomp byte
 	}
 	// Must not panic.
-	_, _, _, err := parseJPEGHeader(data)
+	_, _, _, _, err := parseJPEGHeader(data)
 	if err == nil {
 		t.Error("expected error for truncated SOF segment, got nil")
 	}
@@ -263,7 +263,7 @@ func TestParseJPEGHeaderSegmentCap(t *testing.T) {
 	for range maxJPEGSegments + 10 {
 		buf.Write(app0)
 	}
-	_, _, _, err := parseJPEGHeader(buf.Bytes())
+	_, _, _, _, err := parseJPEGHeader(buf.Bytes())
 	if err == nil || !strings.Contains(err.Error(), "too many segments") {
 		t.Errorf("expected 'too many segments' error, got %v", err)
 	}


### PR DESCRIPTION
## Summary

Two small, self-contained gaps found during a phase 2 audit pass over `font` and `image`:

- **font:** direct unit tests for `parseCompositeComponents` / `resolveComposites` (previously 0% direct coverage), plus a one-line robustness fix where the composite-closure walker accepted out-of-range component GIDs into the glyph set.
- **image:** Adobe APP14 marker detection on CMYK JPEGs. Photoshop-exported CMYK JPEGs store component values inverted relative to PDF's DeviceCMYK default decode range; readers without a `/Decode` array render the colors inverted. Matches the handling used by poppler, mupdf, and Chrome.

## Font changes

`parseCompositeComponents` is on the hot path for every subsetted font that contains accented letters, but it had no direct tests. The composite-closure walker in `resolveComposites` also happily added component GIDs past `numGlyphs` to the working set; the outer iterator later skipped them (`int(gid) >= numGlyphs`) so no crash occurred, but the set accumulated garbage from malformed composites. One-line fix in the inner loop, new test locks the contract.

New tests cover:

- single, multiple (`MORE_COMPONENTS`), and `ARG_1_AND_2_ARE_WORDS` records
- `WE_HAVE_A_SCALE` / `WE_HAVE_AN_X_AND_Y_SCALE` / `WE_HAVE_A_TWO_BY_TWO` transform skips, each verified through a trailing second component so mis-advancement is caught
- combined-flags record that exercises the longest-possible path
- `WE_HAVE_INSTRUCTIONS` trailing bytes ignored safely
- truncated header / transform / record bounds safety
- `resolveComposites` transitive closure, cycle termination, out-of-range component filtering
- integration test that finds a real composite glyph in the installed test font and verifies `Subset` preserves it

## Image changes

- `parseJPEGHeader` now returns an additional `hasAdobe bool`. The existing segment walk already sees every marker once, so checking for the `"Adobe"` identifier inside `0xFFEE` adds no extra scans.
- `Image` carries an `adobeCMYK` flag set when `ncomp == 4` and an Adobe APP14 marker was present. 3-component JPEGs with APP14 (RGB / YCbCr) are intentionally not flagged.
- `BuildXObject` emits `/Decode [1 0 1 0 1 0 1 0]` when `adobeCMYK` is set. The original JPEG bytes still pass through DCTDecode unchanged; the inversion is purely a PDF dictionary hint.

New tests cover:

- synthetic APP14 Adobe + SOF0 CMYK (flag set)
- APP14 on 3-component JPEG (flag not set)
- realistic marker order with a DQT segment between APP14 and SOF0
- bogus APP14 identifier (`"Appli"`) ignored
- truncated APP14 ignored without panic or flag
- element-by-element assertion on the `/Decode` array in the XObject
- plain RGB JPEG negative case (no `/Decode` emitted)
- full `PdfStream.WriteTo` round-trip verifying `/Decode [1 0 1 0 1 0 1 0]` appears in the serialized bytes alongside the untouched Adobe APP14 payload

## API change

`parseJPEGHeader` signature changed from 4 return values to 5 (added `hasAdobe bool`). It is unexported; only `NewJPEG` and the two `limits_test.go` call sites needed updates. No external surface changes.

## Quality gates

- `go test ./...` all pass
- `go vet ./image/... ./font/...` clean
- `golangci-lint run ./image/... ./font/...` 0 issues
- font coverage 84.6% -> 88.3%
- image coverage 92.4% -> 92.5%

## Test plan

- [x] `go test ./font/... -run 'Composite|Subset'`
- [x] `go test ./image/... -run 'JPEG|Adobe|APP14'`
- [x] `go test ./...`
- [x] `go vet ./image/... ./font/...`
- [x] `golangci-lint run ./image/... ./font/...`