### PR TITLE
Parse OpenType GPOS pair and mark-to-base positioning

### DIFF
--- a/font/face.go
+++ b/font/face.go
@@ -92,3 +92,13 @@ type GSUBProvider interface {
 	// The result is cached after the first call.
 	GIDToUnicode() map[uint16]rune
 }
+
+// GPOSProvider is an optional interface that a Face may implement to
+// expose parsed OpenType GPOS positioning tables. GPOS() returns nil
+// when the font has no recognized positioning data. See GSUBProvider
+// for the rationale behind the optional-interface pattern during v0.x.
+//
+// TODO: at v1.0, merge GPOS() back into Face.
+type GPOSProvider interface {
+	GPOS() *GPOSAdjustments
+}

--- a/font/gpos.go
+++ b/font/gpos.go
@@ -1,0 +1,622 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+// GPOSFeature identifies an OpenType GPOS feature tag.
+type GPOSFeature string
+
+const (
+	// GPOSKern is the Pair Positioning feature. It is the GPOS equivalent
+	// of the legacy TrueType kern table and the preferred source of pair
+	// kerning in modern fonts. ISO 14496-22 §6.3 LookupType 2.
+	GPOSKern GPOSFeature = "kern"
+
+	// GPOSMark is the Mark-to-Base Positioning feature. It positions a
+	// combining mark glyph (e.g. an Arabic harakah or Hebrew niqqud) on
+	// an explicit anchor of a base glyph. ISO 14496-22 §6.3 LookupType 4.
+	GPOSMark GPOSFeature = "mark"
+
+	// GPOSMkmk is the Mark-to-Mark Positioning feature. Recognized for
+	// future use; LookupType 6 is not implemented in this iteration.
+	GPOSMkmk GPOSFeature = "mkmk"
+)
+
+// PairAdjustment holds the XAdvance delta to apply to the first glyph of
+// a kerning pair, expressed in font design units (FUnits). Only the
+// horizontal advance is captured: the initial GPOS iteration ignores
+// XPlacement, YPlacement, YAdvance, and any Device tables.
+type PairAdjustment struct {
+	XAdvance int16
+}
+
+// Anchor is an (x, y) point in font design units. Anchor Format 2
+// (indexed anchor point for hinting) and Format 3 (with Device tables)
+// are parsed but their extra fields are discarded.
+type Anchor struct {
+	X, Y int16
+}
+
+// MarkRecord is the entry of a MarkArray: the mark class the mark
+// belongs to plus its attachment anchor.
+type MarkRecord struct {
+	Class  uint16
+	Anchor Anchor
+}
+
+// BaseRecord is the entry of a BaseArray: one anchor per mark class for
+// a given base glyph. The slice is indexed by mark class; a class with
+// no declared anchor yields a zero Anchor.
+type BaseRecord struct {
+	Anchors []Anchor
+}
+
+// GPOSAdjustments holds parsed GPOS positioning data grouped by feature
+// tag. A nil map or nil outer struct means "feature absent".
+type GPOSAdjustments struct {
+	// Pairs holds LookupType 2 adjustments keyed by (left, right) glyph
+	// ID. Only the horizontal XAdvance is stored.
+	Pairs map[GPOSFeature]map[[2]uint16]PairAdjustment
+
+	// Marks holds LookupType 4 mark records keyed by mark glyph ID.
+	Marks map[GPOSFeature]map[uint16]MarkRecord
+
+	// Bases holds LookupType 4 base records keyed by base glyph ID.
+	Bases map[GPOSFeature]map[uint16]BaseRecord
+}
+
+// ParseGPOS reads the GPOS table from raw font bytes and extracts
+// LookupType 2 (Pair Positioning) and LookupType 4 (Mark-to-Base
+// Positioning) data for the "kern" and "mark" features. Extension
+// lookups (LookupType 9) are unwrapped for types 2 and 4.
+//
+// Script selection follows the same preference order as GSUB:
+// "arab" and "latn" when present, "DFLT" as a fallback.
+//
+// Returns nil if the font has no GPOS table or no matching data.
+//
+// Reference: ISO 14496-22 §6.3, OpenType GPOS table.
+func ParseGPOS(data []byte) *GPOSAdjustments {
+	gpos := findTable(data, "GPOS")
+	if len(gpos) < 10 {
+		return nil
+	}
+
+	scriptListOff := int(be16(gpos, 4))
+	featureListOff := int(be16(gpos, 6))
+	lookupListOff := int(be16(gpos, 8))
+	if scriptListOff >= len(gpos) || featureListOff >= len(gpos) || lookupListOff >= len(gpos) {
+		return nil
+	}
+
+	featureIndices := scriptFeatureIndices(gpos, scriptListOff)
+	if len(featureIndices) == 0 {
+		return nil
+	}
+
+	targetTags := map[string]GPOSFeature{
+		"kern": GPOSKern,
+		"mark": GPOSMark,
+		"mkmk": GPOSMkmk,
+	}
+	featureToLookups := matchGPOSFeatures(gpos, featureListOff, featureIndices, targetTags)
+	if len(featureToLookups) == 0 {
+		return nil
+	}
+
+	result := &GPOSAdjustments{
+		Pairs: make(map[GPOSFeature]map[[2]uint16]PairAdjustment),
+		Marks: make(map[GPOSFeature]map[uint16]MarkRecord),
+		Bases: make(map[GPOSFeature]map[uint16]BaseRecord),
+	}
+	for feat, lookupIndices := range featureToLookups {
+		pairs := make(map[[2]uint16]PairAdjustment)
+		marks := make(map[uint16]MarkRecord)
+		bases := make(map[uint16]BaseRecord)
+		parseGPOSLookups(gpos, lookupListOff, lookupIndices, pairs, marks, bases)
+		if len(pairs) > 0 {
+			result.Pairs[feat] = pairs
+		}
+		if len(marks) > 0 {
+			result.Marks[feat] = marks
+		}
+		if len(bases) > 0 {
+			result.Bases[feat] = bases
+		}
+	}
+	if len(result.Pairs) == 0 && len(result.Marks) == 0 && len(result.Bases) == 0 {
+		return nil
+	}
+	return result
+}
+
+// PairAdjust returns the horizontal XAdvance adjustment in FUnits that
+// the GPOS "kern" feature assigns to the pair (left, right), or 0 if the
+// pair is absent. This is the GPOS-table analogue of the legacy kern
+// table lookup.
+func (g *GPOSAdjustments) PairAdjust(left, right uint16) int16 {
+	if g == nil {
+		return 0
+	}
+	pairs, ok := g.Pairs[GPOSKern]
+	if !ok {
+		return 0
+	}
+	return pairs[[2]uint16{left, right}].XAdvance
+}
+
+// MarkOffset returns the (dx, dy) offset in FUnits needed to move a mark
+// glyph's origin so its anchor coincides with the base glyph's anchor
+// for the same mark class. Returns ok=false when either glyph is absent
+// from the feature's mark/base arrays, or when the base has no anchor
+// declared for the mark's class.
+//
+// The formula is the direct anchor subtraction from ISO 14496-22 §6.3
+// LookupType 4: dx = baseAnchor.X - markAnchor.X,
+// dy = baseAnchor.Y - markAnchor.Y.
+func (g *GPOSAdjustments) MarkOffset(baseGID, markGID uint16, feature GPOSFeature) (dx, dy int16, ok bool) {
+	if g == nil {
+		return 0, 0, false
+	}
+	marks, mok := g.Marks[feature]
+	if !mok {
+		return 0, 0, false
+	}
+	mark, hasMark := marks[markGID]
+	if !hasMark {
+		return 0, 0, false
+	}
+	bases, bok := g.Bases[feature]
+	if !bok {
+		return 0, 0, false
+	}
+	base, hasBase := bases[baseGID]
+	if !hasBase {
+		return 0, 0, false
+	}
+	if int(mark.Class) >= len(base.Anchors) {
+		return 0, 0, false
+	}
+	b := base.Anchors[mark.Class]
+	return b.X - mark.Anchor.X, b.Y - mark.Anchor.Y, true
+}
+
+// matchGPOSFeatures is the GPOS counterpart of matchFeatures: it walks
+// the FeatureList, selects only features whose tag is in targetTags and
+// whose index is in allowed, and returns a map from GPOSFeature to the
+// lookup indices it references.
+func matchGPOSFeatures(gpos []byte, off int, allowed []int, targetTags map[string]GPOSFeature) map[GPOSFeature][]int {
+	if off+2 > len(gpos) {
+		return nil
+	}
+	count := int(be16(gpos, off))
+	if off+2+count*6 > len(gpos) {
+		return nil
+	}
+	allowSet := make(map[int]bool, len(allowed))
+	for _, idx := range allowed {
+		allowSet[idx] = true
+	}
+	result := make(map[GPOSFeature][]int)
+	for i := 0; i < count; i++ {
+		if !allowSet[i] {
+			continue
+		}
+		rec := gpos[off+2+i*6:]
+		feat, ok := targetTags[string(rec[:4])]
+		if !ok {
+			continue
+		}
+		featureOff := off + int(be16(rec, 4))
+		if featureOff+4 > len(gpos) {
+			continue
+		}
+		lookupCount := int(be16(gpos, featureOff+2))
+		if featureOff+4+lookupCount*2 > len(gpos) {
+			continue
+		}
+		lookups := make([]int, lookupCount)
+		for j := 0; j < lookupCount; j++ {
+			lookups[j] = int(be16(gpos, featureOff+4+j*2))
+		}
+		result[feat] = append(result[feat], lookups...)
+	}
+	return result
+}
+
+// parseGPOSLookups walks each referenced lookup and dispatches its
+// subtables to the appropriate LookupType parser. LookupType 9
+// (Extension Positioning) is unwrapped inline for types 2 and 4.
+func parseGPOSLookups(gpos []byte, listOff int, indices []int,
+	pairs map[[2]uint16]PairAdjustment,
+	marks map[uint16]MarkRecord,
+	bases map[uint16]BaseRecord,
+) {
+	if listOff+2 > len(gpos) {
+		return
+	}
+	count := int(be16(gpos, listOff))
+	if listOff+2+count*2 > len(gpos) {
+		return
+	}
+	for _, idx := range indices {
+		if idx >= count {
+			continue
+		}
+		lookupOff := listOff + int(be16(gpos, listOff+2+idx*2))
+		parseGPOSLookup(gpos, lookupOff, pairs, marks, bases)
+	}
+}
+
+// parseGPOSLookup reads a single Lookup table and calls the subtable
+// parser matching its lookup type. Extension subtables (type 9) are
+// followed to their target subtable in the same GPOS blob.
+func parseGPOSLookup(gpos []byte, lookupOff int,
+	pairs map[[2]uint16]PairAdjustment,
+	marks map[uint16]MarkRecord,
+	bases map[uint16]BaseRecord,
+) {
+	if lookupOff+6 > len(gpos) {
+		return
+	}
+	lookupType := be16(gpos, lookupOff)
+	subCount := int(be16(gpos, lookupOff+4))
+	if lookupOff+6+subCount*2 > len(gpos) {
+		return
+	}
+	for si := 0; si < subCount; si++ {
+		subOff := lookupOff + int(be16(gpos, lookupOff+6+si*2))
+		t := lookupType
+		off := subOff
+		if t == 9 {
+			// ExtensionPosFormat1:
+			//   posFormat         uint16 (==1)
+			//   extensionLookupType uint16
+			//   extensionOffset    Offset32 (from start of this subtable)
+			if subOff+8 > len(gpos) {
+				continue
+			}
+			t = be16(gpos, subOff+2)
+			off = subOff + int(be32(gpos, subOff+4))
+			if off >= len(gpos) {
+				continue
+			}
+		}
+		switch t {
+		case 2:
+			parsePairPos(gpos, off, pairs)
+		case 4:
+			parseMarkBasePos(gpos, off, marks, bases)
+		}
+	}
+}
+
+// parsePairPos dispatches on the PairPos format byte. Format 1 is
+// explicit per-pair records; Format 2 is class-based pair tables.
+func parsePairPos(gpos []byte, off int, out map[[2]uint16]PairAdjustment) {
+	if off+2 > len(gpos) {
+		return
+	}
+	format := be16(gpos, off)
+	switch format {
+	case 1:
+		parsePairPosFormat1(gpos, off, out)
+	case 2:
+		parsePairPosFormat2(gpos, off, out)
+	}
+}
+
+// parsePairPosFormat1 reads an explicit-pair PairPos subtable.
+//
+// Layout:
+//
+//	posFormat       uint16 (==1)
+//	coverageOffset  Offset16
+//	valueFormat1    uint16
+//	valueFormat2    uint16
+//	pairSetCount    uint16
+//	pairSetOffsets[pairSetCount] Offset16 (from subtable start)
+//
+// Each PairSet:
+//
+//	pairValueCount  uint16
+//	pairValueRecords[pairValueCount] {
+//	    secondGlyph uint16
+//	    valueRecord1 (valueFormat1 shape)
+//	    valueRecord2 (valueFormat2 shape)
+//	}
+//
+// Only the XAdvance component of valueRecord1 is extracted: that is the
+// horizontal kerning delta applied to the first glyph's advance.
+func parsePairPosFormat1(gpos []byte, off int, out map[[2]uint16]PairAdjustment) {
+	if off+10 > len(gpos) {
+		return
+	}
+	coverageOff := off + int(be16(gpos, off+2))
+	valueFormat1 := be16(gpos, off+4)
+	valueFormat2 := be16(gpos, off+6)
+	pairSetCount := int(be16(gpos, off+8))
+	if off+10+pairSetCount*2 > len(gpos) {
+		return
+	}
+	covered := parseCoverage(gpos, coverageOff)
+	if covered == nil {
+		return
+	}
+
+	size1 := valueRecordSize(valueFormat1)
+	size2 := valueRecordSize(valueFormat2)
+	recSize := 2 + size1 + size2
+
+	for i, firstGID := range covered {
+		if i >= pairSetCount {
+			break
+		}
+		setOff := off + int(be16(gpos, off+10+i*2))
+		if setOff+2 > len(gpos) {
+			continue
+		}
+		pairValueCount := int(be16(gpos, setOff))
+		if setOff+2+pairValueCount*recSize > len(gpos) {
+			continue
+		}
+		for j := 0; j < pairValueCount; j++ {
+			base := setOff + 2 + j*recSize
+			secondGID := be16(gpos, base)
+			xAdv := valueRecordXAdvance(gpos, base+2, valueFormat1)
+			if xAdv == 0 {
+				continue
+			}
+			out[[2]uint16{firstGID, secondGID}] = PairAdjustment{XAdvance: xAdv}
+		}
+	}
+}
+
+// parsePairPosFormat2 reads a class-based PairPos subtable.
+//
+// Layout:
+//
+//	posFormat       uint16 (==2)
+//	coverageOffset  Offset16
+//	valueFormat1    uint16
+//	valueFormat2    uint16
+//	classDef1Offset Offset16
+//	classDef2Offset Offset16
+//	class1Count     uint16
+//	class2Count     uint16
+//	class1Records[class1Count] of class2Records[class2Count] of
+//	    { valueRecord1, valueRecord2 }
+//
+// The coverage table bounds which glyphs are eligible as the first of a
+// pair; class 0 in ClassDef1 represents "covered but not otherwise
+// classified". Second glyphs are classified by classDef2 over all glyphs
+// in the font; class 0 there represents the implicit catch-all.
+func parsePairPosFormat2(gpos []byte, off int, out map[[2]uint16]PairAdjustment) {
+	if off+16 > len(gpos) {
+		return
+	}
+	coverageOff := off + int(be16(gpos, off+2))
+	valueFormat1 := be16(gpos, off+4)
+	valueFormat2 := be16(gpos, off+6)
+	classDef1Off := off + int(be16(gpos, off+8))
+	classDef2Off := off + int(be16(gpos, off+10))
+	class1Count := int(be16(gpos, off+12))
+	class2Count := int(be16(gpos, off+14))
+
+	covered := parseCoverage(gpos, coverageOff)
+	if covered == nil {
+		return
+	}
+	class1 := parseClassDef(gpos, classDef1Off)
+	class2 := parseClassDef(gpos, classDef2Off)
+
+	size1 := valueRecordSize(valueFormat1)
+	size2 := valueRecordSize(valueFormat2)
+	class2RecSize := size1 + size2
+	class1RecSize := class2Count * class2RecSize
+	total := class1Count * class1RecSize
+	if off+16+total > len(gpos) {
+		return
+	}
+
+	// Bucket second-glyph classes for efficient iteration.
+	class2ToGIDs := make(map[uint16][]uint16)
+	for gid, cls := range class2 {
+		if int(cls) >= class2Count {
+			continue
+		}
+		class2ToGIDs[cls] = append(class2ToGIDs[cls], gid)
+	}
+
+	for _, leftGID := range covered {
+		c1 := class1[leftGID]
+		if int(c1) >= class1Count {
+			continue
+		}
+		rowOff := off + 16 + int(c1)*class1RecSize
+		for c2 := 0; c2 < class2Count; c2++ {
+			recOff := rowOff + c2*class2RecSize
+			xAdv := valueRecordXAdvance(gpos, recOff, valueFormat1)
+			if xAdv == 0 {
+				continue
+			}
+			rights, ok := class2ToGIDs[uint16(c2)]
+			if !ok {
+				continue
+			}
+			for _, rightGID := range rights {
+				out[[2]uint16{leftGID, rightGID}] = PairAdjustment{XAdvance: xAdv}
+			}
+		}
+	}
+}
+
+// valueRecordSize returns the byte size of a ValueRecord whose fields
+// are selected by the given ValueFormat bitmask. Each set bit contributes
+// one int16 (two bytes) field; the field order is fixed per
+// ISO 14496-22 §6.3: XPlacement, YPlacement, XAdvance, YAdvance,
+// XPlaDevice, YPlaDevice, XAdvDevice, YAdvDevice.
+func valueRecordSize(vf uint16) int {
+	n := 0
+	for b := uint16(1); b != 0 && b <= 0x80; b <<= 1 {
+		if vf&b != 0 {
+			n++
+		}
+	}
+	return n * 2
+}
+
+// valueRecordXAdvance reads the XAdvance int16 out of a ValueRecord
+// located at off, given its ValueFormat bitmask. Returns 0 if the bit is
+// clear or the field lies beyond the data end.
+//
+// Field order per ISO 14496-22 §6.3 Table "ValueRecord":
+//
+//	bit 0 XPlacement, bit 1 YPlacement, bit 2 XAdvance, bit 3 YAdvance,
+//	bit 4 XPlaDevice, bit 5 YPlaDevice, bit 6 XAdvDevice, bit 7 YAdvDevice.
+func valueRecordXAdvance(data []byte, off int, vf uint16) int16 {
+	if vf&0x0004 == 0 {
+		return 0
+	}
+	// Count the number of int16 fields preceding XAdvance.
+	pos := 0
+	if vf&0x0001 != 0 {
+		pos++ // XPlacement
+	}
+	if vf&0x0002 != 0 {
+		pos++ // YPlacement
+	}
+	fieldOff := off + pos*2
+	if fieldOff+2 > len(data) {
+		return 0
+	}
+	return int16(be16(data, fieldOff))
+}
+
+// parseMarkBasePos reads a MarkBasePosFormat1 subtable.
+//
+// Layout:
+//
+//	posFormat        uint16 (==1)
+//	markCoverageOff  Offset16
+//	baseCoverageOff  Offset16
+//	markClassCount   uint16
+//	markArrayOff     Offset16
+//	baseArrayOff     Offset16
+//
+// The MarkArray and BaseArray are parsed through parseMarkArray and
+// parseBaseArray. Marks and bases are keyed by glyph ID in the returned
+// maps; look-up with MarkOffset combines them via mark class.
+func parseMarkBasePos(gpos []byte, off int,
+	marks map[uint16]MarkRecord,
+	bases map[uint16]BaseRecord,
+) {
+	if off+12 > len(gpos) {
+		return
+	}
+	format := be16(gpos, off)
+	if format != 1 {
+		return
+	}
+	markCoverageOff := off + int(be16(gpos, off+2))
+	baseCoverageOff := off + int(be16(gpos, off+4))
+	markClassCount := int(be16(gpos, off+6))
+	markArrayOff := off + int(be16(gpos, off+8))
+	baseArrayOff := off + int(be16(gpos, off+10))
+
+	markCov := parseCoverage(gpos, markCoverageOff)
+	baseCov := parseCoverage(gpos, baseCoverageOff)
+	if markCov == nil || baseCov == nil {
+		return
+	}
+
+	parseMarkArray(gpos, markArrayOff, markCov, marks)
+	parseBaseArray(gpos, baseArrayOff, baseCov, markClassCount, bases)
+}
+
+// parseMarkArray reads a MarkArray and populates marks.
+//
+// Layout:
+//
+//	markCount         uint16
+//	markRecords[markCount] {
+//	    markClass       uint16
+//	    markAnchorOff   Offset16 (from MarkArray start)
+//	}
+//
+// Each index in markRecords corresponds to the coverage entry at the
+// same coverage index, so markCov is indexed positionally.
+func parseMarkArray(gpos []byte, off int, markCov []uint16, out map[uint16]MarkRecord) {
+	if off+2 > len(gpos) {
+		return
+	}
+	count := int(be16(gpos, off))
+	if off+2+count*4 > len(gpos) {
+		return
+	}
+	for i := 0; i < count && i < len(markCov); i++ {
+		rec := off + 2 + i*4
+		class := be16(gpos, rec)
+		anchorOff := off + int(be16(gpos, rec+2))
+		anchor, ok := parseAnchor(gpos, anchorOff)
+		if !ok {
+			continue
+		}
+		out[markCov[i]] = MarkRecord{Class: class, Anchor: anchor}
+	}
+}
+
+// parseBaseArray reads a BaseArray and populates bases.
+//
+// Layout:
+//
+//	baseCount     uint16
+//	baseRecords[baseCount] {
+//	    baseAnchorOffsets[markClassCount] Offset16 (from BaseArray start)
+//	}
+//
+// A zero anchor offset means "no anchor for this class"; such slots are
+// left as the zero Anchor in the BaseRecord's Anchors slice.
+func parseBaseArray(gpos []byte, off int, baseCov []uint16, markClassCount int, out map[uint16]BaseRecord) {
+	if off+2 > len(gpos) {
+		return
+	}
+	count := int(be16(gpos, off))
+	rowSize := markClassCount * 2
+	if off+2+count*rowSize > len(gpos) {
+		return
+	}
+	for i := 0; i < count && i < len(baseCov); i++ {
+		rowOff := off + 2 + i*rowSize
+		anchors := make([]Anchor, markClassCount)
+		for c := 0; c < markClassCount; c++ {
+			aOffRaw := int(be16(gpos, rowOff+c*2))
+			if aOffRaw == 0 {
+				continue
+			}
+			anchor, ok := parseAnchor(gpos, off+aOffRaw)
+			if !ok {
+				continue
+			}
+			anchors[c] = anchor
+		}
+		out[baseCov[i]] = BaseRecord{Anchors: anchors}
+	}
+}
+
+// parseAnchor reads an Anchor table at off. All three formats share the
+// same first six bytes (format, x, y); formats 2 and 3 carry trailing
+// fields (an anchor-point index, or Device table offsets) that this
+// iteration deliberately ignores.
+func parseAnchor(data []byte, off int) (Anchor, bool) {
+	if off+6 > len(data) {
+		return Anchor{}, false
+	}
+	format := be16(data, off)
+	if format < 1 || format > 3 {
+		return Anchor{}, false
+	}
+	x := int16(be16(data, off+2))
+	y := int16(be16(data, off+4))
+	return Anchor{X: x, Y: y}, true
+}

