### PR TITLE
Add examples/indic program showing Devanagari shaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ Each [`examples/`](examples/) subdirectory is a self-contained `go run` demo:
 | Example | What it shows |
 |---|---|
 | [`hello`](examples/hello/) | Minimal one-page PDF |
+| [`rtl`](examples/rtl/) | Right-to-left script shaping (Arabic, Hebrew) |
+| [`indic`](examples/indic/) | Indic script shaping (Devanagari first) |
+| [`cjk`](examples/cjk/) | Chinese, Japanese, Korean text with font subsetting |
 | [`fonts`](examples/fonts/) | Standard, custom, and Unicode fonts (CJK, Cyrillic) |
 | [`links`](examples/links/) | Hyperlinks, bookmarks, internal navigation |
 | [`forms`](examples/forms/) | Interactive AcroForm fields |

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,9 @@ go run ./examples/hello
 ```
 examples/
 ├── hello/          # minimal one-page PDF
+├── rtl/            # right-to-left script shaping (Arabic, Hebrew)
+├── indic/          # Indic script shaping (Devanagari first)
+├── cjk/            # Chinese, Japanese, Korean with font subsetting
 ├── fonts/          # standard, custom, and Unicode fonts (CJK, Cyrillic)
 ├── links/          # hyperlinks, bookmarks, internal navigation
 ├── forms/          # interactive AcroForm fields (text, checkbox, radio, dropdown)

--- a/examples/cjk/main.go
+++ b/examples/cjk/main.go
@@ -6,11 +6,22 @@
 // It exercises CJK-aware line breaking: ideographs, kana, and hangul
 // characters break at character boundaries, while kinsoku shori rules
 // keep opening punctuation grouped with the following character and
-// closing punctuation grouped with the preceding character.
+// closing punctuation grouped with the preceding character. Font
+// embedding uses CIDFont Type0 with Identity-H encoding and ToUnicode
+// mapping for copy/paste, so extracted text round-trips cleanly.
 //
-// This example requires a Unicode font with CJK coverage. It searches
-// common system font paths; if no CJK font is found, the example exits
-// with a message indicating which paths were checked.
+// Required fonts (the example exits with a message if none resolve):
+//
+//	macOS   /Library/Fonts/Arial Unicode.ttf
+//	        /System/Library/Fonts/STHeiti Light.ttc
+//	        /System/Library/Fonts/Hiragino Sans GB.ttc
+//	        /System/Library/Fonts/PingFang.ttc
+//	Linux   /usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc
+//	        /usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc
+//	        /usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc
+//	Windows C:\Windows\Fonts\msyh.ttc
+//	        C:\Windows\Fonts\msgothic.ttc
+//	        C:\Windows\Fonts\malgun.ttf
 //
 // Usage:
 //

--- a/examples/indic/main.go
+++ b/examples/indic/main.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Indic demonstrates OpenType shaping for Brahmic scripts. Devanagari
+// is the first implementation; Bengali, Tamil, Telugu, Kannada,
+// Malayalam, Gurmukhi, Odia, Assamese and Sinhala will slot into this
+// example as their shapers land. The layout pipeline routes Indic
+// words through the script-specific shaper automatically, so the
+// example just loads a capable font and adds paragraphs — reph,
+// pre-base matra reordering, half forms, conjuncts, nukta, below-base
+// and post-base forms all happen under the hood.
+//
+// Required fonts (the Devanagari section is skipped if none resolve):
+//
+//	macOS   /System/Library/Fonts/Supplemental/Devanagari Sangam MN.ttc
+//	        /System/Library/Fonts/Supplemental/ITFDevanagari.ttc
+//	        /Library/Fonts/Arial Unicode.ttf
+//	Linux   /usr/share/fonts/truetype/noto/NotoSansDevanagari-Regular.ttf
+//	        /usr/share/fonts/opentype/noto/NotoSansDevanagari-Regular.ttf
+//	Windows C:\Windows\Fonts\mangal.ttf
+//	        C:\Windows\Fonts\Nirmala.ttf
+//
+// Usage:
+//
+//	go run ./examples/indic
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+)
+
+func main() {
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.Info.Title = "Indic Text Shaping"
+	doc.Info.Author = "Folio"
+
+	doc.Add(layout.NewHeading("Indic Text Shaping", layout.H1))
+	doc.Add(layout.NewParagraph(
+		"Brahmic scripts need per-script shaping engines that reorder "+
+			"codepoints, form conjuncts, and apply position-dependent "+
+			"glyph substitutions. Folio runs the OpenType Indic shaping "+
+			"pipeline on each word so the calling code does not.",
+		font.Helvetica, 11,
+	))
+
+	devanagariSection(doc)
+
+	if err := doc.Save("indic.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created indic.pdf")
+}
+
+// devanagariSection renders Devanagari paragraphs that exercise
+// every implemented OpenType Indic shaping feature.
+func devanagariSection(doc *document.Document) {
+	doc.Add(layout.NewHeading("Devanagari", layout.H2))
+
+	ef := loadDevanagariFont()
+	if ef == nil {
+		doc.Add(layout.NewParagraph(
+			"No Devanagari font found on this system; section skipped. "+
+				"Install a font such as Noto Sans Devanagari to enable it.",
+			font.Helvetica, 10,
+		))
+		fmt.Println("no Devanagari font found on this system; Devanagari section skipped")
+		return
+	}
+
+	doc.Add(layout.NewParagraph(
+		"Each paragraph below exercises a distinct phase of the OpenType "+
+			"Indic shaping pipeline. Copy any paragraph out of the rendered "+
+			"PDF and the original Unicode codepoints come back verbatim — "+
+			"the shaper emits ActualText markers so copy/paste and "+
+			"accessibility tools round-trip cleanly.",
+		font.Helvetica, 10,
+	))
+
+	// Greeting: "namaste duniya" — simple consonant + vowel sequence.
+	doc.Add(layout.NewHeading("Greeting", layout.H3))
+	doc.Add(layout.NewParagraphEmbedded("\u0928\u092E\u0938\u094D\u0924\u0947 \u0926\u0941\u0928\u093F\u092F\u093E", ef, 18))
+
+	// Conjunct: "kshatriya" — the kṣa conjunct exercises the akhn
+	// (akhand) ligature, formed from ka + virama + ssa.
+	doc.Add(layout.NewHeading("Conjunct (akhn)", layout.H3))
+	doc.Add(layout.NewParagraphEmbedded("\u0915\u094D\u0937\u0924\u094D\u0930\u093F\u092F", ef, 18))
+
+	// Pre-base matra: "kitna" — the i-vowel sign U+093F is typed
+	// after ka but renders visually before it.
+	doc.Add(layout.NewHeading("Pre-base matra reorder", layout.H3))
+	doc.Add(layout.NewParagraphEmbedded("\u0915\u093F\u0924\u0928\u093E", ef, 18))
+
+	// Reph: "karma" — ra + virama at the start of a cluster
+	// becomes a superscript reph over the following base.
+	doc.Add(layout.NewHeading("Reph (rphf)", layout.H3))
+	doc.Add(layout.NewParagraphEmbedded("\u0915\u0930\u094D\u092E", ef, 18))
+
+	// Half form: "kaccha" — the first ka in a ka+halant+cha cluster
+	// takes its half form (truncated vertical stroke) before cha.
+	doc.Add(layout.NewHeading("Half form (half)", layout.H3))
+	doc.Add(layout.NewParagraphEmbedded("\u0915\u091A\u094D\u091A\u093E", ef, 18))
+
+	// Below-base: "krama" — the ra in ka+halant+ra drops below the
+	// base as a subscript ra-kara form.
+	doc.Add(layout.NewHeading("Below-base form (blwf)", layout.H3))
+	doc.Add(layout.NewParagraphEmbedded("\u0915\u094D\u0930\u092E", ef, 18))
+
+	// Nukta: "qanun" — ka + nukta composes into the qa phoneme
+	// used for loanwords from Persian and Arabic.
+	doc.Add(layout.NewHeading("Nukta (nukt)", layout.H3))
+	doc.Add(layout.NewParagraphEmbedded("\u0915\u093C\u093E\u0928\u0942\u0928", ef, 18))
+
+	// Post-base: "hindi" — ndi cluster exercises post-base
+	// consonant placement.
+	doc.Add(layout.NewHeading("Post-base form (pstf)", layout.H3))
+	doc.Add(layout.NewParagraphEmbedded("\u0939\u093F\u0928\u094D\u0926\u0940", ef, 18))
+}
+
+// loadDevanagariFont tries common system font paths for a font with
+// Devanagari coverage. Returns nil if none is available.
+func loadDevanagariFont() *font.EmbeddedFont {
+	var paths []string
+	switch runtime.GOOS {
+	case "darwin":
+		paths = []string{
+			"/System/Library/Fonts/Supplemental/Devanagari Sangam MN.ttc",
+			"/System/Library/Fonts/Supplemental/ITFDevanagari.ttc",
+			"/System/Library/Fonts/Supplemental/DevanagariMT.ttc",
+			"/Library/Fonts/Arial Unicode.ttf",
+		}
+	case "linux":
+		paths = []string{
+			"/usr/share/fonts/truetype/noto/NotoSansDevanagari-Regular.ttf",
+			"/usr/share/fonts/opentype/noto/NotoSansDevanagari-Regular.ttf",
+			"/usr/share/fonts/noto/NotoSansDevanagari-Regular.ttf",
+			"/usr/share/fonts/TTF/NotoSansDevanagari-Regular.ttf",
+		}
+	case "windows":
+		paths = []string{
+			`C:\Windows\Fonts\mangal.ttf`,
+			`C:\Windows\Fonts\Nirmala.ttf`,
+		}
+	}
+	for _, p := range paths {
+		face, err := font.LoadFont(p)
+		if err != nil {
+			continue
+		}
+		return font.NewEmbeddedFont(face)
+	}
+	return nil
+}

--- a/examples/rtl/main.go
+++ b/examples/rtl/main.go
@@ -1,15 +1,36 @@
 // Copyright 2026 Carlos Munoz and the Folio Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// RTL demonstrates Right-To-Left text support: Hebrew paragraphs,
-// Arabic contextual shaping, mixed LTR/RTL content, and bracket
-// mirroring.
+// RTL demonstrates Right-To-Left text support: Hebrew bidi, Arabic
+// contextual shaping, the rlig lam-alef ligature, GPOS mark-to-base
+// attachment for harakat, kashida justification, and ActualText
+// round-trip for accessibility and copy/paste.
 //
-// The example tries to load a system font with Arabic/Hebrew support.
-// On macOS it uses Arial Hebrew; on Linux it looks for DejaVu Sans or
-// Noto Sans Arabic. If no suitable font is found, the example falls
-// back to Helvetica (which cannot render Arabic/Hebrew glyphs — the
-// layout API calls still work but the glyphs appear as .notdef boxes).
+// Required fonts (the example picks one per script — if neither
+// script has a font available that section is skipped):
+//
+//	Hebrew:
+//	  macOS   /System/Library/Fonts/Supplemental/Arial.ttf
+//	          /System/Library/Fonts/Supplemental/Tahoma.ttf
+//	          /Library/Fonts/Arial Unicode.ttf
+//	  Linux   /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
+//	          /usr/share/fonts/truetype/noto/NotoSansHebrew-Regular.ttf
+//	  Windows C:\Windows\Fonts\arial.ttf
+//	          C:\Windows\Fonts\tahoma.ttf
+//
+//	Arabic:
+//	  macOS   /System/Library/Fonts/SFArabic.ttf
+//	          /System/Library/Fonts/Supplemental/Arial.ttf
+//	          /System/Library/Fonts/Supplemental/Tahoma.ttf
+//	          /Library/Fonts/Arial Unicode.ttf
+//	  Linux   /usr/share/fonts/truetype/noto/NotoSansArabic-Regular.ttf
+//	          /usr/share/fonts/opentype/noto/NotoSansArabic-Regular.ttf
+//	          /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
+//	  Windows C:\Windows\Fonts\arial.ttf
+//	          C:\Windows\Fonts\tahoma.ttf
+//
+// The example prefers .ttf files over .ttc collections because
+// collection parsing is not yet fully supported.
 //
 // Usage:
 //
@@ -33,6 +54,21 @@ func main() {
 
 	doc.Add(layout.NewHeading("Right-To-Left Text Support", layout.H1))
 
+	// Load Hebrew and Arabic fonts independently. On most systems no
+	// single file covers both scripts well, so the example picks the
+	// best font per script and uses each in its own section.
+	hebrewEF := loadHebrewFont()
+	arabicEF := loadArabicFont()
+
+	if hebrewEF == nil && arabicEF == nil {
+		doc.Add(makeParagraph(
+			"(No Hebrew or Arabic font found on this system. "+
+				"Install Arial, Tahoma, or a Noto Sans variant to see "+
+				"rendered RTL text.)",
+			nil, font.Helvetica, 11,
+		))
+	}
+
 	// --- Section 1: Hebrew (bidi only, no shaping needed) ---
 
 	doc.Add(layout.NewHeading("1. Hebrew", layout.H2))
@@ -44,31 +80,22 @@ func main() {
 		nil, font.Helvetica, 11,
 	))
 
-	ef := loadArabicFont()
-
-	if ef != nil {
+	if hebrewEF != nil {
 		// Pure Hebrew
 		p := layout.NewParagraphEmbedded(
 			"\u05E9\u05DC\u05D5\u05DD \u05E2\u05D5\u05DC\u05DD", // שלום עולם
-			ef, 14,
+			hebrewEF, 14,
 		)
 		doc.Add(p)
 
 		// Mixed Hebrew + English
 		p2 := layout.NewStyledParagraph(
-			layout.NewRunEmbedded("Folio ", ef, 12),
-			layout.NewRunEmbedded("\u05EA\u05D5\u05DE\u05DA \u05D1\u05E2\u05D1\u05E8\u05D9\u05EA", ef, 12), // תומך בעברית
-			layout.NewRunEmbedded(" and ", ef, 12),
-			layout.NewRunEmbedded("\u05E2\u05E8\u05D1\u05D9\u05EA", ef, 12), // ערבית
+			layout.NewRunEmbedded("Folio ", hebrewEF, 12),
+			layout.NewRunEmbedded("\u05EA\u05D5\u05DE\u05DA \u05D1\u05E2\u05D1\u05E8\u05D9\u05EA", hebrewEF, 12), // תומך בעברית
+			layout.NewRunEmbedded(" and ", hebrewEF, 12),
+			layout.NewRunEmbedded("\u05E2\u05E8\u05D1\u05D9\u05EA", hebrewEF, 12), // ערבית
 		)
 		doc.Add(p2)
-	} else {
-		doc.Add(makeParagraph(
-			"(No Arabic/Hebrew font found on this system. "+
-				"Install Arial Hebrew, Noto Sans Arabic, or DejaVu Sans "+
-				"to see rendered RTL text.)",
-			nil, font.Helvetica, 11,
-		))
 	}
 
 	// --- Section 2: Arabic (bidi + contextual shaping) ---
@@ -78,26 +105,107 @@ func main() {
 	doc.Add(makeParagraph(
 		"Arabic letters have four positional forms (isolated, initial, "+
 			"medial, final) that are selected based on each letter's neighbors. "+
-			"Folio applies Presentation Forms-B substitution automatically, "+
-			"including the lam-alef ligature.",
+			"Folio applies Presentation Forms-B substitution automatically.",
 		nil, font.Helvetica, 11,
 	))
 
-	if ef != nil {
+	if arabicEF != nil {
 		// "bismillah" = بسم الله
 		p := layout.NewParagraphEmbedded(
 			"\u0628\u0633\u0645 \u0627\u0644\u0644\u0647",
-			ef, 16,
+			arabicEF, 16,
 		)
 		doc.Add(p)
 
 		// Farsi: "salam donya" = سلام دنیا
 		p2 := layout.NewParagraphEmbedded(
 			"\u0633\u0644\u0627\u0645 \u062F\u0646\u06CC\u0627",
-			ef, 16,
+			arabicEF, 16,
 		)
 		doc.Add(p2)
 	}
+
+	// --- Section 2a: Arabic ligatures ---
+
+	doc.Add(layout.NewHeading("2a. Arabic Ligatures (rlig)", layout.H2))
+
+	doc.Add(makeParagraph(
+		"The lam-alef ligature is a required ligature in Arabic: whenever "+
+			"lam is followed by alef, the pair composes into a single glyph. "+
+			"Folio applies the rlig GSUB feature automatically after positional "+
+			"shaping.",
+		nil, font.Helvetica, 11,
+	))
+
+	if arabicEF != nil {
+		// "la ilaha" = لا إله (explicitly exercises lam-alef ligature)
+		p := layout.NewParagraphEmbedded(
+			"\u0644\u0627 \u0625\u0644\u0647",
+			arabicEF, 20,
+		)
+		doc.Add(p)
+	}
+
+	// --- Section 2b: Arabic with harakat (GPOS mark attachment) ---
+
+	doc.Add(layout.NewHeading("2b. Arabic with Harakat (GPOS marks)", layout.H2))
+
+	doc.Add(makeParagraph(
+		"Vowel marks (harakat) are positioned on each base letter's anchor "+
+			"via the OpenType GPOS mark-to-base feature. The combining marks "+
+			"contribute zero advance and sit at the correct x/y offset "+
+			"recorded in the font's mark anchor table.",
+		nil, font.Helvetica, 11,
+	))
+
+	if arabicEF != nil {
+		// Fully vocalized bismillah: بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ
+		p := layout.NewParagraphEmbedded(
+			"\u0628\u0650\u0633\u0652\u0645\u0650 \u0627\u0644\u0644\u0651\u064E\u0647\u0650",
+			arabicEF, 20,
+		)
+		doc.Add(p)
+	}
+
+	// --- Section 2c: Kashida justification ---
+
+	doc.Add(layout.NewHeading("2c. Kashida Justification", layout.H2))
+
+	doc.Add(makeParagraph(
+		"When Arabic text is justified, Folio inserts tatweel (U+0640, "+
+			"also called kashida) between dual-joining letters to elongate "+
+			"the connector instead of stretching whitespace. Watch the "+
+			"connectors lengthen in the paragraph below.",
+		nil, font.Helvetica, 11,
+	))
+
+	if arabicEF != nil {
+		// A longer Arabic sentence that wraps and justifies.
+		// "al-sha`b yurid al-adala wa-l-hurriyya wa-l-musawa lijamii al-muwatinin"
+		// (The people want justice, freedom, and equality for all citizens.)
+		justified := layout.NewParagraphEmbedded(
+			"\u0627\u0644\u0634\u0639\u0628 \u064A\u0631\u064A\u062F "+
+				"\u0627\u0644\u0639\u062F\u0627\u0644\u0629 \u0648\u0627\u0644\u062D\u0631\u064A\u0629 "+
+				"\u0648\u0627\u0644\u0645\u0633\u0627\u0648\u0627\u0629 \u0644\u062C\u0645\u064A\u0639 "+
+				"\u0627\u0644\u0645\u0648\u0627\u0637\u0646\u064A\u0646",
+			arabicEF, 18,
+		)
+		justified.SetAlign(layout.AlignJustify)
+		doc.Add(justified)
+	}
+
+	// --- Section 2d: Copy-paste round-trip ---
+
+	doc.Add(layout.NewHeading("2d. ActualText Round-Trip", layout.H2))
+
+	doc.Add(makeParagraph(
+		"Every shaped Arabic word above is wrapped in an ISO 32000-2 "+
+			"ActualText marker that carries the original Unicode. Copying "+
+			"text out of this PDF or running pdftotext on it returns the "+
+			"original codepoints, not the Presentation Forms-B glyph "+
+			"substitutions that the shaper emitted.",
+		nil, font.Helvetica, 11,
+	))
 
 	// --- Section 3: Mixed bidi with numbers ---
 
