### PR TITLE
examples/optimize: multi-fixture comparison and README mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,32 @@ Reproduce locally:
 go test -run='^$' -bench=. -benchmem ./document/
 ```
 
+### Output size
+
+The writer can emit cross-reference streams (ISO 32000-1 §7.5.8) and pack
+eligible indirect objects into compressed object streams (ISO 32000-1
+§7.5.7). Both modes are opt-in via `document.WriteOptions`:
+
+```go
+doc.SaveWithOptions("out.pdf", document.WriteOptions{
+    UseXRefStream:    true,
+    UseObjectStreams: true,
+})
+```
+
+Existing callers of `Save`, `WriteTo`, and `ToBytes` see byte-identical
+output. The savings depend on the document shape — content streams are
+already Flate-compressed and ineligible for object stream packing, so
+text-heavy documents save less than metadata-heavy ones:
+
+| Fixture | Default | Optimized | Saved |
+|---|---:|---:|---:|
+| Text-heavy report (25 sections) | 6913 B | 5621 B | 18.7% |
+| 50 empty pages | 6317 B | 932 B | 85.2% |
+| 60-row data table | 8063 B | 7785 B | 3.4% |
+
+Run [`examples/optimize`](examples/optimize/) to reproduce these numbers.
+
 ---
 
 ## Architecture
@@ -466,6 +492,7 @@ Each [`examples/`](examples/) subdirectory is a self-contained `go run` demo:
 | [`html-to-pdf`](examples/html-to-pdf/) | Rich HTML+CSS report with flexbox and tables |
 | [`import-page`](examples/import-page/) | Load existing PDF as template, fill in data |
 | [`merge`](examples/merge/) | Parse, merge, and extract text |
+| [`optimize`](examples/optimize/) | Cross-reference and object stream output, side-by-side size comparison |
 | [`redact`](examples/redact/) | Permanently remove sensitive text |
 | [`report`](examples/report/) | Multi-page report with layout API |
 | [`sign`](examples/sign/) | PAdES digital signature |

--- a/examples/optimize/main.go
+++ b/examples/optimize/main.go
@@ -1,10 +1,17 @@
 // Copyright 2026 Carlos Munoz and the Folio Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Optimize writes the same document twice — once with the historical
-// default writer and once with cross-reference streams (ISO 32000-1
-// §7.5.8) and object streams (ISO 32000-1 §7.5.7) enabled — and
-// reports the byte-size difference.
+// Optimize compares the default writer with the optimized writer
+// (cross-reference streams per ISO 32000-1 §7.5.8 plus object streams
+// per ISO 32000-1 §7.5.7) across several document shapes and reports
+// the byte-size delta for each.
+//
+// The compression ratio depends heavily on what the document contains:
+// content streams are already Flate-compressed and ineligible for
+// object stream packing, so text-heavy documents save less than
+// metadata-heavy documents. The fixture set in this example is chosen
+// to surface that difference, so callers can decide whether the
+// optimizer is worth turning on for their workload.
 //
 // Usage:
 //
@@ -20,53 +27,117 @@ import (
 	"github.com/carlos7ags/folio/layout"
 )
 
-func buildDocument() *document.Document {
-	doc := document.NewDocument(document.PageSizeLetter)
-	doc.Info.Title = "Optimization demo"
-	doc.Info.Author = "Folio"
+// fixture is one row of the comparison table.
+type fixture struct {
+	name  string
+	build func() *document.Document
+}
 
+func textHeavy() *document.Document {
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.Info.Title = "Text-heavy fixture"
 	for i := 1; i <= 25; i++ {
 		doc.Add(layout.NewHeading(fmt.Sprintf("Section %d", i), layout.H1))
 		doc.Add(layout.NewParagraph(
-			"This document exists to demonstrate the byte-size impact of the "+
-				"cross-reference stream and object stream output modes. Each section "+
-				"adds a few indirect objects (page tree node, content stream, "+
-				"resources dictionary), so the savings grow with the number of "+
-				"sections in the document.",
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do "+
+				"eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut "+
+				"enim ad minim veniam, quis nostrud exercitation ullamco laboris.",
 			font.Helvetica, 11,
 		))
 	}
 	return doc
 }
 
-func main() {
-	tradBytes, err := buildDocument().ToBytes()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "default write failed: %v\n", err)
-		os.Exit(1)
+func manyPages() *document.Document {
+	// Page-tree-heavy: many empty pages produce many small dictionaries
+	// (one page object plus its resources per page) and almost no
+	// content stream bytes. This is the shape where the optimizer wins
+	// the most because nearly every object is eligible for packing.
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.Info.Title = "Many empty pages fixture"
+	for range 50 {
+		doc.AddPage()
 	}
+	return doc
+}
 
-	optBytes, err := buildDocument().ToBytesWithOptions(document.WriteOptions{
+func tableHeavy() *document.Document {
+	// One large table with many rows. Tables register multiple resource
+	// dictionaries and per-cell styling, so they exercise the resource
+	// path that the optimizer compresses well.
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.Info.Title = "Table-heavy fixture"
+	tbl := layout.NewTable().SetAutoColumnWidths()
+	header := tbl.AddRow()
+	header.AddCell("SKU", font.Helvetica, 10)
+	header.AddCell("Description", font.Helvetica, 10)
+	header.AddCell("Quantity", font.Helvetica, 10)
+	header.AddCell("Unit price", font.Helvetica, 10)
+	header.AddCell("Line total", font.Helvetica, 10)
+	for i := 1; i <= 60; i++ {
+		row := tbl.AddRow()
+		row.AddCell(fmt.Sprintf("SKU-%04d", i), font.Helvetica, 10)
+		row.AddCell(fmt.Sprintf("Item description %d", i), font.Helvetica, 10)
+		row.AddCell(fmt.Sprintf("%d", i), font.Helvetica, 10)
+		row.AddCell(fmt.Sprintf("$%d.99", i*5), font.Helvetica, 10)
+		row.AddCell(fmt.Sprintf("$%d.45", i*i*5), font.Helvetica, 10)
+	}
+	doc.Add(tbl)
+	return doc
+}
+
+func writeBoth(f fixture) (defaultBytes, optimizedBytes []byte, err error) {
+	defaultBytes, err = f.build().ToBytes()
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s default: %w", f.name, err)
+	}
+	optimizedBytes, err = f.build().ToBytesWithOptions(document.WriteOptions{
 		UseXRefStream:    true,
 		UseObjectStreams: true,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "optimized write failed: %v\n", err)
-		os.Exit(1)
+		return nil, nil, fmt.Errorf("%s optimized: %w", f.name, err)
+	}
+	return defaultBytes, optimizedBytes, nil
+}
+
+func main() {
+	fixtures := []fixture{
+		{name: "text-heavy", build: textHeavy},
+		{name: "many empty pages", build: manyPages},
+		{name: "table-heavy", build: tableHeavy},
 	}
 
-	if err := os.WriteFile("optimize-default.pdf", tradBytes, 0o644); err != nil {
+	fmt.Printf("%-20s %12s %12s %10s\n", "fixture", "default", "optimized", "saved")
+	fmt.Println("-------------------- ------------ ------------ ----------")
+
+	for _, f := range fixtures {
+		def, opt, err := writeBoth(f)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		saved := len(def) - len(opt)
+		pct := 100.0 * float64(saved) / float64(len(def))
+		fmt.Printf("%-20s %10d B %10d B %8.1f %%\n",
+			f.name, len(def), len(opt), pct)
+	}
+
+	// Write the text-heavy fixture to disk so the user has a concrete
+	// pair of files to inspect with qpdf or any PDF viewer.
+	def, opt, err := writeBoth(fixtures[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile("optimize-default.pdf", def, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "write default file: %v\n", err)
 		os.Exit(1)
 	}
-	if err := os.WriteFile("optimize-compressed.pdf", optBytes, 0o644); err != nil {
+	if err := os.WriteFile("optimize-compressed.pdf", opt, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "write optimized file: %v\n", err)
 		os.Exit(1)
 	}
-
-	delta := len(tradBytes) - len(optBytes)
-	pct := 100.0 * float64(delta) / float64(len(tradBytes))
-	fmt.Printf("default     : %d bytes (optimize-default.pdf)\n", len(tradBytes))
-	fmt.Printf("optimized   : %d bytes (optimize-compressed.pdf)\n", len(optBytes))
-	fmt.Printf("saved       : %d bytes (%.1f%%)\n", delta, pct)
+	fmt.Println()
+	fmt.Println("wrote optimize-default.pdf and optimize-compressed.pdf (text-heavy fixture)")
 }


### PR DESCRIPTION
## Summary

Follow-up to #177. Two small additions, both feedback from the post-merge review of the optimizer landing.

- **Rewrites `examples/optimize`** to compare three document shapes side by side (text-heavy report, 50 empty pages, 60-row table). The original single-document version masked the most interesting fact about the optimizer: the compression ratio depends heavily on what the document contains. Content streams are already Flate-compressed and ineligible for object stream packing, so text-heavy documents save less than metadata-heavy ones.
- **Adds an Output Size subsection** to the README under Performance, with the same fixture table and a code snippet showing the option struct. Adds the `optimize` example to the examples table.

## Numbers from the new fixtures

| Fixture | Default | Optimized | Saved |
|---|---:|---:|---:|
| Text-heavy report (25 sections) | 6913 B | 5621 B | 18.7% |
| 50 empty pages | 6317 B | 932 B | 85.2% |
| 60-row data table | 8063 B | 7785 B | 3.4% |

The 85% number on the empty-pages fixture is the headline: when nothing in the document is a content stream, almost every object is eligible for packing and the win is large. The 3.4% on the table fixture is the floor: with one large content stream dominating the file, the optimizer can only compress the surrounding metadata.

## Test plan

- [ ] `go run ./examples/optimize` reports the table above
- [ ] `go test ./...` clean
- [ ] README renders correctly on GitHub