--- a/font/gpos_test.go
+++ b/font/gpos_test.go
@@ -1,0 +1,602 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// gposBuilder accumulates raw bytes. All synthetic GPOS tables in this
+// file are assembled by hand so each test reads like a byte-level
+// picture of the structure under test.
+type gposBuilder struct {
+	buf []byte
+}
+
+func (b *gposBuilder) u16(v uint16) {
+	var tmp [2]byte
+	binary.BigEndian.PutUint16(tmp[:], v)
+	b.buf = append(b.buf, tmp[:]...)
+}
+
+func (b *gposBuilder) u32(v uint32) {
+	var tmp [4]byte
+	binary.BigEndian.PutUint32(tmp[:], v)
+	b.buf = append(b.buf, tmp[:]...)
+}
+
+func (b *gposBuilder) i16(v int16) { b.u16(uint16(v)) }
+
+// patchU16 rewrites a previously reserved uint16 at position p.
+func (b *gposBuilder) patchU16(p int, v uint16) {
+	binary.BigEndian.PutUint16(b.buf[p:p+2], v)
+}
+
+// patchU32 rewrites a previously reserved uint32 at position p.
+func (b *gposBuilder) patchU32(p int, v uint32) {
+	binary.BigEndian.PutUint32(b.buf[p:p+4], v)
+}
+
+// pos returns the current write offset.
+func (b *gposBuilder) pos() int { return len(b.buf) }
+
+// wrapTTF builds a minimal single-font TTF wrapper containing a GPOS
+// table whose body is the given bytes. The rest of the required tables
+// are stubbed: we only need findTable to locate "GPOS".
+func wrapTTF(gposBody []byte) []byte {
+	// Header: sfntVersion(4), numTables(2), searchRange(2),
+	// entrySelector(2), rangeShift(2). One table record: tag(4),
+	// checkSum(4), offset(4), length(4). Then the body.
+	const numTables = 1
+	headerSize := 12 + numTables*16
+	var out gposBuilder
+	out.u32(0x00010000) // sfntVersion
+	out.u16(numTables)
+	out.u16(0) // searchRange
+	out.u16(0) // entrySelector
+	out.u16(0) // rangeShift
+	// Table record for GPOS.
+	out.buf = append(out.buf, []byte("GPOS")...)
+	out.u32(0) // checkSum
+	out.u32(uint32(headerSize))
+	out.u32(uint32(len(gposBody)))
+	out.buf = append(out.buf, gposBody...)
+	return out.buf
+}
+
+// buildGPOSHeader produces a GPOS header that points at a single "DFLT"
+// script with one LangSys referencing one feature, one feature, and one
+// lookup. The caller supplies the feature tag and the raw lookup
+// subtable bytes (lookupBody). A lookup-type code identifies the
+// LookupType field. extensionType controls whether the lookup is wrapped
+// in a LookupType 9 extension indirection; pass 0 for no wrapping.
+//
+// The return value is the full GPOS table bytes.
+func buildGPOSHeader(featureTag string, lookupType uint16, lookupBody []byte, extensionType uint16) []byte {
+	var b gposBuilder
+
+	// Header: version(4), scriptListOffset(2), featureListOffset(2),
+	// lookupListOffset(2). Offsets are from the start of the GPOS
+	// table, and we will patch them once we know their positions.
+	b.u32(0x00010000)
+	scriptListPos := b.pos()
+	b.u16(0)
+	featureListPos := b.pos()
+	b.u16(0)
+	lookupListPos := b.pos()
+	b.u16(0)
+
+	// ScriptList.
+	scriptListOff := b.pos()
+	b.patchU16(scriptListPos, uint16(scriptListOff))
+	b.u16(1) // scriptCount
+	b.buf = append(b.buf, []byte("DFLT")...)
+	scriptRecordOffPos := b.pos()
+	b.u16(0) // scriptOffset placeholder (from ScriptList start)
+
+	// Script table.
+	scriptTableOff := b.pos()
+	b.patchU16(scriptRecordOffPos, uint16(scriptTableOff-scriptListOff))
+	defaultLangSysPos := b.pos()
+	b.u16(0) // defaultLangSysOffset placeholder
+	b.u16(0) // langSysCount
+
+	// Default LangSys table.
+	defaultLangSysOff := b.pos()
+	b.patchU16(defaultLangSysPos, uint16(defaultLangSysOff-scriptTableOff))
+	b.u16(0) // lookupOrder (reserved)
+	b.u16(0xFFFF)
+	b.u16(1) // featureIndexCount
+	b.u16(0) // referenced feature index 0
+
+	// FeatureList.
+	featureListOff := b.pos()
+	b.patchU16(featureListPos, uint16(featureListOff))
+	b.u16(1) // featureCount
+	b.buf = append(b.buf, []byte(featureTag)...)
+	featureRecordOffPos := b.pos()
+	b.u16(0) // featureOffset placeholder
+
+	// Feature table.
+	featureTableOff := b.pos()
+	b.patchU16(featureRecordOffPos, uint16(featureTableOff-featureListOff))
+	b.u16(0) // featureParams
+	b.u16(1) // lookupIndexCount
+	b.u16(0) // lookupListIndices[0]
+
+	// LookupList.
+	lookupListOff := b.pos()
+	b.patchU16(lookupListPos, uint16(lookupListOff))
+	b.u16(1) // lookupCount
+	lookupRecordOffPos := b.pos()
+	b.u16(0) // lookup offset placeholder
+
+	// Lookup table.
+	lookupTableOff := b.pos()
+	b.patchU16(lookupRecordOffPos, uint16(lookupTableOff-lookupListOff))
+	if extensionType != 0 {
+		b.u16(9) // lookupType = extension
+	} else {
+		b.u16(lookupType)
+	}
+	b.u16(0) // lookupFlag
+	b.u16(1) // subTableCount
+	subOffPos := b.pos()
+	b.u16(0) // subtableOffset placeholder (from lookup start)
+
+	if extensionType != 0 {
+		// Extension subtable: format(2), extensionLookupType(2),
+		// extensionOffset(4, from start of this subtable).
+		extSubOff := b.pos()
+		b.patchU16(subOffPos, uint16(extSubOff-lookupTableOff))
+		b.u16(1) // posFormat
+		b.u16(extensionType)
+		extOffPos := b.pos()
+		b.u32(0) // extensionOffset placeholder (from extSubOff)
+		realSubOff := b.pos()
+		b.patchU32(extOffPos, uint32(realSubOff-extSubOff))
+		b.buf = append(b.buf, lookupBody...)
+	} else {
+		subOff := b.pos()
+		b.patchU16(subOffPos, uint16(subOff-lookupTableOff))
+		b.buf = append(b.buf, lookupBody...)
+	}
+
+	return b.buf
+}
+
+// buildCoverageFormat1 produces a Coverage Format 1 table listing gids
+// in order. The caller must ensure gids are strictly ascending.
+func buildCoverageFormat1(gids ...uint16) []byte {
+	var b gposBuilder
+	b.u16(1)
+	b.u16(uint16(len(gids)))
+	for _, g := range gids {
+		b.u16(g)
+	}
+	return b.buf
+}
+
+// buildClassDefFormat2 produces a ClassDef Format 2 from range records
+// each describing { startGID, endGID, class }.
+type classRange struct {
+	start, end, class uint16
+}
+
+func buildClassDefFormat2(ranges ...classRange) []byte {
+	var b gposBuilder
+	b.u16(2)
+	b.u16(uint16(len(ranges)))
+	for _, r := range ranges {
+		b.u16(r.start)
+		b.u16(r.end)
+		b.u16(r.class)
+	}
+	return b.buf
+}
+
+// TestValueRecordSize locks the size-counting helper against every
+// single-bit and a couple of combinations. Pair kerning only uses bit 2
+// but the helper must skip past all preceding fields correctly.
+func TestValueRecordSize(t *testing.T) {
+	cases := []struct {
+		vf   uint16
+		want int
+	}{
+		{0x0000, 0},
+		{0x0001, 2}, // XPlacement
+		{0x0002, 2}, // YPlacement
+		{0x0004, 2}, // XAdvance
+		{0x0005, 4}, // XPlacement + XAdvance
+		{0x000F, 8}, // all four placements/advances
+		{0x00FF, 16},
+	}
+	for _, c := range cases {
+		if got := valueRecordSize(c.vf); got != c.want {
+			t.Errorf("valueRecordSize(%#x) = %d, want %d", c.vf, got, c.want)
+		}
+	}
+}
+
+// TestValueRecordXAdvance verifies the XAdvance reader skips preceding
+// XPlacement/YPlacement fields so that a valueFormat of 0x05 lands at
+// the second int16 rather than the first.
+func TestValueRecordXAdvance(t *testing.T) {
+	// ValueRecord with XPlacement=7, XAdvance=-50. valueFormat = 0x05.
+	var b gposBuilder
+	b.i16(7)
+	b.i16(-50)
+	got := valueRecordXAdvance(b.buf, 0, 0x0005)
+	if got != -50 {
+		t.Errorf("XAdvance with XPlacement present = %d, want -50", got)
+	}
+
+	// Bit 2 clear: must return 0 regardless of buffer contents.
+	if v := valueRecordXAdvance(b.buf, 0, 0x0003); v != 0 {
+		t.Errorf("XAdvance with bit 2 clear = %d, want 0", v)
+	}
+}
+
+// pairPosFormat1Body assembles a PairPosFormat1 subtable with a single
+// coverage entry (leftGID) and a single PairSet containing a single
+// pair (leftGID, rightGID) with the given XAdvance. valueFormat1 is
+// caller-controlled to let tests exercise ValueFormat masking; the
+// valueRecord is always laid out matching the declared format but only
+// the XAdvance field carries the test value.
+func pairPosFormat1Body(leftGID, rightGID uint16, xAdvance int16, valueFormat1 uint16) []byte {
+	var b gposBuilder
+	b.u16(1) // posFormat
+	covOffPos := b.pos()
+	b.u16(0) // coverageOffset placeholder
+	b.u16(valueFormat1)
+	b.u16(0) // valueFormat2
+	b.u16(1) // pairSetCount
+	setOffPos := b.pos()
+	b.u16(0) // pairSetOffset[0] placeholder
+
+	// Coverage table at current position.
+	covOff := b.pos()
+	b.patchU16(covOffPos, uint16(covOff))
+	b.buf = append(b.buf, buildCoverageFormat1(leftGID)...)
+
+	// PairSet table.
+	setOff := b.pos()
+	b.patchU16(setOffPos, uint16(setOff))
+	b.u16(1) // pairValueCount
+	b.u16(rightGID)
+	// Write a valueRecord1 matching valueFormat1.
+	// Field order per the spec: XPlacement, YPlacement, XAdvance.
+	if valueFormat1&0x0001 != 0 {
+		b.i16(0) // XPlacement filler
+	}
+	if valueFormat1&0x0002 != 0 {
+		b.i16(0) // YPlacement filler
+	}
+	if valueFormat1&0x0004 != 0 {
+		b.i16(xAdvance)
+	}
+	return b.buf
+}
+
+// TestParseGPOSPairPosFormat1 covers the happy path of LookupType 2
+// Format 1: one pair, one adjustment, plus a miss lookup.
+func TestParseGPOSPairPosFormat1(t *testing.T) {
+	body := pairPosFormat1Body(10, 20, -50, 0x0004)
+	gpos := buildGPOSHeader("kern", 2, body, 0)
+	font := wrapTTF(gpos)
+
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	if got := g.PairAdjust(10, 20); got != -50 {
+		t.Errorf("PairAdjust(10,20) = %d, want -50", got)
+	}
+	if got := g.PairAdjust(10, 21); got != 0 {
+		t.Errorf("PairAdjust(10,21) = %d, want 0", got)
+	}
+	if got := g.PairAdjust(11, 20); got != 0 {
+		t.Errorf("PairAdjust(11,20) = %d, want 0", got)
+	}
+}
+
+// TestParseGPOSPairPosValueFormatMasking verifies that a ValueRecord
+// carrying both XPlacement and XAdvance still yields the correct
+// XAdvance, i.e. the parser walks past the XPlacement slot.
+func TestParseGPOSPairPosValueFormatMasking(t *testing.T) {
+	// valueFormat1 = 0x05 -> XPlacement + XAdvance.
+	body := pairPosFormat1Body(5, 6, -42, 0x0005)
+	gpos := buildGPOSHeader("kern", 2, body, 0)
+	font := wrapTTF(gpos)
+
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	if got := g.PairAdjust(5, 6); got != -42 {
+		t.Errorf("PairAdjust(5,6) with XPlacement+XAdvance = %d, want -42", got)
+	}
+}
+
+// TestParseGPOSPairPosFormat2 exercises class-based pair positioning:
+// two left-classes x two right-classes with four distinct adjustments.
+func TestParseGPOSPairPosFormat2(t *testing.T) {
+	// Left-class map: GID 10 -> class 1, GID 11 -> class 2.
+	// Right-class map: GID 20 -> class 1, GID 21 -> class 2.
+	// Coverage picks up {10, 11} as eligible left glyphs.
+	//
+	// Expected adjustments (class1, class2) -> value:
+	//   (1,1) = -10   -> (10,20)
+	//   (1,2) = -20   -> (10,21)
+	//   (2,1) = -30   -> (11,20)
+	//   (2,2) = -40   -> (11,21)
+	var b gposBuilder
+	b.u16(2) // posFormat
+	covOffPos := b.pos()
+	b.u16(0) // coverage
+	b.u16(0x0004)
+	b.u16(0)
+	cd1OffPos := b.pos()
+	b.u16(0) // classDef1Offset
+	cd2OffPos := b.pos()
+	b.u16(0) // classDef2Offset
+	b.u16(3) // class1Count (includes class 0)
+	b.u16(3) // class2Count (includes class 0)
+
+	// class1Records[0]: class 0 row (3 class2 records, all zeros).
+	// class1Records[1]: class 1 row.
+	// class1Records[2]: class 2 row.
+	// Each class2 record here is one int16 (XAdvance).
+	b.i16(0) // (0,0)
+	b.i16(0) // (0,1)
+	b.i16(0) // (0,2)
+
+	b.i16(0)   // (1,0)
+	b.i16(-10) // (1,1) -> (10,20)
+	b.i16(-20) // (1,2) -> (10,21)
+
+	b.i16(0)   // (2,0)
+	b.i16(-30) // (2,1) -> (11,20)
+	b.i16(-40) // (2,2) -> (11,21)
+
+	covOff := b.pos()
+	b.patchU16(covOffPos, uint16(covOff))
+	b.buf = append(b.buf, buildCoverageFormat1(10, 11)...)
+
+	cd1Off := b.pos()
+	b.patchU16(cd1OffPos, uint16(cd1Off))
+	b.buf = append(b.buf, buildClassDefFormat2(
+		classRange{start: 10, end: 10, class: 1},
+		classRange{start: 11, end: 11, class: 2},
+	)...)
+
+	cd2Off := b.pos()
+	b.patchU16(cd2OffPos, uint16(cd2Off))
+	b.buf = append(b.buf, buildClassDefFormat2(
+		classRange{start: 20, end: 20, class: 1},
+		classRange{start: 21, end: 21, class: 2},
+	)...)
+
+	gpos := buildGPOSHeader("kern", 2, b.buf, 0)
+	font := wrapTTF(gpos)
+
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	cases := []struct {
+		l, r uint16
+		want int16
+	}{
+		{10, 20, -10},
+		{10, 21, -20},
+		{11, 20, -30},
+		{11, 21, -40},
+		{10, 99, 0},
+		{99, 20, 0},
+	}
+	for _, c := range cases {
+		if got := g.PairAdjust(c.l, c.r); got != c.want {
+			t.Errorf("PairAdjust(%d,%d) = %d, want %d", c.l, c.r, got, c.want)
+		}
+	}
+}
+
+// markBasePosBody assembles a MarkBasePosFormat1 subtable with one mark
+// coverage entry (markGID), one base coverage entry (baseGID), one mark
+// class, and an anchor written in the given Anchor format. The mark and
+// base anchors use independently specified (x,y) pairs.
+func markBasePosBody(markGID, baseGID uint16, markX, markY, baseX, baseY int16, anchorFormat uint16) []byte {
+	var b gposBuilder
+	b.u16(1) // posFormat
+	markCovOffPos := b.pos()
+	b.u16(0) // markCoverageOffset
+	baseCovOffPos := b.pos()
+	b.u16(0) // baseCoverageOffset
+	b.u16(1) // markClassCount
+	markArrayOffPos := b.pos()
+	b.u16(0) // markArrayOffset
+	baseArrayOffPos := b.pos()
+	b.u16(0) // baseArrayOffset
+
+	markCovOff := b.pos()
+	b.patchU16(markCovOffPos, uint16(markCovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(markGID)...)
+
+	baseCovOff := b.pos()
+	b.patchU16(baseCovOffPos, uint16(baseCovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(baseGID)...)
+
+	markArrayOff := b.pos()
+	b.patchU16(markArrayOffPos, uint16(markArrayOff))
+	b.u16(1) // markCount
+	b.u16(0) // markClass
+	markAnchorOffPos := b.pos()
+	b.u16(0) // markAnchorOffset (from markArrayOff)
+
+	baseArrayOff := b.pos()
+	b.patchU16(baseArrayOffPos, uint16(baseArrayOff))
+	b.u16(1) // baseCount
+	baseAnchorOffPos := b.pos()
+	b.u16(0) // baseAnchorOffset (from baseArrayOff)
+
+	// Mark anchor.
+	markAnchorOff := b.pos()
+	b.patchU16(markAnchorOffPos, uint16(markAnchorOff-markArrayOff))
+	b.u16(anchorFormat)
+	b.i16(markX)
+	b.i16(markY)
+	switch anchorFormat {
+	case 2:
+		b.u16(0) // anchorPoint index (ignored)
+	case 3:
+		b.u16(0) // xDeviceOffset (ignored)
+		b.u16(0) // yDeviceOffset (ignored)
+	}
+
+	// Base anchor.
+	baseAnchorOff := b.pos()
+	b.patchU16(baseAnchorOffPos, uint16(baseAnchorOff-baseArrayOff))
+	b.u16(anchorFormat)
+	b.i16(baseX)
+	b.i16(baseY)
+	switch anchorFormat {
+	case 2:
+		b.u16(0)
+	case 3:
+		b.u16(0)
+		b.u16(0)
+	}
+
+	return b.buf
+}
+
+// TestParseGPOSMarkBasePosFormat1 checks that a mark with its anchor at
+// (200,300) attached to a base with anchor (500,800) yields an offset of
+// (300, 500) — i.e. base.X - mark.X, base.Y - mark.Y.
+func TestParseGPOSMarkBasePosFormat1(t *testing.T) {
+	body := markBasePosBody(50, 100, 200, 300, 500, 800, 1)
+	gpos := buildGPOSHeader("mark", 4, body, 0)
+	font := wrapTTF(gpos)
+
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	dx, dy, ok := g.MarkOffset(100, 50, GPOSMark)
+	if !ok {
+		t.Fatal("MarkOffset returned ok=false, want true")
+	}
+	if dx != 300 || dy != 500 {
+		t.Errorf("MarkOffset = (%d, %d), want (300, 500)", dx, dy)
+	}
+	if _, _, okMiss := g.MarkOffset(999, 50, GPOSMark); okMiss {
+		t.Error("MarkOffset for unknown base should return ok=false")
+	}
+	if _, _, okMiss := g.MarkOffset(100, 999, GPOSMark); okMiss {
+		t.Error("MarkOffset for unknown mark should return ok=false")
+	}
+}
+
+// TestParseGPOSAnchorFormats2And3 locks down that anchor formats 2 and 3
+// yield the same x,y as format 1 for the same base values. The extra
+// anchor-point index and Device offsets must be read past without
+// polluting the extracted coordinates.
+func TestParseGPOSAnchorFormats2And3(t *testing.T) {
+	for _, fmt := range []uint16{1, 2, 3} {
+		body := markBasePosBody(50, 100, 10, 20, 30, 40, fmt)
+		gpos := buildGPOSHeader("mark", 4, body, 0)
+		font := wrapTTF(gpos)
+
+		g := ParseGPOS(font)
+		if g == nil {
+			t.Fatalf("format %d: ParseGPOS returned nil", fmt)
+		}
+		dx, dy, ok := g.MarkOffset(100, 50, GPOSMark)
+		if !ok {
+			t.Fatalf("format %d: MarkOffset ok=false", fmt)
+		}
+		if dx != 20 || dy != 20 {
+			t.Errorf("format %d: MarkOffset = (%d, %d), want (20, 20)", fmt, dx, dy)
+		}
+	}
+}
+
+// TestParseGPOSExtensionWrap wraps a PairPosFormat1 subtable inside a
+// LookupType 9 Extension and verifies it still resolves.
+func TestParseGPOSExtensionWrap(t *testing.T) {
+	body := pairPosFormat1Body(42, 43, -25, 0x0004)
+	gpos := buildGPOSHeader("kern", 2, body, 2)
+	font := wrapTTF(gpos)
+
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	if got := g.PairAdjust(42, 43); got != -25 {
+		t.Errorf("PairAdjust through extension = %d, want -25", got)
+	}
+}
+
+// TestParseGPOSReturnsNilWithoutTable sanity-checks the nil return path
+// for fonts that don't carry a GPOS table.
+func TestParseGPOSReturnsNilWithoutTable(t *testing.T) {
+	if ParseGPOS(nil) != nil {
+		t.Error("ParseGPOS(nil) should return nil")
+	}
+	if ParseGPOS([]byte{0}) != nil {
+		t.Error("ParseGPOS short buffer should return nil")
+	}
+}
+
+// TestFaceKernPrefersGPOS verifies that a Face whose backing font has
+// both a GPOS kern pair and a legacy kern pair for the same (l,r) pair
+// returns the GPOS value. It also verifies that a pair with only legacy
+// kern data still comes through via the fallthrough branch.
+func TestFaceKernPrefersGPOS(t *testing.T) {
+	face := loadTestFace(t).(*sfntFace)
+
+	// Force the GPOS cache to contain a known entry.
+	face.gposResult = &GPOSAdjustments{
+		Pairs: map[GPOSFeature]map[[2]uint16]PairAdjustment{
+			GPOSKern: {
+				[2]uint16{1, 2}: {XAdvance: -77},
+			},
+		},
+	}
+	face.gposParsed = true
+
+	// Force the legacy kern cache to contain a different value for the
+	// same pair plus a legacy-only pair.
+	face.kernPairs = map[[2]uint16]int16{
+		{1, 2}: -11,
+		{3, 4}: -22,
+	}
+	face.kernPairsParsed = true
+
+	if got := face.Kern(1, 2); got != -77 {
+		t.Errorf("Kern(1,2) = %d, want -77 (GPOS wins over legacy kern)", got)
+	}
+	if got := face.Kern(3, 4); got != -22 {
+		t.Errorf("Kern(3,4) = %d, want -22 (legacy kern fallback)", got)
+	}
+	if got := face.Kern(9, 9); got != 0 {
+		t.Errorf("Kern(9,9) = %d, want 0", got)
+	}
+}
+
+// TestFaceGPOSCacheIdentity exercises the GPOS one-shot cache flag.
+func TestFaceGPOSCacheIdentity(t *testing.T) {
+	face := loadTestFace(t).(*sfntFace)
+	_ = face.GPOS()
+	if !face.gposParsed {
+		t.Fatal("expected gposParsed=true after first GPOS call")
+	}
+	first := face.gposResult
+	_ = face.GPOS()
+	if face.gposResult != first {
+		t.Error("second GPOS call rebuilt the cached result")
+	}
+}

--- a/font/truetype.go
+++ b/font/truetype.go
@@ -44,6 +44,12 @@ type sfntFace struct {
 	// guards re-parsing.
 	kernPairs       map[[2]uint16]int16
 	kernPairsParsed bool
+
+	// Cached GPOS adjustments. gposParsed distinguishes "not yet parsed"
+	// (false) from "parsed and empty" (true, gposResult nil). Populated
+	// on the first GPOS() call.
+	gposResult *GPOSAdjustments
+	gposParsed bool
 }
 
 // ParseTTF parses a TrueType (.ttf) or OpenType (.otf) font from raw bytes.
@@ -210,11 +216,17 @@ func (f *sfntFace) StemV() int {
 	return max(stemV, 10)
 }
 
-// Kern returns the kerning adjustment between two glyphs by consulting
-// the cached parsed kern table. Returns 0 if the font has no kern table,
-// no supported subtables, or no entry for the pair. The cache is built
-// on the first call.
+// Kern returns the kerning adjustment between two glyphs. GPOS
+// LookupType 2 ("kern" feature) takes precedence over the legacy kern
+// table when a pair is present in both, per Microsoft OpenType guidance
+// on GPOS being the canonical source of pair positioning in modern
+// fonts. Returns 0 when neither source carries an adjustment.
 func (f *sfntFace) Kern(left, right uint16) int {
+	if g := f.GPOS(); g != nil {
+		if v := g.PairAdjust(left, right); v != 0 {
+			return int(v)
+		}
+	}
 	if !f.kernPairsParsed {
 		if tables := f.rawTables(); tables != nil {
 			if kern, ok := tables["kern"]; ok {
@@ -323,6 +335,19 @@ func (f *sfntFace) GSUB() *GSUBSubstitutions {
 	f.gsubResult = ParseGSUB(f.rawData)
 	f.gsubParsed = true
 	return f.gsubResult
+}
+
+// GPOS returns the parsed GPOS positioning tables. The result is cached
+// after the first call; a nil return means the font has no recognized
+// GPOS data (no "kern"/"mark" features, or only unsupported lookup
+// types).
+func (f *sfntFace) GPOS() *GPOSAdjustments {
+	if f.gposParsed {
+		return f.gposResult
+	}
+	f.gposResult = ParseGPOS(f.rawData)
+	f.gposParsed = true
+	return f.gposResult
 }
 
 // GIDToUnicode returns a reverse mapping from glyph ID to Unicode codepoint.


### PR DESCRIPTION
## Summary

Adds a spec-driven parser for the OpenType GPOS table and wires its pair-positioning output into the existing `Face.Kern` call. Mark-to-base positioning data is parsed and exposed, but not yet applied during layout — that's the next PR.

New file `font/gpos.go` extracts:

- **LookupType 2 (Pair Positioning)**, formats 1 and 2. Only the horizontal `XAdvance` component of `ValueRecord` is consumed; the parser walks past any `XPlacement`/`YPlacement` fields and ignores `YAdvance` and every Device table.
- **LookupType 4 (Mark-to-Base Positioning)**, format 1. Mark records carry `{class, anchor}`, base records carry one anchor per mark class, and `MarkOffset(base, mark, feature)` returns the `(dx, dy)` delta an applied-positioning pass needs to move the mark glyph's origin so its anchor lands on the matching base anchor.
- **LookupType 9 Extension** unwrapping for the two supported subtable types so fonts that hide their positioning behind extensions decode transparently.

Anchor formats 1, 2, and 3 all parse; the anchor-point index in format 2 and the Device offsets in format 3 are read past and discarded for this iteration.

`sfntFace` gains a `GPOS() *GPOSAdjustments` accessor with the same lazy-cache pattern as `GSUB()`. A matching optional `GPOSProvider` interface is exposed alongside `GSUBProvider`.

`Face.Kern` now prefers GPOS over the legacy kern table when both sources carry an adjustment for the same pair. This matches Microsoft's OpenType guidance on GPOS being the canonical source in modern fonts, and because `font.MeasureString` already routes through `Kern()`, every caller picks up GPOS-driven kerning without an API change.

## Trade-offs

- **Parser + data plumbing only.** Wiring `MarkOffset` into draw/layout needs cluster-aware glyph emission (a sibling phase-2 task). Doing both together would produce an unreviewable diff, so this PR ships the substrate and leaves the layout hookup for the follow-up.
- **Horizontal XAdvance only.** YAdvance, XPlacement, YPlacement, and Device tables are skipped past, not consumed. That covers the kerning case completely; vertical positioning and device-dependent adjustments are deferred.
- **Anchor formats 2 and 3 are parsed as format 1.** Hinting anchor points and Device-table x/y deltas are discarded. Well-behaved fonts degrade gracefully.
- **GPOS beats legacy `kern`.** First source to return a non-zero adjustment wins, GPOS first. Fonts with only a legacy `kern` table continue to work through the fallthrough branch.
- **Deferred lookup types.** LookupType 1 (SinglePos), 3 (Cursive), 5 (MarkLig), 6 (MarkMark), 7 (ContextPos), 8 (ChainContextPos). Called out as follow-up work.

## Test plan

- [x] `go test ./font/...` — new synthetic tests:
  - `TestValueRecordSize` / `TestValueRecordXAdvance` — ValueFormat field sizing and masking.
  - `TestParseGPOSPairPosFormat1` — explicit pair.
  - `TestParseGPOSPairPosValueFormatMasking` — XPlacement + XAdvance layout.
  - `TestParseGPOSPairPosFormat2` — 2x2 class-based matrix, four distinct adjustments.
  - `TestParseGPOSMarkBasePosFormat1` — anchor arithmetic `(base - mark)`.
  - `TestParseGPOSAnchorFormats2And3` — formats 2/3 parse to the same (x,y) as format 1.
  - `TestParseGPOSExtensionWrap` — PairPos reached through LookupType 9.
  - `TestParseGPOSReturnsNilWithoutTable` — missing-table nil path.
  - `TestParseClassDefFormat1` — simpler ClassDef shape.
  - `TestFaceKernPrefersGPOS` — GPOS wins over legacy kern, legacy kern still flows through.
  - `TestFaceGPOSCacheIdentity` — one-shot cache flag.
- [x] `go test ./...` — full suite green.
- [x] `go vet ./...` — clean.
- [x] `gofmt -s -l .` — clean.

Reference: ISO 14496-22 section 6.3, OpenType GPOS table.