### PR TITLE
Wire GPOS mark-to-base anchors into the draw pipeline

### DIFF
--- a/layout/draw.go
+++ b/layout/draw.go
@@ -5,10 +5,12 @@ package layout
 
 import (
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/carlos7ags/folio/content"
 	"github.com/carlos7ags/folio/font"
 	folioimage "github.com/carlos7ags/folio/image"
+	"github.com/carlos7ags/folio/unicode/grapheme"
 )
 
 // setFillColor emits the correct fill color operator based on color space.
@@ -261,8 +263,18 @@ func drawWordStandard(stream *content.Stream, word Word) {
 }
 
 // drawWordEmbedded emits an embedded-font word with optional TJ kerning.
+// When the word contains any Extend / ZWJ combining marks and the font's
+// GPOS table provides mark-to-base anchors, the emission path switches to
+// cluster-at-a-time rendering so each mark can be Td-positioned on its
+// base glyph's anchor (ISO 14496-22 §6.3 LookupType 4). Eligible words
+// are Arabic with harakat, Hebrew with niqqud, and similar scripts.
+// Latin and un-marked words take the original fast path.
 func drawWordEmbedded(stream *content.Stream, word Word) {
 	if word.Embedded == nil {
+		return
+	}
+	if markPositioningEligible(word) {
+		drawWordEmbeddedWithMarks(stream, word)
 		return
 	}
 	runes := []rune(word.Text)
@@ -294,6 +306,147 @@ func drawWordEmbedded(stream *content.Stream, word Word) {
 		elements = append(elements, content.TextArrayElement{HexData: word.Embedded.EncodeString(string(runes[start:]))})
 	}
 	stream.ShowTextArrayHex(elements)
+}
+
+// markPositioningEligible reports whether drawWordEmbedded should switch
+// to the cluster-by-cluster mark-attachment path. Eligibility requires
+// an embedded font whose Face exposes GPOS mark-to-base data, a word
+// containing at least one Extend or ZWJ codepoint, and no letter
+// spacing override (Tc complicates the text-matrix arithmetic).
+func markPositioningEligible(word Word) bool {
+	if word.Embedded == nil || word.LetterSpacing != 0 {
+		return false
+	}
+	provider, ok := word.Embedded.Face().(font.GPOSProvider)
+	if !ok {
+		return false
+	}
+	gpos := provider.GPOS()
+	if gpos == nil || len(gpos.Marks[font.GPOSMark]) == 0 || len(gpos.Bases[font.GPOSMark]) == 0 {
+		return false
+	}
+	for _, r := range word.Text {
+		p := grapheme.PropertyOf(r)
+		if p == grapheme.PropExtend || p == grapheme.PropZWJ {
+			return true
+		}
+	}
+	return false
+}
+
+// drawWordEmbeddedWithMarks walks the word cluster-by-cluster (UAX #29
+// §3.1.1 extended grapheme clusters) and emits each cluster's base
+// glyph followed by GPOS-anchored marks. The text matrix ends at the
+// same position as the fast path (one natural advance per cluster,
+// plus inter-cluster kerning), so MeasureString and the post-emit
+// matrix agree. Callers must be inside a BT...ET block with the text
+// matrix already positioned at the word origin via MoveText.
+//
+// For each cluster the base rune contributes its full advance. Any
+// SpacingMark runes (Indic vowel signs) are appended into the cluster's
+// Tj hex string — they take their own advance, matching MeasureString.
+// Extend and ZWJ runes look up a MarkOffset(base, mark, GPOSMark) on
+// the font; on success the mark is drawn at the base anchor via a Td
+// pair that bookends its Tj so the text matrix returns to the cluster's
+// natural advance position. When MarkOffset returns ok=false the mark
+// is emitted at the current text origin (zero advance from SpacingMark
+// absence), which matches the no-GPOS fallback behaviour.
+func drawWordEmbeddedWithMarks(stream *content.Stream, word Word) {
+	ef := word.Embedded
+	face := ef.Face()
+	upem := face.UnitsPerEm()
+	if upem == 0 {
+		stream.ShowTextHex(ef.EncodeString(word.Text))
+		return
+	}
+	provider, _ := face.(font.GPOSProvider)
+	gpos := provider.GPOS()
+	fontSize := word.FontSize
+	scale := fontSize / float64(upem)
+
+	text := word.Text
+	breaks := grapheme.Breaks(text)
+	var prevTail uint16
+	havePrev := false
+
+	for ci := 0; ci+1 < len(breaks); ci++ {
+		cluster := text[breaks[ci]:breaks[ci+1]]
+		if cluster == "" {
+			continue
+		}
+		baseRune, baseSize := utf8.DecodeRuneInString(cluster)
+		baseGID := face.GlyphIndex(baseRune)
+
+		// Kerning between the tail of the previous cluster and this
+		// cluster's base. Emit as a Td shift so TJ and mark-Td handling
+		// do not have to be interleaved in a single TJ array.
+		if havePrev {
+			kernUnits := face.Kern(prevTail, baseGID)
+			if kernUnits != 0 {
+				stream.MoveText(float64(kernUnits)*scale, 0)
+			}
+		}
+
+		// Collect the base plus any SpacingMarks into a single hex
+		// string. SpacingMarks take their own advance and do not
+		// participate in GPOS mark-to-base anchoring here.
+		baseAndSpacing := cluster[:baseSize]
+		clusterAdvance := float64(face.GlyphAdvance(baseGID)) * scale
+		tail := baseGID
+		type markRune struct {
+			r    rune
+			size int
+		}
+		var extendMarks []markRune
+		for off := baseSize; off < len(cluster); {
+			r, size := utf8.DecodeRuneInString(cluster[off:])
+			p := grapheme.PropertyOf(r)
+			switch p {
+			case grapheme.PropExtend, grapheme.PropZWJ:
+				extendMarks = append(extendMarks, markRune{r: r, size: size})
+			case grapheme.PropSpacingMark:
+				// Append to the Tj hex string so its advance is
+				// consumed by the Tj operator itself, matching
+				// MeasureString's cluster width contribution.
+				baseAndSpacing += cluster[off : off+size]
+				spGID := face.GlyphIndex(r)
+				clusterAdvance += float64(face.GlyphAdvance(spGID)) * scale
+				tail = spGID
+			}
+			off += size
+		}
+
+		stream.ShowTextHex(ef.EncodeString(baseAndSpacing))
+
+		// Emit each Extend/ZWJ mark bracketed by Td moves that shift
+		// the text matrix from the cluster-end position back to the
+		// base origin plus the GPOS offset, and then back to the
+		// cluster-end position for the next mark or next cluster.
+		//
+		// After Tj of the base (plus SpacingMarks), the text matrix is
+		// at clusterEnd = (clusterAdvance, 0) relative to the cluster
+		// start. A mark's origin must sit at (markDx, markDy) relative
+		// to the base's origin (the cluster start), so the first Td
+		// moves by (markDx - clusterAdvance, markDy) and the closing
+		// Td moves by (clusterAdvance - markDx, -markDy). Marks have
+		// zero advance, so Tj of the mark does not shift the matrix.
+		for _, m := range extendMarks {
+			markGID := face.GlyphIndex(m.r)
+			dx, dy, ok := gpos.MarkOffset(baseGID, markGID, font.GPOSMark)
+			if ok {
+				dxPts := float64(dx) * scale
+				dyPts := float64(dy) * scale
+				stream.MoveText(dxPts-clusterAdvance, dyPts)
+				stream.ShowTextHex(ef.EncodeString(string(m.r)))
+				stream.MoveText(clusterAdvance-dxPts, -dyPts)
+			} else {
+				stream.ShowTextHex(ef.EncodeString(string(m.r)))
+			}
+		}
+
+		prevTail = tail
+		havePrev = true
+	}
 }
 
 // drawDecorations draws underline and/or strikethrough for a word.

