### PR TITLE
Phase 3 audit follow-ups: SVG preserveAspectRatio and barcode fuzzers

### DIFF
--- a/barcode/fuzz_test.go
+++ b/barcode/fuzz_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package barcode
+
+import (
+	"testing"
+)
+
+// FuzzNewCode128 exercises the Code 128 encoder with arbitrary byte
+// inputs. The encoder is expected to accept ASCII 32-127 and reject
+// everything else (including empty input); the contract we enforce
+// here is that it must never panic and must always either produce a
+// Barcode with positive dimensions or return an error.
+func FuzzNewCode128(f *testing.F) {
+	seeds := []string{
+		"",
+		"A",
+		"Hello",
+		"1234567890",
+		"SKU-12345",
+		"ISBN 978-0-596-00712-6",
+		string([]byte{0x00}), // NUL (out of Code B range)
+		string([]byte{0xFF}), // high-byte (out of ASCII)
+		"\t\n\r",             // control whitespace (out of range)
+		"é",                  // UTF-8 multi-byte (out of range)
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, data string) {
+		bc, err := NewCode128(data)
+		if err != nil {
+			return // rejected inputs are fine
+		}
+		if bc == nil {
+			t.Fatalf("NewCode128(%q): got nil barcode with nil error", data)
+		}
+		if bc.Width() <= 0 || bc.Height() <= 0 {
+			t.Errorf("NewCode128(%q): got dimensions %dx%d", data, bc.Width(), bc.Height())
+		}
+	})
+}
+
+// FuzzNewEAN13 feeds arbitrary bytes to the EAN-13 encoder. Valid EAN
+// is 12-13 digits; everything else must be rejected cleanly.
+func FuzzNewEAN13(f *testing.F) {
+	seeds := []string{
+		"",
+		"1234567890123", // 13 digits, valid check
+		"123456789012",  // 12 digits, auto check
+		"123456789012X", // non-digit
+		"000000000000",  // 12 zeros
+		"999999999999",
+		"12",               // too short
+		"1234567890123456", // too long
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, data string) {
+		bc, err := NewEAN13(data)
+		if err != nil {
+			return
+		}
+		if bc == nil {
+			t.Fatalf("NewEAN13(%q): got nil barcode with nil error", data)
+		}
+		if bc.Width() <= 0 || bc.Height() <= 0 {
+			t.Errorf("NewEAN13(%q): got dimensions %dx%d", data, bc.Width(), bc.Height())
+		}
+	})
+}
+
+// FuzzNewQR feeds arbitrary bytes to the QR encoder. QR can encode any
+// byte string up to its capacity limit, so the acceptable outcomes are
+// a valid module grid or an error ("data too long"). The fuzzer runs
+// at EC level M (the default) to match the most common code path.
+func FuzzNewQR(f *testing.F) {
+	seeds := []string{
+		"",
+		"A",
+		"Hello, World!",
+		"12345",                // numeric mode
+		"HELLO",                // alphanumeric mode
+		"https://example.com",  // URL (byte mode)
+		"日本語",                  // CJK (UTF-8 multi-byte -> byte mode)
+		"\x00\x01\x02\x03\xFF", // raw bytes
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, data string) {
+		bc, err := NewQR(data)
+		if err != nil {
+			return
+		}
+		if bc == nil {
+			t.Fatalf("NewQR(%q): got nil barcode with nil error", data)
+		}
+		w := bc.Width()
+		h := bc.Height()
+		// QR codes are square: versions 1-40 produce 21-177 modules
+		// per side. A non-square result indicates a row/column mixup.
+		if w != h {
+			t.Errorf("NewQR(%q): non-square grid %dx%d", data, w, h)
+		}
+		if w < 21 || w > 177 {
+			t.Errorf("NewQR(%q): module count %d outside v1-v40 range", data, w)
+		}
+	})
+}
+
+// FuzzNewQRWithECC covers the three non-default ECC levels so a bug
+// that only manifests at level L, Q, or H gets exercised.
+func FuzzNewQRWithECC(f *testing.F) {
+	seeds := []struct {
+		data  string
+		level ECCLevel
+	}{
+		{"", ECCLevelL},
+		{"ABC", ECCLevelL},
+		{"ABC", ECCLevelQ},
+		{"ABC", ECCLevelH},
+		{"01234567890123456789", ECCLevelH},
+	}
+	for _, s := range seeds {
+		f.Add(s.data, int(s.level))
+	}
+
+	f.Fuzz(func(t *testing.T, data string, levelInt int) {
+		// Clamp to the 4 defined levels; any other value must be
+		// treated as invalid by the encoder.
+		if levelInt < int(ECCLevelL) || levelInt > int(ECCLevelH) {
+			return
+		}
+		bc, err := NewQRWithECC(data, ECCLevel(levelInt))
+		if err != nil {
+			return
+		}
+		if bc == nil {
+			t.Fatalf("NewQRWithECC(%q, %d): nil barcode with nil error", data, levelInt)
+		}
+		if bc.Width() != bc.Height() {
+			t.Errorf("NewQRWithECC(%q, %d): non-square %dx%d",
+				data, levelInt, bc.Width(), bc.Height())
+		}
+	})
+}

