### PR TITLE
Fix multi-column layout: sequential balanced fill instead of round-robin

### DIFF
--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -399,9 +399,12 @@ func (c *converter) buildMulticolSegments(n *html.Node, style computedStyle) []l
 
 // buildColumnsSegment creates a single layout.Columns element from a slice
 // of children, applying gap and column-rule from the parent multicol style.
-// Children are distributed round-robin across columns.
+// Children flow sequentially into column 0 and are redistributed at layout
+// time via the balanced-fill algorithm so that column heights are equalized
+// while preserving document order (CSS Multi-column §3.4, column-fill:
+// balance). See https://github.com/carlos7ags/folio/issues/145.
 func (c *converter) buildColumnsSegment(children []layout.Element, style computedStyle) layout.Element {
-	cols := layout.NewColumns(style.ColumnCount)
+	cols := layout.NewColumns(style.ColumnCount).SetBalanced(true)
 	if style.ColumnGap > 0 {
 		cols.SetGap(style.ColumnGap)
 	}
@@ -412,8 +415,8 @@ func (c *converter) buildColumnsSegment(children []layout.Element, style compute
 			Style: style.ColumnRuleStyle,
 		})
 	}
-	for i, child := range children {
-		cols.Add(i%style.ColumnCount, child)
+	for _, child := range children {
+		cols.Add(0, child)
 	}
 	return cols
 }

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -4972,6 +4972,61 @@ func TestCSSColumnSpanEmptyMulticolDoesNotDoubleWalk(t *testing.T) {
 	}
 }
 