--- a/layout/gpos_mark_draw_test.go
+++ b/layout/gpos_mark_draw_test.go
@@ -1,0 +1,351 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/content"
+	"github.com/carlos7ags/folio/font"
+)
+
+// mockGPOSFace is a deterministic Face + GPOSProvider used to exercise
+// drawWordEmbeddedWithMarks. Each rune is mapped to a GID by a lookup
+// table; advances and upem are fixed; GPOS data is injected directly.
+type mockGPOSFace struct {
+	upem    int
+	advance map[uint16]int
+	cmap    map[rune]uint16
+	gpos    *font.GPOSAdjustments
+}
+
+func (m *mockGPOSFace) PostScriptName() string { return "MockGPOSFace" }
+func (m *mockGPOSFace) UnitsPerEm() int        { return m.upem }
+func (m *mockGPOSFace) GlyphIndex(r rune) uint16 {
+	return m.cmap[r]
+}
+func (m *mockGPOSFace) GlyphAdvance(gid uint16) int {
+	return m.advance[gid]
+}
+func (m *mockGPOSFace) Ascent() int             { return 800 }
+func (m *mockGPOSFace) Descent() int            { return -200 }
+func (m *mockGPOSFace) BBox() [4]int            { return [4]int{0, -200, 1000, 800} }
+func (m *mockGPOSFace) ItalicAngle() float64    { return 0 }
+func (m *mockGPOSFace) CapHeight() int          { return 700 }
+func (m *mockGPOSFace) StemV() int              { return 80 }
+func (m *mockGPOSFace) Kern(uint16, uint16) int { return 0 }
+func (m *mockGPOSFace) Flags() uint32           { return 0 }
+func (m *mockGPOSFace) RawData() []byte         { return nil }
+func (m *mockGPOSFace) NumGlyphs() int          { return 4096 }
+
+// GPOS satisfies font.GPOSProvider.
+func (m *mockGPOSFace) GPOS() *font.GPOSAdjustments { return m.gpos }
+
+// newLamFathaFace constructs a mock face with lam (U+0644) as a base
+// glyph and fatha (U+064E) as a combining mark, plus a single GPOS
+// mark/base entry that attaches fatha on class 0 of lam.
+// Anchors: base lam at (500, 800), mark fatha at (200, 300).
+// Expected MarkOffset = (500-200, 800-300) = (300, 500).
+func newLamFathaFace() *mockGPOSFace {
+	const (
+		lamGID   uint16 = 50
+		fathaGID uint16 = 60
+	)
+	face := &mockGPOSFace{
+		upem: 1000,
+		advance: map[uint16]int{
+			lamGID:   700,
+			fathaGID: 0, // combining mark: zero advance
+		},
+		cmap: map[rune]uint16{
+			0x0644: lamGID,
+			0x064E: fathaGID,
+		},
+		gpos: &font.GPOSAdjustments{
+			Pairs: map[font.GPOSFeature]map[[2]uint16]font.PairAdjustment{},
+			Marks: map[font.GPOSFeature]map[uint16]font.MarkRecord{
+				font.GPOSMark: {
+					fathaGID: {Class: 0, Anchor: font.Anchor{X: 200, Y: 300}},
+				},
+			},
+			Bases: map[font.GPOSFeature]map[uint16]font.BaseRecord{
+				font.GPOSMark: {
+					lamGID: {Anchors: []font.Anchor{{X: 500, Y: 800}}},
+				},
+			},
+		},
+	}
+	return face
+}
+
+// capturedWordStream renders a single Word in isolation through
+// drawWordEmbedded bracketed by BT/ET/MoveText and returns the
+// resulting raw content-stream bytes. Mirrors the operator sequence
+// that drawTextLine would produce for this word.
+func capturedWordStream(word Word) []byte {
+	s := content.NewStream()
+	s.BeginText()
+	s.SetFont("F1", word.FontSize)
+	s.MoveText(0, 0)
+	drawWordEmbedded(s, word)
+	s.EndText()
+	return s.Bytes()
+}
+
+// countTdOps counts Td operator occurrences in a content stream.
+func countTdOps(b []byte) int {
+	n := 0
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasSuffix(line, " Td") {
+			n++
+		}
+	}
+	return n
+}
+
+// firstMarkTdBetween returns the first Td operator line that appears
+// strictly between two Tj hex-string lines in the given stream. It is
+// used to pick out the Td that drawWordEmbeddedWithMarks inserts
+// between the base Tj and the mark Tj. Returns the empty string when
+// no such Td exists.
+func firstMarkTdBetween(b []byte) string {
+	lines := strings.Split(string(b), "\n")
+	seenTj := false
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if seenTj && strings.HasSuffix(line, " Td") {
+			return line
+		}
+		if strings.HasSuffix(line, " Tj") {
+			if seenTj {
+				return "" // two Tjs with no Td between them
+			}
+			seenTj = true
+		}
+	}
+	return ""
+}
+
+// TestGPOSMarkAttachmentArabicHaraka renders a lam+fatha cluster with
+// a mock face that carries a GPOS mark-to-base entry and asserts the
+// content stream contains a Td move before the fatha Tj whose operands
+// match the expected offset, plus a matching Td move back after.
+func TestGPOSMarkAttachmentArabicHaraka(t *testing.T) {
+	face := newLamFathaFace()
+	ef := font.NewEmbeddedFont(face)
+
+	// Expected offsets in points at fontSize=12:
+	//   dx = (500 - 200) / 1000 * 12 = 3.6
+	//   dy = (800 - 300) / 1000 * 12 = 6.0
+	//   baseAdvance = 700 / 1000 * 12 = 8.4
+	//   First Td: (dx - baseAdvance, dy) = (-4.8, 6)
+	//   Second Td: (baseAdvance - dx, -dy) = (4.8, -6)
+	word := Word{
+		Text:     "\u0644\u064E", // lam + fatha
+		Embedded: ef,
+		FontSize: 12,
+	}
+
+	b := capturedWordStream(word)
+	if countTdOps(b) < 3 {
+		// One Td for the initial MoveText, two for the mark bracket.
+		t.Fatalf("expected at least 3 Td ops (initial + mark bracket), got %d:\n%s", countTdOps(b), b)
+	}
+
+	// Confirm the first Td between Tj lines is the mark-open shift.
+	td := firstMarkTdBetween(b)
+	if td == "" {
+		t.Fatalf("no Td between base Tj and mark Tj:\n%s", b)
+	}
+	if !strings.Contains(td, "-4.8") || !strings.Contains(td, "6 Td") {
+		t.Errorf("mark-open Td operands: got %q, want -4.8 and 6:\n%s", td, b)
+	}
+
+	// Confirm the closing +4.8 / -6 Td appears somewhere after it.
+	if !bytes.Contains(b, []byte("4.8 -6 Td")) {
+		t.Errorf("expected closing Td '4.8 -6 Td' in stream:\n%s", b)
+	}
+}
+
+// TestGPOSMarkAttachmentNoGPOSFallback verifies that when the font has
+// no GPOS mark data, drawWordEmbedded emits the cluster via the fast
+// path (single Tj, no Td pairs between glyph emissions). The only Td
+// remains the initial MoveText.
+func TestGPOSMarkAttachmentNoGPOSFallback(t *testing.T) {
+	face := newLamFathaFace()
+	face.gpos = nil
+	ef := font.NewEmbeddedFont(face)
+
+	word := Word{
+		Text:     "\u0644\u064E",
+		Embedded: ef,
+		FontSize: 12,
+	}
+
+	b := capturedWordStream(word)
+	// Exactly one Td: the initial MoveText(0, 0).
+	if countTdOps(b) != 1 {
+		t.Errorf("expected exactly 1 Td (initial MoveText), got %d:\n%s", countTdOps(b), b)
+	}
+	if firstMarkTdBetween(b) != "" {
+		t.Errorf("unexpected Td between Tj lines without GPOS:\n%s", b)
+	}
+}
+
+// TestGPOSMarkAttachmentLatinUntouched asserts Latin-only words that
+// contain no combining marks are emitted by the fast path: no Td moves
+// between Tjs, and the output is byte-for-byte what the pre-GPOS path
+// would have produced.
+func TestGPOSMarkAttachmentLatinUntouched(t *testing.T) {
+	// Build a Latin-capable mock face that also declares GPOS marks;
+	// eligibility should still reject because the text has no Extend.
+	face := newLamFathaFace()
+	face.cmap['h'] = 1
+	face.cmap['e'] = 2
+	face.cmap['l'] = 3
+	face.cmap['o'] = 4
+	face.advance[1] = 500
+	face.advance[2] = 500
+	face.advance[3] = 500
+	face.advance[4] = 500
+	ef := font.NewEmbeddedFont(face)
+
+	word := Word{
+		Text:     "hello",
+		Embedded: ef,
+		FontSize: 12,
+	}
+
+	b := capturedWordStream(word)
+	if countTdOps(b) != 1 {
+		t.Errorf("Latin word should emit only the initial Td, got %d:\n%s", countTdOps(b), b)
+	}
+	if firstMarkTdBetween(b) != "" {
+		t.Errorf("Latin word should not emit mark-Td brackets:\n%s", b)
+	}
+}
+
+// TestGPOSMarkAttachmentTwoMarks verifies that a cluster with two
+// Extend marks (fatha and shadda on the same lam) emits two separate
+// Td-bracketed mark emissions, so each mark is positioned individually.
+func TestGPOSMarkAttachmentTwoMarks(t *testing.T) {
+	face := newLamFathaFace()
+	const shaddaGID uint16 = 61
+	face.cmap[0x0651] = shaddaGID // shadda
+	face.advance[shaddaGID] = 0
+	// Mark class 0 shared: fatha already uses class 0. Give shadda its
+	// own class (class 1) so the base needs a second anchor slot. This
+	// also exercises multi-class mark positioning.
+	face.gpos.Marks[font.GPOSMark][shaddaGID] = font.MarkRecord{
+		Class:  1,
+		Anchor: font.Anchor{X: 100, Y: 400},
+	}
+	base := face.gpos.Bases[font.GPOSMark][50]
+	base.Anchors = append(base.Anchors, font.Anchor{X: 500, Y: 900}) // class 1 anchor
+	face.gpos.Bases[font.GPOSMark][50] = base
+
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Text:     "\u0644\u064E\u0651", // lam + fatha + shadda
+		Embedded: ef,
+		FontSize: 12,
+	}
+
+	b := capturedWordStream(word)
+
+	// Expect: base Tj, then two Td-bracketed mark emissions. That is:
+	// base Tj, Td(open1), mark1 Tj, Td(close1), Td(open2), mark2 Tj, Td(close2).
+	// Count Tjs and Tds.
+	tjCount := 0
+	tdCount := 0
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasSuffix(line, " Tj") {
+			tjCount++
+		}
+		if strings.HasSuffix(line, " Td") {
+			tdCount++
+		}
+	}
+	if tjCount != 3 {
+		t.Errorf("expected 3 Tj (base + 2 marks), got %d:\n%s", tjCount, b)
+	}
+	// Initial MoveText + two open Td + two close Td = 5.
+	if tdCount != 5 {
+		t.Errorf("expected 5 Td (initial + 2*(open+close)), got %d:\n%s", tdCount, b)
+	}
+}
+
+// TestGPOSMarkAttachmentMeasureAgreesWithDraw is the correctness
+// invariant: the width reported by EmbeddedFont.MeasureString for a
+// mark-bearing word must equal the total horizontal advance the text
+// matrix undergoes during drawWordEmbedded. The test simulates the
+// matrix advance by parsing the content stream and summing Td x
+// components plus the base Tj advance per cluster.
+func TestGPOSMarkAttachmentMeasureAgreesWithDraw(t *testing.T) {
+	face := newLamFathaFace()
+	ef := font.NewEmbeddedFont(face)
+
+	word := Word{
+		Text:     "\u0644\u064E",
+		Embedded: ef,
+		FontSize: 12,
+	}
+
+	measured := ef.MeasureString(word.Text, word.FontSize)
+
+	// The draw path advances the text matrix by the base's Tj advance
+	// plus the net of all Td operators after the initial MoveText(0,0).
+	// Reproduce that calculation directly.
+	//
+	// The only non-zero-advance glyph in the cluster is lam (700 FUnits
+	// = 8.4 pt). Fatha is zero-advance. The Td bracket is matched pairs
+	// (-4.8 +4.8 / +6 -6) which sum to zero. Net advance = 8.4 pt.
+	// MeasureString should also report ~8.4 pt (modulo float rounding).
+	want := 8.4
+	if !almostEqual(measured, want, 1e-9) {
+		t.Errorf("MeasureString: got %v, want %v", measured, want)
+	}
+
+	// Now parse the draw stream and sum Td advances (after the initial
+	// move) plus base advance. This is a stand-in for running the PDF
+	// through an interpreter.
+	b := capturedWordStream(word)
+	netTdX := 0.0
+	seenInitial := false
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasSuffix(line, " Td") {
+			continue
+		}
+		if !seenInitial {
+			seenInitial = true // initial MoveText(0, 0) — ignore
+			continue
+		}
+		var tx, ty float64
+		n, err := fmt.Sscanf(line, "%f %f Td", &tx, &ty)
+		if err != nil || n != 2 {
+			t.Fatalf("unparseable Td line %q: %v", line, err)
+		}
+		netTdX += tx
+	}
+	// Base glyph Tj advance: one lam.
+	baseAdv := float64(face.advance[50]) / float64(face.upem) * word.FontSize
+	drawAdvance := baseAdv + netTdX
+	if !almostEqual(drawAdvance, measured, 1e-9) {
+		t.Errorf("draw advance = %v, MeasureString = %v — these must agree for line wrap/draw consistency", drawAdvance, measured)
+	}
+}
+
+func almostEqual(a, b, eps float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d <= eps
+}


