### PR TITLE
Dispatch GSUB chain context actions to ligature and chain lookups

### DIFF
--- a/font/gsub.go
+++ b/font/gsub.go
@@ -71,14 +71,31 @@ type GSUBSubstitutions struct {
 	Ligature     map[GSUBFeature]map[uint16][]LigatureSubst
 	ChainContext map[GSUBFeature]map[uint16][]ChainContextSubst
 
-	// lookupTable is indexed by GSUB LookupList slot and holds just the
-	// flattened Single-Substitution map for that lookup. It is populated
-	// for every lookup in the LookupList (not only feature-reachable
-	// ones) so that ChainContext actions can dispatch to any lookup slot
-	// referenced by a SubstLookupRecord. Nil entries mean "lookup slot
-	// has no Single-Substitution subtable we understand".
-	lookupTable []map[uint16]uint16
+	// lookupTable is indexed by GSUB LookupList slot and carries a
+	// per-lookup record so that ChainContext actions can dispatch to any
+	// lookup slot referenced by a SubstLookupRecord, regardless of its
+	// lookup type. Nil entries mean "lookup slot has no subtable shape
+	// we understand as a dispatch target". See lookupRecord for the
+	// per-type payload.
+	lookupTable []*lookupRecord
 }
+
+// lookupRecord is the per-slot dispatch payload used by ChainContext
+// action recursion. Type carries the GSUB LookupType after any LookupType
+// 7 (Extension) unwrap; exactly one of Single/Lig/Chain is populated to
+// match Type.
+type lookupRecord struct {
+	Type   uint16
+	Single map[uint16]uint16
+	Lig    map[uint16][]LigatureSubst
+	Chain  map[uint16][]ChainContextSubst
+}
+
+// maxChainDepth bounds recursive ChainContext action dispatch. OpenType
+// does not specify a limit; in practice fonts use shallow chains and
+// widely deployed shapers cap recursion at 64 to prevent stack overflow
+// from pathological or adversarial rule sets. We use the same bound.
+const maxChainDepth = 64
 
 // ParseGSUB reads the GSUB table from raw TrueType/OpenType font bytes
 // and extracts Single (LookupType 1) and Ligature (LookupType 4)
@@ -130,10 +147,11 @@ func ParseGSUB(data []byte) *GSUBSubstitutions {
 	}
 
 	// Pre-scan the full LookupList once to build the internal per-slot
