### PR TITLE
Emit /ActualText markers around shaped Arabic words

### DIFF
--- a/content/stream.go
+++ b/content/stream.go
@@ -571,6 +571,47 @@ func (s *Stream) BeginMarkedContentWithID(tag string, mcid int) {
 	s.writeln(fmt.Sprintf("/%s <</MCID %d>> BDC", tag, mcid))
 }
 
+// BeginMarkedContentActualText writes the BDC operator with a /Span tag and a
+// property list containing /ActualText. Per ISO 32000-2 §14.9.4, the
+// /ActualText entry overrides the displayed text for accessibility, search,
+// and copy/paste, while the rendered glyphs remain unchanged. The text is
+// encoded as a UTF-16BE PDF text string with the byte-order mark FEFF, per
+// ISO 32000-2 §7.9.2.2. Pair every call with a single EndMarkedContent;
+// nested ActualText sequences are not supported by this helper.
+func (s *Stream) BeginMarkedContentActualText(text string) {
+	enc := encodeTextStringUTF16BE(text)
+	s.writeln(fmt.Sprintf("/Span <</ActualText (%s)>> BDC",
+		core.EscapeLiteralString(enc)))
+}
+
+// encodeTextStringUTF16BE returns the UTF-16BE byte representation of s
+// prefixed with the UTF-16 byte-order mark (\xFE\xFF). The result is suitable
+// for use as the value of a PDF text string per ISO 32000-2 §7.9.2.2.
+// Code points outside the Basic Multilingual Plane are emitted as a UTF-16
+// surrogate pair (high surrogate + low surrogate).
+func encodeTextStringUTF16BE(s string) string {
+	var b strings.Builder
+	b.Grow(2 + 2*len(s))
+	b.WriteByte(0xFE)
+	b.WriteByte(0xFF)
+	for _, r := range s {
+		if r <= 0xFFFF {
+			b.WriteByte(byte(r >> 8))
+			b.WriteByte(byte(r))
+			continue
+		}
+		// Astral plane: encode as a surrogate pair (UTF-16, RFC 2781).
+		v := uint32(r) - 0x10000
+		hi := 0xD800 + (v >> 10)
+		lo := 0xDC00 + (v & 0x3FF)
+		b.WriteByte(byte(hi >> 8))
+		b.WriteByte(byte(hi))
+		b.WriteByte(byte(lo >> 8))
+		b.WriteByte(byte(lo))
+	}
+	return b.String()
+}
+
 // MarkedPoint writes the MP operator: designate a marked-content point.
 // tag is the marked-content tag (structure type).
 func (s *Stream) MarkedPoint(tag string) {

--- a/content/stream_test.go
+++ b/content/stream_test.go
@@ -767,6 +767,176 @@ func TestEndMarkedContent(t *testing.T) {
 	}
 }
 
