### PR TITLE
Parse and apply GSUB LookupType 6 chaining contextual substitution

### DIFF
--- a/font/gsub.go
+++ b/font/gsub.go
@@ -18,6 +18,7 @@ const (
 	GSUBLiga GSUBFeature = "liga" // standard ligatures
 	GSUBRlig GSUBFeature = "rlig" // required ligatures
 	GSUBClig GSUBFeature = "clig" // contextual ligatures
+	GSUBCalt GSUBFeature = "calt" // contextual alternates
 )
 
 // LigatureSubst describes a single ligature substitution: a sequence of
@@ -26,6 +27,30 @@ const (
 type LigatureSubst struct {
 	Components  []uint16 // component GIDs after the first (may be empty)
 	LigatureGID uint16
+}
+
+// ChainSubstAction is one SubstLookupRecord entry inside a chaining
+// contextual substitution rule: at a given position within the matched
+// input sequence, invoke another GSUB lookup.
+type ChainSubstAction struct {
+	SequenceIndex   uint16 // zero-based position in the input sequence
+	LookupListIndex uint16 // index into the GSUB LookupList
+}
+
+// ChainContextSubst is the unified runtime representation of an OpenType
+// LookupType 6 rule. All three subtable formats (simple/class/coverage)
+// are decompressed at parse time into this shape: each element of the
+// Backtrack, Input, and Lookahead slices is a set of acceptable GIDs at
+// that position. The Backtrack slice is stored in reverse order so that
+// Backtrack[0] is the glyph immediately preceding Input[0]. Input[0] is
+// the trigger glyph: the outer apply loop uses it as the dispatch key.
+//
+// Reference: ISO 14496-22 §6.2 LookupType 6.
+type ChainContextSubst struct {
+	Backtrack [][]uint16
+	Input     [][]uint16
+	Lookahead [][]uint16
+	Actions   []ChainSubstAction
 }
 
 // GSUBSubstitutions holds parsed GSUB lookups grouped by feature tag.
@@ -37,9 +62,22 @@ type LigatureSubst struct {
 // the first component glyph ID to a slice of candidate ligatures sharing
 // that prefix. Slices are ordered so that longest matches appear first,
 // which matches the OpenType greedy matching rule.
+//
+// ChainContext holds LookupType 6 chaining contextual substitutions: a
+// per-feature map keyed by the trigger glyph (Input[0]) to the set of
+// rules that may fire when that glyph is seen.
 type GSUBSubstitutions struct {
-	Single   map[GSUBFeature]map[uint16]uint16
-	Ligature map[GSUBFeature]map[uint16][]LigatureSubst
+	Single       map[GSUBFeature]map[uint16]uint16
+	Ligature     map[GSUBFeature]map[uint16][]LigatureSubst
+	ChainContext map[GSUBFeature]map[uint16][]ChainContextSubst
+
+	// lookupTable is indexed by GSUB LookupList slot and holds just the
+	// flattened Single-Substitution map for that lookup. It is populated
+	// for every lookup in the LookupList (not only feature-reachable
+	// ones) so that ChainContext actions can dispatch to any lookup slot
+	// referenced by a SubstLookupRecord. Nil entries mean "lookup slot
+	// has no Single-Substitution subtable we understand".
+	lookupTable []map[uint16]uint16
 }
 
 // ParseGSUB reads the GSUB table from raw TrueType/OpenType font bytes
@@ -84,20 +122,30 @@ func ParseGSUB(data []byte) *GSUBSubstitutions {
 		"liga": GSUBLiga,
 		"rlig": GSUBRlig,
 		"clig": GSUBClig,
+		"calt": GSUBCalt,
 	}
 	featureToLookups := matchFeatures(gsub, featureListOff, featureIndices, targetTags)
 	if len(featureToLookups) == 0 {
 		return nil
 	}
 
+	// Pre-scan the full LookupList once to build the internal per-slot
+	// Single-Substitution table used by ChainContext action dispatch.
+	// This table is sparse: a slot is left nil unless it carries a
+	// LookupType 1 (optionally wrapped in LookupType 7) subtable.
+	lookupTable := buildLookupSingleTable(gsub, lookupListOff)
+
 	result := &GSUBSubstitutions{
-		Single:   make(map[GSUBFeature]map[uint16]uint16),
-		Ligature: make(map[GSUBFeature]map[uint16][]LigatureSubst),
+		Single:       make(map[GSUBFeature]map[uint16]uint16),
+		Ligature:     make(map[GSUBFeature]map[uint16][]LigatureSubst),
+		ChainContext: make(map[GSUBFeature]map[uint16][]ChainContextSubst),
+		lookupTable:  lookupTable,
 	}
 	for feat, lookupIndices := range featureToLookups {
 		single := make(map[uint16]uint16)
 		lig := make(map[uint16][]LigatureSubst)
-		parseLookups(gsub, lookupListOff, lookupIndices, single, lig)
+		chain := make(map[uint16][]ChainContextSubst)
+		parseLookups(gsub, lookupListOff, lookupIndices, single, lig, chain)
 		if len(single) > 0 {
 			result.Single[feat] = single
 		}
@@ -110,8 +158,11 @@ func ParseGSUB(data []byte) *GSUBSubstitutions {
 			}
 			result.Ligature[feat] = lig
 		}
+		if len(chain) > 0 {
+			result.ChainContext[feat] = chain
+		}
 	}
-	if len(result.Single) == 0 && len(result.Ligature) == 0 {
+	if len(result.Single) == 0 && len(result.Ligature) == 0 && len(result.ChainContext) == 0 {
 		return nil
 	}
 	return result
@@ -324,7 +375,7 @@ func matchFeatures(gsub []byte, off int, allowed []int, targetTags map[string]GS
 // to the appropriate LookupType parser. Extension lookups (type 7) are
 // unwrapped; nested extensions are not expected by the spec and are
 // ignored if encountered.
-func parseLookups(gsub []byte, listOff int, indices []int, single map[uint16]uint16, lig map[uint16][]LigatureSubst) {
+func parseLookups(gsub []byte, listOff int, indices []int, single map[uint16]uint16, lig map[uint16][]LigatureSubst, chain map[uint16][]ChainContextSubst) {
 	if listOff+2 > len(gsub) {
 		return
 	}
@@ -334,13 +385,13 @@ func parseLookups(gsub []byte, listOff int, indices []int, single map[uint16]uin
 			continue
 		}
 		lookupOff := listOff + int(be16(gsub, listOff+2+idx*2))
-		parseLookup(gsub, lookupOff, single, lig)
+		parseLookup(gsub, lookupOff, single, lig, chain)
 	}
 }
 
 // parseLookup reads a single Lookup table, following each subtable offset
 // and calling the appropriate subtable parser for supported lookup types.
-func parseLookup(gsub []byte, lookupOff int, single map[uint16]uint16, lig map[uint16][]LigatureSubst) {
+func parseLookup(gsub []byte, lookupOff int, single map[uint16]uint16, lig map[uint16][]LigatureSubst, chain map[uint16][]ChainContextSubst) {
 	if lookupOff+6 > len(gsub) {
 		return
 	}
@@ -356,6 +407,8 @@ func parseLookup(gsub []byte, lookupOff int, single map[uint16]uint16, lig map[u
 			parseSingleSubst(gsub, subOff, single)
 		case 4:
 			parseLigatureSubst(gsub, subOff, lig)
+		case 6:
+			parseChainContextSubst(gsub, subOff, chain)
 		case 7:
 			// Extension table: format(2), extensionLookupType(2),
 			// extensionOffset(4, relative to the extension subtable start).
@@ -372,9 +425,69 @@ func parseLookup(gsub []byte, lookupOff int, single map[uint16]uint16, lig map[u
 				parseSingleSubst(gsub, extOff, single)
 			case 4:
 				parseLigatureSubst(gsub, extOff, lig)
+			case 6:
+				parseChainContextSubst(gsub, extOff, chain)
 			}
 		}
 	}
+}
+
+// buildLookupSingleTable walks every lookup in the GSUB LookupList and,
+// for each slot that carries a LookupType 1 subtable (directly or wrapped
+// in LookupType 7), records its flattened GID->GID map. The returned
+// slice is indexed by lookupListIndex. Slots carrying only other lookup
+// types receive a nil entry. This table is the dispatch target for
+// ChainContext actions.
+func buildLookupSingleTable(gsub []byte, listOff int) []map[uint16]uint16 {
+	if listOff+2 > len(gsub) {
+		return nil
+	}
+	count := int(be16(gsub, listOff))
+	if listOff+2+count*2 > len(gsub) {
+		return nil
+	}
+	out := make([]map[uint16]uint16, count)
+	for i := 0; i < count; i++ {
+		lookupOff := listOff + int(be16(gsub, listOff+2+i*2))
+		if lookupOff+6 > len(gsub) {
+			continue
+		}
+		lookupType := be16(gsub, lookupOff)
+		subCount := int(be16(gsub, lookupOff+4))
+		if lookupOff+6+subCount*2 > len(gsub) {
+			continue
+		}
+		var single map[uint16]uint16
+		for si := 0; si < subCount; si++ {
+			subOff := lookupOff + int(be16(gsub, lookupOff+6+si*2))
+			switch lookupType {
+			case 1:
+				if single == nil {
+					single = make(map[uint16]uint16)
+				}
+				parseSingleSubst(gsub, subOff, single)
+			case 7:
+				if subOff+8 > len(gsub) {
+					continue
+				}
+				extType := be16(gsub, subOff+2)
+				extOff := subOff + int(be32(gsub, subOff+4))
+				if extOff >= len(gsub) {
+					continue
+				}
+				if extType == 1 {
+					if single == nil {
+						single = make(map[uint16]uint16)
+					}
+					parseSingleSubst(gsub, extOff, single)
+				}
+			}
+		}
+		if len(single) > 0 {
+			out[i] = single
+		}
+	}
+	return out
 }
 
 // parseSingleSubst reads a SingleSubstitution subtable (format 1 or 2)
@@ -546,6 +659,613 @@ func parseCoverage(gsub []byte, off int) []uint16 {
 		return result
 	}
 	return nil
+}
+
+// parseClassDef reads an OpenType ClassDef table (format 1 or 2) and
+// returns a map from glyph ID to class number. Glyphs not present in
+// the table map to class 0 per ISO 14496-22 §3. Returns nil on malformed
+// input. Callers should treat a missing entry the same as class 0.
+func parseClassDef(data []byte, off int) map[uint16]uint16 {
+	if off+2 > len(data) {
+		return nil
+	}
+	format := be16(data, off)
+	out := make(map[uint16]uint16)
+	switch format {
+	case 1:
+		if off+6 > len(data) {
+			return nil
+		}
+		startGID := be16(data, off+2)
+		count := int(be16(data, off+4))
+		if off+6+count*2 > len(data) {
+			return nil
+		}
+		for i := 0; i < count; i++ {
+			cls := be16(data, off+6+i*2)
+			if cls != 0 {
+				out[startGID+uint16(i)] = cls
+			}
+		}
+	case 2:
+		if off+4 > len(data) {
+			return nil
+		}
+		rangeCount := int(be16(data, off+2))
+		if off+4+rangeCount*6 > len(data) {
+			return nil
+		}
+		for i := 0; i < rangeCount; i++ {
+			rec := off + 4 + i*6
+			startGID := be16(data, rec)
+			endGID := be16(data, rec+2)
+			cls := be16(data, rec+4)
+			if cls == 0 {
+				continue
+			}
+			for gid := int(startGID); gid <= int(endGID); gid++ {
+				out[uint16(gid)] = cls
+			}
+		}
+	default:
+		return nil
+	}
+	return out
+}
+
+// classMembers inverts a class map: for the given class number it
+// returns every GID mapped to that class. For class 0 it returns nil,
+// since class 0 is "everything not otherwise listed" and enumerating it
+// would require the full glyph space; ChainContext parsing treats
+// class-0 positions specially (see parseChainContextFormat2).
+func classMembers(classMap map[uint16]uint16, class uint16) []uint16 {
+	if class == 0 || len(classMap) == 0 {
+		return nil
+	}
+	var out []uint16
+	for gid, cls := range classMap {
+		if cls == class {
+			out = append(out, gid)
+		}
+	}
+	return out
+}
+
+// parseChainContextSubst dispatches a ChainContextSubst subtable by
+// format. All three formats compile into the uniform ChainContextSubst
+// runtime representation keyed by the trigger GID (Input[0]).
+func parseChainContextSubst(gsub []byte, off int, chain map[uint16][]ChainContextSubst) {
+	if off+2 > len(gsub) {
+		return
+	}
+	format := be16(gsub, off)
+	switch format {
+	case 1:
+		parseChainContextFormat1(gsub, off, chain)
+	case 2:
+		parseChainContextFormat2(gsub, off, chain)
+	case 3:
+		parseChainContextFormat3(gsub, off, chain)
+	}
+}
+
+// parseChainContextFormat1 handles ChainContextSubstFormat1:
+//
+//	format(2) = 1
+//	coverageOff(2)
+//	chainSubRuleSetCount(2)
+//	chainSubRuleSetOffsets[chainSubRuleSetCount] (2 each, relative to subtable)
+//
+// Each ChainSubRuleSet is parallel to Coverage: set[i] applies to
+// coverage[i]. Each set holds ChainSubRules with explicit GID sequences.
+func parseChainContextFormat1(gsub []byte, off int, chain map[uint16][]ChainContextSubst) {
+	if off+6 > len(gsub) {
+		return
+	}
+	coverageOff := off + int(be16(gsub, off+2))
+	setCount := int(be16(gsub, off+4))
+	if off+6+setCount*2 > len(gsub) {
+		return
+	}
+	covered := parseCoverage(gsub, coverageOff)
+	if covered == nil {
+		return
+	}
+	for i, firstGID := range covered {
+		if i >= setCount {
+			break
+		}
+		setOff := off + int(be16(gsub, off+6+i*2))
+		if setOff+2 > len(gsub) {
+			continue
+		}
+		ruleCount := int(be16(gsub, setOff))
+		if setOff+2+ruleCount*2 > len(gsub) {
+			continue
+		}
+		for r := 0; r < ruleCount; r++ {
+			ruleOff := setOff + int(be16(gsub, setOff+2+r*2))
+			rule := parseChainSubRule(gsub, ruleOff, firstGID)
+			if rule != nil {
+				chain[firstGID] = append(chain[firstGID], *rule)
+			}
+		}
+	}
+}
+
+// parseChainSubRule reads a ChainSubRule:
+//
+//	backtrackGlyphCount(2) + backtrackSequence[backtrackGlyphCount](2 each)
+//	inputGlyphCount(2)     + inputSequence[inputGlyphCount-1](2 each)
+//	lookaheadGlyphCount(2) + lookaheadSequence[lookaheadGlyphCount](2 each)
+//	substCount(2)          + substLookupRecords[substCount](4 each)
+//
+// The input sequence in the on-disk representation omits the first glyph
+// (it came from Coverage); here we prepend firstGID so that Input[0]
+// is the trigger and ApplyChainContext can uniformly use it as the key.
+// Backtrack is stored reversed per the ChainContextSubst convention.
+func parseChainSubRule(gsub []byte, off int, firstGID uint16) *ChainContextSubst {
+	if off+2 > len(gsub) {
+		return nil
+	}
+	p := off
+	backCount := int(be16(gsub, p))
+	p += 2
+	if p+backCount*2 > len(gsub) {
+		return nil
+	}
+	backtrack := make([][]uint16, backCount)
+	for i := 0; i < backCount; i++ {
+		// Spec order is nearest-to-farthest from the input start, which
+		// already matches our "reversed" convention (Backtrack[0] is the
+		// glyph immediately preceding Input[0]).
+		backtrack[i] = []uint16{be16(gsub, p+i*2)}
+	}
+	p += backCount * 2
+	if p+2 > len(gsub) {
+		return nil
+	}
+	inputCount := int(be16(gsub, p))
+	p += 2
+	if inputCount < 1 {
+		return nil
+	}
+	restInput := inputCount - 1
+	if p+restInput*2 > len(gsub) {
+		return nil
+	}
+	input := make([][]uint16, inputCount)
+	input[0] = []uint16{firstGID}
+	for i := 0; i < restInput; i++ {
+		input[i+1] = []uint16{be16(gsub, p+i*2)}
+	}
+	p += restInput * 2
+	if p+2 > len(gsub) {
+		return nil
+	}
+	lookCount := int(be16(gsub, p))
+	p += 2
+	if p+lookCount*2 > len(gsub) {
+		return nil
+	}
+	lookahead := make([][]uint16, lookCount)
+	for i := 0; i < lookCount; i++ {
+		lookahead[i] = []uint16{be16(gsub, p+i*2)}
+	}
+	p += lookCount * 2
+	actions := parseSubstLookupRecords(gsub, p)
+	return &ChainContextSubst{
+		Backtrack: backtrack,
+		Input:     input,
+		Lookahead: lookahead,
+		Actions:   actions,
+	}
+}
+
+// parseChainContextFormat2 handles ChainContextSubstFormat2:
+//
+//	format(2) = 2
+//	coverageOff(2)
+//	backtrackClassDefOff(2)
+//	inputClassDefOff(2)
+//	lookaheadClassDefOff(2)
+//	chainSubClassSetCount(2)
+//	chainSubClassSetOffsets[chainSubClassSetCount](2 each)
+//
+// Each chainSubClassSet corresponds to one input class. Class 0 in the
+// input class definition is "any glyph not explicitly assigned", and
+// the spec allows a class-set offset of 0 to mean "no rules for this
+// class". Inside each set, ChainSubClassRule carries class numbers
+// instead of explicit GIDs for its back/input/lookahead sequences.
+//
+// At parse time we invert each referenced class back to the list of
+// actual GIDs in that class so the runtime ChainContextSubst can
+// uniformly test candidates. Backtrack and lookahead class-0 entries
+// become empty GID sets, which ApplyChainContext treats as "matches
+// any GID not listed in any non-zero class at that position"; since we
+// don't carry the full glyph space, we emit the special empty set and
+// the matcher interprets an empty set as a wildcard.
+func parseChainContextFormat2(gsub []byte, off int, chain map[uint16][]ChainContextSubst) {
+	if off+12 > len(gsub) {
+		return
+	}
+	coverageOff := off + int(be16(gsub, off+2))
+	backClassOff := off + int(be16(gsub, off+4))
+	inputClassOff := off + int(be16(gsub, off+6))
+	lookClassOff := off + int(be16(gsub, off+8))
+	setCount := int(be16(gsub, off+10))
+	if off+12+setCount*2 > len(gsub) {
+		return
+	}
+	covered := parseCoverage(gsub, coverageOff)
+	if covered == nil {
+		return
+	}
+
+	// Missing ClassDef offsets (value 0 in the spec) mean "no classes",
+	// which parseClassDef will read as a malformed offset. We detect that
+	// case via the raw offset value before turning it into an absolute
+	// position.
+	var backClass, inputClass, lookClass map[uint16]uint16
+	if be16(gsub, off+4) != 0 {
+		backClass = parseClassDef(gsub, backClassOff)
+	}
+	if be16(gsub, off+6) != 0 {
+		inputClass = parseClassDef(gsub, inputClassOff)
+	}
+	if be16(gsub, off+8) != 0 {
+		lookClass = parseClassDef(gsub, lookClassOff)
+	}
+	if inputClass == nil {
+		inputClass = map[uint16]uint16{}
+	}
+
+	// Every covered GID shares the whole set of class-based rules, but
+	// rules only fire when the input classes align. We expand the rules
+	// per trigger GID by keying on the input's first-class members.
+	for cls := 0; cls < setCount; cls++ {
+		setRel := int(be16(gsub, off+12+cls*2))
+		if setRel == 0 {
+			continue
+		}
+		setOff := off + setRel
+		if setOff+2 > len(gsub) {
+			continue
+		}
+		ruleCount := int(be16(gsub, setOff))
+		if setOff+2+ruleCount*2 > len(gsub) {
+			continue
+		}
+		// Members of this input class that are ALSO in Coverage: those
+		// are the GIDs that can actually trigger the rule. Coverage
+		// bounds the set since Format 2 only applies at coverage hits.
+		triggerGIDs := intersectCoverageWithClass(covered, inputClass, uint16(cls))
+		if len(triggerGIDs) == 0 {
+			continue
+		}
+		for r := 0; r < ruleCount; r++ {
+			ruleOff := setOff + int(be16(gsub, setOff+2+r*2))
+			rule := parseChainSubClassRule(gsub, ruleOff, backClass, inputClass, lookClass, uint16(cls), covered)
+			if rule == nil {
+				continue
+			}
+			for _, trig := range triggerGIDs {
+				// Each trigger GID gets its own rule whose Input[0] is
+				// fixed to that specific trigger — this keeps the outer
+				// ApplyChainContext dispatch simple even though the
+				// underlying rule was class-based.
+				copyRule := cloneChainRuleWithTrigger(rule, trig)
+				chain[trig] = append(chain[trig], copyRule)
+			}
+		}
+	}
+}
+
+// intersectCoverageWithClass returns covered GIDs whose class in
+// classMap is exactly cls. When cls is 0 the result is the covered
+// GIDs that are NOT in any non-zero class.
+func intersectCoverageWithClass(covered []uint16, classMap map[uint16]uint16, cls uint16) []uint16 {
+	var out []uint16
+	for _, gid := range covered {
+		gidCls := classMap[gid]
+		if gidCls == cls {
+			out = append(out, gid)
+		}
+	}
+	return out
+}
+
+// cloneChainRuleWithTrigger returns a shallow copy of rule whose
+// Input[0] set is replaced by the single-element {trigger} set.
+func cloneChainRuleWithTrigger(rule *ChainContextSubst, trigger uint16) ChainContextSubst {
+	input := make([][]uint16, len(rule.Input))
+	copy(input, rule.Input)
+	input[0] = []uint16{trigger}
+	return ChainContextSubst{
+		Backtrack: rule.Backtrack,
+		Input:     input,
+		Lookahead: rule.Lookahead,
+		Actions:   rule.Actions,
+	}
+}
+
+// parseChainSubClassRule reads a ChainSubClassRule:
+//
+//	backtrackGlyphCount(2) + backtrackSequence[...](2 class numbers each)
+//	inputGlyphCount(2)     + inputSequence[inputGlyphCount-1](2 each)
+//	lookaheadGlyphCount(2) + lookaheadSequence[...](2 each)
+//	substCount(2)          + substLookupRecords[...](4 each)
+//
+// Class numbers are resolved against the supplied class maps; an empty
+// GID set is emitted for class 0 entries, which the matcher treats as
+// a wildcard (any glyph at that position).
+func parseChainSubClassRule(gsub []byte, off int, backClass, inputClass, lookClass map[uint16]uint16, firstInputClass uint16, covered []uint16) *ChainContextSubst {
+	if off+2 > len(gsub) {
+		return nil
+	}
+	p := off
+	backCount := int(be16(gsub, p))
+	p += 2
+	if p+backCount*2 > len(gsub) {
+		return nil
+	}
+	backtrack := make([][]uint16, backCount)
+	for i := 0; i < backCount; i++ {
+		backtrack[i] = classMembers(backClass, be16(gsub, p+i*2))
+	}
+	p += backCount * 2
+	if p+2 > len(gsub) {
+		return nil
+	}
+	inputCount := int(be16(gsub, p))
+	p += 2
+	if inputCount < 1 {
+		return nil
+	}
+	restInput := inputCount - 1
+	if p+restInput*2 > len(gsub) {
+		return nil
+	}
+	input := make([][]uint16, inputCount)
+	// Input[0] is the trigger; cloneChainRuleWithTrigger will replace it
+	// per-GID. Temporarily stash the class-0 members restricted to
+	// coverage here so we have a well-formed placeholder.
+	input[0] = classMembers(inputClass, firstInputClass)
+	if input[0] == nil {
+		// Input class 0 under Coverage: use the covered GIDs directly.
+		input[0] = append([]uint16(nil), covered...)
+	}
+	for i := 0; i < restInput; i++ {
+		input[i+1] = classMembers(inputClass, be16(gsub, p+i*2))
+	}
+	p += restInput * 2
+	if p+2 > len(gsub) {
+		return nil
+	}
+	lookCount := int(be16(gsub, p))
+	p += 2
+	if p+lookCount*2 > len(gsub) {
+		return nil
+	}
+	lookahead := make([][]uint16, lookCount)
+	for i := 0; i < lookCount; i++ {
+		lookahead[i] = classMembers(lookClass, be16(gsub, p+i*2))
+	}
+	p += lookCount * 2
+	actions := parseSubstLookupRecords(gsub, p)
+	return &ChainContextSubst{
+		Backtrack: backtrack,
+		Input:     input,
+		Lookahead: lookahead,
+		Actions:   actions,
+	}
+}
+
+// parseChainContextFormat3 handles ChainContextSubstFormat3:
+//
+//	format(2) = 3
+//	backtrackGlyphCount(2) + backtrackCoverageOffsets[...](2 each)
+//	inputGlyphCount(2)     + inputCoverageOffsets[...](2 each)
+//	lookaheadGlyphCount(2) + lookaheadCoverageOffsets[...](2 each)
+//	substCount(2)          + substLookupRecords[...](4 each)
+//
+// Each position references a Coverage table directly. inputCoverage[0]
+// is the trigger; we expand it per member GID into individual runtime
+// rules keyed by that trigger, matching the format-2 shape.
+func parseChainContextFormat3(gsub []byte, off int, chain map[uint16][]ChainContextSubst) {
+	if off+4 > len(gsub) {
+		return
+	}
+	p := off + 2
+	backCount := int(be16(gsub, p))
+	p += 2
+	if p+backCount*2 > len(gsub) {
+		return
+	}
+	backtrack := make([][]uint16, backCount)
+	for i := 0; i < backCount; i++ {
+		covOff := off + int(be16(gsub, p+i*2))
+		backtrack[i] = parseCoverage(gsub, covOff)
+	}
+	p += backCount * 2
+	if p+2 > len(gsub) {
+		return
+	}
+	inputCount := int(be16(gsub, p))
+	p += 2
+	if inputCount < 1 || p+inputCount*2 > len(gsub) {
+		return
+	}
+	input := make([][]uint16, inputCount)
+	for i := 0; i < inputCount; i++ {
+		covOff := off + int(be16(gsub, p+i*2))
+		input[i] = parseCoverage(gsub, covOff)
+	}
+	p += inputCount * 2
+	if p+2 > len(gsub) {
+		return
+	}
+	lookCount := int(be16(gsub, p))
+	p += 2
+	if p+lookCount*2 > len(gsub) {
+		return
+	}
+	lookahead := make([][]uint16, lookCount)
+	for i := 0; i < lookCount; i++ {
+		covOff := off + int(be16(gsub, p+i*2))
+		lookahead[i] = parseCoverage(gsub, covOff)
+	}
+	p += lookCount * 2
+	actions := parseSubstLookupRecords(gsub, p)
+	// Expand per trigger GID.
+	triggers := input[0]
+	for _, trig := range triggers {
+		rule := ChainContextSubst{
+			Backtrack: backtrack,
+			Input:     append([][]uint16{{trig}}, input[1:]...),
+			Lookahead: lookahead,
+			Actions:   actions,
+		}
+		chain[trig] = append(chain[trig], rule)
+	}
+}
+
+// parseSubstLookupRecords reads substCount (uint16) followed by substCount
+// SubstLookupRecord entries of 4 bytes each: sequenceIndex, lookupIndex.
+func parseSubstLookupRecords(gsub []byte, off int) []ChainSubstAction {
+	if off+2 > len(gsub) {
+		return nil
+	}
+	count := int(be16(gsub, off))
+	if off+2+count*4 > len(gsub) {
+		return nil
+	}
+	out := make([]ChainSubstAction, count)
+	for i := 0; i < count; i++ {
+		out[i] = ChainSubstAction{
+			SequenceIndex:   be16(gsub, off+2+i*4),
+			LookupListIndex: be16(gsub, off+2+i*4+2),
+		}
+	}
+	return out
+}
+
+// ApplyChainContext walks gids left-to-right and applies chaining
+// contextual substitution rules for the given feature. At each position
+// the trigger GID is used as a map key into the feature's rule table;
+// each candidate rule is tested for backtrack, input, and lookahead
+// matches and, on success, its SubstLookupRecord actions are dispatched.
+//
+// Action dispatch is currently limited to LookupType 1 (Single)
+// substitutions — recursing into Ligature or another ChainContext from
+// inside an action requires bounded recursion tracking and is deferred
+// to a follow-up. Rules whose actions reference non-Single lookups are
+// silently skipped for that action but the rule itself still matches.
+//
+// Reference: ISO 14496-22 §6.2 LookupType 6.
+func (g *GSUBSubstitutions) ApplyChainContext(gids []uint16, feature GSUBFeature) []uint16 {
+	if g == nil || len(g.ChainContext) == 0 || len(gids) == 0 {
+		return gids
+	}
+	table, ok := g.ChainContext[feature]
+	if !ok || len(table) == 0 {
+		return gids
+	}
+	out := make([]uint16, len(gids))
+	copy(out, gids)
+	for i := 0; i < len(out); i++ {
+		rules := table[out[i]]
+		if len(rules) == 0 {
+			continue
+		}
+		for _, rule := range rules {
+			if !chainRuleMatches(out, i, &rule) {
+				continue
+			}
+			// Action dispatch: Single-Substitution only.
+			for _, act := range rule.Actions {
+				pos := i + int(act.SequenceIndex)
+				if pos < 0 || pos >= len(out) {
+					continue
+				}
+				if int(act.LookupListIndex) >= len(g.lookupTable) {
+					continue
+				}
+				lookup := g.lookupTable[act.LookupListIndex]
+				if lookup == nil {
+					continue
+				}
+				if repl, found := lookup[out[pos]]; found {
+					out[pos] = repl
+				}
+			}
+			// Per the spec the outer loop advances by 1 regardless of
+			// input-sequence length; chained rules are the rule author's
+			// responsibility to design without self-overlap loops.
+			break
+		}
+	}
+	return out
+}
+
+// chainRuleMatches tests a single ChainContextSubst rule against gids
+// anchored at position i (where gids[i] is the trigger / Input[0]).
+// Returns true when the full backtrack, input, and lookahead all match.
+// An empty GID set at any position is treated as a wildcard — this is
+// how Format 2 class-0 positions are encoded.
+func chainRuleMatches(gids []uint16, i int, rule *ChainContextSubst) bool {
+	if i < 0 || i >= len(gids) {
+		return false
+	}
+	if len(rule.Input) == 0 {
+		return false
+	}
+	// Input: starting at i, each position must match.
+	for k := 0; k < len(rule.Input); k++ {
+		if i+k >= len(gids) {
+			return false
+		}
+		if !gidSetMatches(rule.Input[k], gids[i+k]) {
+			return false
+		}
+	}
+	// Backtrack: Backtrack[0] is the glyph immediately before Input[0].
+	for k := 0; k < len(rule.Backtrack); k++ {
+		pos := i - 1 - k
+		if pos < 0 {
+			return false
+		}
+		if !gidSetMatches(rule.Backtrack[k], gids[pos]) {
+			return false
+		}
+	}
+	// Lookahead starts right after the input sequence.
+	lookStart := i + len(rule.Input)
+	for k := 0; k < len(rule.Lookahead); k++ {
+		pos := lookStart + k
+		if pos >= len(gids) {
+			return false
+		}
+		if !gidSetMatches(rule.Lookahead[k], gids[pos]) {
+			return false
+		}
+	}
+	return true
+}
+
+// gidSetMatches returns true if gid is in set, OR if set is empty (a
+// wildcard, used by Format 2 class-0 positions where the full glyph
+// space can't be materialized at parse time).
+func gidSetMatches(set []uint16, gid uint16) bool {
+	if len(set) == 0 {
+		return true
+	}
+	for _, s := range set {
+		if s == gid {
+			return true
+		}
+	}
+	return false
 }
 
 // be16 reads a big-endian uint16 from data at the given offset.

--- a/font/gsub_test.go
+++ b/font/gsub_test.go
@@ -491,6 +491,598 @@ func buildLigatureGSUB(opt ligOptions) []byte {
 	return out
 }
 
+// --- LookupType 6 (Chaining Contextual Substitution) unit tests ---
+
+// TestParseClassDefFormat1 verifies that a Format 1 ClassDef (consecutive
+// glyph range starting at startGlyphID) is decoded correctly.
+func TestParseClassDefFormat1(t *testing.T) {
+	// format(2)=1, startGID(2)=10, count(2)=4, classes=[1,2,0,1]
+	data := []byte{
+		0, 1,
+		0, 10,
+		0, 4,
+		0, 1,
+		0, 2,
+		0, 0,
+		0, 1,
+	}
+	m := parseClassDef(data, 0)
+	if m[10] != 1 || m[11] != 2 || m[13] != 1 {
+		t.Errorf("Format 1 ClassDef wrong: %v", m)
+	}
+	if _, ok := m[12]; ok {
+		t.Errorf("class 0 entry should be absent, got %v", m[12])
+	}
+}
+
+// TestParseClassDefFormat2 verifies that a Format 2 ClassDef (range
+// records) is decoded correctly.
+func TestParseClassDefFormat2(t *testing.T) {
+	// format=2, rangeCount=2, {start=5,end=7,cls=3}, {start=20,end=20,cls=9}
+	data := []byte{
+		0, 2,
+		0, 2,
+		0, 5, 0, 7, 0, 3,
+		0, 20, 0, 20, 0, 9,
+	}
+	m := parseClassDef(data, 0)
+	if m[5] != 3 || m[6] != 3 || m[7] != 3 || m[20] != 9 {
+		t.Errorf("Format 2 ClassDef wrong: %v", m)
+	}
+}
+
+// chainOptions controls buildChainContextGSUB.
+type chainOptions struct {
+	// Format is 1, 2, or 3. Defaults to 1.
+	Format int
+	// Extension wraps the chain context subtable in a LookupType 7.
+	Extension bool
+}
+
+// TestChainContextFormat1Basic builds a synthetic GSUB with a Format 1
+// chain rule "if backtrack=[5], input=[10,20], lookahead=[30], substitute
+// glyph at sequenceIndex 0 via a single-sub lookup [10->99]" and verifies
+// that ApplyChainContext substitutes 10 to 99 only when the full chain
+// matches.
+func TestChainContextFormat1Basic(t *testing.T) {
+	gsub := buildChainContextGSUB(chainOptions{Format: 1})
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil")
+	}
+	got := subs.ApplyChainContext([]uint16{5, 10, 20, 30}, GSUBCalt)
+	if !uint16SliceEq(got, []uint16{5, 99, 20, 30}) {
+		t.Errorf("matching chain: got %v, want [5 99 20 30]", got)
+	}
+	// Backtrack doesn't match (6 instead of 5).
+	got2 := subs.ApplyChainContext([]uint16{6, 10, 20, 30}, GSUBCalt)
+	if !uint16SliceEq(got2, []uint16{6, 10, 20, 30}) {
+		t.Errorf("non-matching backtrack: got %v, want [6 10 20 30]", got2)
+	}
+}
+
+// TestChainContextFormat1Extension wraps the Format 1 chain subtable
+// inside a LookupType 7 and confirms ParseGSUB follows the extension.
+func TestChainContextFormat1Extension(t *testing.T) {
+	gsub := buildChainContextGSUB(chainOptions{Format: 1, Extension: true})
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil for extension-wrapped chain")
+	}
+	got := subs.ApplyChainContext([]uint16{5, 10, 20, 30}, GSUBCalt)
+	if !uint16SliceEq(got, []uint16{5, 99, 20, 30}) {
+		t.Errorf("extension-wrapped chain: got %v, want [5 99 20 30]", got)
+	}
+}
+
+// TestChainContextFormat2ClassBased verifies a class-based chain rule
+// fires correctly for two different GIDs in the same input class.
+func TestChainContextFormat2ClassBased(t *testing.T) {
+	gsub := buildChainContextGSUB(chainOptions{Format: 2})
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil for Format 2 chain")
+	}
+	// Input class 1 = {10, 11}. Both should trigger the same rule,
+	// which substitutes via lookup [10->99, 11->98].
+	got1 := subs.ApplyChainContext([]uint16{5, 10, 20, 30}, GSUBCalt)
+	if !uint16SliceEq(got1, []uint16{5, 99, 20, 30}) {
+		t.Errorf("Format 2 trigger 10: got %v, want [5 99 20 30]", got1)
+	}
+	got2 := subs.ApplyChainContext([]uint16{5, 11, 20, 30}, GSUBCalt)
+	if !uint16SliceEq(got2, []uint16{5, 98, 20, 30}) {
+		t.Errorf("Format 2 trigger 11: got %v, want [5 98 20 30]", got2)
+	}
+}
+
+// TestChainContextFormat3CoverageBased verifies a rule whose backtrack
+// uses a coverage of three GIDs accepts any of those three.
+func TestChainContextFormat3CoverageBased(t *testing.T) {
+	gsub := buildChainContextGSUB(chainOptions{Format: 3})
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil for Format 3 chain")
+	}
+	for _, back := range []uint16{4, 5, 6} {
+		got := subs.ApplyChainContext([]uint16{back, 10, 20, 30}, GSUBCalt)
+		want := []uint16{back, 99, 20, 30}
+		if !uint16SliceEq(got, want) {
+			t.Errorf("Format 3 backtrack %d: got %v, want %v", back, got, want)
+		}
+	}
+	// A backtrack GID not in the coverage must not trigger.
+	got := subs.ApplyChainContext([]uint16{7, 10, 20, 30}, GSUBCalt)
+	if !uint16SliceEq(got, []uint16{7, 10, 20, 30}) {
+		t.Errorf("Format 3 non-matching backtrack: got %v", got)
+	}
+}
+
+// TestChainContextSequenceIndexOne confirms that when the action's
+// SequenceIndex is 1, the second glyph (not the trigger) is substituted.
+func TestChainContextSequenceIndexOne(t *testing.T) {
+	// Input=[10,20], action targets sequenceIndex=1, lookup is [20->77].
+	gsub := buildChainContextGSUBSeqOne()
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil")
+	}
+	got := subs.ApplyChainContext([]uint16{5, 10, 20, 30}, GSUBCalt)
+	if !uint16SliceEq(got, []uint16{5, 10, 77, 30}) {
+		t.Errorf("seqIndex 1: got %v, want [5 10 77 30]", got)
+	}
+}
+
+// TestChainContextNoMatchPreserves verifies that glyph runs that don't
+// match any rule pass through unchanged.
+func TestChainContextNoMatchPreserves(t *testing.T) {
+	gsub := buildChainContextGSUB(chainOptions{Format: 1})
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil")
+	}
+	// No trigger glyph (10) present.
+	in := []uint16{1, 2, 3, 4, 5}
+	got := subs.ApplyChainContext(in, GSUBCalt)
+	if !uint16SliceEq(got, in) {
+		t.Errorf("no-match: got %v, want %v", got, in)
+	}
+}
+
+// TestApplyChainContextEmptyCases verifies nil receivers and missing
+// features no-op cleanly.
+func TestApplyChainContextEmptyCases(t *testing.T) {
+	var g *GSUBSubstitutions
+	if got := g.ApplyChainContext([]uint16{1, 2}, GSUBCalt); !uint16SliceEq(got, []uint16{1, 2}) {
+		t.Errorf("nil receiver: got %v", got)
+	}
+	empty := &GSUBSubstitutions{}
+	if got := empty.ApplyChainContext([]uint16{1, 2}, GSUBCalt); !uint16SliceEq(got, []uint16{1, 2}) {
+		t.Errorf("empty chain map: got %v", got)
+	}
+}
+
+// put16 is a tiny helper used by the chain-context GSUB builders.
+func put16(buf []byte, v uint16) { buf[0] = byte(v >> 8); buf[1] = byte(v) }
+
+// put32 is a tiny helper used by the chain-context GSUB builders.
+func put32(buf []byte, v uint32) {
+	buf[0] = byte(v >> 24)
+	buf[1] = byte(v >> 16)
+	buf[2] = byte(v >> 8)
+	buf[3] = byte(v)
+}
+
+// buildChainContextGSUB constructs a synthetic GSUB blob for chain context
+// testing. The layout uses a single "latn" script with a "calt" feature
+// that references TWO lookups in the LookupList:
+//
+//	lookup 0: LookupType 1 Single [10->99, 11->98, 20->77]
+//	lookup 1: LookupType 6 Chain Context (format per opt)
+//
+// The calt feature lists lookup 1 only (the ChainContext). The ChainContext
+// rule's action dispatches to lookup 0 with sequenceIndex 0. The extra
+// Single lookup is intentionally NOT directly wired into the feature so
+// that we exercise the action-dispatch path (not just feature-level single
+// substitution).
+func buildChainContextGSUB(opt chainOptions) []byte {
+	// ---- Single lookup (lookup index 0) ----
+	// SingleSubstFormat2: format(2)=2, coverageOff(2), substCount(2),
+	// substitute[substCount](2 each). Coverage is format 1 with GIDs
+	// [10, 11, 20] in order; substitutes are [99, 98, 77].
+	singleCoverage := make([]byte, 4+3*2)
+	put16(singleCoverage[0:2], 1)
+	put16(singleCoverage[2:4], 3)
+	put16(singleCoverage[4:6], 10)
+	put16(singleCoverage[6:8], 11)
+	put16(singleCoverage[8:10], 20)
+	singleSub := make([]byte, 6+3*2)
+	put16(singleSub[0:2], 2) // format
+	put16(singleSub[2:4], 6) // coverageOff relative to subtable
+	put16(singleSub[4:6], 3) // substCount
+	put16(singleSub[6:8], 99)
+	put16(singleSub[8:10], 98)
+	put16(singleSub[10:12], 77)
+	singleSub = append(singleSub, singleCoverage...)
+	// Correct the coverage offset to point AFTER the header.
+	put16(singleSub[2:4], 12)
+
+	// ---- Chain context subtable (lookup index 1) ----
+	var chainSub []byte
+	switch opt.Format {
+	case 2:
+		chainSub = buildChainContextFormat2Subtable()
+	case 3:
+		chainSub = buildChainContextFormat3Subtable()
+	default:
+		chainSub = buildChainContextFormat1Subtable()
+	}
+
+	// Optional LookupType 7 wrapping for the chain subtable.
+	if opt.Extension {
+		ext := make([]byte, 8+len(chainSub))
+		put16(ext[0:2], 1)
+		put16(ext[2:4], 6)
+		put32(ext[4:8], 8)
+		copy(ext[8:], chainSub)
+		chainSub = ext
+	}
+
+	return assembleTwoLookupGSUB(singleSub, chainSub, opt.Extension)
+}
+
+// buildChainContextFormat1Subtable constructs a ChainContextSubstFormat1
+// subtable: one covered trigger GID (10), one ChainSubRuleSet, one rule
+// with backtrack=[5], input=[10,20] (on-disk omits the first), lookahead=[30],
+// and a single SubstLookupRecord (sequenceIndex=0, lookupListIndex=0).
+func buildChainContextFormat1Subtable() []byte {
+	// Rule: backCount(2)=1, back[0](2)=5,
+	//       inputCount(2)=2, input[0](2)=20 (input[0] in on-disk is second glyph),
+	//       lookCount(2)=1, look[0](2)=30,
+	//       substCount(2)=1, substLookupRecord(4): seqIndex=0, lookupIndex=0.
+	rule := make([]byte, 0)
+	rule = append(rule, 0, 1, 0, 5)
+	rule = append(rule, 0, 2, 0, 20)
+	rule = append(rule, 0, 1, 0, 30)
+	rule = append(rule, 0, 1, 0, 0, 0, 0)
+
+	// ChainSubRuleSet: ruleCount(2)=1, ruleOff(2)=4, then rule bytes.
+	ruleSet := make([]byte, 4+len(rule))
+	put16(ruleSet[0:2], 1)
+	put16(ruleSet[2:4], 4)
+	copy(ruleSet[4:], rule)
+
+	// Coverage for trigger GID 10 (format 1).
+	cov := make([]byte, 6)
+	put16(cov[0:2], 1)
+	put16(cov[2:4], 1)
+	put16(cov[4:6], 10)
+
+	// Subtable: format(2)=1, coverageOff(2), setCount(2)=1, setOff[0](2),
+	// then coverage, then ruleSet.
+	hdr := 8
+	sub := make([]byte, hdr+len(cov)+len(ruleSet))
+	put16(sub[0:2], 1)
+	put16(sub[2:4], uint16(hdr))
+	put16(sub[4:6], 1)
+	put16(sub[6:8], uint16(hdr+len(cov)))
+	copy(sub[hdr:], cov)
+	copy(sub[hdr+len(cov):], ruleSet)
+	return sub
+}
+
+// buildChainContextFormat2Subtable constructs a Format 2 subtable where:
+//
+//	coverage = {10, 11}
+//	inputClassDef: 10->1, 11->1 (both in class 1)
+//	backtrackClassDef: 5->1
+//	lookaheadClassDef: 30->1
+//	one rule under class 1 with back=[1], input=[1,?], look=[1]
+//
+// The second input position in a class-based rule is a class number,
+// not a GID, so we use another class for GID 20. inputClass: 20->2.
+// The rule's inputSequence (class 2) therefore matches only GID 20.
+func buildChainContextFormat2Subtable() []byte {
+	// Rule: backCount(2)=1, back[0](2)=1 (class 1),
+	//       inputCount(2)=2, inputSeq[0](2)=2 (class 2),
+	//       lookCount(2)=1, look[0](2)=1 (class 1),
+	//       substCount(2)=1, substLookupRecord: seqIndex=0, lookupIndex=0
+	rule := make([]byte, 0)
+	rule = append(rule, 0, 1, 0, 1)
+	rule = append(rule, 0, 2, 0, 2)
+	rule = append(rule, 0, 1, 0, 1)
+	rule = append(rule, 0, 1, 0, 0, 0, 0)
+	set1 := make([]byte, 4+len(rule))
+	put16(set1[0:2], 1)
+	put16(set1[2:4], 4)
+	copy(set1[4:], rule)
+
+	// Coverage format 1 for {10, 11}.
+	cov := make([]byte, 8)
+	put16(cov[0:2], 1)
+	put16(cov[2:4], 2)
+	put16(cov[4:6], 10)
+	put16(cov[6:8], 11)
+
+	// Input ClassDef (format 1): startGID=10, count=11,
+	// classes covering GIDs 10..20. 10->1, 11->1, 12..19->0, 20->2.
+	inputClassDef := make([]byte, 6+11*2)
+	put16(inputClassDef[0:2], 1)
+	put16(inputClassDef[2:4], 10)
+	put16(inputClassDef[4:6], 11)
+	put16(inputClassDef[6:8], 1)  // 10
+	put16(inputClassDef[8:10], 1) // 11
+	// 12..19 already zero
+	put16(inputClassDef[6+10*2:6+10*2+2], 2) // 20
+
+	// Backtrack ClassDef (format 2): one range {5..5, class=1}.
+	backClassDef := make([]byte, 4+6)
+	put16(backClassDef[0:2], 2)
+	put16(backClassDef[2:4], 1)
+	put16(backClassDef[4:6], 5)
+	put16(backClassDef[6:8], 5)
+	put16(backClassDef[8:10], 1)
+
+	// Lookahead ClassDef (format 2): one range {30..30, class=1}.
+	lookClassDef := make([]byte, 4+6)
+	put16(lookClassDef[0:2], 2)
+	put16(lookClassDef[2:4], 1)
+	put16(lookClassDef[4:6], 30)
+	put16(lookClassDef[6:8], 30)
+	put16(lookClassDef[8:10], 1)
+
+	// Header layout: format(2)=2, covOff(2), backOff(2), inOff(2),
+	// lookOff(2), setCount(2), setOffs[setCount](2).
+	// setCount needs to cover class 1 — i.e. at least 2 entries (class 0, class 1).
+	setCount := 2
+	hdr := 12 + setCount*2
+
+	// Place coverage, classDefs, and set1 after the header.
+	body := make([]byte, 0)
+	cOff := hdr
+	body = append(body, cov...)
+	backOff := cOff + len(cov)
+	body = append(body, backClassDef...)
+	inOff := backOff + len(backClassDef)
+	body = append(body, inputClassDef...)
+	lookOff := inOff + len(inputClassDef)
+	body = append(body, lookClassDef...)
+	set1Off := lookOff + len(lookClassDef)
+	body = append(body, set1...)
+
+	sub := make([]byte, hdr+len(body))
+	put16(sub[0:2], 2)
+	put16(sub[2:4], uint16(cOff))
+	put16(sub[4:6], uint16(backOff))
+	put16(sub[6:8], uint16(inOff))
+	put16(sub[8:10], uint16(lookOff))
+	put16(sub[10:12], uint16(setCount))
+	put16(sub[12:14], 0)               // class 0 set offset = 0 (none)
+	put16(sub[14:16], uint16(set1Off)) // class 1 set offset
+	copy(sub[hdr:], body)
+	return sub
+}
+
+// buildChainContextFormat3Subtable constructs a Format 3 subtable:
+//
+//	backtrack coverage = {4, 5, 6}  (a 3-glyph set)
+//	input coverage     = {10}       (a 1-glyph set, single trigger)
+//	input coverage 2   = {20}
+//	lookahead coverage = {30}
+//	action: seqIndex=0, lookupIndex=0
+func buildChainContextFormat3Subtable() []byte {
+	// Construct each coverage format 1 independently.
+	back := make([]byte, 4+3*2)
+	put16(back[0:2], 1)
+	put16(back[2:4], 3)
+	put16(back[4:6], 4)
+	put16(back[6:8], 5)
+	put16(back[8:10], 6)
+
+	in1 := make([]byte, 6)
+	put16(in1[0:2], 1)
+	put16(in1[2:4], 1)
+	put16(in1[4:6], 10)
+
+	in2 := make([]byte, 6)
+	put16(in2[0:2], 1)
+	put16(in2[2:4], 1)
+	put16(in2[4:6], 20)
+
+	look := make([]byte, 6)
+	put16(look[0:2], 1)
+	put16(look[2:4], 1)
+	put16(look[4:6], 30)
+
+	// Header fields before the coverage blobs:
+	// format(2)=3, backCount(2)=1, backCovOff[1](2),
+	// inputCount(2)=2, inputCovOff[2](2 each),
+	// lookCount(2)=1, lookCovOff[1](2),
+	// substCount(2)=1, substLookupRecord(4).
+	hdr := 2 + 2 + 1*2 + 2 + 2*2 + 2 + 1*2 + 2 + 4
+
+	bodyOff := hdr
+	body := make([]byte, 0)
+	backOff := bodyOff
+	body = append(body, back...)
+	in1Off := bodyOff + len(back)
+	body = append(body, in1...)
+	in2Off := in1Off + len(in1)
+	body = append(body, in2...)
+	lookOff := in2Off + len(in2)
+	body = append(body, look...)
+
+	sub := make([]byte, hdr+len(body))
+	p := 0
+	put16(sub[p:p+2], 3)
+	p += 2
+	put16(sub[p:p+2], 1)
+	p += 2
+	put16(sub[p:p+2], uint16(backOff))
+	p += 2
+	put16(sub[p:p+2], 2)
+	p += 2
+	put16(sub[p:p+2], uint16(in1Off))
+	p += 2
+	put16(sub[p:p+2], uint16(in2Off))
+	p += 2
+	put16(sub[p:p+2], 1)
+	p += 2
+	put16(sub[p:p+2], uint16(lookOff))
+	p += 2
+	put16(sub[p:p+2], 1)
+	p += 2
+	put16(sub[p:p+2], 0)
+	p += 2
+	put16(sub[p:p+2], 0)
+	copy(sub[hdr:], body)
+	return sub
+}
+
+// buildChainContextGSUBSeqOne is a variant that builds a Format 1 chain
+// context rule whose action targets sequenceIndex=1 (the second input
+// glyph). The underlying Single lookup is [20->77].
+func buildChainContextGSUBSeqOne() []byte {
+	// Single lookup: format 2, coverage=[20], substitute=[77].
+	cov := make([]byte, 6)
+	put16(cov[0:2], 1)
+	put16(cov[2:4], 1)
+	put16(cov[4:6], 20)
+	singleSub := make([]byte, 6)
+	put16(singleSub[0:2], 2)
+	put16(singleSub[2:4], 0) // placeholder, patched below
+	put16(singleSub[4:6], 1) // substCount
+	singleSub = append(singleSub, 0, 77)
+	// Coverage lives after the substitute array: 6-byte header + 2 bytes
+	// per substitute = offset 8.
+	put16(singleSub[2:4], uint16(len(singleSub)))
+	singleSub = append(singleSub, cov...)
+
+	// Rule: back=[5], input=[10,20] (on-disk omits first), look=[30],
+	// action seqIndex=1 targeting lookup 0.
+	rule := make([]byte, 0)
+	rule = append(rule, 0, 1, 0, 5)
+	rule = append(rule, 0, 2, 0, 20)
+	rule = append(rule, 0, 1, 0, 30)
+	rule = append(rule, 0, 1, 0, 1, 0, 0)
+
+	ruleSet := make([]byte, 4+len(rule))
+	put16(ruleSet[0:2], 1)
+	put16(ruleSet[2:4], 4)
+	copy(ruleSet[4:], rule)
+
+	triggerCov := make([]byte, 6)
+	put16(triggerCov[0:2], 1)
+	put16(triggerCov[2:4], 1)
+	put16(triggerCov[4:6], 10)
+
+	hdr := 8
+	chainSub := make([]byte, hdr+len(triggerCov)+len(ruleSet))
+	put16(chainSub[0:2], 1)
+	put16(chainSub[2:4], uint16(hdr))
+	put16(chainSub[4:6], 1)
+	put16(chainSub[6:8], uint16(hdr+len(triggerCov)))
+	copy(chainSub[hdr:], triggerCov)
+	copy(chainSub[hdr+len(triggerCov):], ruleSet)
+
+	return assembleTwoLookupGSUB(singleSub, chainSub, false)
+}
+
+// assembleTwoLookupGSUB wires together a script/feature/lookup list for
+// a GSUB with two lookups: lookup 0 is a LookupType 1 single subtable,
+// lookup 1 is a LookupType 6 chain context subtable. Only the chain
+// lookup is referenced by the calt feature. If extension is true the
+// chain lookup is tagged as LookupType 7 (the subtable is assumed to
+// already carry its extension wrapper).
+func assembleTwoLookupGSUB(singleSub, chainSub []byte, extension bool) []byte {
+	// Lookup 0: type=1, flag=0, subCount=1, subOff[0]=8, then singleSub.
+	lookup0 := make([]byte, 8+len(singleSub))
+	put16(lookup0[0:2], 1)
+	put16(lookup0[2:4], 0)
+	put16(lookup0[4:6], 1)
+	put16(lookup0[6:8], 8)
+	copy(lookup0[8:], singleSub)
+
+	// Lookup 1: type=6 (or 7 if extension), flag=0, subCount=1,
+	// subOff[0]=8, then chainSub.
+	lookupType := uint16(6)
+	if extension {
+		lookupType = 7
+	}
+	lookup1 := make([]byte, 8+len(chainSub))
+	put16(lookup1[0:2], lookupType)
+	put16(lookup1[2:4], 0)
+	put16(lookup1[4:6], 1)
+	put16(lookup1[6:8], 8)
+	copy(lookup1[8:], chainSub)
+
+	// LookupList: lookupCount(2)=2, lookupOffs[2](2 each), then lookups.
+	lookupListHdr := 2 + 2*2
+	lookup0Off := lookupListHdr
+	lookup1Off := lookup0Off + len(lookup0)
+	lookupList := make([]byte, lookup1Off+len(lookup1))
+	put16(lookupList[0:2], 2)
+	put16(lookupList[2:4], uint16(lookup0Off))
+	put16(lookupList[4:6], uint16(lookup1Off))
+	copy(lookupList[lookup0Off:], lookup0)
+	copy(lookupList[lookup1Off:], lookup1)
+
+	// Feature references lookup index 1 only.
+	feature := make([]byte, 6)
+	put16(feature[0:2], 0)
+	put16(feature[2:4], 1)
+	put16(feature[4:6], 1) // lookupListIndex = 1 (the chain lookup)
+
+	featListHdr := 8
+	featList := make([]byte, featListHdr+len(feature))
+	put16(featList[0:2], 1)
+	copy(featList[2:6], []byte("calt"))
+	put16(featList[6:8], uint16(featListHdr))
+	copy(featList[featListHdr:], feature)
+
+	// LangSys: lookupOrder=0, reqFeature=0xFFFF, count=1, indices=[0].
+	langSys := make([]byte, 8)
+	put16(langSys[0:2], 0)
+	put16(langSys[2:4], 0xFFFF)
+	put16(langSys[4:6], 1)
+	put16(langSys[6:8], 0)
+
+	scriptHdr := 4
+	script := make([]byte, scriptHdr+len(langSys))
+	put16(script[0:2], uint16(scriptHdr))
+	put16(script[2:4], 0)
+	copy(script[scriptHdr:], langSys)
+
+	scriptListHdr := 8
+	scriptList := make([]byte, scriptListHdr+len(script))
+	put16(scriptList[0:2], 1)
+	copy(scriptList[2:6], []byte("latn"))
+	put16(scriptList[6:8], uint16(scriptListHdr))
+	copy(scriptList[scriptListHdr:], script)
+
+	header := make([]byte, 10)
+	scriptListOff := len(header)
+	featListOff := scriptListOff + len(scriptList)
+	lookupListOff := featListOff + len(featList)
+	put16(header[0:2], 1)
+	put16(header[2:4], 0)
+	put16(header[4:6], uint16(scriptListOff))
+	put16(header[6:8], uint16(featListOff))
+	put16(header[8:10], uint16(lookupListOff))
+
+	out := make([]byte, 0, lookupListOff+len(lookupList))
+	out = append(out, header...)
+	out = append(out, scriptList...)
+	out = append(out, featList...)
+	out = append(out, lookupList...)
+	return out
+}
+
 func arabicFontPath() string {
 	switch runtime.GOOS {
 	case "darwin":


### PR DESCRIPTION
## Summary

Extend `font/gsub.go` with OpenType GSUB LookupType 6 (Chaining Contextual Substitution) parsing and runtime application across all three subtable formats, plus ClassDef parsing needed for Format 2. Adds the `calt` feature tag and surfaces chain context lookups under the existing Arabic positional features so complex shaping pipelines can build on this substrate.

Reference: ISO 14496-22 section 6.2 LookupType 6 and section 3 (ClassDef tables).

## What's in the diff

- New public types: `ChainContextSubst` and `ChainSubstAction`. New `GSUBSubstitutions.ChainContext` field keyed by feature then by trigger GID (`Input[0]`).
- `parseClassDef` supports ClassDef Format 1 (`startGlyphID` + `classValueArray`) and Format 2 (ClassRangeRecord list).
- `parseChainContextSubst` dispatches by format:
  - Format 1 (simple glyph contexts): explicit GID sequences for backtrack, input, lookahead.
  - Format 2 (class-based): back / input / lookahead ClassDefs plus chainSubClassSets. Each class-based rule is materialized per trigger GID so the runtime representation is uniform.
  - Format 3 (coverage-based): direct Coverage tables at every position.
- `ApplyChainContext` walks glyphs left to right, dispatches by trigger GID, tests backtrack/input/lookahead, and invokes actions on a match. Empty GID sets act as wildcards (used for Format 2 class-0 positions where the full glyph space cannot be materialized).
- Internal `lookupTable []map[uint16]uint16` indexed by LookupList slot is populated by a one-pass scan of the full LookupList (not just feature-reachable lookups) so that `SubstLookupRecord.lookupListIndex` can resolve.
- Extension (LookupType 7) wrapping is extended to unwrap LookupType 6.

## Trade-offs

- **Unified runtime shape.** All three on-disk formats decompress into one `ChainContextSubst` representation of per-position GID sets. This keeps `ApplyChainContext` simple at the cost of expanding class- and coverage-based forms at parse time. For a first implementation the simplicity win is worth the extra work at parse time.
- **Single-Substitution action dispatch only.** When a chain rule fires, the dispatched action is resolved against the per-slot Single map. Recursing into Ligature or another ChainContext from inside an action is deferred to a follow-up: doing it correctly requires bounded recursion-depth tracking and would balloon the diff. Non-Single action targets are silently skipped without failing the rule match. One-line comment in `ApplyChainContext` notes the restriction.
- **Internal `lookupTable` field.** Kept lower-case so it does not enter the public API. `ParseGSUB` populates it regardless of feature selection so cross-lookup action dispatch works.
- **Format 2 class-0 positions.** The spec defines class 0 as "any glyph not explicitly assigned". Materializing the complement against the full glyph space at parse time is not practical, so class-0 positions are stored as empty GID sets and the matcher treats empty as wildcard. This is safe for backtrack and lookahead; for the input-sequence trigger, Format 2 rules are expanded per covered trigger GID so `Input[0]` is always a concrete single-element set.

## Test plan

- [x] `go test ./font/... ./layout/... ./html/... ./document/...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] New unit tests in `font/gsub_test.go`:
  - `TestParseClassDefFormat1` and `TestParseClassDefFormat2`
  - `TestChainContextFormat1Basic` (matching and non-matching backtrack)
  - `TestChainContextFormat1Extension` (LookupType 7 wrapping)
  - `TestChainContextFormat2ClassBased` (two different GIDs in the same input class fire the same class-based rule)
  - `TestChainContextFormat3CoverageBased` (three-GID backtrack coverage accepts any of the three, rejects outside)
  - `TestChainContextSequenceIndexOne` (action targeting a non-zero sequence index substitutes the right position)
  - `TestChainContextNoMatchPreserves`
  - `TestApplyChainContextEmptyCases` (nil receiver / empty map)