-	// Single-Substitution table used by ChainContext action dispatch.
-	// This table is sparse: a slot is left nil unless it carries a
-	// LookupType 1 (optionally wrapped in LookupType 7) subtable.
-	lookupTable := buildLookupSingleTable(gsub, lookupListOff)
+	// dispatch table used by ChainContext action recursion. This table
+	// is sparse: a slot is left nil unless it carries a subtable shape
+	// we can dispatch into (LookupType 1, 4, or 6; LookupType 7 is
+	// unwrapped).
+	lookupTable := buildLookupDispatchTable(gsub, lookupListOff)
 
 	result := &GSUBSubstitutions{
 		Single:       make(map[GSUBFeature]map[uint16]uint16),
@@ -179,36 +197,55 @@ func (g *GSUBSubstitutions) ApplyLigature(gids []uint16, feature GSUBFeature) []
 	if !ok || len(table) == 0 {
 		return gids
 	}
-	out := make([]uint16, 0, len(gids))
+	out := make([]uint16, len(gids))
+	copy(out, gids)
 	i := 0
-	for i < len(gids) {
-		candidates := table[gids[i]]
-		matched := false
-		for _, cand := range candidates {
-			need := len(cand.Components)
-			if i+1+need > len(gids) {
-				continue
-			}
-			ok := true
-			for j := 0; j < need; j++ {
-				if gids[i+1+j] != cand.Components[j] {
-					ok = false
-					break
-				}
-			}
-			if ok {
-				out = append(out, cand.LigatureGID)
-				i += 1 + need
-				matched = true
+	for i < len(out) {
+		next, consumed := applyLigatureAt(out, i, table)
+		if consumed > 0 {
+			out = next
+			i++
+			continue
+		}
+		i++
+	}
+	return out
+}
+
+// applyLigatureAt tests the ligature table at position pos and, on a
+// longest greedy match, splices the matched components out of gids and
+// inserts the ligature GID in place. The returned slice may alias gids
+// on no match, or be shorter than gids when a multi-component ligature
+// fires. consumed is the number of input positions that were collapsed
+// (0 on no match, 1+len(components) on a match).
+func applyLigatureAt(gids []uint16, pos int, table map[uint16][]LigatureSubst) ([]uint16, int) {
+	if pos < 0 || pos >= len(gids) {
+		return gids, 0
+	}
+	candidates := table[gids[pos]]
+	for _, cand := range candidates {
+		need := len(cand.Components)
+		if pos+1+need > len(gids) {
+			continue
+		}
+		matched := true
+		for j := 0; j < need; j++ {
+			if gids[pos+1+j] != cand.Components[j] {
+				matched = false
 				break
 			}
 		}
 		if !matched {
-			out = append(out, gids[i])
-			i++
+			continue
 		}
+		// Splice: replace [pos : pos+1+need] with a single GID.
+		gids[pos] = cand.LigatureGID
+		if need > 0 {
+			gids = append(gids[:pos+1], gids[pos+1+need:]...)
+		}
+		return gids, 1 + need
 	}
-	return out
+	return gids, 0
 }
 
 // sortLigsByLenDesc sorts ligatures so that longer component sequences
@@ -432,13 +469,14 @@ func parseLookup(gsub []byte, lookupOff int, single map[uint16]uint16, lig map[u
 	}
 }
 
-// buildLookupSingleTable walks every lookup in the GSUB LookupList and,
-// for each slot that carries a LookupType 1 subtable (directly or wrapped
-// in LookupType 7), records its flattened GID->GID map. The returned
-// slice is indexed by lookupListIndex. Slots carrying only other lookup
-// types receive a nil entry. This table is the dispatch target for
-// ChainContext actions.
-func buildLookupSingleTable(gsub []byte, listOff int) []map[uint16]uint16 {
+// buildLookupDispatchTable walks every lookup in the GSUB LookupList
+// once and builds a per-slot dispatch record. For each supported lookup
+// type it populates the matching map on a lookupRecord: Single for
+// LookupType 1, Lig for LookupType 4, Chain for LookupType 6. LookupType
+// 7 (Extension) is unwrapped and the extension's effective type drives
+// the target map. The returned slice is indexed by lookupListIndex.
+// Slots carrying no understood subtable shape receive a nil entry.
+func buildLookupDispatchTable(gsub []byte, listOff int) []*lookupRecord {
 	if listOff+2 > len(gsub) {
 		return nil
 	}
@@ -446,7 +484,7 @@ func buildLookupSingleTable(gsub []byte, listOff int) []map[uint16]uint16 {
 	if listOff+2+count*2 > len(gsub) {
 		return nil
 	}
-	out := make([]map[uint16]uint16, count)
+	out := make([]*lookupRecord, count)
 	for i := 0; i < count; i++ {
 		lookupOff := listOff + int(be16(gsub, listOff+2+i*2))
 		if lookupOff+6 > len(gsub) {
@@ -457,34 +495,57 @@ func buildLookupSingleTable(gsub []byte, listOff int) []map[uint16]uint16 {
 		if lookupOff+6+subCount*2 > len(gsub) {
 			continue
 		}
-		var single map[uint16]uint16
+		rec := &lookupRecord{}
 		for si := 0; si < subCount; si++ {
 			subOff := lookupOff + int(be16(gsub, lookupOff+6+si*2))
-			switch lookupType {
-			case 1:
-				if single == nil {
-					single = make(map[uint16]uint16)
-				}
-				parseSingleSubst(gsub, subOff, single)
-			case 7:
+			effType := lookupType
+			effOff := subOff
+			if lookupType == 7 {
 				if subOff+8 > len(gsub) {
 					continue
 				}
-				extType := be16(gsub, subOff+2)
-				extOff := subOff + int(be32(gsub, subOff+4))
-				if extOff >= len(gsub) {
+				effType = be16(gsub, subOff+2)
+				effOff = subOff + int(be32(gsub, subOff+4))
+				if effOff >= len(gsub) {
 					continue
 				}
-				if extType == 1 {
-					if single == nil {
-						single = make(map[uint16]uint16)
-					}
-					parseSingleSubst(gsub, extOff, single)
+			}
+			switch effType {
+			case 1:
+				if rec.Single == nil {
+					rec.Single = make(map[uint16]uint16)
 				}
+				parseSingleSubst(gsub, effOff, rec.Single)
+			case 4:
+				if rec.Lig == nil {
+					rec.Lig = make(map[uint16][]LigatureSubst)
+				}
+				parseLigatureSubst(gsub, effOff, rec.Lig)
+			case 6:
+				if rec.Chain == nil {
+					rec.Chain = make(map[uint16][]ChainContextSubst)
+				}
+				parseChainContextSubst(gsub, effOff, rec.Chain)
 			}
 		}
-		if len(single) > 0 {
-			out[i] = single
+		// Pick a dispatch type. We only support one per slot; mixing
+		// types in a single lookup is not allowed by the spec anyway
+		// (every subtable in a lookup must share the LookupType).
+		switch {
+		case len(rec.Single) > 0:
+			rec.Type = 1
+			out[i] = rec
+		case len(rec.Lig) > 0:
+			// Sort each bucket longest-first to match ApplyLigature's
+			// greedy-longest scan.
+			for k := range rec.Lig {
+				sortLigsByLenDesc(rec.Lig[k])
+			}
+			rec.Type = 4
+			out[i] = rec
+		case len(rec.Chain) > 0:
+			rec.Type = 6
+			out[i] = rec
 		}
 	}
 	return out
@@ -1156,11 +1217,11 @@ func parseSubstLookupRecords(gsub []byte, off int) []ChainSubstAction {
 // each candidate rule is tested for backtrack, input, and lookahead
 // matches and, on success, its SubstLookupRecord actions are dispatched.
 //
-// Action dispatch is currently limited to LookupType 1 (Single)
-// substitutions — recursing into Ligature or another ChainContext from
-// inside an action requires bounded recursion tracking and is deferred
-// to a follow-up. Rules whose actions reference non-Single lookups are
-// silently skipped for that action but the rule itself still matches.
+// Action dispatch supports LookupType 1 (Single), LookupType 4 (Ligature),
+// and recursive LookupType 6 (ChainContext) targets. LookupType 7
+// (Extension) wrappers are transparently unwrapped at parse time.
+// Recursion depth is bounded by maxChainDepth to defend against
+// pathological self-referential rule sets.
 //
 // Reference: ISO 14496-22 §6.2 LookupType 6.
 func (g *GSUBSubstitutions) ApplyChainContext(gids []uint16, feature GSUBFeature) []uint16 {
@@ -1173,39 +1234,82 @@ func (g *GSUBSubstitutions) ApplyChainContext(gids []uint16, feature GSUBFeature
 	}
 	out := make([]uint16, len(gids))
 	copy(out, gids)
-	for i := 0; i < len(out); i++ {
-		rules := table[out[i]]
-		if len(rules) == 0 {
-			continue
-		}
-		for _, rule := range rules {
-			if !chainRuleMatches(out, i, &rule) {
-				continue
-			}
-			// Action dispatch: Single-Substitution only.
-			for _, act := range rule.Actions {
-				pos := i + int(act.SequenceIndex)
-				if pos < 0 || pos >= len(out) {
-					continue
-				}
-				if int(act.LookupListIndex) >= len(g.lookupTable) {
-					continue
-				}
-				lookup := g.lookupTable[act.LookupListIndex]
-				if lookup == nil {
-					continue
-				}
-				if repl, found := lookup[out[pos]]; found {
-					out[pos] = repl
-				}
-			}
-			// Per the spec the outer loop advances by 1 regardless of
-			// input-sequence length; chained rules are the rule author's
-			// responsibility to design without self-overlap loops.
-			break
-		}
+	i := 0
+	for i < len(out) {
+		out = g.applyChainContextAt(out, i, table, 0)
+		i++
 	}
 	return out
+}
+
+// applyChainContextAt tests every rule bucketed under the trigger glyph
+// at position i and, on the first matching rule, dispatches each of
+// its SubstLookupRecord actions via applyLookup. Returns the gids slice
+// (possibly reallocated by a ligature splice). depth counts how many
+// nested ChainContext applies we are inside; applyLookup enforces the
+// maxChainDepth ceiling.
+func (g *GSUBSubstitutions) applyChainContextAt(gids []uint16, i int, table map[uint16][]ChainContextSubst, depth int) []uint16 {
+	if i < 0 || i >= len(gids) {
+		return gids
+	}
+	rules := table[gids[i]]
+	if len(rules) == 0 {
+		return gids
+	}
+	for ri := range rules {
+		rule := &rules[ri]
+		if !chainRuleMatches(gids, i, rule) {
+			continue
+		}
+		for _, act := range rule.Actions {
+			pos := i + int(act.SequenceIndex)
+			if pos < 0 || pos >= len(gids) {
+				continue
+			}
+			gids = g.applyLookup(gids, act.LookupListIndex, pos, depth)
+		}
+		// OpenType does not specify a post-match advance for the outer
+		// loop; the existing behavior advances by 1 regardless of the
+		// input sequence length, which matches both the spec's silence
+		// and the historic Folio behavior. We keep that to avoid
+		// changing the dispatch shape for Single-only rules.
+		return gids
+	}
+	return gids
+}
+
+// applyLookup dispatches a ChainContext action into the target lookup
+// at the given gid position. It mutates gids according to the target
+// lookup's type (Single: point substitution; Ligature: greedy splice;
+// ChainContext: recursive match with depth+1). Returns the possibly
+// reallocated gids slice. Recursion is capped at maxChainDepth.
+func (g *GSUBSubstitutions) applyLookup(gids []uint16, lookupIdx uint16, position, depth int) []uint16 {
+	if depth >= maxChainDepth {
+		return gids
+	}
+	if int(lookupIdx) >= len(g.lookupTable) {
+		return gids
+	}
+	rec := g.lookupTable[lookupIdx]
+	if rec == nil {
+		return gids
+	}
+	if position < 0 || position >= len(gids) {
+		return gids
+	}
+	switch rec.Type {
+	case 1:
+		if repl, found := rec.Single[gids[position]]; found {
+			gids[position] = repl
+		}
+		return gids
+	case 4:
+		next, _ := applyLigatureAt(gids, position, rec.Lig)
+		return next
+	case 6:
+		return g.applyChainContextAt(gids, position, rec.Chain, depth+1)
+	}
+	return gids
 }
 
 // chainRuleMatches tests a single ChainContextSubst rule against gids

--- a/font/gsub_test.go
+++ b/font/gsub_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 )
 
 // TestParseGSUBFindsArabicFeatures loads a system font known to have
@@ -1081,6 +1082,398 @@ func assembleTwoLookupGSUB(singleSub, chainSub []byte, extension bool) []byte {
 	out = append(out, featList...)
 	out = append(out, lookupList...)
 	return out
+}
+
+// --- Recursive ChainContext action dispatch tests (PR #17x follow-up) ---
+
+// lookupSpec describes one lookup to be packaged into a synthetic GSUB
+// blob by assembleMultiLookupGSUB. Type is the on-disk LookupType to
+// write for this slot (1, 4, 6, or 7). Sub is the raw subtable bytes.
+// When Type is 7, Sub must already carry the LookupType 7 extension
+// wrapper; the helper does not add one.
+type lookupSpec struct {
+	Type uint16
+	Sub  []byte
+}
+
+// assembleMultiLookupGSUB assembles a synthetic GSUB blob with an
+// arbitrary number of lookups, a single "calt" feature that references
+// one lookup slot (featureRef), and a "latn" script binding that feature
+// as the default. It mirrors the layout conventions used by the existing
+// chain-context test builders.
+func assembleMultiLookupGSUB(lookups []lookupSpec, featureRef uint16) []byte {
+	// Pack each lookup: type(2) + flag(2) + subCount(2) + subOff[0]=8 + sub.
+	lookupBytes := make([][]byte, len(lookups))
+	for i, lk := range lookups {
+		buf := make([]byte, 8+len(lk.Sub))
+		put16(buf[0:2], lk.Type)
+		put16(buf[2:4], 0)
+		put16(buf[4:6], 1)
+		put16(buf[6:8], 8)
+		copy(buf[8:], lk.Sub)
+		lookupBytes[i] = buf
+	}
+
+	lookupListHdr := 2 + 2*len(lookups)
+	offs := make([]int, len(lookups))
+	total := lookupListHdr
+	for i, b := range lookupBytes {
+		offs[i] = total
+		total += len(b)
+	}
+	lookupList := make([]byte, total)
+	put16(lookupList[0:2], uint16(len(lookups)))
+	for i, off := range offs {
+		put16(lookupList[2+i*2:4+i*2], uint16(off))
+		copy(lookupList[off:], lookupBytes[i])
+	}
+
+	// Feature: featureParams(2)=0, lookupCount(2)=1, lookupIndex(2)=featureRef.
+	feature := make([]byte, 6)
+	put16(feature[0:2], 0)
+	put16(feature[2:4], 1)
+	put16(feature[4:6], featureRef)
+
+	featListHdr := 8
+	featList := make([]byte, featListHdr+len(feature))
+	put16(featList[0:2], 1)
+	copy(featList[2:6], []byte("calt"))
+	put16(featList[6:8], uint16(featListHdr))
+	copy(featList[featListHdr:], feature)
+
+	langSys := make([]byte, 8)
+	put16(langSys[0:2], 0)
+	put16(langSys[2:4], 0xFFFF)
+	put16(langSys[4:6], 1)
+	put16(langSys[6:8], 0)
+
+	scriptHdr := 4
+	script := make([]byte, scriptHdr+len(langSys))
+	put16(script[0:2], uint16(scriptHdr))
+	put16(script[2:4], 0)
+	copy(script[scriptHdr:], langSys)
+
+	scriptListHdr := 8
+	scriptList := make([]byte, scriptListHdr+len(script))
+	put16(scriptList[0:2], 1)
+	copy(scriptList[2:6], []byte("latn"))
+	put16(scriptList[6:8], uint16(scriptListHdr))
+	copy(scriptList[scriptListHdr:], script)
+
+	header := make([]byte, 10)
+	scriptListOff := len(header)
+	featListOff := scriptListOff + len(scriptList)
+	lookupListOff := featListOff + len(featList)
+	put16(header[0:2], 1)
+	put16(header[2:4], 0)
+	put16(header[4:6], uint16(scriptListOff))
+	put16(header[6:8], uint16(featListOff))
+	put16(header[8:10], uint16(lookupListOff))
+
+	out := make([]byte, 0, lookupListOff+len(lookupList))
+	out = append(out, header...)
+	out = append(out, scriptList...)
+	out = append(out, featList...)
+	out = append(out, lookupList...)
+	return out
+}
+
+// buildSingleSubstSubtable returns a SingleSubstFormat2 subtable that
+// maps each source GID to the corresponding target GID, in the order
+// given by sources. Sources must be sorted ascending so Coverage Format 1
+// can list them directly.
+func buildSingleSubstSubtable(sources, targets []uint16) []byte {
+	n := len(sources)
+	cov := make([]byte, 4+n*2)
+	put16(cov[0:2], 1)
+	put16(cov[2:4], uint16(n))
+	for i, gid := range sources {
+		put16(cov[4+i*2:6+i*2], gid)
+	}
+	hdr := 6
+	sub := make([]byte, hdr+n*2+len(cov))
+	put16(sub[0:2], 2)
+	put16(sub[2:4], uint16(hdr+n*2))
+	put16(sub[4:6], uint16(n))
+	for i, gid := range targets {
+		put16(sub[hdr+i*2:hdr+i*2+2], gid)
+	}
+	copy(sub[hdr+n*2:], cov)
+	return sub
+}
+
+// buildLigatureSubstSubtable returns a LigatureSubstFormat1 subtable
+// for a single trigger GID with one ligature: [trigger, components...]
+// -> ligGID. The components slice lists the glyphs that must follow
+// the trigger to fire the ligature.
+func buildLigatureSubstSubtable(trigger uint16, components []uint16, ligGID uint16) []byte {
+	// Ligature record: ligGlyph(2) + componentCount(2) + comps[components](2 each).
+	compCount := 1 + len(components)
+	lig := make([]byte, 4+len(components)*2)
+	put16(lig[0:2], ligGID)
+	put16(lig[2:4], uint16(compCount))
+	for i, c := range components {
+		put16(lig[4+i*2:6+i*2], c)
+	}
+	// LigatureSet: ligCount(2) + ligOff[0]=4 + lig.
+	set := make([]byte, 4+len(lig))
+	put16(set[0:2], 1)
+	put16(set[2:4], 4)
+	copy(set[4:], lig)
+	// Coverage format 1 for {trigger}.
+	cov := make([]byte, 6)
+	put16(cov[0:2], 1)
+	put16(cov[2:4], 1)
+	put16(cov[4:6], trigger)
+	// Subtable: format=1 + coverageOff + setCount=1 + setOff[0].
+	hdr := 8
+	sub := make([]byte, hdr+len(cov)+len(set))
+	put16(sub[0:2], 1)
+	put16(sub[2:4], uint16(hdr))
+	put16(sub[4:6], 1)
+	put16(sub[6:8], uint16(hdr+len(cov)))
+	copy(sub[hdr:], cov)
+	copy(sub[hdr+len(cov):], set)
+	return sub
+}
+
+// buildChainCtxFormat1Rule builds a ChainSubRule with the supplied back,
+// input (including the trigger), and lookahead GID sequences and
+// SubstLookupRecord actions. Returns the raw rule bytes.
+func buildChainCtxFormat1Rule(back, input, look []uint16, actions []ChainSubstAction) []byte {
+	if len(input) < 1 {
+		panic("input must include the trigger glyph at index 0")
+	}
+	rest := input[1:]
+	n := 2 + len(back)*2 + 2 + len(rest)*2 + 2 + len(look)*2 + 2 + len(actions)*4
+	rule := make([]byte, n)
+	p := 0
+	put16(rule[p:p+2], uint16(len(back)))
+	p += 2
+	for _, g := range back {
+		put16(rule[p:p+2], g)
+		p += 2
+	}
+	put16(rule[p:p+2], uint16(len(input)))
+	p += 2
+	for _, g := range rest {
+		put16(rule[p:p+2], g)
+		p += 2
+	}
+	put16(rule[p:p+2], uint16(len(look)))
+	p += 2
+	for _, g := range look {
+		put16(rule[p:p+2], g)
+		p += 2
+	}
+	put16(rule[p:p+2], uint16(len(actions)))
+	p += 2
+	for _, a := range actions {
+		put16(rule[p:p+2], a.SequenceIndex)
+		p += 2
+		put16(rule[p:p+2], a.LookupListIndex)
+		p += 2
+	}
+	return rule
+}
+
+// buildChainCtxFormat1Subtable builds a ChainContextSubstFormat1 subtable
+// for a single trigger GID with one rule. The trigger is taken from
+// input[0].
+func buildChainCtxFormat1Subtable(back, input, look []uint16, actions []ChainSubstAction) []byte {
+	if len(input) < 1 {
+		panic("input must include the trigger glyph at index 0")
+	}
+	trigger := input[0]
+	rule := buildChainCtxFormat1Rule(back, input, look, actions)
+
+	set := make([]byte, 4+len(rule))
+	put16(set[0:2], 1)
+	put16(set[2:4], 4)
+	copy(set[4:], rule)
+
+	cov := make([]byte, 6)
+	put16(cov[0:2], 1)
+	put16(cov[2:4], 1)
+	put16(cov[4:6], trigger)
+
+	hdr := 8
+	sub := make([]byte, hdr+len(cov)+len(set))
+	put16(sub[0:2], 1)
+	put16(sub[2:4], uint16(hdr))
+	put16(sub[4:6], 1)
+	put16(sub[6:8], uint16(hdr+len(cov)))
+	copy(sub[hdr:], cov)
+	copy(sub[hdr+len(cov):], set)
+	return sub
+}
+
+// wrapExtension wraps a subtable in a LookupType 7 Extension header with
+// the given effective type. The caller must set the outer lookup's type
+// to 7.
+func wrapExtension(effectiveType uint16, inner []byte) []byte {
+	out := make([]byte, 8+len(inner))
+	put16(out[0:2], 1)
+	put16(out[2:4], effectiveType)
+	put32(out[4:8], 8)
+	copy(out[8:], inner)
+	return out
+}
+
+// TestChainContextActionTargetsLigature constructs a font where a chain
+// context rule matches [back=5, input=10 20, look=30] and its action
+// fires a Ligature lookup keyed at position 0 (the trigger, GID 10). The
+// ligature [10, 20] -> 99 collapses two glyphs into one inside the
+// chain's matched range; the action's target is a genuine LookupType 4,
+// which is the behavior this test exercises.
+func TestChainContextActionTargetsLigature(t *testing.T) {
+	ligSub := buildLigatureSubstSubtable(10, []uint16{20}, 99)
+	chainSub := buildChainCtxFormat1Subtable(
+		[]uint16{5}, []uint16{10, 20}, []uint16{30},
+		[]ChainSubstAction{{SequenceIndex: 0, LookupListIndex: 0}},
+	)
+	gsub := assembleMultiLookupGSUB([]lookupSpec{
+		{Type: 4, Sub: ligSub},
+		{Type: 6, Sub: chainSub},
+	}, 1)
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil")
+	}
+	got := subs.ApplyChainContext([]uint16{5, 10, 20, 30}, GSUBCalt)
+	want := []uint16{5, 99, 30}
+	if !uint16SliceEq(got, want) {
+		t.Errorf("ligature action: got %v, want %v", got, want)
+	}
+}
+
+// TestChainContextActionTargetsChainContext nests one chain rule inside
+// another: the outer rule's action dispatches into a second chain lookup
+// whose own action performs a Single substitution. Exercises the
+// recursive ChainContext case.
+func TestChainContextActionTargetsChainContext(t *testing.T) {
+	// lookup 0: Single [10 -> 99]
+	singleSub := buildSingleSubstSubtable([]uint16{10}, []uint16{99})
+	// lookup 1: Inner chain, back=[5], input=[10], look=[20], action -> 0.
+	innerChain := buildChainCtxFormat1Subtable(
+		[]uint16{5}, []uint16{10}, []uint16{20},
+		[]ChainSubstAction{{SequenceIndex: 0, LookupListIndex: 0}},
+	)
+	// lookup 2: Outer chain, same context, action -> 1 (inner chain).
+	outerChain := buildChainCtxFormat1Subtable(
+		[]uint16{5}, []uint16{10}, []uint16{20},
+		[]ChainSubstAction{{SequenceIndex: 0, LookupListIndex: 1}},
+	)
+	gsub := assembleMultiLookupGSUB([]lookupSpec{
+		{Type: 1, Sub: singleSub},
+		{Type: 6, Sub: innerChain},
+		{Type: 6, Sub: outerChain},
+	}, 2)
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil")
+	}
+	got := subs.ApplyChainContext([]uint16{5, 10, 20}, GSUBCalt)
+	want := []uint16{5, 99, 20}
+	if !uint16SliceEq(got, want) {
+		t.Errorf("recursive chain dispatch: got %v, want %v", got, want)
+	}
+}
+
+// TestChainContextRecursionDepthGuard builds a single chain lookup whose
+// action dispatches into itself. Without the maxChainDepth ceiling,
+// ApplyChainContext would recurse forever; the guard must short-circuit
+// the recursion and return a value without exceeding the test timeout.
+func TestChainContextRecursionDepthGuard(t *testing.T) {
+	selfRef := buildChainCtxFormat1Subtable(
+		[]uint16{5}, []uint16{10}, []uint16{20},
+		[]ChainSubstAction{{SequenceIndex: 0, LookupListIndex: 0}},
+	)
+	gsub := assembleMultiLookupGSUB([]lookupSpec{
+		{Type: 6, Sub: selfRef},
+	}, 0)
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil")
+	}
+	done := make(chan []uint16, 1)
+	go func() {
+		done <- subs.ApplyChainContext([]uint16{5, 10, 20}, GSUBCalt)
+	}()
+	select {
+	case got := <-done:
+		// The action doesn't actually substitute anything (the target is
+		// a chain lookup and all it does is recurse), so the input passes
+		// through unchanged. What matters is that the call returned.
+		if !uint16SliceEq(got, []uint16{5, 10, 20}) {
+			t.Errorf("unexpected mutation under depth guard: got %v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("ApplyChainContext did not return within 2s: depth guard failed")
+	}
+}
+
+// TestChainContextMixedActionDispatch checks a rule with two actions in
+// the same SubstLookupRecord array targeting different lookup types:
+// seqIdx=0 targets a Single lookup, seqIdx=1 targets a Ligature lookup.
+// Input [5, 10, 20, 30]: single action rewrites position 1 (10->99),
+// then the ligature action at position 2 consumes 20,30 -> 77.
+// Result: [5, 99, 77].
+func TestChainContextMixedActionDispatch(t *testing.T) {
+	singleSub := buildSingleSubstSubtable([]uint16{10}, []uint16{99})
+	ligSub := buildLigatureSubstSubtable(20, []uint16{30}, 77)
+	chainSub := buildChainCtxFormat1Subtable(
+		[]uint16{5}, []uint16{10, 20}, []uint16{30},
+		[]ChainSubstAction{
+			{SequenceIndex: 0, LookupListIndex: 0},
+			{SequenceIndex: 1, LookupListIndex: 1},
+		},
+	)
+	gsub := assembleMultiLookupGSUB([]lookupSpec{
+		{Type: 1, Sub: singleSub},
+		{Type: 4, Sub: ligSub},
+		{Type: 6, Sub: chainSub},
+	}, 2)
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil")
+	}
+	got := subs.ApplyChainContext([]uint16{5, 10, 20, 30}, GSUBCalt)
+	want := []uint16{5, 99, 77}
+	if !uint16SliceEq(got, want) {
+		t.Errorf("mixed dispatch: got %v, want %v", got, want)
+	}
+}
+
+// TestChainContextExtensionWrappedDispatchTarget wraps the inner Ligature
+// lookup in a LookupType 7 Extension and verifies the chain action still
+// reaches it. This exercises the extension-unwrap branch of
+// buildLookupDispatchTable.
+func TestChainContextExtensionWrappedDispatchTarget(t *testing.T) {
+	ligSub := buildLigatureSubstSubtable(10, []uint16{20}, 99)
+	extWrapped := wrapExtension(4, ligSub)
+	chainSub := buildChainCtxFormat1Subtable(
+		[]uint16{5}, []uint16{10, 20}, []uint16{30},
+		[]ChainSubstAction{{SequenceIndex: 0, LookupListIndex: 0}},
+	)
+	gsub := assembleMultiLookupGSUB([]lookupSpec{
+		{Type: 7, Sub: extWrapped},
+		{Type: 6, Sub: chainSub},
+	}, 1)
+	ttf := buildTTFWithGSUB(gsub)
+	subs := ParseGSUB(ttf)
+	if subs == nil {
+		t.Fatalf("ParseGSUB returned nil")
+	}
+	got := subs.ApplyChainContext([]uint16{5, 10, 20, 30}, GSUBCalt)
+	want := []uint16{5, 99, 30}
+	if !uint16SliceEq(got, want) {
+		t.Errorf("extension-wrapped dispatch: got %v, want %v", got, want)
+	}
 }
 
 func arabicFontPath() string {


### PR DESCRIPTION
## Summary

Extend `(*GSUBSubstitutions).ApplyChainContext` so that a chaining contextual substitution action can dispatch into Ligature (LookupType 4) and recursive ChainContext (LookupType 6) targets, not only Single (LookupType 1). Per ISO 14496-22 §6.2, a `SubstLookupRecord` may reference any lookup in the LookupList. Prior behavior silently skipped non-Single targets, which held back some Indic and complex-script fonts that chain through ligature or sub-chain lookups.

- Replace the unexported `lookupTable []map[uint16]uint16` with `[]*lookupRecord`, a per-slot dispatch record carrying the parsed `Single` / `Lig` / `Chain` payload matching the lookup's effective type. LookupType 7 (Extension) is unwrapped to its effective type at parse time, just like the existing feature-side path.
- Add `applyLookup(gids, lookupIdx, position, depth)` which dispatches by `rec.Type` and applies the matching behavior at the given position: point substitution for Single; greedy longest-match splice for Ligature; recursive match for ChainContext with `depth+1`.
- Factor `ApplyLigature` and `ApplyChainContext` around the shared per-position helpers `applyLigatureAt` and `applyChainContextAt`.
- Add a `maxChainDepth = 64` ceiling so a self-referential or adversarial rule set cannot stack-overflow the shaper.

## Trade-offs

- **Depth cap of 64.** OpenType §6.2 does not specify a recursion limit, but in practice fonts use shallow action chains and mature shapers cap recursion at 64 to defend against pathological or hostile rule sets. We use the same bound as a conservative default. If a real font needs more we can revisit, but 64 is well above observed real-world depth.
- **Unexported data model change only.** `GSUBSubstitutions`, `ApplyChainContext`, and `ApplyLigature` keep their public signatures. The deeper per-lookup payload lives on the unexported `lookupTable` field so callers are unaffected.
- **Ligature splicing mutates gids in place (with `append` shrink).** When a ligature action fires inside a chain context action, the gids slice is collapsed in place and the new (shorter) slice is returned; the caller reassigns. Returning a fresh allocation on every action would be cleaner functionally but doubles allocations for every chain rule; in-place mutation matches the cost model of the existing outer loops and the subsequent actions in the same rule naturally see the updated slice.
- **Advance-by-1 after a matching chain rule is preserved.** The existing ApplyChainContext behavior advances the outer loop by one position regardless of the matched input length. The OpenType spec is silent on this, and changing it would be a behavior change for Single-only rules — out of scope for this PR.

## Test plan

- [x] `go test ./...` (entire repo green)
- [x] `gofmt -s -w .`, `go vet ./...`, `golangci-lint run ./...` (all clean)
- [x] New unit tests, each driven by a synthetic GSUB blob built via a new multi-lookup assembler:
    - `TestChainContextActionTargetsLigature` — chain rule whose action targets a LookupType 4 Ligature lookup.
    - `TestChainContextActionTargetsChainContext` — outer chain rule whose action recurses into an inner chain rule which in turn dispatches a Single substitution.
    - `TestChainContextRecursionDepthGuard` — self-referential chain rule; guarded by a 2s test timeout to catch unbounded recursion in CI.
    - `TestChainContextMixedActionDispatch` — one rule with two actions targeting a Single and a Ligature lookup respectively.
    - `TestChainContextExtensionWrappedDispatchTarget` — the inner dispatch target wrapped in LookupType 7 (Extension).
- [x] Existing `TestChainContextSequenceIndexOne` still passes byte-for-byte.

## Reference

ISO/IEC 14496-22 §6.2, OpenType GSUB table, LookupType 6 chaining contextual substitution and its SubstLookupRecord action list.