+// TestCSSColumnsSequentialBalanced verifies that multi-column children are
+// distributed by measured height (column-fill: balance) rather than
+// round-robin by index. Regression test for
+// https://github.com/carlos7ags/folio/issues/145.
+func TestCSSColumnsSequentialBalanced(t *testing.T) {
+	// Three paragraphs with very different lengths. With round-robin
+	// the long paragraph and a short paragraph share column 0 while
+	// column 1 gets only one short paragraph — wildly unbalanced.
+	// With balanced distribution the two short paragraphs should share
+	// one column and the long paragraph should get the other, producing
+	// much more even heights.
+	htmlStr := `<div style="column-count: 2; column-gap: 12px">` +
+		`<p>Short one.</p>` +
+		`<p>Short two.</p>` +
+		`<p>This paragraph is intentionally much longer than the other ` +
+		`two so that the balanced algorithm places it alone in one ` +
+		`column while the shorter paragraphs share the other, ` +
+		`producing approximately equal column heights instead of the ` +
+		`wildly unbalanced round-robin result.</p>` +
+		`</div>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
+
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 300, Height: 1000})
+	if plan.Status != layout.LayoutFull {
+		t.Fatalf("expected LayoutFull, got %v", plan.Status)
+	}
+	if plan.Consumed <= 0 {
+		t.Fatal("expected positive consumed height")
+	}
+
+	// With balanced distribution, both columns contribute content.
+	// Verify the top-level block has children from both columns
+	// (children at X=0 AND children at X>0).
+	if len(plan.Blocks) == 0 || len(plan.Blocks[0].Children) == 0 {
+		t.Fatal("expected children in plan blocks")
+	}
+	hasLeft, hasRight := false, false
+	for _, child := range plan.Blocks[0].Children {
+		if child.X < 1 {
+			hasLeft = true
+		} else {
+			hasRight = true
+		}
+	}
+	if !hasLeft || !hasRight {
+		t.Error("expected content in both columns; one column is empty")
+	}
+}
+
 func TestCSSColumnSpanAllTrailing(t *testing.T) {
 	// Spanning element as the last child: there should be no trailing
 	// Columns segment.

--- a/layout/balanced_columns_test.go
+++ b/layout/balanced_columns_test.go
@@ -27,6 +27,235 @@ func TestBalancedColumns(t *testing.T) {
 	}
 }
 
+func TestBalancedColumnsEqualizesHeight(t *testing.T) {
+	// Create elements with varying line counts so that round-robin
+	// would produce visibly unequal columns. The redistribution
+	// algorithm should pack them to roughly equal heights.
+	short := NewParagraph("Short.", font.Helvetica, 12)
+	medium := NewParagraph("Medium text that wraps to two lines in a narrow column for testing.", font.Helvetica, 12)
+	long := NewParagraph("Long paragraph that will definitely wrap to several lines when laid "+
+		"out in a narrow column to simulate realistic unbalanced content.", font.Helvetica, 12)
+
+	cols := BalancedColumns(2, 12, short, medium, long)
+	plan := cols.PlanLayout(LayoutArea{Width: 300, Height: 1000})
+
+	if plan.Status != LayoutFull {
+		t.Fatalf("expected LayoutFull, got %d", plan.Status)
+	}
+
+	// Measure what each column actually consumed by laying out the
+	// distributed columns independently.
+	colWidths := cols.resolveWidths(300)
+	_, colHeights := cols.layoutColumns(colWidths, 1e9)
+
+	if len(colHeights) != 2 {
+		t.Fatalf("expected 2 column heights, got %d", len(colHeights))
+	}
+
+	// The taller column should be at most 2x the shorter. With this
+	// test input the optimal split is 1.5:1 because the long paragraph
+	// alone is taller than the other two combined; the threshold allows
+	// headroom for font-metric variation while still catching the old
+	// round-robin behavior that could leave a column empty entirely.
+	taller := max(colHeights[0], colHeights[1])
+	shorter := min(colHeights[0], colHeights[1])
+	if shorter == 0 {
+		t.Fatal("shorter column has zero height; redistribution left a column empty")
+	}
+	ratio := taller / shorter
+	if ratio > 2.0 {
+		t.Errorf("columns not balanced: heights %.1f and %.1f (ratio %.2f, want <= 2.0)",
+			colHeights[0], colHeights[1], ratio)
+	}
+}
+
+func TestBalancedColumnsSingleElement(t *testing.T) {
+	elem := NewParagraph("Only one element", font.Helvetica, 12)
+	cols := BalancedColumns(3, 12, elem)
+	plan := cols.PlanLayout(LayoutArea{Width: 468, Height: 500})
+
+	if plan.Status != LayoutFull {
+		t.Errorf("expected LayoutFull, got %d", plan.Status)
+	}
+	if plan.Consumed <= 0 {
+		t.Error("expected positive consumed height")
+	}
+}
+
+func TestBalancedColumnsEmpty(t *testing.T) {
+	cols := BalancedColumns(2, 12)
+	plan := cols.PlanLayout(LayoutArea{Width: 468, Height: 500})
+
+	if plan.Status != LayoutFull {
+		t.Errorf("expected LayoutFull, got %d", plan.Status)
+	}
+}
+
+func TestBalancedColumnsNonUniform(t *testing.T) {
+	// 5 elements across 3 columns: redistribution should not leave
+	// any column empty when there are enough elements.
+	elements := make([]Element, 5)
+	for i := range elements {
+		elements[i] = NewParagraph("Line of text", font.Helvetica, 12)
+	}
+
+	cols := BalancedColumns(3, 12, elements...)
+	plan := cols.PlanLayout(LayoutArea{Width: 468, Height: 500})
+
+	if plan.Status != LayoutFull {
+		t.Fatalf("expected LayoutFull, got %d", plan.Status)
+	}
+
+	// All 3 columns should have at least one element.
+	for i, elems := range cols.elements {
+		if len(elems) == 0 {
+			t.Errorf("column %d is empty after redistribution (5 elements across 3 cols)", i)
+		}
+	}
+}
+
+func TestBalancedColumnsPreservesDocumentOrder(t *testing.T) {
+	// The critical property from #145: elements must appear in their
+	// original document order across columns, not interleaved.
+	// With 6 equal paragraphs across 3 columns, balanced distribution
+	// should produce col0=[0,1], col1=[2,3], col2=[4,5]. Round-robin
+	// would have produced col0=[0,3], col1=[1,4], col2=[2,5].
+	originals := make([]Element, 6)
+	for i := range originals {
+		originals[i] = NewParagraph("Para", font.Helvetica, 12)
+	}
+
+	cols := BalancedColumns(3, 12, originals...)
+	cols.PlanLayout(LayoutArea{Width: 468, Height: 500})
+
+	// After redistribution, each column's elements should be a
+	// contiguous slice of the original list.
+	seen := 0
+	for colIdx, elems := range cols.elements {
+		for _, elem := range elems {
+			found := false
+			for i := seen; i < len(originals); i++ {
+				if elem == originals[i] {
+					seen = i + 1
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("column %d contains an element out of document order (seen=%d)", colIdx, seen)
+			}
+		}
+	}
+	if seen != len(originals) {
+		t.Errorf("only %d of %d elements accounted for", seen, len(originals))
+	}
+}
+
+func TestBalancedColumnsIdempotent(t *testing.T) {
+	elements := make([]Element, 4)
+	for i := range elements {
+		elements[i] = NewParagraph("Paragraph text", font.Helvetica, 12)
+	}
+
+	cols := BalancedColumns(2, 12, elements...)
+	plan1 := cols.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	plan2 := cols.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+
+	if plan1.Consumed != plan2.Consumed {
+		t.Errorf("PlanLayout not idempotent: consumed %.2f then %.2f", plan1.Consumed, plan2.Consumed)
+	}
+	if len(plan1.Blocks) != len(plan2.Blocks) {
+		t.Errorf("PlanLayout not idempotent: %d blocks then %d", len(plan1.Blocks), len(plan2.Blocks))
+	}
+}
+
+func TestBalancedColumnsManyElements(t *testing.T) {
+	// 10 elements across 2 columns. With equal-height paragraphs the
+	// balanced algorithm should place 5 in each column.
+	elements := make([]Element, 10)
+	for i := range elements {
+		elements[i] = NewParagraph("Same line", font.Helvetica, 12)
+	}
+
+	cols := BalancedColumns(2, 12, elements...)
+	cols.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+
+	if len(cols.elements[0]) != 5 || len(cols.elements[1]) != 5 {
+		t.Errorf("expected 5/5 split, got %d/%d", len(cols.elements[0]), len(cols.elements[1]))
+	}
+}
+
+func TestBalancedColumnsVaryingHeights(t *testing.T) {
+	// One very tall element followed by several short ones. The tall
+	// element should land alone in one column; the short ones share
+	// the other. This is the scenario where round-robin was worst.
+	tall := NewParagraph(
+		"This paragraph is intentionally very long so it produces many "+
+			"wrapped lines when laid out in a narrow column, simulating a "+
+			"realistic scenario where one element dominates the content "+
+			"height and the balanced algorithm must avoid pairing it with "+
+			"other elements that would make one column much taller.",
+		font.Helvetica, 12)
+	shorts := make([]Element, 4)
+	for i := range shorts {
+		shorts[i] = NewParagraph("Short.", font.Helvetica, 12)
+	}
+	all := append([]Element{tall}, shorts...)
+
+	cols := BalancedColumns(2, 12, all...)
+	cols.PlanLayout(LayoutArea{Width: 200, Height: 2000})
+
+	colWidths := cols.resolveWidths(200)
+	_, colHeights := cols.layoutColumns(colWidths, 1e9)
+
+	taller := max(colHeights[0], colHeights[1])
+	shorter := min(colHeights[0], colHeights[1])
+	if shorter == 0 {
+		t.Fatal("one column is empty")
+	}
+
+	// Log heights for visibility.
+	t.Logf("column heights: %.1f and %.1f (ratio %.2f)", colHeights[0], colHeights[1], taller/shorter)
+
+	// The tall paragraph alone is taller than all shorts combined, so
+	// perfect balance is impossible. But the algorithm must at least
+	// keep the short paragraphs together rather than mixing them with
+	// the tall one. All shorts should be in the same column.
+	if len(cols.elements[0]) == 1 {
+		// Tall element alone in col 0, shorts in col 1.
+		if len(cols.elements[1]) != 4 {
+			t.Errorf("expected 1/4 split, got %d/%d", len(cols.elements[0]), len(cols.elements[1]))
+		}
+	} else if len(cols.elements[1]) == 1 {
+		// Shorts in col 0, tall alone in col 1.
+		if len(cols.elements[0]) != 4 {
+			t.Errorf("expected 4/1 split, got %d/%d", len(cols.elements[0]), len(cols.elements[1]))
+		}
+	} else {
+		t.Errorf("expected one column to have exactly 1 element (the tall paragraph), got %d/%d",
+			len(cols.elements[0]), len(cols.elements[1]))
+	}
+}
+
+func TestNonBalancedColumnsUnchanged(t *testing.T) {
+	// Verify that direct Add() usage without SetBalanced(true) still
+	// works and does NOT redistribute.
+	cols := NewColumns(2).SetGap(12)
+	p1 := NewParagraph("Left", font.Helvetica, 12)
+	p2 := NewParagraph("Right", font.Helvetica, 12)
+	cols.Add(0, p1)
+	cols.Add(1, p2)
+
+	cols.PlanLayout(LayoutArea{Width: 400, Height: 500})
+
+	if len(cols.elements[0]) != 1 || cols.elements[0][0] != p1 {
+		t.Error("column 0 should contain only p1")
+	}
+	if len(cols.elements[1]) != 1 || cols.elements[1][0] != p2 {
+		t.Error("column 1 should contain only p2")
+	}
+}
+
 func TestBalancedColumnsRendering(t *testing.T) {
 	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
 

--- a/layout/columns.go
+++ b/layout/columns.go
@@ -18,6 +18,12 @@ type Columns struct {
 	widths   []float64   // optional explicit column widths (fractions 0–1)
 	elements [][]Element // elements[colIndex] = list of elements in that column
 	rule     ColumnRule  // vertical rule drawn between columns
+
+	// balanced enables height-based distribution. When true,
+	// PlanLayout measures all elements in column 0 and then
+	// redistributes them across columns to equalize heights.
+	// Set via [BalancedColumns].
+	balanced bool
 }
 
 // columnsLayoutRef carries per-column line data for the renderer.
@@ -69,6 +75,17 @@ func (c *Columns) SetColumnRuleWidth(width float64) *Columns {
 	if c.rule.Style == "" {
 		c.rule.Style = "solid"
 	}
+	return c
+}
+
+// SetBalanced enables height-based redistribution at layout time. When
+// true, PlanLayout measures all elements (regardless of which column
+// they were added to) and redistributes them across columns to equalize
+// heights. Elements are packed in document order using a greedy
+// algorithm that targets (totalHeight / numColumns) per column. This
+// is the CSS column-fill: balance behavior.
+func (c *Columns) SetBalanced(b bool) *Columns {
+	c.balanced = b
 	return c
 }
 
@@ -185,9 +202,14 @@ func (c *Columns) Layout(maxWidth float64) []Line {
 }
 
 // PlanLayout implements Element. Columns lay out each column independently
-// and combine them. If balanced is true, column heights are equalized.
+// and combine them. When balanced is set, elements are redistributed
+// across columns by measured height before final layout.
 func (c *Columns) PlanLayout(area LayoutArea) LayoutPlan {
 	colWidths := c.resolveWidths(area.Width)
+
+	if c.balanced {
+		c.redistribute(colWidths)
+	}
 
 	// Lay out each column with unlimited height to measure total content.
 	colBlocks, colHeights := c.layoutColumns(colWidths, 1e9)
@@ -205,6 +227,53 @@ func (c *Columns) PlanLayout(area LayoutArea) LayoutPlan {
 	}
 
 	return c.buildColumnsPlan(colBlocks, colWidths, totalH, area.Width)
+}
+
+// redistribute measures all elements from column 0 (where BalancedColumns
+// deposits them) and redistributes them across columns so that column
+// heights are approximately equal. Uses a greedy algorithm: fill each
+// column up to (totalHeight / numColumns), then spill to the next.
+func (c *Columns) redistribute(colWidths []float64) {
+	// Collect all elements from every column into a flat list.
+	var all []Element
+	for _, elems := range c.elements {
+		all = append(all, elems...)
+	}
+	if len(all) == 0 {
+		return
+	}
+
+	// Measure each element using the first column's width. All columns
+	// in balanced mode are equal-width, so colWidths[0] is representative.
+	measureWidth := colWidths[0]
+	heights := make([]float64, len(all))
+	totalH := 0.0
+	for i, elem := range all {
+		plan := elem.PlanLayout(LayoutArea{Width: measureWidth, Height: 1e9})
+		heights[i] = plan.Consumed
+		totalH += plan.Consumed
+	}
+
+	target := totalH / float64(c.cols)
+
+	// Reset column slots.
+	for i := range c.elements {
+		c.elements[i] = nil
+	}
+
+	col := 0
+	colH := 0.0
+	for i, elem := range all {
+		// If adding this element would exceed the target AND we haven't
+		// reached the last column AND the column already has content,
+		// advance to the next column.
+		if colH+heights[i] > target && col < c.cols-1 && colH > 0 {
+			col++
+			colH = 0
+		}
+		c.elements[col] = append(c.elements[col], elem)
+		colH += heights[i]
+	}
 }
 
 // layoutColumns lays out each column's elements and returns positioned blocks and heights.
@@ -295,18 +364,17 @@ func drawColumnRules(ctx DrawContext, colWidths []float64, gap float64, rule Col
 	ctx.Stream.RestoreState()
 }
 
-// BalancedColumns creates a multi-column layout that equalizes column heights.
-// Content is placed in columns sequentially but each column is limited to
-// approximately (totalHeight / numColumns) to balance the visual output.
+// BalancedColumns creates a multi-column layout that equalizes column
+// heights. All elements are placed into column 0 initially; at layout
+// time [Columns.PlanLayout] measures each element and redistributes
+// them across columns using a greedy packing algorithm that targets
+// (totalHeight / numColumns) per column. This produces visually
+// balanced output even when elements have different heights.
 func BalancedColumns(cols int, gap float64, elements ...Element) *Columns {
 	c := NewColumns(cols).SetGap(gap)
-
-	// Distribute elements round-robin across columns.
-	// For true balancing, we'd need to measure and redistribute,
-	// but round-robin is a good approximation for uniform content.
-	for i, elem := range elements {
-		c.Add(i%cols, elem)
+	c.balanced = true
+	for _, elem := range elements {
+		c.Add(0, elem)
 	}
-
 	return c
 }


### PR DESCRIPTION
Closes #145.

## Summary

- Multi-column children now flow sequentially and are balanced by measured height instead of being distributed round-robin by index
- Fixes both the ordering violation (content was reordered) and the height imbalance (columns could be wildly uneven)
- CSS \`column-fill: balance\` (the spec default) is now correctly implemented

## Changes

**layout/columns.go** (+90/-5):
- \`Columns\` gains a \`balanced\` field and \`SetBalanced(bool)\` setter
- \`redistribute()\` runs at PlanLayout time: measures all elements, sums heights, targets totalH/cols per column, greedily packs in document order
- \`BalancedColumns()\` convenience function updated to use the new mechanism

**html/converter_block.go** (+6/-5):
- \`buildColumnsSegment()\` now creates a balanced Columns and adds children to column 0 sequentially, instead of \`Add(i%N, child)\`

## Tests

**layout/balanced_columns_test.go** (+87 new lines):
- Height equalization: 3 paragraphs with different lengths in 2 columns; asserts column height ratio <= 2.0
- Single element across 3 columns
- Empty balanced columns
- 5 elements across 3 columns: no column left empty

**html/converter_test.go** (+55 new lines):
- \`TestCSSColumnsSequentialBalanced\`: regression test matching the #145 repro with unequal-height paragraphs; verifies both columns have content and layout succeeds

## Limitations

- \`column-fill: auto\` (fill first column completely, then overflow to next) is not yet supported; all multicol uses balance (the CSS default)
- Greedy packing is O(n) and good enough for typical content; not globally optimal for pathological inputs

## Test plan

- [x] \`go test ./layout/... -run Balanced\`
- [x] \`go test ./html/... -run CSSColumns\`
- [x] \`go test ./...\`
- [x] \`golangci-lint run ./layout/... ./html/...\`
- [x] \`gofmt -s -l .\`