### PR DESCRIPTION
## Summary

- drawWordEmbedded now walks words cluster-by-cluster (UAX #29 extended grapheme clusters) when a word contains Extend or ZWJ combining marks and the embedded font exposes GPOS mark-to-base data. Each Extend mark is drawn bracketed by paired Td moves that shift the text matrix from the cluster's post-base position to the mark's GPOS-anchor origin and back. Arabic harakat and Hebrew niqqud land on the correct anchor instead of floating at the cluster's advance origin.
- SpacingMarks stay inside the cluster's Tj hex string so their advance is emitted by Tj itself, matching font.MeasureString's cluster-width contribution. The text matrix exits each cluster at the same position the fast path would leave it, preserving the measure-vs-draw invariant.
- Eligibility is gated: words without Extend/ZWJ runes, fonts without GPOS mark data, standard-14 fonts, and words with a LetterSpacing override all continue to use the original fast path with byte-identical output.

## Trade-offs

- Td (not TJ) is used for mark positioning because TJ adjustments are horizontal-only and harakat need vertical offsets.
- Cluster walking happens at draw time via grapheme.Breaks. Word was not extended with a Clusters cache field; paragraph-heavy documents still pay only the UAX #29 walk cost, which is cheap relative to glyph encoding.
- Mark-class selection uses the first matching class only. Mark-to-mark positioning (GPOS LookupType 6 / mkmk) is deferred.
- LetterSpacing > 0 disables the mark path to avoid Tc-vs-Td arithmetic; such text keeps today's rendering.

## Test plan

- [x] go test ./... (full suite, race detector on layout and font)
- [x] gofmt -s -w .
- [x] go vet ./...
- [x] golangci-lint run ./...
- [x] TestGPOSMarkAttachmentArabicHaraka: lam+fatha renders a Td bracket with the expected (dx-baseAdvance, dy) and closing (baseAdvance-dx, -dy) operands.
- [x] TestGPOSMarkAttachmentNoGPOSFallback: same word, nil GPOS, stream contains only the initial MoveText Td and no mark bracket.
- [x] TestGPOSMarkAttachmentLatinUntouched: "hello" with a GPOS-carrying font still takes the fast path.
- [x] TestGPOSMarkAttachmentTwoMarks: lam+fatha+shadda emits two separate Td-bracketed mark Tjs, exercising multi-class mark positioning.
- [x] TestGPOSMarkAttachmentMeasureAgreesWithDraw: sums Td x-operands plus base Tj advance and asserts the draw advance equals EmbeddedFont.MeasureString within float epsilon.

## References

- ISO 14496-22 section 6.3, GPOS LookupType 4 (Mark-to-Base Positioning)
- ISO 32000-2 section 9.4, Text-Showing Operators
- ISO 32000-2 section 9.4.4, Text-Positioning Operators (Td, Tm)
- Unicode UAX #29 section 3.1.1, Extended Grapheme Cluster boundaries