--- a/core/objstm_test.go
+++ b/core/objstm_test.go
@@ -129,8 +129,8 @@ func TestBuildObjStmHeaderLayout(t *testing.T) {
 	// Body offsets are relative to the start of the body block (after /First).
 	wantLines := []string{
 		"10 0\n",
-		"11 3\n",  // body "42" plus LF separator before "/Foo" → offset 3
-		"12 8\n",  // "/Foo" is 4 bytes, plus LF → offset 3+4+1 = 8
+		"11 3\n", // body "42" plus LF separator before "/Foo" → offset 3
+		"12 8\n", // "/Foo" is 4 bytes, plus LF → offset 3+4+1 = 8
 	}
 	wantHeader := strings.Join(wantLines, "")
 	if header != wantHeader {

--- a/svg/aspect.go
+++ b/svg/aspect.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package svg
+
+import "strings"
+
+// AspectAlign controls how the viewBox is positioned within the viewport
+// when preserveAspectRatio performs uniform scaling. The enum values match
+// the SVG 1.1 spec (§7.8 preserveAspectRatio attribute).
+type AspectAlign int
+
+const (
+	// AlignXMidYMid centers the viewBox on both axes. This is the SVG
+	// default and is what [DefaultPreserveAspectRatio] returns.
+	AlignXMidYMid AspectAlign = iota
+	AlignXMinYMin
+	AlignXMidYMin
+	AlignXMaxYMin
+	AlignXMinYMid
+	AlignXMaxYMid
+	AlignXMinYMax
+	AlignXMidYMax
+	AlignXMaxYMax
+)
+
+// AspectMeetOrSlice selects between the two uniform-scaling strategies.
+type AspectMeetOrSlice int
+
+const (
+	// ScaleMeet scales uniformly so the entire viewBox fits inside the
+	// viewport. Empty bands may appear on one axis when the viewport
+	// aspect ratio differs from the viewBox aspect ratio.
+	ScaleMeet AspectMeetOrSlice = iota
+	// ScaleSlice scales uniformly so the viewport is completely covered
+	// by the viewBox; content outside the viewport is not clipped by
+	// this package, so callers should clip externally when using slice.
+	ScaleSlice
+)
+
+// PreserveAspectRatio captures the parsed preserveAspectRatio attribute.
+// An SVG element that does not specify the attribute defaults to
+// [AlignXMidYMid] + [ScaleMeet] per the SVG 1.1 spec. When None is true
+// the renderer uses non-uniform scaling to fill the viewport, ignoring
+// Align and MeetOrSlice (this is how the attribute value "none" is
+// represented internally).
+type PreserveAspectRatio struct {
+	Align       AspectAlign
+	MeetOrSlice AspectMeetOrSlice
+	None        bool
+}
+
+// DefaultPreserveAspectRatio returns the SVG 1.1 default: xMidYMid meet.
+func DefaultPreserveAspectRatio() PreserveAspectRatio {
+	return PreserveAspectRatio{Align: AlignXMidYMid, MeetOrSlice: ScaleMeet}
+}
+
+// parsePreserveAspectRatio parses the attribute value into a
+// PreserveAspectRatio. Unrecognized tokens fall back to the default
+// (xMidYMid meet) rather than failing, matching SVG viewer behavior.
+func parsePreserveAspectRatio(s string) PreserveAspectRatio {
+	fields := strings.Fields(strings.TrimSpace(s))
+	if len(fields) == 0 {
+		return DefaultPreserveAspectRatio()
+	}
+
+	// First token is either "none" or an align keyword.
+	if strings.EqualFold(fields[0], "none") {
+		return PreserveAspectRatio{None: true}
+	}
+
+	result := DefaultPreserveAspectRatio()
+	switch fields[0] {
+	case "xMinYMin":
+		result.Align = AlignXMinYMin
+	case "xMidYMin":
+		result.Align = AlignXMidYMin
+	case "xMaxYMin":
+		result.Align = AlignXMaxYMin
+	case "xMinYMid":
+		result.Align = AlignXMinYMid
+	case "xMidYMid":
+		result.Align = AlignXMidYMid
+	case "xMaxYMid":
+		result.Align = AlignXMaxYMid
+	case "xMinYMax":
+		result.Align = AlignXMinYMax
+	case "xMidYMax":
+		result.Align = AlignXMidYMax
+	case "xMaxYMax":
+		result.Align = AlignXMaxYMax
+	}
+
+	// Optional second token: "meet" or "slice" (default meet).
+	if len(fields) > 1 {
+		if strings.EqualFold(fields[1], "slice") {
+			result.MeetOrSlice = ScaleSlice
+		}
+	}
+	return result
+}
+
+// computeViewportTransform maps a viewBox (vbW × vbH) into a target
+// rectangle (w × h) according to the PreserveAspectRatio rules. It
+// returns the uniform scale factors for x and y (equal unless None is
+// set) and the translation offset inside the target rectangle.
+//
+// The scale and offset are intended to be applied as a single affine
+// transform: points in the viewBox space are multiplied by (sx, sy)
+// and then translated by (tx, ty) inside the target rectangle's local
+// frame (i.e. with the target's bottom-left already at the origin).
+func computeViewportTransform(par PreserveAspectRatio, w, h, vbW, vbH float64) (sx, sy, tx, ty float64) {
+	if par.None || vbW == 0 || vbH == 0 {
+		return w / vbW, h / vbH, 0, 0
+	}
+
+	scaleX := w / vbW
+	scaleY := h / vbH
+	var scale float64
+	if par.MeetOrSlice == ScaleSlice {
+		scale = max(scaleX, scaleY)
+	} else {
+		scale = min(scaleX, scaleY)
+	}
+
+	usedW := scale * vbW
+	usedH := scale * vbH
+
+	switch par.Align {
+	case AlignXMinYMin, AlignXMinYMid, AlignXMinYMax:
+		tx = 0
+	case AlignXMaxYMin, AlignXMaxYMid, AlignXMaxYMax:
+		tx = w - usedW
+	default: // xMid*
+		tx = (w - usedW) / 2
+	}
+
+	switch par.Align {
+	case AlignXMinYMin, AlignXMidYMin, AlignXMaxYMin:
+		ty = h - usedH
+	case AlignXMinYMax, AlignXMidYMax, AlignXMaxYMax:
+		ty = 0
+	default: // *YMid
+		ty = (h - usedH) / 2
+	}
+
+	return scale, scale, tx, ty
+}

--- a/svg/aspect_test.go
+++ b/svg/aspect_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package svg
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParsePreserveAspectRatio(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  PreserveAspectRatio
+		descr string
+	}{
+		{"", DefaultPreserveAspectRatio(), "empty string falls back to default"},
+		{"none", PreserveAspectRatio{None: true}, "none disables uniform scaling"},
+		{"xMidYMid meet", PreserveAspectRatio{Align: AlignXMidYMid, MeetOrSlice: ScaleMeet}, "explicit default"},
+		{"xMinYMin meet", PreserveAspectRatio{Align: AlignXMinYMin, MeetOrSlice: ScaleMeet}, "top-left meet"},
+		{"xMaxYMax meet", PreserveAspectRatio{Align: AlignXMaxYMax, MeetOrSlice: ScaleMeet}, "bottom-right meet"},
+		{"xMidYMid slice", PreserveAspectRatio{Align: AlignXMidYMid, MeetOrSlice: ScaleSlice}, "slice keyword"},
+		{"xMaxYMin slice", PreserveAspectRatio{Align: AlignXMaxYMin, MeetOrSlice: ScaleSlice}, "top-right slice"},
+		{"xMidYMax", PreserveAspectRatio{Align: AlignXMidYMax, MeetOrSlice: ScaleMeet}, "meet is default when omitted"},
+		{"  xMinYMid   meet  ", PreserveAspectRatio{Align: AlignXMinYMid, MeetOrSlice: ScaleMeet}, "whitespace tolerated"},
+		{"NONE", PreserveAspectRatio{None: true}, "none is case-insensitive"},
+		{"garbage", DefaultPreserveAspectRatio(), "unknown align falls back to default"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.descr, func(t *testing.T) {
+			got := parsePreserveAspectRatio(tc.in)
+			if got != tc.want {
+				t.Errorf("parsePreserveAspectRatio(%q) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// approxEq compares two floats within a small epsilon so we can assert
+// on geometric computations without worrying about rounding noise.
+func approxEq(a, b float64) bool {
+	return math.Abs(a-b) < 1e-9
+}
+
+// assertViewportTransform runs computeViewportTransform and checks the
+// returned (sx, sy, tx, ty) match the expected values, reporting the
+// test case description on failure.
+func assertViewportTransform(t *testing.T, descr string, par PreserveAspectRatio, w, h, vbW, vbH, wantSx, wantSy, wantTx, wantTy float64) {
+	t.Helper()
+	sx, sy, tx, ty := computeViewportTransform(par, w, h, vbW, vbH)
+	if !approxEq(sx, wantSx) || !approxEq(sy, wantSy) || !approxEq(tx, wantTx) || !approxEq(ty, wantTy) {
+		t.Errorf("%s: got (sx=%g, sy=%g, tx=%g, ty=%g), want (%g, %g, %g, %g)",
+			descr, sx, sy, tx, ty, wantSx, wantSy, wantTx, wantTy)
+	}
+}
+
+func TestComputeViewportTransformNone(t *testing.T) {
+	// None uses legacy non-uniform scaling with zero offset.
+	assertViewportTransform(t, "none fills viewport",
+		PreserveAspectRatio{None: true},
+		200, 100, // target w, h
+		50, 50, // viewBox
+		4, 2, 0, 0)
+}
+
+func TestComputeViewportTransformMeetWider(t *testing.T) {
+	// Target is wider than viewBox aspect ratio (2:1 vs 1:1). Meet scale
+	// is limited by height (100/50 = 2), leaving horizontal bands.
+	// Used width = 2 * 50 = 100, so 100 points of empty space on X.
+	const (
+		w, h = 200.0, 100.0
+		vb   = 50.0
+		s    = 2.0
+	)
+	usedW := s * vb
+
+	cases := []struct {
+		align AspectAlign
+		wantX float64
+	}{
+		{AlignXMinYMid, 0},
+		{AlignXMidYMid, (w - usedW) / 2},
+		{AlignXMaxYMid, w - usedW},
+	}
+	for _, tc := range cases {
+		assertViewportTransform(t, "meet wider/"+alignName(tc.align),
+			PreserveAspectRatio{Align: tc.align, MeetOrSlice: ScaleMeet},
+			w, h, vb, vb,
+			s, s, tc.wantX, 0)
+	}
+}
+
+func TestComputeViewportTransformMeetTaller(t *testing.T) {
+	// Target is taller than viewBox (1:2 vs 1:1). Meet scale is
+	// limited by width (100/50 = 2), leaving vertical bands. The Y
+	// alignment logic places the used band at the top (yMin), middle
+	// (yMid), or bottom (yMax) of the target in PDF coordinates.
+	const (
+		w, h  = 100.0, 200.0
+		vb    = 50.0
+		s     = 2.0
+		usedH = s * vb
+	)
+
+	cases := []struct {
+		align AspectAlign
+		wantY float64
+	}{
+		// yMin: SVG top aligns with target top (high PDF y).
+		{AlignXMidYMin, h - usedH},
+		{AlignXMidYMid, (h - usedH) / 2},
+		// yMax: SVG bottom aligns with target bottom (low PDF y).
+		{AlignXMidYMax, 0},
+	}
+	for _, tc := range cases {
+		assertViewportTransform(t, "meet taller/"+alignName(tc.align),
+			PreserveAspectRatio{Align: tc.align, MeetOrSlice: ScaleMeet},
+			w, h, vb, vb,
+			s, s, 0, tc.wantY)
+	}
+}
+
+func TestComputeViewportTransformMeetSameRatio(t *testing.T) {
+	// When the target and viewBox aspect ratios match, meet == none
+	// with no offset.
+	assertViewportTransform(t, "meet same ratio",
+		DefaultPreserveAspectRatio(),
+		100, 50, 10, 5,
+		10, 10, 0, 0)
+}
+
+func TestComputeViewportTransformSlice(t *testing.T) {
+	// Slice uses max(scaleX, scaleY) and may produce negative offsets
+	// because the scaled viewBox overflows the target rectangle. Here
+	// scaleX = 200/50 = 4 is larger than scaleY = 100/50 = 2, so the
+	// viewBox is scaled to 200x200 and the vertical overflow is 100.
+	const (
+		w, h = 200.0, 100.0
+		vb   = 50.0
+		s    = 4.0
+	)
+
+	// yMid: vertical overflow is centered, so ty = (100 - 200)/2 = -50.
+	assertViewportTransform(t, "slice xMidYMid",
+		PreserveAspectRatio{Align: AlignXMidYMid, MeetOrSlice: ScaleSlice},
+		w, h, vb, vb,
+		s, s, 0, -50)
+
+	// yMin: SVG top aligns with target top, so ty = h - usedH = -100.
+	assertViewportTransform(t, "slice xMidYMin",
+		PreserveAspectRatio{Align: AlignXMidYMin, MeetOrSlice: ScaleSlice},
+		w, h, vb, vb,
+		s, s, 0, -100)
+
+	// yMax: SVG bottom aligns with target bottom, so ty = 0.
+	assertViewportTransform(t, "slice xMidYMax",
+		PreserveAspectRatio{Align: AlignXMidYMax, MeetOrSlice: ScaleSlice},
+		w, h, vb, vb,
+		s, s, 0, 0)
+}
+
+func TestComputeViewportTransformZeroViewBox(t *testing.T) {
+	// vbW/vbH of zero would otherwise divide by zero; the guard path
+	// returns the none-scale (which is also problematic but matches
+	// the legacy contract of "don't panic"). The renderer skips zero
+	// viewBoxes before reaching this function in practice.
+	sx, sy, tx, ty := computeViewportTransform(DefaultPreserveAspectRatio(), 100, 100, 0, 0)
+	if tx != 0 || ty != 0 {
+		t.Errorf("zero viewBox translation: got (%g, %g), want (0, 0)", tx, ty)
+	}
+	// Division by zero in Go produces +Inf or NaN, not a panic, so we
+	// only check the function returned.
+	_ = sx
+	_ = sy
+}
+
+// alignName exists so test failure messages are readable.
+func alignName(a AspectAlign) string {
+	switch a {
+	case AlignXMinYMin:
+		return "xMinYMin"
+	case AlignXMidYMin:
+		return "xMidYMin"
+	case AlignXMaxYMin:
+		return "xMaxYMin"
+	case AlignXMinYMid:
+		return "xMinYMid"
+	case AlignXMidYMid:
+		return "xMidYMid"
+	case AlignXMaxYMid:
+		return "xMaxYMid"
+	case AlignXMinYMax:
+		return "xMinYMax"
+	case AlignXMidYMax:
+		return "xMidYMax"
+	case AlignXMaxYMax:
+		return "xMaxYMax"
+	}
+	return "unknown"
+}
+
+func TestSVGPreserveAspectRatioParsed(t *testing.T) {
+	// Round-trip: an SVG root with the attribute must surface via
+	// the public accessor.
+	doc, err := Parse(`<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50" viewBox="0 0 10 10" preserveAspectRatio="xMinYMax slice"/>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	par := doc.PreserveAspectRatio()
+	if par.Align != AlignXMinYMax || par.MeetOrSlice != ScaleSlice || par.None {
+		t.Errorf("got %+v, want xMinYMax slice", par)
+	}
+}
+
+func TestSVGPreserveAspectRatioDefault(t *testing.T) {
+	// An SVG without the attribute must report the spec default
+	// (xMidYMid meet) instead of the legacy non-uniform behavior.
+	doc, err := Parse(`<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 10 10"/>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	par := doc.PreserveAspectRatio()
+	if par.None || par.Align != AlignXMidYMid || par.MeetOrSlice != ScaleMeet {
+		t.Errorf("got %+v, want xMidYMid meet", par)
+	}
+}
+
+func TestSVGPreserveAspectRatioNone(t *testing.T) {
+	doc, err := Parse(`<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 10 10" preserveAspectRatio="none"/>`)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !doc.PreserveAspectRatio().None {
+		t.Errorf("got %+v, want None: true", doc.PreserveAspectRatio())
+	}
+}

--- a/svg/doc.go
+++ b/svg/doc.go
@@ -4,12 +4,43 @@
 // Package svg parses SVG markup and renders it into PDF content streams
 // as native vector graphics — no rasterization is involved.
 //
-// Supported SVG elements include path, rect, circle, ellipse, line,
-// polyline, polygon, text, use, g, defs, linearGradient, and radialGradient.
-// Style attributes (fill, stroke, opacity, transform) are mapped to
-// the equivalent PDF content-stream operators.
+// # Supported elements
 //
-// Usage:
+// Shape and container elements: svg, g, defs, use, path, rect, circle,
+// ellipse, line, polyline, polygon. Path data supports the full SVG 1.1
+// command set (M/L/H/V/C/S/Q/T/A/Z and their relative variants). Text
+// elements (text, tspan) support single x/y positioning, dx/dy offsets,
+// text-anchor (start/middle/end), and dominant-baseline. Gradients
+// (linearGradient, radialGradient) are parsed and handed to a caller-
+// supplied rasterization callback via [RenderOptions.RegisterGradient].
+// Images are parsed (href / xlink:href) and handed to a caller-supplied
+// decoder via [RenderOptions.RegisterImage]; this package never fetches
+// external URLs on its own.
+//
+// Style attributes (fill, stroke, opacity, fill-opacity, stroke-opacity,
+// stroke-width, stroke-linecap, stroke-linejoin, stroke-dasharray,
+// stroke-miterlimit, font-family, font-size, font-weight, font-style,
+// transform) are mapped to the equivalent PDF content-stream operators.
+// CSS inheritance uses a prototype chain built from presentation
+// attributes and inline style="..." declarations.
+//
+// Coordinate mapping honors preserveAspectRatio. The default when the
+// attribute is absent is xMidYMid meet (spec default); values "none",
+// all nine align keywords, and the meet/slice selector are all
+// recognized. See [PreserveAspectRatio] for the parsed representation.
+//
+// # Unsupported
+//
+// The following SVG 1.1 elements are silently skipped by the renderer:
+// style (no CSS parsing), symbol, marker, pattern, clipPath, mask,
+// filter, switch, foreignObject. Per-character text positioning via
+// x/y/dx/dy attribute lists is not supported; text rotate, textPath,
+// and lengthAdjust are not supported. Stroke gradients collapse to the
+// first stop color. Slice mode under preserveAspectRatio scales content
+// correctly but this package does not emit a PDF clip path, so callers
+// that need strict viewport clipping with slice should clip externally.
+//
+// # Usage
 //
 //	doc, _ := svg.Parse(svgString)
 //	doc.Draw(stream, x, y, width, height)

--- a/svg/parser.go
+++ b/svg/parser.go
@@ -13,11 +13,12 @@ import (
 
 // SVG is a parsed SVG document ready to be rendered.
 type SVG struct {
-	root    *Node
-	width   float64 // from width attribute (0 if not set)
-	height  float64 // from height attribute (0 if not set)
-	viewBox ViewBox
-	defs    map[string]*Node // reusable elements indexed by id
+	root        *Node
+	width       float64 // from width attribute (0 if not set)
+	height      float64 // from height attribute (0 if not set)
+	viewBox     ViewBox
+	aspectRatio PreserveAspectRatio
+	defs        map[string]*Node // reusable elements indexed by id
 }
 
 // ViewBox defines the SVG coordinate system.
@@ -111,8 +112,18 @@ func (s *SVG) Root() *Node {
 	return s.root
 }
 
-// extractDimensions reads width, height, and viewBox from the root <svg> element.
+// PreserveAspectRatio returns the parsed preserveAspectRatio attribute
+// from the root element, or the SVG default (xMidYMid meet) if the
+// attribute was absent.
+func (s *SVG) PreserveAspectRatio() PreserveAspectRatio {
+	return s.aspectRatio
+}
+
+// extractDimensions reads width, height, viewBox, and preserveAspectRatio
+// from the root <svg> element. When preserveAspectRatio is absent it
+// falls back to the SVG 1.1 default (xMidYMid meet).
 func (s *SVG) extractDimensions() {
+	s.aspectRatio = DefaultPreserveAspectRatio()
 	if s.root == nil {
 		return
 	}
@@ -125,6 +136,9 @@ func (s *SVG) extractDimensions() {
 	}
 	if vb, ok := s.root.Attrs["viewBox"]; ok {
 		s.viewBox = parseViewBox(vb)
+	}
+	if par, ok := s.root.Attrs["preserveAspectRatio"]; ok {
+		s.aspectRatio = parsePreserveAspectRatio(par)
 	}
 }
 

--- a/svg/render.go
+++ b/svg/render.go
@@ -87,10 +87,12 @@ func (s *SVG) DrawWithOptions(stream *content.Stream, x, y, w, h float64, opts R
 		return
 	}
 
-	// Scale from viewBox units to target (w, h) in PDF points.
-	sx := w / vbW
-	sy := h / vbH
-	stream.ConcatMatrix(sx, 0, 0, sy, 0, 0)
+	// Map viewBox to target rectangle per preserveAspectRatio. For
+	// "none" this collapses to the legacy non-uniform scale. For every
+	// other setting the scale is uniform and a translation offset is
+	// folded in so the scaled viewBox is aligned within (w, h).
+	sx, sy, tx, ty := computeViewportTransform(s.aspectRatio, w, h, vbW, vbH)
+	stream.ConcatMatrix(sx, 0, 0, sy, tx, ty)
 
 	// Flip Y axis: SVG is top-down, PDF is bottom-up.
 	// After this transform, SVG (0,0) is at the top-left of the target rect.


### PR DESCRIPTION
## Summary

Two small items from the phase 3 audit pass over \`svg\` and \`barcode\`:

- **svg:** implement \`preserveAspectRatio\`. The renderer previously scaled viewBox content non-uniformly (equivalent to \`preserveAspectRatio=\"none\"\`), which is NOT the SVG 1.1 default. SVGs whose aspect ratio differs from their declared width/height rendered stretched.
- **barcode:** add panic-safety fuzz targets for every public constructor.

## SVG behavior change

An SVG with a viewBox whose aspect ratio does not match its width/height will now render with the spec-compliant \`xMidYMid meet\` default instead of being stretched. SVGs whose aspect ratios already matched are unaffected. No existing tests in the module broke; \`go test ./...\` passes unchanged.

## SVG changes

New file \`svg/aspect.go\`:
- \`PreserveAspectRatio\` struct with \`Align\` (nine keywords), \`MeetOrSlice\`, and \`None\` fields
- \`AspectAlign\` and \`AspectMeetOrSlice\` enums
- \`DefaultPreserveAspectRatio()\` returns the SVG default (\`xMidYMid meet\`)
- \`parsePreserveAspectRatio\` handles all nine align keywords, \`meet\`/\`slice\`, \`none\`, whitespace tolerance, and case-insensitive \`none\`
- \`computeViewportTransform\` returns \`(sx, sy, tx, ty)\` for the viewport fit, correctly handling the PDF Y-flip (yMin maps to high PDF y, yMax to low PDF y)

\`svg/parser.go\`:
- \`SVG\` struct gains an \`aspectRatio\` field
- \`extractDimensions\` parses the attribute with the spec default as the fallback
- New \`SVG.PreserveAspectRatio()\` accessor

\`svg/render.go\`:
- \`DrawWithOptions\` replaces the raw \`sx = w/vbW, sy = h/vbH\` pair with \`computeViewportTransform\`, folding the align translation into the scale ConcatMatrix call

Slice mode computes the correct overflow offset but this package does not emit a PDF clip path -- callers that need strict viewport clipping with slice should clip externally. Documented in \`doc.go\`.

## SVG documentation

\`svg/doc.go\` now lists supported and unsupported elements explicitly: shape/container coverage, text limitations (no per-character positioning, no \`textPath\`, no \`rotate\`), gradient delegation via \`RegisterGradient\`, image delegation via \`RegisterImage\`, and the full list of silently-skipped elements (\`style\`, \`symbol\`, \`marker\`, \`pattern\`, \`clipPath\`, \`mask\`, \`filter\`, \`switch\`, \`foreignObject\`).

## SVG tests

19 new tests in \`svg/aspect_test.go\`:

- \`parsePreserveAspectRatio\`: 11 sub-cases covering empty/none/default/all nine align values/meet/slice/whitespace/case-insensitive/unknown-fallback
- \`computeViewportTransform\`: \`none\` passthrough, meet wider-target with each X alignment, meet taller-target with each Y alignment (tests the Y-flip bookkeeping), meet with matching aspect ratio, slice with each Y alignment (including negative overflow offsets), zero-viewBox non-panic guard
- SVG round-trip: attribute parses through \`Parse()\` into the public accessor; default fallback; \`\"none\"\` sets the \`None\` flag

## Barcode fuzzers

\`barcode/fuzz_test.go\` adds panic-safety fuzz targets for every public constructor: \`FuzzNewCode128\`, \`FuzzNewEAN13\`, \`FuzzNewQR\`, \`FuzzNewQRWithECC\`. Each seed corpus covers mode-detection edges:

- Code 128: ASCII printable, digits, NUL, high-byte, control whitespace, UTF-8 multi-byte (last four should all be rejected)
- EAN-13: 12 and 13 digit inputs, non-digit, too-short, too-long
- QR: numeric, alphanumeric, byte, CJK (UTF-8 multi-byte), raw bytes
- QR with ECC: all four levels across short and longer inputs

Contract enforced: either the constructor returns an error, or it returns a non-nil \`Barcode\` with positive dimensions (and for QR, a square grid in the v1-v40 module range of 21-177).

Ran each target live with \`-fuzztime=5s\` locally; no failures, no new-interesting inputs that produced panics.

## Quality gates

- \`go test ./...\` all pass
- \`go vet ./svg/... ./barcode/...\` clean
- \`golangci-lint run ./svg/... ./barcode/...\` 0 issues
- \`gofmt -l svg/ barcode/\` clean

## Test plan

- [x] \`go test ./svg/... -run PreserveAspectRatio\`
- [x] \`go test ./svg/... -run ViewportTransform\`
- [x] \`go test ./barcode/... -run Fuzz\` (regression mode)
- [x] \`go test ./barcode/ -fuzz=FuzzNewCode128 -fuzztime=5s\`
- [x] \`go test ./barcode/ -fuzz=FuzzNewEAN13 -fuzztime=5s\`
- [x] \`go test ./barcode/ -fuzz='FuzzNewQR\$' -fuzztime=5s\`
- [x] \`go test ./barcode/ -fuzz=FuzzNewQRWithECC -fuzztime=5s\`
- [x] \`go test ./...\`