### PR TITLE
Kashida (tatweel) justification for Arabic paragraphs

### DIFF
--- a/layout/draw.go
+++ b/layout/draw.go
@@ -37,12 +37,27 @@ func drawTextLine(ctx DrawContext, words []Word, x, baselineY, maxWidth float64,
 		return
 	}
 
-	// For justified text, compute extra space between words.
+	// For justified text, compute extra space between words. When the line
+	// contains Arabic words, prefer kashida (tatweel) elongation over
+	// inter-word stretching: insert U+0640 into Arabic words to consume
+	// the slack above the natural inter-word gap. Whatever slack remains
+	// after kashida insertion (no Arabic on the line, no legal sites,
+	// or partial fill) falls through to whitespace stretching.
 	extraSpace := 0.0
 	if align == AlignJustify && !isLast && len(words) > 1 {
 		totalWordWidth := 0.0
 		for _, w := range words {
 			totalWordWidth += w.Width
+		}
+		// Slack = space available beyond the natural inter-word gaps.
+		naturalGaps := 0.0
+		for i := 0; i < len(words)-1; i++ {
+			naturalGaps += words[i].SpaceAfter
+		}
+		kashidaSlack := maxWidth - totalWordWidth - naturalGaps
+		if kashidaSlack > 0 {
+			consumed := applyKashidaJustification(words, kashidaSlack)
+			totalWordWidth += consumed
 		}
 		gaps := float64(len(words) - 1)
 		extraSpace = (maxWidth - totalWordWidth) / gaps

--- a/layout/kashida.go
+++ b/layout/kashida.go
@@ -1,0 +1,459 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Kashida (tatweel, U+0640) is the Arabic baseline-extension character.
+// In Arabic typography, justification is achieved by elongating the
+// connectors between letters rather than by widening inter-word spaces.
+// Tatweel is dual-joining: inserted between two glyphs that already
+// connect on both sides, it stretches the connection without changing
+// the visual identity of either neighbour.
+//
+// This file implements two operations:
+//
+//   - FindKashidaCandidates scans a string and returns every rune-boundary
+//     where a tatweel could legally be inserted under the simplified rule
+//     "the left neighbour can join on its left side AND the right neighbour
+//     can join on its right side".
+//
+//   - InsertKashidas takes a target count and inserts that many tatweels
+//     at the highest-priority sites returned by FindKashidaCandidates.
+//
+// The candidate finder works on both raw Arabic codepoints (U+0600..U+06FF)
+// and on already-shaped Presentation Forms-B glyphs (U+FE70..U+FEFF), so it
+// can be applied either before or after the Arabic shaper has run. This is
+// important: the layout engine shapes a word once at measurement time, and
+// kashida insertion happens during justification, after shaping.
+//
+// Reference: Unicode Standard, "Arabic" block; ArabicShaping.txt; the
+// semantics of U+0640 ARABIC TATWEEL. The Unicode Standard does not
+// prescribe a specific kashida placement algorithm — only the elongation
+// character itself. The priority heuristic used here is intentionally
+// simple; full typographic kashida placement is a follow-up topic.
+
+// kashidaTatweel is the rune for ARABIC TATWEEL (U+0640).
+const kashidaTatweel = '\u0640'
+
+// KashidaCandidate marks one rune-boundary position in a string where
+// inserting a tatweel (U+0640) is legal under the simplified Arabic
+// joining rules. Position is the byte offset of the boundary in the
+// original string — i.e. the byte index at which a U+0640 would be
+// inserted, NOT the byte offset of either neighbour.
+type KashidaCandidate struct {
+	// Position is the byte offset where a tatweel would be inserted.
+	Position int
+	// Priority indicates how preferred this site is. Higher values are
+	// preferred. The priority table is documented above this type.
+	Priority uint8
+}
+
+// Priority constants for kashida candidate sites. Higher = more preferred.
+//
+// The priority order is intentionally simple for a first iteration:
+//
+//   - kashidaPriorityAfterSeen: after a seen-family letter (seen, sheen,
+//     sad, dad). These letters carry a long horizontal baseline and accept
+//     elongation gracefully.
+//   - kashidaPriorityAfterFinal: after a letter that is in its final form
+//     and itself follows a connection. Reserved for ligature-aware setups;
+//     not currently distinguished from priority 1 in this implementation.
+//   - kashidaPriorityMedialPair: between two dual-joining letters that are
+//     both already medial (i.e. word-internal connections far from edges).
+//   - kashidaPriorityBasic: any other legal insertion point.
+const (
+	kashidaPriorityBasic      uint8 = 1
+	kashidaPriorityMedialPair uint8 = 2
+	kashidaPriorityAfterFinal uint8 = 3
+	kashidaPriorityAfterSeen  uint8 = 4
+)
+
+// joinSide describes which side(s) of a glyph can connect to a neighbour.
+// A glyph that can join on its left side may have a tatweel inserted to
+// the right of it (on its left edge). A glyph that can join on its right
+// side may have a tatweel inserted to the left of it (on its right edge).
+type joinSide uint8
+
+const (
+	joinNone  joinSide = 0
+	joinLeft  joinSide = 1 << 0 // left side connects (dual or initial form)
+	joinRight joinSide = 1 << 1 // right side connects (dual, final, medial form)
+	joinBoth           = joinLeft | joinRight
+)
+
+// pfbJoinSide is a reverse-lookup table built from arabicFormsTable that
+// maps each Presentation Forms-B codepoint to the side(s) it joins on.
+// Initialised once in init() so subsequent calls are O(1) lookups.
+var pfbJoinSide map[rune]joinSide
+
+func init() {
+	pfbJoinSide = make(map[rune]joinSide, len(arabicFormsTable)*4)
+	for _, forms := range arabicFormsTable {
+		// Isolated form: stands alone, no joining.
+		if forms.isolated != 0 {
+			pfbJoinSide[forms.isolated] = joinNone
+		}
+		// Final form: connects on its right side to a preceding glyph.
+		if forms.final != 0 {
+			pfbJoinSide[forms.final] = joinRight
+		}
+		// Initial form: connects on its left side to a following glyph.
+		if forms.initial != 0 {
+			pfbJoinSide[forms.initial] = joinLeft
+		}
+		// Medial form: connects on both sides.
+		if forms.medial != 0 {
+			pfbJoinSide[forms.medial] = joinBoth
+		}
+	}
+	// Lam-alef ligatures behave like a final form for the leading lam:
+	// they connect on the right side to a preceding glyph but never on
+	// the left (alef breaks the connection). The "final" variants of
+	// each lam-alef ligature carry that connection.
+	for _, lig := range []rune{0xFEF6, 0xFEF8, 0xFEFA, 0xFEFC} {
+		pfbJoinSide[lig] = joinRight
+	}
+	// Tatweel itself connects on both sides — the very property that
+	// makes it usable as an elongation glyph.
+	pfbJoinSide[kashidaTatweel] = joinBoth
+}
+
+// joinSideOf returns the join sides for a rune. It handles both base
+// Arabic codepoints (via the existing joining-type classifier) and
+// Presentation Forms-B glyphs (via pfbJoinSide). Non-Arabic runes return
+// joinNone.
+func joinSideOf(r rune) joinSide {
+	if side, ok := pfbJoinSide[r]; ok {
+		return side
+	}
+	switch getJoiningType(r) {
+	case jtDual:
+		return joinBoth
+	case jtRight:
+		return joinRight
+	default:
+		return joinNone
+	}
+}
+
+// isSeenFamily reports whether r is one of seen/sheen/sad/dad in any of
+// its forms (base codepoint or any of the four Presentation Forms-B
+// positional variants). These letters carry a long horizontal baseline
+// and are the canonical preferred sites for kashida insertion.
+func isSeenFamily(r rune) bool {
+	switch r {
+	case 0x0633, 0x0634, 0x0635, 0x0636: // seen, sheen, sad, dad (base)
+		return true
+	// seen forms
+	case 0xFEB1, 0xFEB2, 0xFEB3, 0xFEB4:
+		return true
+	// sheen forms
+	case 0xFEB5, 0xFEB6, 0xFEB7, 0xFEB8:
+		return true
+	// sad forms
+	case 0xFEB9, 0xFEBA, 0xFEBB, 0xFEBC:
+		return true
+	// dad forms
+	case 0xFEBD, 0xFEBE, 0xFEBF, 0xFEC0:
+		return true
+	}
+	return false
+}
+
+// FindKashidaCandidates returns every legal tatweel insertion point in s,
+// in left-to-right (logical) byte order. A site is legal when the rune to
+// the left of the boundary can join on its left side AND the rune to the
+// right can join on its right side. Each candidate carries a priority
+// derived from the simple heuristic described in the priority constants.
+//
+// The function operates on both raw Arabic codepoints and on already-
+// shaped Presentation Forms-B glyphs, so callers can apply it either
+// before or after Arabic shaping.
+func FindKashidaCandidates(s string) []KashidaCandidate {
+	if s == "" {
+		return nil
+	}
+	var out []KashidaCandidate
+	var prev rune
+	hasPrev := false
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if hasPrev {
+			// The boundary is between prev and r at byte offset i.
+			leftSides := joinSideOf(prev)
+			rightSides := joinSideOf(r)
+			if leftSides&joinLeft != 0 && rightSides&joinRight != 0 {
+				priority := kashidaPriorityBasic
+				if isSeenFamily(prev) {
+					priority = kashidaPriorityAfterSeen
+				} else if leftSides == joinBoth && rightSides == joinBoth {
+					priority = kashidaPriorityMedialPair
+				}
+				out = append(out, KashidaCandidate{
+					Position: i,
+					Priority: priority,
+				})
+			}
+		}
+		prev = r
+		hasPrev = true
+		i += size
+	}
+	return out
+}
+
+// InsertKashidas returns a copy of s with up to count tatweel characters
+// (U+0640) inserted at the highest-priority candidate sites. If count is
+// zero or there are no legal sites, s is returned unchanged. If count
+// exceeds the number of legal sites, only the available sites are used
+// and the remaining slack is left for the caller to consume by other
+// means (whitespace stretching).
+//
+// Insertion strategy: candidates are ranked by priority (descending),
+// with ties broken by position (ascending in logical order). At most one
+// tatweel is inserted at each candidate site — duplicates would compound
+// at a single connection and produce a visually wrong stair-stepped
+// result. Callers wanting more elongation than there are sites should
+// fall back to whitespace stretching.
+//
+// Precondition: count >= 0. Negative counts are treated as zero.
+func InsertKashidas(s string, count int) string {
+	if count <= 0 || s == "" {
+		return s
+	}
+	candidates := FindKashidaCandidates(s)
+	if len(candidates) == 0 {
+		return s
+	}
+	if count > len(candidates) {
+		count = len(candidates)
+	}
+
+	// Select the top-priority sites. We pick by priority descending,
+	// breaking ties by spreading across the word: among sites of the same
+	// priority we prefer the earliest, then the latest, then the next
+	// earliest, and so on. This avoids piling all tatweels into one
+	// adjacent cluster when the word has many equal-priority sites.
+	picked := pickKashidaSites(candidates, count)
+	if len(picked) == 0 {
+		return s
+	}
+
+	// Sort picked offsets ascending and rebuild the string in one pass.
+	insertSortAscending(picked)
+	var sb strings.Builder
+	sb.Grow(len(s) + count*len(string(kashidaTatweel)))
+	cursor := 0
+	for _, pos := range picked {
+		sb.WriteString(s[cursor:pos])
+		sb.WriteRune(kashidaTatweel)
+		cursor = pos
+	}
+	sb.WriteString(s[cursor:])
+	return sb.String()
+}
+
+// pickKashidaSites selects count positions from candidates, preferring
+// higher priority and spreading equal-priority sites across the word.
+func pickKashidaSites(candidates []KashidaCandidate, count int) []int {
+	if count <= 0 || len(candidates) == 0 {
+		return nil
+	}
+	// Group candidates by priority (highest first). We don't need a full
+	// sort because the priority space is tiny (1..4): bucket once.
+	const maxPriority = 4
+	buckets := make([][]int, maxPriority+1)
+	for _, c := range candidates {
+		p := c.Priority
+		if p > maxPriority {
+			p = maxPriority
+		}
+		buckets[p] = append(buckets[p], c.Position)
+	}
+	picked := make([]int, 0, count)
+	for p := maxPriority; p >= 1 && len(picked) < count; p-- {
+		bucket := buckets[p]
+		if len(bucket) == 0 {
+			continue
+		}
+		need := count - len(picked)
+		if need >= len(bucket) {
+			picked = append(picked, bucket...)
+			continue
+		}
+		// Spread selection across the bucket: alternate from the ends
+		// inward so the chosen sites are not adjacent.
+		picked = append(picked, spreadPick(bucket, need)...)
+	}
+	return picked
+}
+
+// spreadPick selects n positions from sorted-ascending bucket by
+// alternating from the front and back of the bucket. With n=1 it returns
+// the front. With n=2 it returns front and back. With n>=3 it interleaves
+// front, back, front+1, back-1, ... until n positions are gathered.
+func spreadPick(bucket []int, n int) []int {
+	if n <= 0 || len(bucket) == 0 {
+		return nil
+	}
+	if n >= len(bucket) {
+		out := make([]int, len(bucket))
+		copy(out, bucket)
+		return out
+	}
+	out := make([]int, 0, n)
+	lo, hi := 0, len(bucket)-1
+	front := true
+	for len(out) < n && lo <= hi {
+		if front {
+			out = append(out, bucket[lo])
+			lo++
+		} else {
+			out = append(out, bucket[hi])
+			hi--
+		}
+		front = !front
+	}
+	return out
+}
+
+// applyKashidaJustification mutates words in place to consume up to slack
+// extra width by inserting tatweels into Arabic words. It returns the
+// number of points actually consumed; the caller subtracts that from the
+// remaining slack and distributes whatever is left via whitespace
+// stretching.
+//
+// Eligibility rules:
+//   - The word must use an embedded font that contains a real tatweel
+//     glyph. Standard PDF fonts (Helvetica, Times, ...) cover only Latin
+//     and have no Arabic glyphs, so they are skipped.
+//   - The word's text must contain at least one legal kashida candidate
+//     after Arabic shaping has produced its Presentation Forms-B output.
+//
+// Distribution strategy: total slack is divided evenly across the eligible
+// Arabic words by kashida-glyph count. Each word gets roughly slack/N/adv
+// tatweels where adv is the tatweel advance in the word's font. Words
+// with too few legal sites take what they can; the residual rolls to the
+// next word and ultimately back to the caller.
+//
+// After insertion, each modified word's Width and Text are updated. The
+// re-measure path uses the same TextMeasurer the original measurement
+// used, so kerning behaves identically.
+func applyKashidaJustification(words []Word, slack float64) float64 {
+	if slack <= 0 || len(words) == 0 {
+		return 0
+	}
+	// Identify eligible word indices and their tatweel advances. We need
+	// to know per-word advance because mixed-font lines may have different
+	// tatweel glyph widths.
+	type eligible struct {
+		idx          int
+		tatweelAdv   float64
+		candidateCnt int
+	}
+	var elig []eligible
+	for i := range words {
+		w := words[i]
+		if w.InlineBlock != nil || w.Embedded == nil {
+			continue
+		}
+		if !wordIsArabic(w.Text) {
+			continue
+		}
+		face := w.Embedded.Face()
+		if face.GlyphIndex(kashidaTatweel) == 0 {
+			continue
+		}
+		adv := w.Embedded.MeasureString(string(kashidaTatweel), w.FontSize)
+		if adv <= 0 {
+			continue
+		}
+		cnt := len(FindKashidaCandidates(w.Text))
+		if cnt == 0 {
+			continue
+		}
+		elig = append(elig, eligible{idx: i, tatweelAdv: adv, candidateCnt: cnt})
+	}
+	if len(elig) == 0 {
+		return 0
+	}
+
+	consumed := 0.0
+	remaining := slack
+	// Pass over eligible words, allotting an even share of remaining slack
+	// to each. We iterate left-to-right; words that can't absorb their
+	// share roll the residual to the next word.
+	for k, e := range elig {
+		if remaining <= 0 {
+			break
+		}
+		share := remaining / float64(len(elig)-k)
+		count := int(share / e.tatweelAdv)
+		if count <= 0 {
+			continue
+		}
+		if count > e.candidateCnt {
+			count = e.candidateCnt
+		}
+		newText := InsertKashidas(words[e.idx].Text, count)
+		// Re-measure with the same TextMeasurer used at layout time.
+		newWidth := words[e.idx].Embedded.MeasureString(newText, words[e.idx].FontSize)
+		if words[e.idx].LetterSpacing != 0 {
+			n := len([]rune(newText))
+			if n > 1 {
+				newWidth += words[e.idx].LetterSpacing * float64(n-1)
+			}
+		}
+		delta := newWidth - words[e.idx].Width
+		if delta <= 0 {
+			continue
+		}
+		words[e.idx].Text = newText
+		words[e.idx].Width = newWidth
+		consumed += delta
+		remaining -= delta
+	}
+	return consumed
+}
+
+// wordIsArabic reports whether s contains any Arabic-script codepoint
+// (base block, supplement, Presentation Forms-A or Presentation Forms-B).
+// The check is intentionally a single rune scan that exits at the first
+// match — Arabic words usually have an Arabic letter very early.
+func wordIsArabic(s string) bool {
+	for _, r := range s {
+		if r >= 0x0600 && r <= 0x06FF {
+			return true
+		}
+		if r >= 0x0750 && r <= 0x077F {
+			return true
+		}
+		if r >= 0xFB50 && r <= 0xFDFF {
+			return true
+		}
+		if r >= 0xFE70 && r <= 0xFEFF {
+			return true
+		}
+	}
+	return false
+}
+
+// insertSortAscending sorts a small slice of ints in place. The slices
+// here are tiny (one tatweel count per Arabic word, typically <16) so an
+// insertion sort is fine and avoids pulling in sort for a hot path.
+func insertSortAscending(a []int) {
+	for i := 1; i < len(a); i++ {
+		v := a[i]
+		j := i - 1
+		for j >= 0 && a[j] > v {
+			a[j+1] = a[j]
+			j--
+		}
+		a[j+1] = v
+	}
+}