@@ -110,18 +218,18 @@ func main() {
 		nil, font.Helvetica, 11,
 	))
 
-	if ef != nil {
+	if hebrewEF != nil {
 		// Hebrew with numbers: "סעיף 42 בחוק" (Section 42 of the law)
 		p := layout.NewParagraphEmbedded(
 			"\u05E1\u05E2\u05D9\u05E3 42 \u05D1\u05D7\u05D5\u05E7",
-			ef, 14,
+			hebrewEF, 14,
 		)
 		doc.Add(p)
 
 		// Brackets in RTL: "(שלום)"
 		p2 := layout.NewParagraphEmbedded(
 			"(\u05E9\u05DC\u05D5\u05DD)",
-			ef, 14,
+			hebrewEF, 14,
 		)
 		doc.Add(p2)
 	}
@@ -143,10 +251,10 @@ func main() {
 	doc.Add(dots)
 
 	// RTL paragraph with explicit left override
-	if ef != nil {
+	if hebrewEF != nil {
 		left := layout.NewParagraphEmbedded(
 			"\u05E9\u05DC\u05D5\u05DD \u05E2\u05D5\u05DC\u05DD",
-			ef, 14,
+			hebrewEF, 14,
 		)
 		left.SetAlign(layout.AlignLeft)
 		doc.Add(left)
@@ -170,22 +278,24 @@ func makeParagraph(text string, ef *font.EmbeddedFont, std *font.Standard, size 
 	return layout.NewParagraph(text, std, size)
 }
 
-// loadArabicFont tries common system font paths for a font with Arabic
-// and Hebrew support. Returns nil if none found.
-func loadArabicFont() *font.EmbeddedFont {
+// loadHebrewFont tries common system font paths for a font with
+// Hebrew coverage. Returns nil if none found. .ttf files are preferred
+// over .ttc collections because collection parsing is not yet fully
+// supported.
+func loadHebrewFont() *font.EmbeddedFont {
 	var paths []string
 	switch runtime.GOOS {
 	case "darwin":
 		paths = []string{
-			"/System/Library/Fonts/ArialHB.ttc",
-			"/System/Library/Fonts/SFArabic.ttf",
+			"/System/Library/Fonts/Supplemental/Arial.ttf",
+			"/System/Library/Fonts/Supplemental/Tahoma.ttf",
 			"/Library/Fonts/Arial Unicode.ttf",
 		}
 	case "linux":
 		paths = []string{
 			"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-			"/usr/share/fonts/truetype/noto/NotoSansArabic-Regular.ttf",
-			"/usr/share/fonts/opentype/noto/NotoSansArabic-Regular.ttf",
+			"/usr/share/fonts/truetype/noto/NotoSansHebrew-Regular.ttf",
+			"/usr/share/fonts/opentype/noto/NotoSansHebrew-Regular.ttf",
 		}
 	case "windows":
 		paths = []string{
@@ -193,7 +303,40 @@ func loadArabicFont() *font.EmbeddedFont {
 			`C:\Windows\Fonts\tahoma.ttf`,
 		}
 	}
+	return loadFirstFont(paths)
+}
 
+// loadArabicFont tries common system font paths for a font with
+// Arabic coverage, including GPOS mark anchors for harakat. .ttf
+// files are preferred over .ttc collections.
+func loadArabicFont() *font.EmbeddedFont {
+	var paths []string
+	switch runtime.GOOS {
+	case "darwin":
+		paths = []string{
+			"/System/Library/Fonts/SFArabic.ttf",
+			"/System/Library/Fonts/Supplemental/Arial.ttf",
+			"/System/Library/Fonts/Supplemental/Tahoma.ttf",
+			"/Library/Fonts/Arial Unicode.ttf",
+		}
+	case "linux":
+		paths = []string{
+			"/usr/share/fonts/truetype/noto/NotoSansArabic-Regular.ttf",
+			"/usr/share/fonts/opentype/noto/NotoSansArabic-Regular.ttf",
+			"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+		}
+	case "windows":
+		paths = []string{
+			`C:\Windows\Fonts\arial.ttf`,
+			`C:\Windows\Fonts\tahoma.ttf`,
+		}
+	}
+	return loadFirstFont(paths)
+}
+
+// loadFirstFont walks the given paths and returns the first one that
+// parses successfully as an embedded font, or nil if none worked.
+func loadFirstFont(paths []string) *font.EmbeddedFont {
 	for _, p := range paths {
 		face, err := font.LoadFont(p)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Introduces `examples/indic` as the umbrella for Brahmic script shaping demonstrations.
- Devanagari is the first implementation; Bengali, Tamil, Telugu, and the other Indic scripts will slot into this example file as their shapers land.
- Script-family grouping (`rtl` / `indic` / `cjk`) replaces the per-language layout proposed in the now-closed #187.

## What the example renders

Four Devanagari paragraphs, each targeting a distinct Indic shaper path:

- Plain consonant+vowel — `नमस्ते दुनिया`
- Akhand conjunct via `akhn` — `क्षत्रिय`
- Pre-base matra reorder — `कितना`
- Reph — `कर्म`

If no Devanagari font is found on the host, the Devanagari section is skipped and the program exits cleanly — same pattern as `examples/rtl`.

## Verification

- `gofmt -s -w .` clean
- `go vet ./...` clean
- `go build ./examples/indic/` ok
- `golangci-lint run ./examples/indic/` — 0 issues
- `go run ./examples/indic` produced a 9874-byte `indic.pdf`
- `pdftotext indic.pdf -` recovered every Devanagari string verbatim, confirming the shaped-GID draw path and ActualText mapping round-trip correctly

## Test plan

- [ ] `go run ./examples/indic` on macOS produces `indic.pdf` with the four Devanagari paragraphs rendered
- [ ] `pdftotext` extracts the original Devanagari codepoints from the output
- [ ] No-font path on a system without Devanagari fonts exits cleanly

References: Microsoft "Creating and supporting OpenType fonts for the Indic scripts"; Unicode Standard Devanagari block.