+// TestBeginMarkedContentActualTextASCII verifies that an ASCII input is
+// encoded as UTF-16BE with the byte-order mark. UTF-16BE places the high
+// (zero) byte before each ASCII byte, and the literal-string escaper turns
+// each \x00 into the octal escape \000.
+func TestBeginMarkedContentActualTextASCII(t *testing.T) {
+	s := NewStream()
+	s.BeginMarkedContentActualText("hello")
+	got := string(s.Bytes())
+	want := "/Span <</ActualText (\xFE\xFF\\000h\\000e\\000l\\000l\\000o)>> BDC"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+	roundTrip := decodeActualTextLiteral(t, got)
+	if roundTrip != "hello" {
+		t.Errorf("round trip: got %q, want %q", roundTrip, "hello")
+	}
+}
+
+// TestBeginMarkedContentActualTextEmpty verifies that the empty string still
+// emits the byte-order mark inside the literal value.
+func TestBeginMarkedContentActualTextEmpty(t *testing.T) {
+	s := NewStream()
+	s.BeginMarkedContentActualText("")
+	got := string(s.Bytes())
+	want := "/Span <</ActualText (\xFE\xFF)>> BDC"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+// TestBeginMarkedContentActualTextArabic verifies that an Arabic input is
+// encoded as UTF-16BE so that the marker round-trips the original Unicode
+// codepoints. Tests the word \u0633\u0644\u0627\u0645 (salam, "peace").
+// The high byte for each Arabic letter is 0x06, which is a control byte
+// and must be octal-escaped inside the literal string.
+func TestBeginMarkedContentActualTextArabic(t *testing.T) {
+	s := NewStream()
+	s.BeginMarkedContentActualText("\u0633\u0644\u0627\u0645")
+	got := string(s.Bytes())
+	want := "/Span <</ActualText (\xFE\xFF\\0063\\006D\\006'\\006E)>> BDC"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+	// Independent decode pass: strip the operator wrapper, undo PDF
+	// literal-string escapes, drop the BOM, decode UTF-16BE, and compare
+	// to the original input. This guards against mistakes in the literal
+	// expectation above.
+	roundTrip := decodeActualTextLiteral(t, got)
+	if roundTrip != "\u0633\u0644\u0627\u0645" {
+		t.Errorf("round trip: got %q, want %q", roundTrip, "\u0633\u0644\u0627\u0645")
+	}
+}
+
+// TestBeginMarkedContentActualTextEscaping verifies that bytes that collide
+// with the literal-string syntax (backslash and parentheses) are escaped
+// inside the property list.
+func TestBeginMarkedContentActualTextEscaping(t *testing.T) {
+	s := NewStream()
+	// Inputs whose UTF-16BE low byte equals '(' (0x28), ')' (0x29), '\\' (0x5C):
+	// U+0028 → 00 28, U+0029 → 00 29, U+005C → 00 5C.
+	s.BeginMarkedContentActualText("(\\)")
+	got := string(s.Bytes())
+	want := "/Span <</ActualText (\xFE\xFF\\000\\(\\000\\\\\\000\\))>> BDC"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+// TestBeginMarkedContentActualTextSurrogatePair verifies that an astral-plane
+// codepoint (above U+FFFF) is encoded as a UTF-16 surrogate pair per
+// RFC 2781. Uses U+1F600 (grinning face) which encodes as D83D DE00.
+// The trailing 0x00 is escaped as \000 by the literal-string escaper.
+func TestBeginMarkedContentActualTextSurrogatePair(t *testing.T) {
+	s := NewStream()
+	s.BeginMarkedContentActualText("\U0001F600")
+	got := string(s.Bytes())
+	want := "/Span <</ActualText (\xFE\xFF\xD8\x3D\xDE\\000)>> BDC"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+	roundTrip := decodeActualTextLiteral(t, got)
+	if roundTrip != "\U0001F600" {
+		t.Errorf("round trip: got %q, want %q", roundTrip, "\U0001F600")
+	}
+}
+
+// decodeActualTextLiteral parses an emitted /Span /ActualText BDC line back
+// into its UTF-8 string. It is the inverse of BeginMarkedContentActualText
+// and is used by tests to confirm round-trip behavior independently of the
+// literal byte expectations elsewhere in the suite. It only handles the
+// escapes EscapeLiteralString actually emits.
+func decodeActualTextLiteral(t *testing.T, line string) string {
+	t.Helper()
+	const prefix = "/Span <</ActualText ("
+	const suffix = ")>> BDC"
+	if !strings.HasPrefix(line, prefix) || !strings.HasSuffix(line, suffix) {
+		t.Fatalf("unexpected ActualText line shape: %q", line)
+	}
+	body := line[len(prefix) : len(line)-len(suffix)]
+	// Undo PDF literal-string escapes.
+	var raw []byte
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if c != '\\' {
+			raw = append(raw, c)
+			continue
+		}
+		if i+1 >= len(body) {
+			t.Fatalf("trailing backslash in %q", body)
+		}
+		next := body[i+1]
+		switch next {
+		case '\\', '(', ')':
+			raw = append(raw, next)
+			i++
+		case 'n':
+			raw = append(raw, '\n')
+			i++
+		case 'r':
+			raw = append(raw, '\r')
+			i++
+		case 't':
+			raw = append(raw, '\t')
+			i++
+		default:
+			// Octal escape: \ddd. EscapeLiteralString always emits three
+			// octal digits for control bytes, so consume exactly three.
+			if i+3 >= len(body) {
+				t.Fatalf("short octal escape in %q at %d", body, i)
+			}
+			var v byte
+			for j := 1; j <= 3; j++ {
+				d := body[i+j]
+				if d < '0' || d > '7' {
+					t.Fatalf("bad octal digit %q in %q", d, body)
+				}
+				v = v*8 + (d - '0')
+			}
+			raw = append(raw, v)
+			i += 3
+		}
+	}
+	if len(raw) < 2 || raw[0] != 0xFE || raw[1] != 0xFF {
+		t.Fatalf("missing UTF-16BE BOM in %x", raw)
+	}
+	raw = raw[2:]
+	if len(raw)%2 != 0 {
+		t.Fatalf("odd-length UTF-16BE payload: %x", raw)
+	}
+	var runes []rune
+	for i := 0; i < len(raw); i += 2 {
+		u := uint16(raw[i])<<8 | uint16(raw[i+1])
+		if u >= 0xD800 && u <= 0xDBFF {
+			if i+3 >= len(raw) {
+				t.Fatalf("dangling high surrogate at %d in %x", i, raw)
+			}
+			lo := uint16(raw[i+2])<<8 | uint16(raw[i+3])
+			if lo < 0xDC00 || lo > 0xDFFF {
+				t.Fatalf("invalid low surrogate %04X at %d", lo, i+2)
+			}
+			r := 0x10000 + (uint32(u-0xD800) << 10) + uint32(lo-0xDC00)
+			runes = append(runes, rune(r))
+			i += 2
+			continue
+		}
+		runes = append(runes, rune(u))
+	}
+	return string(runes)
+}
+
 func TestRoundedRectPerCorner(t *testing.T) {
 	s := NewStream()
 	s.RoundedRectPerCorner(0, 0, 100, 50, 10, 5, 3, 8)

--- a/document/document.go
+++ b/document/document.go
@@ -85,6 +85,7 @@ type Document struct {
 	watermark        *WatermarkConfig
 	encryption       *EncryptionConfig
 	tagged           bool        // if true, produce tagged PDF with structure tree
+	actualText       bool        // if true (default), wrap shaped Arabic words in /ActualText markers
 	pdfA             *PdfAConfig // if non-nil, produce PDF/A conformant output
 	acroForm         interface {
 		Build(func(core.PdfObject) *core.PdfIndirectReference, []*core.PdfIndirectReference) (*core.PdfIndirectReference, map[int][]*core.PdfIndirectReference)
@@ -96,10 +97,13 @@ type Document struct {
 }
 
 // NewDocument creates a new PDF document with the given page size.
+// /ActualText emission for shaped Arabic words is enabled by default; call
+// SetActualText(false) on the returned document to opt out.
 func NewDocument(ps PageSize) *Document {
 	return &Document{
-		pageSize: ps,
-		margins:  layout.Margins{Top: 72, Right: 72, Bottom: 72, Left: 72},
+		pageSize:   ps,
+		margins:    layout.Margins{Top: 72, Right: 72, Bottom: 72, Left: 72},
+		actualText: true,
 	}
 }
 
@@ -110,6 +114,17 @@ func NewDocument(ps PageSize) *Document {
 // accessibility compliance (Section 508, EN 301 549).
 func (d *Document) SetTagged(enabled bool) {
 	d.tagged = enabled
+}
+
+// SetActualText controls whether the document wraps shaped Arabic words in
+// ISO 32000-2 §14.9.4 /Span /ActualText marked-content sequences. When
+// enabled (the default), copy/paste and accessibility consumers recover the
+// original Unicode codepoints rather than the Arabic Presentation Forms-B
+// substitutions emitted by the shaper. Disabling shaves a few dozen bytes
+// per shaped Arabic word and is appropriate for size-sensitive documents
+// that do not need text round-tripping.
+func (d *Document) SetActualText(enabled bool) {
+	d.actualText = enabled
 }
 
 // SetAcroForm attaches an interactive form to the document.
@@ -352,6 +367,7 @@ func (d *Document) buildAllPages() (all []*Page, structTags []layout.StructTagIn
 		if d.tagged {
 			r.SetTagged(true)
 		}
+		r.SetActualText(d.actualText)
 		for _, e := range d.elements {
 			r.Add(e)
 		}

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -153,6 +153,17 @@ func drawTextLine(ctx DrawContext, words []Word, x, baselineY, maxWidth float64,
 			curColor = word.Color
 		}
 
+		// When a shaper substituted glyph-form codepoints (currently
+		// Arabic Presentation Forms-B), wrap the text-showing operators
+		// in an ISO 32000-2 §14.9.4 /Span /ActualText marked-content
+		// sequence so that copy/paste and accessibility tools recover
+		// the original Unicode codepoints. The opt-out lives on the
+		// renderer (default on) and travels through DrawContext.
+		emitActualText := word.OriginalText != "" && ctx.ActualText
+		if emitActualText {
+			ctx.Stream.BeginMarkedContentActualText(word.OriginalText)
+		}
+
 		ctx.Stream.BeginText()
 		resName := registerFont(ctx.Page, word)
 		ctx.Stream.SetFont(resName, word.FontSize)
@@ -171,6 +182,10 @@ func drawTextLine(ctx DrawContext, words []Word, x, baselineY, maxWidth float64,
 			ctx.Stream.SetCharSpacing(0)
 		}
 		ctx.Stream.EndText()
+
+		if emitActualText {
+			ctx.Stream.EndMarkedContent()
+		}
 
 		// Compute the advance to the next word (used for spacing and underline extension).
 		var advance float64

--- a/layout/draw_test.go
+++ b/layout/draw_test.go
@@ -182,6 +182,213 @@ func TestDrawColumnRules(t *testing.T) {
 	}
 }
 
+// TestActualTextArabicWord verifies that an Arabic-only paragraph rendered
+// through the full pipeline emits at least one /Span /ActualText marker and
+// that the marker's UTF-16BE payload round-trips to the original Arabic
+// input string. The check is per-word: every shaped Arabic word should
+// carry its own ActualText sequence.
+func TestActualTextArabicWord(t *testing.T) {
+	// "سلام" — salam, "peace". A single Arabic word, four codepoints,
+	// shaped into Presentation Forms-B by ShapeArabic.
+	const input = "\u0633\u0644\u0627\u0645"
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.Add(NewParagraph(input, font.Helvetica, 12))
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("no pages produced")
+	}
+	stream := string(pages[0].Stream.Bytes())
+	if !strings.Contains(stream, "/ActualText") {
+		t.Fatalf("expected /ActualText marker in content stream:\n%s", stream)
+	}
+	// Decode the first ActualText payload back to UTF-8 and compare to
+	// the original input. There should be exactly one for this word.
+	got := extractFirstActualText(t, stream)
+	if got != input {
+		t.Errorf("ActualText round trip: got %q, want %q", got, input)
+	}
+	// Confirm marked-content brackets are balanced (one BDC per EMC).
+	bdc := strings.Count(stream, " BDC")
+	emc := strings.Count(stream, "EMC")
+	if bdc != emc {
+		t.Errorf("BDC/EMC unbalanced: %d BDC vs %d EMC", bdc, emc)
+	}
+}
+
+// TestActualTextLatinUnchanged verifies that a Latin-only paragraph
+// produces no /ActualText markers (no shaping happened).
+func TestActualTextLatinUnchanged(t *testing.T) {
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.Add(NewParagraph("Hello world", font.Helvetica, 12))
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("no pages produced")
+	}
+	stream := string(pages[0].Stream.Bytes())
+	if strings.Contains(stream, "/ActualText") {
+		t.Errorf("Latin-only paragraph should produce no /ActualText markers:\n%s", stream)
+	}
+}
+
+// TestActualTextOptOut verifies that SetActualText(false) suppresses
+// /ActualText emission even for shaped Arabic words.
+func TestActualTextOptOut(t *testing.T) {
+	const input = "\u0633\u0644\u0627\u0645"
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.SetActualText(false)
+	r.Add(NewParagraph(input, font.Helvetica, 12))
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("no pages produced")
+	}
+	stream := string(pages[0].Stream.Bytes())
+	if strings.Contains(stream, "/ActualText") {
+		t.Errorf("SetActualText(false) should suppress markers:\n%s", stream)
+	}
+}
+
+// TestActualTextMixedArabicLatin verifies that in a paragraph mixing Arabic
+// and Latin words, the Arabic words carry /ActualText markers and the Latin
+// words are emitted plain. The number of markers should equal the number of
+// Arabic words.
+func TestActualTextMixedArabicLatin(t *testing.T) {
+	// "Hello سلام world" — Latin, Arabic, Latin. Each is its own
+	// whitespace-delimited token.
+	const input = "Hello \u0633\u0644\u0627\u0645 world"
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.Add(NewParagraph(input, font.Helvetica, 12))
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("no pages produced")
+	}
+	stream := string(pages[0].Stream.Bytes())
+	count := strings.Count(stream, "/ActualText")
+	if count != 1 {
+		t.Errorf("expected exactly 1 /ActualText marker for the Arabic word, got %d:\n%s", count, stream)
+	}
+	got := extractFirstActualText(t, stream)
+	if got != "\u0633\u0644\u0627\u0645" {
+		t.Errorf("ActualText payload: got %q, want %q", got, "\u0633\u0644\u0627\u0645")
+	}
+}
+
+// extractFirstActualText decodes the first /Span /ActualText literal-string
+// payload found in stream and returns its UTF-8 representation. It is the
+// inverse of content.Stream.BeginMarkedContentActualText. The stream may
+// contain other operators on either side of the marker.
+func extractFirstActualText(t *testing.T, stream string) string {
+	t.Helper()
+	const marker = "/Span <</ActualText ("
+	start := strings.Index(stream, marker)
+	if start < 0 {
+		t.Fatalf("no /ActualText marker found")
+	}
+	body := stream[start+len(marker):]
+	// Walk forward, honoring escape sequences, until we hit the closing
+	// ')' that terminates the literal string. Track parenthesis nesting
+	// because PDF allows balanced unescaped parentheses inside strings.
+	depth := 1
+	end := -1
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if c == '\\' {
+			// Skip the escape sequence: either \n/\r/\t/\\/(/) (one char)
+			// or \ddd (up to three octal digits).
+			if i+1 >= len(body) {
+				break
+			}
+			next := body[i+1]
+			if next >= '0' && next <= '7' {
+				j := 1
+				for j < 3 && i+1+j < len(body) && body[i+1+j] >= '0' && body[i+1+j] <= '7' {
+					j++
+				}
+				i += j
+				continue
+			}
+			i++
+			continue
+		}
+		if c == '(' {
+			depth++
+			continue
+		}
+		if c == ')' {
+			depth--
+			if depth == 0 {
+				end = i
+				break
+			}
+		}
+	}
+	if end < 0 {
+		t.Fatalf("unterminated /ActualText literal")
+	}
+	literal := body[:end]
+	// Undo PDF literal-string escapes to recover raw bytes.
+	var raw []byte
+	for i := 0; i < len(literal); i++ {
+		c := literal[i]
+		if c != '\\' {
+			raw = append(raw, c)
+			continue
+		}
+		if i+1 >= len(literal) {
+			t.Fatalf("trailing backslash")
+		}
+		next := literal[i+1]
+		switch next {
+		case '\\', '(', ')':
+			raw = append(raw, next)
+			i++
+		case 'n':
+			raw = append(raw, '\n')
+			i++
+		case 'r':
+			raw = append(raw, '\r')
+			i++
+		case 't':
+			raw = append(raw, '\t')
+			i++
+		default:
+			if next < '0' || next > '7' {
+				t.Fatalf("unsupported escape %q", next)
+			}
+			var v byte
+			j := 0
+			for j < 3 && i+1+j < len(literal) && literal[i+1+j] >= '0' && literal[i+1+j] <= '7' {
+				v = v*8 + (literal[i+1+j] - '0')
+				j++
+			}
+			raw = append(raw, v)
+			i += j
+		}
+	}
+	if len(raw) < 2 || raw[0] != 0xFE || raw[1] != 0xFF {
+		t.Fatalf("missing UTF-16BE BOM in payload: %x", raw)
+	}
+	raw = raw[2:]
+	if len(raw)%2 != 0 {
+		t.Fatalf("odd-length UTF-16BE payload: %x", raw)
+	}
+	var runes []rune
+	for i := 0; i < len(raw); i += 2 {
+		u := uint16(raw[i])<<8 | uint16(raw[i+1])
+		if u >= 0xD800 && u <= 0xDBFF {
+			if i+3 >= len(raw) {
+				t.Fatalf("dangling high surrogate at %d", i)
+			}
+			lo := uint16(raw[i+2])<<8 | uint16(raw[i+3])
+			r := 0x10000 + (uint32(u-0xD800) << 10) + uint32(lo-0xDC00)
+			runes = append(runes, rune(r))
+			i += 2
+			continue
+		}
+		runes = append(runes, rune(u))
+	}
+	return string(runes)
+}
+
 func TestDrawSaveRestoreBalance(t *testing.T) {
 	// Complex element: Div with background, border, shadow, outline.
 	// Verify all q/Q are balanced.

--- a/layout/element.go
+++ b/layout/element.go
@@ -310,6 +310,16 @@ type Word struct {
 	// Used to honor explicit \n characters in paragraph text.
 	LineBreak bool
 
+	// OriginalText holds the pre-shaping Unicode text for this word when a
+	// shaper (currently ShapeArabic) substituted glyph-form codepoints. The
+	// renderer wraps such words in an ISO 32000-2 §14.9.4 /Span /ActualText
+	// marked-content sequence so that copy/paste and accessibility tools
+	// recover the original codepoints rather than the shaped Presentation
+	// Forms-B substitutions. Empty when no shaping happened. Words split by
+	// breakLongWords lose this field on subsequent chunks because there is
+	// no per-chunk slice of the original text.
+	OriginalText string
+
 	// LinkURI is the hyperlink target for this word. If non-empty, the
 	// renderer creates a link annotation covering this word's area.
 	LinkURI string

--- a/layout/layouter.go
+++ b/layout/layouter.go
@@ -94,6 +94,14 @@ type PlacedBlock struct {
 type DrawContext struct {
 	Stream *content.Stream
 	Page   *PageResult
+	// ActualText, when true, allows drawTextLine to emit ISO 32000-2
+	// §14.9.4 /Span /ActualText marked-content sequences around shaped
+	// Arabic words so that copy/paste and accessibility tools recover the
+	// original Unicode codepoints rather than the Presentation Forms-B
+	// substitutions emitted by ShapeArabic. The Renderer sets this from
+	// its actualText field; tests that build a DrawContext directly may
+	// leave it false to suppress emission.
+	ActualText bool
 }
 
 // measureConsumed returns the height an element consumes at the given width.

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -268,18 +268,13 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 				nextLineBreak = true
 				continue
 			}
-			// Apply Arabic contextual shaping before measurement so the
-			// shaped codepoints (which may have different glyph widths)
-			// are measured correctly.
-			w = ShapeArabic(w)
-			wordW := measurer.MeasureString(w, run.FontSize)
-			// Account for letter-spacing: adds extra space after each character except last.
-			if run.LetterSpacing != 0 && len([]rune(w)) > 1 {
-				wordW += run.LetterSpacing * float64(len([]rune(w))-1)
-			}
+			// Build the word from the unshaped text first so that
+			// splitMixedBidiWord can split on the original codepoints.
+			// Each piece is then shaped independently and its pre-shape
+			// text is captured into OriginalText so the renderer can
+			// emit ISO 32000-2 §14.9.4 /Span /ActualText markers.
 			word := Word{
 				Text:            w,
-				Width:           wordW,
 				Font:            run.Font,
 				Embedded:        run.Embedded,
 				FontSize:        run.FontSize,
@@ -302,10 +297,14 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 			// between Hebrew and digit characters.
 			if subs := splitMixedBidiWord(word); subs != nil {
 				for si, sub := range subs {
+					subOrig := sub.Text
 					sub.Text = ShapeArabic(sub.Text)
 					sub.Width = measurer.MeasureString(sub.Text, run.FontSize)
 					if run.LetterSpacing != 0 && len([]rune(sub.Text)) > 1 {
 						sub.Width += run.LetterSpacing * float64(len([]rune(sub.Text))-1)
+					}
+					if sub.Text != subOrig {
+						sub.OriginalText = subOrig
 					}
 					if si == 0 {
 						sub.LineBreak = nextLineBreak
@@ -313,6 +312,15 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 					measured = append(measured, sub)
 				}
 			} else {
+				origW := word.Text
+				word.Text = ShapeArabic(word.Text)
+				word.Width = measurer.MeasureString(word.Text, run.FontSize)
+				if run.LetterSpacing != 0 && len([]rune(word.Text)) > 1 {
+					word.Width += run.LetterSpacing * float64(len([]rune(word.Text))-1)
+				}
+				if word.Text != origW {
+					word.OriginalText = origW
+				}
 				measured = append(measured, word)
 			}
 			nextLineBreak = false
@@ -1212,14 +1220,11 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 				nextLineBreak = true
 				continue
 			}
-			w = ShapeArabic(w)
-			wordW := measurer.MeasureString(w, run.FontSize)
-			if run.LetterSpacing != 0 && len([]rune(w)) > 1 {
-				wordW += run.LetterSpacing * float64(len([]rune(w))-1)
-			}
+			// Build the word from the unshaped text first so the bidi
+			// split sees the original codepoints; each piece is then
+			// shaped and its pre-shape text recorded for /ActualText.
 			word := Word{
 				Text:            w,
-				Width:           wordW,
 				Font:            run.Font,
 				Embedded:        run.Embedded,
 				FontSize:        run.FontSize,
@@ -1238,10 +1243,14 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 			}
 			if subs := splitMixedBidiWord(word); subs != nil {
 				for si, sub := range subs {
+					subOrig := sub.Text
 					sub.Text = ShapeArabic(sub.Text)
 					sub.Width = measurer.MeasureString(sub.Text, run.FontSize)
 					if run.LetterSpacing != 0 && len([]rune(sub.Text)) > 1 {
 						sub.Width += run.LetterSpacing * float64(len([]rune(sub.Text))-1)
+					}
+					if sub.Text != subOrig {
+						sub.OriginalText = subOrig
 					}
 					if si == 0 {
 						sub.LineBreak = nextLineBreak
@@ -1249,6 +1258,15 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 					measured = append(measured, sub)
 				}
 			} else {
+				origW := word.Text
+				word.Text = ShapeArabic(word.Text)
+				word.Width = measurer.MeasureString(word.Text, run.FontSize)
+				if run.LetterSpacing != 0 && len([]rune(word.Text)) > 1 {
+					word.Width += run.LetterSpacing * float64(len([]rune(word.Text))-1)
+				}
+				if word.Text != origW {
+					word.OriginalText = origW
+				}
 				measured = append(measured, word)
 			}
 			nextLineBreak = false

--- a/layout/render_plans.go
+++ b/layout/render_plans.go
@@ -64,6 +64,7 @@ func (r *Renderer) renderWithPlans() []PageResult {
 				Images: curImages,
 				Links:  curLinks,
 			},
+			ActualText: r.actualText,
 		}
 		for _, block := range curBlocks {
 			drawBlock(block, curMargins.Left, r.pageHeight-curMargins.Top, &ctx, r.tagged, &r.structTags, pageIdx)
@@ -444,13 +445,13 @@ func (r *Renderer) renderAbsolutes(pages []PageResult, defaultWidth float64) {
 		if item.zIndex < 0 {
 			// Render into a temporary stream and prepend to draw behind flow content.
 			bgStream := content.NewStream()
-			bgCtx := DrawContext{Stream: bgStream, Page: page}
+			bgCtx := DrawContext{Stream: bgStream, Page: page, ActualText: r.actualText}
 			for _, block := range plan.Blocks {
 				drawBlock(block, x, item.y, &bgCtx, r.tagged, &r.structTags, pageIdx)
 			}
 			page.Stream.PrependBytes(bgStream.Bytes())
 		} else {
-			ctx := DrawContext{Stream: page.Stream, Page: page}
+			ctx := DrawContext{Stream: page.Stream, Page: page, ActualText: r.actualText}
 			for _, block := range plan.Blocks {
 				drawBlock(block, x, item.y, &ctx, r.tagged, &r.structTags, pageIdx)
 			}

--- a/layout/renderer.go
+++ b/layout/renderer.go
@@ -98,6 +98,7 @@ type Renderer struct {
 	elements         []Element
 	absolutes        []absoluteItem
 	tagged           bool            // if true, emit BDC/EMC marked content
+	actualText       bool            // if true, emit ISO 32000-2 §14.9.4 /ActualText for shaped Arabic
 	structTags       []StructTagInfo // collected during rendering
 
 	// Running string values for CSS string-set / string() support.
@@ -149,11 +150,14 @@ func (r *Renderer) marginsForPage(pageIdx int) Margins {
 }
 
 // NewRenderer creates a renderer for the given page dimensions and margins.
+// /ActualText emission for shaped Arabic words is enabled by default; call
+// SetActualText(false) to opt out (e.g. to minimise content stream size).
 func NewRenderer(pageWidth, pageHeight float64, margins Margins) *Renderer {
 	return &Renderer{
 		pageWidth:  pageWidth,
 		pageHeight: pageHeight,
 		margins:    margins,
+		actualText: true,
 	}
 }
 
@@ -315,6 +319,17 @@ func (r *Renderer) resolveStringRefs(text string, pageIdx int) string {
 // for the document layer to build the structure tree.
 func (r *Renderer) SetTagged(enabled bool) {
 	r.tagged = enabled
+}
+
+// SetActualText controls whether the renderer emits ISO 32000-2 §14.9.4
+// /Span /ActualText marked-content sequences around words whose text was
+// substituted by the Arabic shaper. When enabled (the default), copy/paste
+// and accessibility consumers see the original Unicode codepoints rather
+// than the Presentation Forms-B substitutions. Disabling shaves a few
+// dozen bytes per shaped Arabic word and is appropriate for size-sensitive
+// documents that do not require text round-tripping.
+func (r *Renderer) SetActualText(enabled bool) {
+	r.actualText = enabled
 }
 
 // StructTags returns the structure tags collected during rendering.


### PR DESCRIPTION
## Summary

Wrap shaped Arabic words in ISO 32000-2 §14.9.4 `/Span /ActualText` marked-content sequences so that copy/paste, search, and accessibility tooling recover the original Unicode codepoints rather than the Arabic Presentation Forms-B substitutions emitted by `ShapeArabic`.

## Background

`layout/arabic.go` substitutes Arabic letters with their Unicode Presentation Forms-B equivalents (U+FE70..U+FEFF) so that fonts shipping only the precomposed forms render correctly. The downside: a reader copying text from the rendered PDF receives the presentation form codepoints, not the original letter codepoints, so the copied text fails equality with the source.

ISO 32000-2 §14.9.4 fixes this. A `/Span` marked-content sequence whose property list carries `/ActualText` lets readers substitute the original Unicode for copy/paste while leaving the rendered glyphs alone. The /ActualText value must be a PDF text string per §7.9.2.2; for non-Latin text that means UTF-16BE with the byte-order mark `\xFE\xFF`.

## Changes

- `content/stream.go`: new `BeginMarkedContentActualText(text string)` helper that encodes the input as UTF-16BE with BOM, runs it through the existing literal-string escaper, and emits `/Span <</ActualText (...)>> BDC`. The existing `EndMarkedContent` is unchanged. Astral-plane codepoints are encoded as UTF-16 surrogate pairs.
- `layout/element.go`: new `Word.OriginalText` field that carries the pre-shape text when shaping changed it.
- `layout/paragraph.go`: both `ShapeArabic` call sites now build the word from the unshaped text first, run `splitMixedBidiWord` on it, shape each piece, and capture the pre-shape text into `OriginalText` only when shaping actually changed the bytes. Splitting before shaping is necessary so that sub-pieces of mixed-script tokens carry the right slice of the original.
- `layout/draw.go`: `drawTextLine` wraps the `BeginText/.../EndText` block in `BeginMarkedContentActualText/EndMarkedContent` when `Word.OriginalText` is non-empty and `DrawContext.ActualText` is true.
- `layout/layouter.go`: new `DrawContext.ActualText` boolean.
- `layout/renderer.go`: new `actualText` field defaulting to true via `NewRenderer`, plus a `SetActualText(bool)` opt-out.
- `layout/render_plans.go`: passes `r.actualText` into the per-page `DrawContext`.
- `document/document.go`: new `actualText` field defaulting to true via `NewDocument`, plus a `SetActualText(bool)` opt-out, plumbed into the renderer.

## Trade-offs

- ActualText emission is on by default. Each shaped Arabic word adds a `/Span <</ActualText (...)>> BDC` opener and a trailing `EMC`, plus the UTF-16BE-encoded original text. Documents that need to minimise content stream size can call `Document.SetActualText(false)` or `Renderer.SetActualText(false)`.
- Marked-content sequences emitted by this helper do not nest. Pair every Begin call with exactly one End call.
- `breakLongWords` splits words into character-level chunks when they exceed the line width and drops `OriginalText` on those chunks because there is no per-chunk slice of the original text. Words that fit on a line take the normal path and keep their marker. This is documented on the `OriginalText` field.
- The fallback ToUnicode CMap path in `font/subset.go` is untouched. ActualText overrides it when present and the CMap remains the fallback for any text without a marker.
- This PR only wraps the Arabic Presentation Forms substitution. Future shapers (Indic decomposition, ligature passes, GSUB-driven substitutions in other scripts) can reuse the same `OriginalText` field once their measurement code populates it.

## Test plan

- [x] `go test ./content/... ./layout/... ./font/... ./html/... ./document/... ./reader/...`
- [x] `go test ./...`
- [x] `gofmt -s -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] New `content/stream_test.go` cases cover ASCII, empty, Arabic, escaping, and surrogate-pair encodings, with an independent decoder used to round-trip the literal back to UTF-8.
- [x] New `layout/draw_test.go` cases render Arabic-only, Latin-only, mixed Arabic+Latin, and the opt-out path through the full pipeline. The Arabic and mixed cases parse the emitted content stream and assert the decoded /ActualText payload equals the original input.

## Standards references

- ISO 32000-2 §14.9.4 (Replacement Text)
- ISO 32000-2 §14.6 (Marked Content)
- ISO 32000-2 §7.9.2.2 (PDF text string encoding)