--- a/layout/kashida_paragraph_test.go
+++ b/layout/kashida_paragraph_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// mockArabicFace is a deterministic Face used for kashida justification
+// tests. It exposes a small set of Arabic letters (including the seen
+// family) plus tatweel (U+0640) and their PFB positional variants. All
+// glyphs share a fixed advance so width arithmetic is exact.
+type mockArabicFace struct {
+	advance int // glyph advance in font design units
+	upem    int
+}
+
+func (m *mockArabicFace) PostScriptName() string { return "MockArabicFace" }
+func (m *mockArabicFace) UnitsPerEm() int        { return m.upem }
+func (m *mockArabicFace) GlyphIndex(r rune) uint16 {
+	// Arabic block: every base letter has a glyph (GID = base+1).
+	if r >= 0x0600 && r <= 0x06FF {
+		return uint16(r - 0x0600 + 1)
+	}
+	// Presentation Forms-B: also covered (GID = 0x1000 + offset).
+	if r >= 0xFE70 && r <= 0xFEFF {
+		return uint16(0x1000 + (r - 0xFE70))
+	}
+	// ASCII space — used by paragraph layout to size inter-word gaps.
+	if r == ' ' {
+		return uint16(0xF000)
+	}
+	return 0
+}
+func (m *mockArabicFace) GlyphAdvance(gid uint16) int {
+	if gid == 0 {
+		return 0
+	}
+	return m.advance
+}
+func (m *mockArabicFace) Ascent() int             { return 800 }
+func (m *mockArabicFace) Descent() int            { return -200 }
+func (m *mockArabicFace) BBox() [4]int            { return [4]int{0, -200, 1000, 800} }
+func (m *mockArabicFace) ItalicAngle() float64    { return 0 }
+func (m *mockArabicFace) CapHeight() int          { return 700 }
+func (m *mockArabicFace) StemV() int              { return 80 }
+func (m *mockArabicFace) Kern(uint16, uint16) int { return 0 }
+func (m *mockArabicFace) Flags() uint32           { return 0 }
+func (m *mockArabicFace) RawData() []byte         { return nil }
+func (m *mockArabicFace) NumGlyphs() int          { return 4096 }
+
+// newMockArabicEmbedded returns a font.EmbeddedFont backed by mockArabicFace.
+// The advance/upem ratio is 1:2 so each glyph at FontSize=12 measures 6 pt.
+func newMockArabicEmbedded() *font.EmbeddedFont {
+	face := &mockArabicFace{advance: 500, upem: 1000}
+	return font.NewEmbeddedFont(face)
+}
+
+// countTatweels counts U+0640 occurrences across every word on every line.
+func countTatweels(lines []Line) int {
+	n := 0
+	for _, line := range lines {
+		for _, w := range line.Words {
+			n += strings.Count(w.Text, string(kashidaTatweel))
+		}
+	}
+	return n
+}
+
+// TestKashidaJustificationInsertsTatweels verifies that an Arabic-only
+// justified line with leftover space ends up containing tatweel
+// characters in its words after the draw pass mutates the captured word
+// slice. The test simulates the draw pass by invoking applyKashidaJustification
+// directly with the slack the renderer would compute.
+func TestKashidaJustificationInsertsTatweels(t *testing.T) {
+	ef := newMockArabicEmbedded()
+	// Build a line of three short Arabic words. The mock font measures
+	// every glyph at 6 pt at fontSize=12, so two words of 4 letters each
+	// + a space sum to a small width — leaving lots of slack on a 500 pt
+	// line.
+	words := []Word{
+		{Text: ShapeArabic("سلام"), Embedded: ef, FontSize: 12, SpaceAfter: ef.MeasureString(" ", 12)},
+		{Text: ShapeArabic("سلام"), Embedded: ef, FontSize: 12, SpaceAfter: ef.MeasureString(" ", 12)},
+		{Text: ShapeArabic("سلام"), Embedded: ef, FontSize: 12, SpaceAfter: ef.MeasureString(" ", 12)},
+	}
+	for i := range words {
+		words[i].Width = ef.MeasureString(words[i].Text, words[i].FontSize)
+	}
+
+	// Compute slack the renderer would see.
+	maxWidth := 500.0
+	totalW := 0.0
+	for _, w := range words {
+		totalW += w.Width
+	}
+	natural := words[0].SpaceAfter + words[1].SpaceAfter
+	slack := maxWidth - totalW - natural
+	if slack <= 0 {
+		t.Fatalf("test setup error: no slack available (slack=%v)", slack)
+	}
+
+	consumed := applyKashidaJustification(words, slack)
+	if consumed <= 0 {
+		t.Fatalf("expected kashida insertion to consume slack; consumed=%v", consumed)
+	}
+
+	totalTatweels := 0
+	for _, w := range words {
+		totalTatweels += strings.Count(w.Text, string(kashidaTatweel))
+	}
+	if totalTatweels == 0 {
+		t.Errorf("expected at least one tatweel inserted; got 0")
+	}
+}
+
+// TestKashidaJustificationLatinUntouched is a regression guard: a line
+// of Latin words must not gain any tatweels and the function must report
+// zero consumption.
+func TestKashidaJustificationLatinUntouched(t *testing.T) {
+	ef := newMockArabicEmbedded()
+	words := []Word{
+		{Text: "hello", Embedded: ef, FontSize: 12, SpaceAfter: ef.MeasureString(" ", 12)},
+		{Text: "world", Embedded: ef, FontSize: 12, SpaceAfter: 0},
+	}
+	for i := range words {
+		words[i].Width = ef.MeasureString(words[i].Text, words[i].FontSize)
+	}
+
+	consumed := applyKashidaJustification(words, 200.0)
+	if consumed != 0 {
+		t.Errorf("Latin words should not consume slack; got %v", consumed)
+	}
+	for _, w := range words {
+		if strings.Contains(w.Text, string(kashidaTatweel)) {
+			t.Errorf("Latin word gained a tatweel: %q", w.Text)
+		}
+	}
+}
+
+// TestKashidaJustificationStandardFontUntouched is a regression guard:
+// standard PDF fonts (no embedded face) have no Arabic glyphs and must
+// be skipped entirely. The slack falls through to whitespace stretching
+// just like before this change.
+func TestKashidaJustificationStandardFontUntouched(t *testing.T) {
+	words := []Word{
+		{Text: ShapeArabic("سلام"), Font: font.Helvetica, FontSize: 12, SpaceAfter: 4},
+		{Text: ShapeArabic("سلام"), Font: font.Helvetica, FontSize: 12, SpaceAfter: 0},
+	}
+	for i := range words {
+		words[i].Width = font.Helvetica.MeasureString(words[i].Text, words[i].FontSize)
+	}
+	consumed := applyKashidaJustification(words, 200.0)
+	if consumed != 0 {
+		t.Errorf("standard-font words should be skipped; consumed=%v", consumed)
+	}
+}
+
+// TestKashidaJustificationMixedRunPartialFill verifies that a mixed line
+// (one Arabic word, one Latin word) only mutates the Arabic word and
+// returns slack consumption equal to the inserted-tatweel total.
+func TestKashidaJustificationMixedRunPartialFill(t *testing.T) {
+	ef := newMockArabicEmbedded()
+	words := []Word{
+		{Text: ShapeArabic("سلام"), Embedded: ef, FontSize: 12, SpaceAfter: ef.MeasureString(" ", 12)},
+		{Text: "hello", Embedded: ef, FontSize: 12, SpaceAfter: 0},
+	}
+	for i := range words {
+		words[i].Width = ef.MeasureString(words[i].Text, words[i].FontSize)
+	}
+	originalLatin := words[1].Text
+
+	consumed := applyKashidaJustification(words, 100.0)
+	if consumed <= 0 {
+		t.Errorf("expected kashida slack consumption on Arabic word")
+	}
+	if words[1].Text != originalLatin {
+		t.Errorf("Latin word was modified: got %q want %q", words[1].Text, originalLatin)
+	}
+	if !strings.Contains(words[0].Text, string(kashidaTatweel)) {
+		t.Errorf("Arabic word did not gain a tatweel")
+	}
+}
+
+// TestKashidaJustificationLatinParagraphUnchanged is the high-level
+// regression guard required by the spec: a pure-Latin paragraph still
+// produces identical output before and after this change. We compare
+// against a known-good shape (no tatweels anywhere, no width changes).
+func TestKashidaJustificationLatinParagraphUnchanged(t *testing.T) {
+	p := NewParagraph(
+		"The quick brown fox jumps over the lazy dog and then keeps running.",
+		font.Helvetica, 12,
+	).SetAlign(AlignJustify)
+	lines := p.Layout(200) // narrow column to force multi-line justification
+	if countTatweels(lines) != 0 {
+		t.Errorf("Latin paragraph contains tatweels (%d); expected zero", countTatweels(lines))
+	}
+}

--- a/layout/kashida_test.go
+++ b/layout/kashida_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFindKashidaCandidatesEmpty verifies the empty-string base case.
+func TestFindKashidaCandidatesEmpty(t *testing.T) {
+	if got := FindKashidaCandidates(""); got != nil {
+		t.Errorf("empty input: got %v, want nil", got)
+	}
+}
+
+// TestFindKashidaCandidatesLatin verifies that pure Latin text yields no
+// candidates: no rune has a join side, so every boundary is rejected.
+func TestFindKashidaCandidatesLatin(t *testing.T) {
+	if got := FindKashidaCandidates("hello world"); len(got) != 0 {
+		t.Errorf("latin text: got %d candidates, want 0", len(got))
+	}
+}
+
+// TestFindKashidaCandidatesSalaam exercises the canonical example: the
+// Arabic word "سلام" (salaam) contains a seen-family letter immediately
+// followed by a dual-joining letter, which must produce at least one
+// candidate at the high-priority "after seen" site.
+func TestFindKashidaCandidatesSalaam(t *testing.T) {
+	got := FindKashidaCandidates("سلام")
+	if len(got) == 0 {
+		t.Fatal("expected at least one candidate in 'سلام'")
+	}
+	sawSeenPriority := false
+	for _, c := range got {
+		if c.Priority == kashidaPriorityAfterSeen {
+			sawSeenPriority = true
+			break
+		}
+	}
+	if !sawSeenPriority {
+		t.Errorf("expected an after-seen priority candidate; got %+v", got)
+	}
+}
+
+// TestFindKashidaCandidatesBayt verifies that "بيت" (bayt, "house") — three
+// dual-joining letters — produces at least one candidate at a basic or
+// medial-pair priority site.
+func TestFindKashidaCandidatesBayt(t *testing.T) {
+	got := FindKashidaCandidates("بيت")
+	if len(got) == 0 {
+		t.Fatal("expected at least one candidate in 'بيت'")
+	}
+	for _, c := range got {
+		if c.Priority < kashidaPriorityBasic || c.Priority > kashidaPriorityAfterSeen {
+			t.Errorf("candidate %+v has out-of-range priority", c)
+		}
+	}
+}
+
+// TestInsertKashidasSalaamOne verifies that inserting one tatweel into
+// "سلام" produces a string with exactly one U+0640 in it, and that the
+// length grows by exactly one rune.
+func TestInsertKashidasSalaamOne(t *testing.T) {
+	in := "سلام"
+	out := InsertKashidas(in, 1)
+	if out == in {
+		t.Fatal("expected insertion to change the string")
+	}
+	if got := strings.Count(out, string(kashidaTatweel)); got != 1 {
+		t.Errorf("tatweel count: got %d, want 1", got)
+	}
+	if len([]rune(out)) != len([]rune(in))+1 {
+		t.Errorf("rune length: got %d, want %d", len([]rune(out)), len([]rune(in))+1)
+	}
+}
+
+// TestInsertKashidasMoreThanSites checks that requesting more tatweels
+// than the word has legal sites caps at the available count rather than
+// piling duplicates onto a single site.
+func TestInsertKashidasMoreThanSites(t *testing.T) {
+	in := "سلام"
+	sites := len(FindKashidaCandidates(in))
+	out := InsertKashidas(in, sites+10)
+	got := strings.Count(out, string(kashidaTatweel))
+	if got > sites {
+		t.Errorf("inserted %d tatweels but only %d legal sites exist", got, sites)
+	}
+	if got != sites {
+		t.Errorf("expected to fill all %d sites; got %d", sites, got)
+	}
+}
+
+// TestInsertKashidasRoundTrip verifies that the result of an insertion
+// is itself a valid carrier for further kashida sites — tatweel is
+// dual-joining so each insertion creates two new candidate boundaries
+// around it. The post-insertion candidate count should be at least the
+// pre-insertion count.
+func TestInsertKashidasRoundTrip(t *testing.T) {
+	in := "سلام"
+	before := len(FindKashidaCandidates(in))
+	out := InsertKashidas(in, 1)
+	after := len(FindKashidaCandidates(out))
+	if after < before {
+		t.Errorf("post-insertion candidate count shrank: before=%d after=%d", before, after)
+	}
+}
+
+// TestInsertKashidasLatinNoOp verifies that pure Latin strings are
+// returned unchanged regardless of the requested count.
+func TestInsertKashidasLatinNoOp(t *testing.T) {
+	in := "hello world"
+	out := InsertKashidas(in, 5)
+	if out != in {
+		t.Errorf("latin string was mutated: got %q want %q", out, in)
+	}
+}
+
+// TestInsertKashidasZeroCount verifies that count=0 is a no-op even on
+// Arabic input.
+func TestInsertKashidasZeroCount(t *testing.T) {
+	in := "سلام"
+	out := InsertKashidas(in, 0)
+	if out != in {
+		t.Errorf("count=0 mutated the string: got %q want %q", out, in)
+	}
+}
+
+// TestInsertKashidasNegativeCount verifies the precondition guard:
+// negative counts are treated as zero, not as a panic.
+func TestInsertKashidasNegativeCount(t *testing.T) {
+	in := "سلام"
+	out := InsertKashidas(in, -3)
+	if out != in {
+		t.Errorf("negative count mutated the string: got %q want %q", out, in)
+	}
+}
+
+// TestKashidaCandidatesPostShape verifies that the candidate finder also
+// works on already-shaped Presentation Forms-B text. We shape "سلام"
+// first and then look for candidates in the shaped string. The shaped
+// glyphs are PFB codepoints and must still classify correctly via the
+// PFB reverse-lookup table.
+func TestKashidaCandidatesPostShape(t *testing.T) {
+	shaped := ShapeArabic("سلام")
+	got := FindKashidaCandidates(shaped)
+	if len(got) == 0 {
+		t.Fatalf("expected candidates in shaped 'سلام' (%q)", shaped)
+	}
+}
+
+// TestSpreadPickAlternates verifies that spreadPick alternates between
+// the front and back of the bucket so equal-priority sites are spread
+// across the word rather than clustered.
+func TestSpreadPickAlternates(t *testing.T) {
+	bucket := []int{1, 2, 3, 4, 5}
+	got := spreadPick(bucket, 3)
+	if len(got) != 3 {
+		t.Fatalf("len: got %d want 3", len(got))
+	}
+	// Expected order: front (1), back (5), front+1 (2).
+	want := []int{1, 5, 2}
+	for i, v := range want {
+		if got[i] != v {
+			t.Errorf("spreadPick[%d]: got %d want %d", i, got[i], v)
+		}
+	}
+}
+
+// TestPickKashidaSitesPriorityOrder verifies that higher-priority sites
+// are picked before lower-priority ones.
+func TestPickKashidaSitesPriorityOrder(t *testing.T) {
+	cands := []KashidaCandidate{
+		{Position: 10, Priority: kashidaPriorityBasic},
+		{Position: 20, Priority: kashidaPriorityAfterSeen},
+		{Position: 30, Priority: kashidaPriorityBasic},
+	}
+	got := pickKashidaSites(cands, 1)
+	if len(got) != 1 || got[0] != 20 {
+		t.Errorf("expected highest-priority site at 20; got %v", got)
+	}
+}
+
+// TestInsertKashidasInsertionAtBoundary asserts that insertion happens at
+// rune boundaries (no UTF-8 corruption). The result must be valid UTF-8.
+func TestInsertKashidasInsertionAtBoundary(t *testing.T) {
+	in := "سلام"
+	out := InsertKashidas(in, 2)
+	if !isValidUTF8(out) {
+		t.Errorf("result is not valid UTF-8: %q", out)
+	}
+}
+
+// isValidUTF8 reports whether s contains only well-formed UTF-8 sequences.
+func isValidUTF8(s string) bool {
+	for i, r := range s {
+		if r == 0xFFFD && len(s[i:]) > 0 && s[i] != 0xEF {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Justify Arabic text by inserting U+0640 ARABIC TATWEEL into letter connectors instead of widening inter-word whitespace. The current behaviour stretches the inter-word gaps for every script, which is correct for Latin but visually wrong for Arabic.

## What changes

- New `layout/kashida.go`:
  - `FindKashidaCandidates(s)` walks a string and returns every legal tatweel insertion point. The classifier handles both raw Arabic codepoints (via the existing `getJoiningType`) and Presentation Forms-B glyphs (via a reverse-lookup table built once from `arabicFormsTable`), so it works on text either before or after `ShapeArabic` has run.
  - `InsertKashidas(s, count)` returns a copy with up to `count` tatweels inserted at the highest-priority sites. Equal-priority sites are spread across the word from the front and back inward to avoid clustering.
  - `applyKashidaJustification(words, slack)` is the layout-side hook: it scans a line for eligible Arabic words, allocates slack across them by tatweel-glyph count, inserts the tatweels into each word's text, re-measures with the same `TextMeasurer` used at layout time, and returns the total width consumed.
- `layout/draw.go` calls `applyKashidaJustification` at the top of the justification branch in `drawTextLine`. Slack above the natural inter-word gaps is consumed by kashida insertion first; the residual still flows through the existing whitespace-stretching path. Lines with no Arabic, no candidates, or non-embedded fonts behave exactly as before.

## Eligibility

A word participates in kashida justification only when:

- it uses an embedded font (standard PDF fonts have no Arabic glyphs and are skipped),
- the embedded face contains a real glyph for U+0640 (`face.GlyphIndex(0x0640) != 0`),
- the word's text contains at least one Arabic codepoint,
- `FindKashidaCandidates` returns at least one legal site for it.

## Priority heuristic

For a first iteration the priority table is intentionally minimal:

| priority | rule |
| --- | --- |
| 4 | after a seen-family letter (seen, sheen, sad, dad) in any positional form |
| 3 | reserved (final-after-connection); collapses to basic in this PR |
| 2 | between two medial dual-joining letters |
| 1 | any other legal site |

The Unicode Standard defines U+0640 but does not prescribe a placement algorithm. Real systems differ; this PR uses a simple rule that produces visually reasonable results for the common case and leaves room for a richer typographic algorithm later.

## Trade-offs

- **Re-measuring after insertion vs. incremental width math.** Words are re-measured via the same `TextMeasurer` rather than added incrementally (count * tatweel advance). Re-measuring is one extra `MeasureString` per modified Arabic word per justified line, which is negligible compared to the rest of the layout pass and keeps the result consistent with kerning, letter-spacing, and any future shaper changes.
- **Insertion happens after Arabic shaping, not before.** The layout engine shapes a word once at measurement time, producing Presentation Forms-B glyphs. The tatweel glyph in real Arabic fonts is designed to butt seamlessly against the medial connector strokes of adjacent glyphs, so inserting it into already-shaped text does not require re-shaping. This avoids re-entering the shaper from inside the draw path.
- **Standard PDF fonts are skipped entirely.** Helvetica, Times, etc. have no Arabic glyphs, and inserting tatweels would render as `.notdef` boxes. Such paragraphs continue to use whitespace stretching.
- **No change to layout-time word widths.** Width measurement for line breaking is unchanged; kashida insertion happens at draw time on a clone of the line's words. This means the line break positions are identical to today, only the painted glyphs of justified Arabic lines differ.

## Test plan

- [x] `layout/kashida_test.go`: empty input, Latin no-op, salaam (high-priority site), bayt (basic sites), insertion count caps at available sites, tatweel insertion produces valid UTF-8, post-insertion round-trip finds at least the original sites again, candidate finder works on already-shaped PFB text, priority bucket order, spread selection alternates from ends.
- [x] `layout/kashida_paragraph_test.go`: Arabic-only line consumes slack via tatweels, Latin line unchanged, standard-font Arabic word skipped, mixed Arabic+Latin line only mutates the Arabic word, pure-Latin paragraph (regression guard) contains zero tatweels after justified layout.
- [x] Full `go test ./...` passes.
- [x] `gofmt -s`, `go vet ./...`, `golangci-lint run ./...` all clean.