### PR TITLE
optimize: Flate recompression of stream payloads (#203)

### DIFF
--- a/core/encrypt.go
+++ b/core/encrypt.go
@@ -169,7 +169,7 @@ func (e *Encryptor) walkEncrypt(obj PdfObject, objNum, genNum int) error {
 		// Compress data first (if applicable), then encrypt.
 		data := o.Data
 		if o.compress {
-			compressed, err := deflate(data)
+			compressed, err := DeflateStreamData(data)
 			if err != nil {
 				return fmt.Errorf("compress stream (obj %d): %w", objNum, err)
 			}

--- a/core/stream.go
+++ b/core/stream.go
@@ -44,6 +44,13 @@ func (s *PdfStream) SetCompress(enabled bool) {
 	s.compress = enabled
 }
 
+// WillCompress reports whether WriteTo will Flate-compress this stream's
+// payload before serializing. Useful for writer-side passes that want to
+// skip streams the writer is already going to compress at BestCompression.
+func (s *PdfStream) WillCompress() bool {
+	return s.compress
+}
+
 // Type returns ObjectTypeStream.
 func (s *PdfStream) Type() ObjectType { return ObjectTypeStream }
 
@@ -54,7 +61,7 @@ func (s *PdfStream) WriteTo(w io.Writer) (int64, error) {
 	// Determine the actual bytes to write (compressed or raw)
 	streamData := s.Data
 	if s.compress {
-		compressed, err := deflate(s.Data)
+		compressed, err := DeflateStreamData(s.Data)
 		if err != nil {
 			return 0, fmt.Errorf("flate compress: %w", err)
 		}
@@ -83,9 +90,12 @@ func (s *PdfStream) WriteTo(w io.Writer) (int64, error) {
 	return cw.n, nil
 }
 
-// deflate compresses data using zlib (RFC 1950), which is what PDF's
-// FlateDecode filter expects.
-func deflate(data []byte) ([]byte, error) {
+// DeflateStreamData compresses data using zlib (RFC 1950) at
+// zlib.BestCompression — the encoding PDF's FlateDecode filter
+// (ISO 32000-1 §7.4.4) expects. Exposed as a writer-side primitive
+// for passes that need to produce FlateDecode payloads independently
+// of [PdfStream.WriteTo].
+func DeflateStreamData(data []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	w, err := zlib.NewWriterLevel(&buf, zlib.BestCompression)
 	if err != nil {
@@ -98,4 +108,23 @@ func deflate(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+// InflateStreamData is the inverse of [DeflateStreamData]: it
+// decompresses zlib-framed bytes (PDF FlateDecode payload). It is the
+// writer-side counterpart used by the recompression pass; the reader
+// has its own size-bounded inflate that defends against zip bombs at
+// parse time. Streams reaching the writer are already in memory, so
+// this helper does not impose a size cap — callers control input size.
+func InflateStreamData(data []byte) ([]byte, error) {
+	r, err := zlib.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("inflate: %w", err)
+	}
+	defer func() { _ = r.Close() }()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("inflate: %w", err)
+	}
+	return out, nil
 }

--- a/document/writer_recompress.go
+++ b/document/writer_recompress.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"github.com/carlos7ags/folio/core"
+)
+
+// recompressStreams walks every registered indirect object and, for
+// each PdfStream payload deemed eligible, re-Flate-compresses the
+// payload at zlib.BestCompression. The size-regression guard reverts
+// any rewrite that fails to produce strictly smaller output.
+//
+// Eligibility (see WriteOptions.RecompressStreams godoc for the
+// canonical contract):
+//
+//   - Empty /Filter: payload is plaintext, deflate it.
+//   - Single /FlateDecode filter: inflate then re-deflate.
+//   - Anything else: skip.
+//
+// The pass is encryption-agnostic at this layer; WriteToWithOptions
+// refuses RecompressStreams when an encryptor is configured. The
+// guard at the top of this method is defense in depth so a future
+// caller that bypasses WriteToWithOptions cannot corrupt encrypted
+// payloads.
+//
+// The pass never enlarges any stream and never invalidates any
+// reference, so it composes safely with OrphanSweep, UseXRefStream,
+// and UseObjectStreams.
+func (w *Writer) recompressStreams() {
+	if w.encryptor != nil {
+		return
+	}
+	for _, obj := range w.objects {
+		stream, ok := obj.Object.(*core.PdfStream)
+		if !ok {
+			continue
+		}
+		recompressOne(stream)
+	}
+}
+
+// recompressOne attempts to recompress a single stream's payload.
+// Mutates the stream in place on success; leaves it untouched on
+// failure or when the guard reverts.
+func recompressOne(stream *core.PdfStream) {
+	if stream.WillCompress() {
+		// Stream is already marked for FlateDecode at WriteTo time
+		// (via NewPdfStreamCompressed / SetCompress(true)). Folio's
+		// writer always uses BestCompression for those, so re-running
+		// here would just duplicate work for identical output. Skip.
+		return
+	}
+	mode, ok := classifyForRecompress(stream)
+	if !ok {
+		return
+	}
+
+	original := stream.Data
+	if len(original) == 0 {
+		// Nothing to compress.
+		return
+	}
+
+	// Decode to plaintext according to the eligibility class. The
+	// raw branch is a no-op (plaintext is the data); the FlateDecode
+	// branch inflates. A decode error is treated as "not eligible
+	// after all" — leave the stream alone rather than fail the whole
+	// write.
+	var plaintext []byte
+	switch mode {
+	case recompressRaw:
+		plaintext = original
+	case recompressFlate:
+		decoded, err := core.InflateStreamData(original)
+		if err != nil {
+			return
+		}
+		plaintext = decoded
+	}
+
+	// Run the candidate transform under the size-regression guard.
+	// The guard returns the smaller of (baseline, candidate); if it
+	// returns the baseline, no commit. We compare lengths to detect
+	// the commit decision because the helper does not surface a
+	// boolean flag.
+	candidate, err := sizeRegressionGuard(original, func() ([]byte, error) {
+		return core.DeflateStreamData(plaintext)
+	})
+	if err != nil {
+		// Candidate transform failed; guard already fell back. Leave
+		// the stream untouched.
+		return
+	}
+	if len(candidate) >= len(original) {
+		// Guard preserved the original — no shrink. Skip commit.
+		return
+	}
+
+	// Commit the rewrite. The new payload is FlateDecode-encoded
+	// without a predictor or any other parameterized post-processing,
+	// so /Filter must be /FlateDecode and /DecodeParms must be absent.
+	// classifyForRecompress refuses to mark a Flate-with-/DecodeParms
+	// stream eligible (§7.4.4.4), so the Remove call below is
+	// defensive cleanup against a /DecodeParms set on what was a raw
+	// (no-/Filter) stream — meaningless there, but stripping it is
+	// harmless and keeps the dictionary tidy.
+	stream.Data = candidate
+	stream.SetCompress(false) // payload is already compressed; do not re-deflate on WriteTo
+	stream.Dict.Set("Filter", core.NewPdfName("FlateDecode"))
+	stream.Dict.Remove("DecodeParms")
+	// /Length is reset by PdfStream.WriteTo from len(stream.Data).
+}
+
+// recompressMode names the eligibility class of a stream — primarily
+// to distinguish "data is already plaintext" from "data needs inflate
+// first" without a second filter inspection at decode time.
+type recompressMode int
+
+const (
+	recompressRaw   recompressMode = iota // payload is raw bytes (no /Filter)
+	recompressFlate                       // payload is FlateDecode-encoded
+)
+
+// classifyForRecompress returns the recompression class of a stream
+// and whether the stream is eligible at all. Streams whose filter
+// chain includes a specialized-compression filter (DCT/JPX/CCITT/JBIG2)
+// or any other unsupported filter are not eligible. A malformed
+// /Filter entry (e.g., an array containing a non-name) is treated as
+// not eligible — better to leave the stream untouched than to assume
+// "no filter" against a value that is clearly something else.
+//
+// FlateDecode streams that carry a /DecodeParms entry (most commonly
+// a PNG or TIFF predictor per ISO 32000-1 §7.4.4.4) are also not
+// eligible. The inflated payload of such a stream is predictor-
+// filtered bytes, not plaintext; re-deflating those bytes and
+// dropping /DecodeParms would emit a stream that decodes to garbage
+// in any reader that honors the predictor contract. Skipping is the
+// only safe call without re-applying the predictor inversion, which
+// is out of scope for this pass.
+func classifyForRecompress(stream *core.PdfStream) (recompressMode, bool) {
+	filterObj := stream.Dict.Get("Filter")
+	if filterObj == nil {
+		return recompressRaw, true
+	}
+	filters, ok := filterChainNames(filterObj)
+	if !ok {
+		return 0, false
+	}
+	if len(filters) == 1 && filters[0] == "FlateDecode" {
+		// /DecodeParms (§7.4.4.4) on a Flate stream signals that a
+		// predictor (or other parameterized post-processing) was
+		// applied to the bytes BEFORE Flate. Inflate alone does not
+		// undo the predictor, so we cannot safely re-deflate.
+		if stream.Dict.Get("DecodeParms") != nil {
+			return 0, false
+		}
+		return recompressFlate, true
+	}
+	return 0, false
+}
+
+// filterChainNames extracts the filter names from a /Filter entry,
+// which per ISO 32000-1 §7.4.2 may be either a single name or an
+// array of names. Returns ok=false for any value that does not match
+// one of those two shapes (or an array element that is not a name);
+// callers must distinguish "no /Filter set" from "malformed /Filter"
+// before invoking this helper.
+func filterChainNames(obj core.PdfObject) ([]string, bool) {
+	if name, ok := obj.(*core.PdfName); ok {
+		return []string{name.Value}, true
+	}
+	arr, ok := obj.(*core.PdfArray)
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, 0, arr.Len())
+	for _, elem := range arr.All() {
+		name, ok := elem.(*core.PdfName)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, name.Value)
+	}
+	return out, true
+}

--- a/document/writer_recompress_test.go
+++ b/document/writer_recompress_test.go
@@ -1,0 +1,820 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"bytes"
+	"compress/zlib"
+	"crypto/rand"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/core"
+)
+
+// makeFlateAt produces a Flate-encoded payload for plaintext using the
+// requested zlib level. Used by tests that need a "lower-than-Best"
+// baseline to demonstrate the recompression win.
+func makeFlateAt(t *testing.T, plaintext []byte, level int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := zlib.NewWriterLevel(&buf, level)
+	if err != nil {
+		t.Fatalf("zlib.NewWriterLevel(%d): %v", level, err)
+	}
+	if _, err := zw.Write(plaintext); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// addRawStream wires a raw (uncompressed, no /Filter) stream into a
+// minimal Writer. Mirrors the shape produced by reader/import.go for
+// imported pages whose source was compressed by the resolver.
+func addRawStream(t *testing.T, w *Writer, data []byte) (*core.PdfStream, *core.PdfIndirectReference) {
+	t.Helper()
+	s := core.NewPdfStream(data)
+	ref := w.AddObject(s)
+	// Wire it under /Root so OrphanSweep would not drop it.
+	root, ok := w.objects[0].Object.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("setup: first object is not the root dict")
+	}
+	root.Set("Sample", ref)
+	return s, ref
+}
+
+// addFlateStream wires a pre-Flate-compressed stream (with /Filter
+// /FlateDecode set, compress=false) into the Writer. The level
+// parameter controls how aggressively the source compressed it.
+func addFlateStream(t *testing.T, w *Writer, plaintext []byte, level int) (*core.PdfStream, *core.PdfIndirectReference) {
+	t.Helper()
+	encoded := makeFlateAt(t, plaintext, level)
+	s := core.NewPdfStream(encoded)
+	s.Dict.Set("Filter", core.NewPdfName("FlateDecode"))
+	ref := w.AddObject(s)
+	root, ok := w.objects[0].Object.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("setup: first object is not the root dict")
+	}
+	root.Set("Sample", ref)
+	return s, ref
+}
+
+func TestRecompressStreams_NoOpOnEmptyWriter(t *testing.T) {
+	w := NewWriter("1.7")
+	w.recompressStreams() // must not panic on zero objects
+	if len(w.objects) != 0 {
+		t.Errorf("empty writer gained %d objects", len(w.objects))
+	}
+}
+
+func TestRecompressStreams_SkipsWillCompressStreams(t *testing.T) {
+	// A stream marked compress=true is what NewPdfStreamCompressed
+	// returns; the writer's WriteTo will deflate it at BestCompression
+	// already. Recompression should leave it alone — re-running here
+	// would just duplicate work for identical output.
+	w := minimalCatalogWriter(t)
+	plaintext := bytes.Repeat([]byte("compressible "), 200)
+	s := core.NewPdfStreamCompressed(plaintext)
+	originalData := s.Data
+	originalCompress := s.WillCompress()
+	ref := w.AddObject(s)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("Sample", ref)
+
+	w.recompressStreams()
+
+	if !bytes.Equal(s.Data, originalData) {
+		t.Error("compress=true stream was rewritten")
+	}
+	if s.WillCompress() != originalCompress {
+		t.Error("compress flag flipped on a compress=true stream")
+	}
+	if s.Dict.Get("Filter") != nil {
+		t.Error("compress=true stream got a /Filter set prematurely")
+	}
+}
+
+func TestRecompressStreams_ShrinksRawStream(t *testing.T) {
+	// A raw stream (no /Filter, compress=false) is the shape produced
+	// by reader/import.go when it copies a stream that the resolver
+	// already inflated. Recompression must Flate the payload, set
+	// /Filter /FlateDecode, and shrink the byte count.
+	w := minimalCatalogWriter(t)
+	plaintext := bytes.Repeat([]byte("shrink me "), 500)
+	s, _ := addRawStream(t, w, plaintext)
+	originalLen := len(s.Data)
+
+	w.recompressStreams()
+
+	if len(s.Data) >= originalLen {
+		t.Errorf("recompression did not shrink: was %d, now %d", originalLen, len(s.Data))
+	}
+	filter := s.Dict.Get("Filter")
+	if filter == nil {
+		t.Fatal("missing /Filter after recompression")
+	}
+	name, ok := filter.(*core.PdfName)
+	if !ok || name.Value != "FlateDecode" {
+		t.Errorf("/Filter = %v, want /FlateDecode", filter)
+	}
+	if s.WillCompress() {
+		t.Error("compress flag still set after pre-compression; WriteTo would double-compress")
+	}
+}
+
+func TestRecompressStreams_ReFlatesBestSpeedStream(t *testing.T) {
+	// A stream pre-compressed at BestSpeed by another producer is
+	// eligible: inflate then re-deflate at BestCompression. The win
+	// is producer-dependent but real for sufficiently large payloads.
+	w := minimalCatalogWriter(t)
+	plaintext := bytes.Repeat([]byte("re-Flate me at higher effort "), 500)
+	s, _ := addFlateStream(t, w, plaintext, zlib.BestSpeed)
+	originalLen := len(s.Data)
+
+	w.recompressStreams()
+
+	if len(s.Data) >= originalLen {
+		t.Errorf("re-Flate did not shrink: was %d (BestSpeed), now %d (BestCompression)",
+			originalLen, len(s.Data))
+	}
+	// /Filter must remain /FlateDecode (single name, not array).
+	filter := s.Dict.Get("Filter")
+	name, ok := filter.(*core.PdfName)
+	if !ok || name.Value != "FlateDecode" {
+		t.Errorf("/Filter = %v, want /FlateDecode", filter)
+	}
+}
+
+func TestRecompressStreams_GuardRevertsRandomBytes(t *testing.T) {
+	// Random bytes are incompressible — Flate will produce output
+	// strictly larger than the input thanks to header overhead. The
+	// guard must revert the rewrite, leaving the stream untouched.
+	w := minimalCatalogWriter(t)
+	random := make([]byte, 4096)
+	if _, err := rand.Read(random); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	s, _ := addRawStream(t, w, random)
+	originalData := append([]byte(nil), s.Data...)
+	originalFilter := s.Dict.Get("Filter")
+
+	w.recompressStreams()
+
+	if !bytes.Equal(s.Data, originalData) {
+		t.Error("guard failed to revert: random bytes were rewritten")
+	}
+	if originalFilter == nil && s.Dict.Get("Filter") != nil {
+		t.Error("guard failed to revert: /Filter was added after revert")
+	}
+}
+
+func TestRecompressStreams_SkipsDCTDecode(t *testing.T) {
+	// A JPEG-encoded payload (/Filter /DCTDecode) must not be
+	// touched. Re-Flating already-DCT bytes inflates them and adds
+	// a meaningless filter chain that no reader would correctly
+	// decode without the DCT step.
+	w := minimalCatalogWriter(t)
+	fakeJPEG := bytes.Repeat([]byte{0xff, 0xd8, 0xff, 0xe0}, 200) // not a valid JPEG, but the decoder is not invoked
+	s := core.NewPdfStream(fakeJPEG)
+	s.Dict.Set("Filter", core.NewPdfName("DCTDecode"))
+	ref := w.AddObject(s)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("Sample", ref)
+
+	originalData := append([]byte(nil), s.Data...)
+	w.recompressStreams()
+
+	if !bytes.Equal(s.Data, originalData) {
+		t.Error("DCTDecode stream was modified by recompression")
+	}
+	filter := s.Dict.Get("Filter").(*core.PdfName)
+	if filter.Value != "DCTDecode" {
+		t.Errorf("/Filter = %s, want DCTDecode unchanged", filter.Value)
+	}
+}
+
+func TestRecompressStreams_SkipsAllSpecializedFilters(t *testing.T) {
+	// Per ISO 32000-1 §7.4.7 (CCITTFaxDecode), §7.4.8 (DCTDecode,
+	// JBIG2Decode), and §7.4.9 (JPXDecode), these filters carry
+	// payloads that Flate must not be applied over.
+	specialized := []string{"DCTDecode", "JPXDecode", "CCITTFaxDecode", "JBIG2Decode"}
+	for _, filter := range specialized {
+		t.Run(filter, func(t *testing.T) {
+			w := minimalCatalogWriter(t)
+			payload := bytes.Repeat([]byte("opaque "), 100)
+			s := core.NewPdfStream(payload)
+			s.Dict.Set("Filter", core.NewPdfName(filter))
+			ref := w.AddObject(s)
+			root := w.objects[0].Object.(*core.PdfDictionary)
+			root.Set("Sample", ref)
+			original := append([]byte(nil), s.Data...)
+
+			w.recompressStreams()
+
+			if !bytes.Equal(s.Data, original) {
+				t.Errorf("%s stream was modified", filter)
+			}
+		})
+	}
+}
+
+func TestRecompressStreams_SkipsMultiFilterChain(t *testing.T) {
+	// A multi-filter chain like /Filter [/ASCII85Decode /FlateDecode]
+	// is not in the eligibility set: rewriting would require
+	// understanding the entire chain and producing bytes that round-
+	// trip through it. Conservative skip.
+	w := minimalCatalogWriter(t)
+	payload := bytes.Repeat([]byte("a"), 100)
+	s := core.NewPdfStream(payload)
+	chain := core.NewPdfArray(
+		core.NewPdfName("ASCII85Decode"),
+		core.NewPdfName("FlateDecode"),
+	)
+	s.Dict.Set("Filter", chain)
+	ref := w.AddObject(s)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("Sample", ref)
+	original := append([]byte(nil), s.Data...)
+
+	w.recompressStreams()
+
+	if !bytes.Equal(s.Data, original) {
+		t.Error("multi-filter chain stream was modified")
+	}
+}
+
+func TestRecompressStreams_SkipsFlateWithDecodeParms(t *testing.T) {
+	// CRITICAL correctness: a Flate stream with /DecodeParms (typically
+	// a PNG/TIFF predictor per §7.4.4.4) carries predictor-filtered
+	// bytes after inflation, NOT plaintext. The recompression pass
+	// MUST skip these — otherwise re-deflating the filtered bytes and
+	// dropping /DecodeParms produces a stream that decodes to garbage
+	// in any reader that honors the predictor contract.
+	w := minimalCatalogWriter(t)
+	// Build a synthetic predictor-shaped payload. The bytes themselves
+	// don't have to be valid PNG-filtered data — the eligibility
+	// decision must be made from the dictionary alone, before any
+	// inflate happens. We pre-Flate the bytes so they look like a
+	// typical xref-stream-style payload.
+	preFiltered := bytes.Repeat([]byte("predictor-filtered "), 300)
+	s, _ := addFlateStream(t, w, preFiltered, zlib.BestSpeed)
+	parms := core.NewPdfDictionary()
+	parms.Set("Predictor", core.NewPdfInteger(15))
+	parms.Set("Columns", core.NewPdfInteger(80))
+	s.Dict.Set("DecodeParms", parms)
+
+	originalData := append([]byte(nil), s.Data...)
+
+	w.recompressStreams()
+
+	if !bytes.Equal(s.Data, originalData) {
+		t.Error("Flate-with-/DecodeParms stream was modified — predictor contract violated")
+	}
+	// /DecodeParms must remain — the skip preserves the original
+	// dictionary intact, including the predictor parameters.
+	if s.Dict.Get("DecodeParms") == nil {
+		t.Error("skip path mutated dictionary by removing /DecodeParms")
+	}
+	// /Filter must remain.
+	if name, ok := s.Dict.Get("Filter").(*core.PdfName); !ok || name.Value != "FlateDecode" {
+		t.Errorf("/Filter mutated: %v", s.Dict.Get("Filter"))
+	}
+}
+
+func TestClassifyForRecompress_FlateWithDecodeParmsIneligible(t *testing.T) {
+	// Direct unit on the eligibility decision, separate from the
+	// pass-level test above so a regression in the classifier alone
+	// fails with a clear signal.
+	s := core.NewPdfStream(nil)
+	s.Dict.Set("Filter", core.NewPdfName("FlateDecode"))
+	s.Dict.Set("DecodeParms", core.NewPdfDictionary())
+	if _, ok := classifyForRecompress(s); ok {
+		t.Error("Flate stream with /DecodeParms classified as eligible (would corrupt predictor data)")
+	}
+}
+
+func TestRecompressStreams_LeavesEmptyStreamAlone(t *testing.T) {
+	// An empty stream cannot shrink. The pass must leave it alone
+	// rather than emit a Flate-of-empty header (which is non-zero).
+	w := minimalCatalogWriter(t)
+	s := core.NewPdfStream(nil)
+	ref := w.AddObject(s)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("Sample", ref)
+
+	w.recompressStreams()
+
+	if len(s.Data) != 0 {
+		t.Errorf("empty stream gained %d bytes", len(s.Data))
+	}
+	if s.Dict.Get("Filter") != nil {
+		t.Error("empty stream got a spurious /Filter")
+	}
+}
+
+func TestRecompressStreams_Idempotent(t *testing.T) {
+	// Recompressing twice must produce byte-identical writer output:
+	// the first pass establishes BestCompression bytes, the second
+	// pass inflates them, re-deflates them (same bytes, same output),
+	// and the guard reverts since they're equal-size — no commit.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		addRawStream(t, w, bytes.Repeat([]byte("idempotent "), 400))
+		addFlateStream(t, w, bytes.Repeat([]byte("flate "), 400), zlib.BestSpeed)
+		return w
+	}
+
+	w1 := makeWriter()
+	w1.recompressStreams()
+	var buf1 bytes.Buffer
+	if _, err := w1.WriteToWithOptions(&buf1, WriteOptions{}); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	w2 := makeWriter()
+	w2.recompressStreams()
+	w2.recompressStreams()
+	var buf2 bytes.Buffer
+	if _, err := w2.WriteToWithOptions(&buf2, WriteOptions{}); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	if !bytes.Equal(buf1.Bytes(), buf2.Bytes()) {
+		t.Errorf("recompression is not idempotent: 1 pass %d bytes vs 2 passes %d bytes",
+			buf1.Len(), buf2.Len())
+	}
+}
+
+func TestRecompressStreams_ZeroOptionsByteIdentical(t *testing.T) {
+	// A Writer with eligible streams must produce byte-identical
+	// output between WriteOptions{} and explicit-default options
+	// when RecompressStreams is unset. Defends against the toggle
+	// silently activating.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		addRawStream(t, w, bytes.Repeat([]byte("default "), 200))
+		return w
+	}
+
+	var bufA, bufB bytes.Buffer
+	if _, err := makeWriter().WriteToWithOptions(&bufA, WriteOptions{}); err != nil {
+		t.Fatalf("zero opts: %v", err)
+	}
+	if _, err := makeWriter().WriteTo(&bufB); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if !bytes.Equal(bufA.Bytes(), bufB.Bytes()) {
+		t.Error("zero-options output diverges from WriteTo")
+	}
+}
+
+func TestRecompressStreams_RefusedOnEncryptedDocument(t *testing.T) {
+	// Refusal must fire before any writer mutation so a retry
+	// without RecompressStreams produces correct output (not double-
+	// recompressed, not missing payload). State invariants: object
+	// count and serialized-stream-payload bytes both unchanged.
+	w := minimalCatalogWriter(t)
+	plaintext := bytes.Repeat([]byte("encrypted? "), 200)
+	s, _ := addRawStream(t, w, plaintext)
+	originalPayload := append([]byte(nil), s.Data...)
+
+	enc, err := core.NewEncryptor(core.RevisionAES128, "user", "owner", core.PermPrint)
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+	w.SetEncryption(enc)
+	preCount := len(w.objects)
+
+	var buf bytes.Buffer
+	_, err = w.WriteToWithOptions(&buf, WriteOptions{RecompressStreams: true})
+	if err == nil {
+		t.Fatal("expected error for encryption + RecompressStreams")
+	}
+	if !strings.Contains(err.Error(), "recompression") {
+		t.Errorf("error %q does not mention recompression", err.Error())
+	}
+	if len(w.objects) != preCount {
+		t.Errorf("refusal mutated object count: %d → %d", preCount, len(w.objects))
+	}
+	if !bytes.Equal(s.Data, originalPayload) {
+		t.Error("refusal mutated stream payload")
+	}
+	if s.Dict.Get("Filter") != nil {
+		t.Error("refusal added a /Filter to the stream")
+	}
+}
+
+func TestRecompressStreams_ComposesWithOrphanSweep(t *testing.T) {
+	// Sweep + recompress: the sweep drops orphaned streams first, so
+	// the recompression pass does not waste effort on objects that
+	// will not survive. The output must shrink relative to either
+	// option alone.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		// Reachable, recompressible.
+		addRawStream(t, w, bytes.Repeat([]byte("keep "), 300))
+		// Unreachable orphan with a compressible payload — should be
+		// dropped by sweep, not visited by recompress.
+		orphan := core.NewPdfStream(bytes.Repeat([]byte("drop "), 400))
+		w.AddObject(orphan)
+		return w
+	}
+
+	var sweepOnly, recompressOnly, both bytes.Buffer
+	if _, err := makeWriter().WriteToWithOptions(&sweepOnly, WriteOptions{
+		OrphanSweep: true,
+	}); err != nil {
+		t.Fatalf("sweep only: %v", err)
+	}
+	if _, err := makeWriter().WriteToWithOptions(&recompressOnly, WriteOptions{
+		RecompressStreams: true,
+	}); err != nil {
+		t.Fatalf("recompress only: %v", err)
+	}
+	if _, err := makeWriter().WriteToWithOptions(&both, WriteOptions{
+		OrphanSweep:       true,
+		RecompressStreams: true,
+	}); err != nil {
+		t.Fatalf("both: %v", err)
+	}
+	if both.Len() >= sweepOnly.Len() {
+		t.Errorf("both options not smaller than sweep-only: both=%d, sweep=%d",
+			both.Len(), sweepOnly.Len())
+	}
+	if both.Len() >= recompressOnly.Len() {
+		t.Errorf("both options not smaller than recompress-only: both=%d, recompress=%d",
+			both.Len(), recompressOnly.Len())
+	}
+}
+
+func TestRecompressStreams_ComposesWithXRefStreamAndObjStm(t *testing.T) {
+	// Recompression must compose with the existing optimizer toggles
+	// without breaking either side. Result must reparse structurally.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		addRawStream(t, w, bytes.Repeat([]byte("compose "), 400))
+		return w
+	}
+
+	var noRecompress, withRecompress bytes.Buffer
+	if _, err := makeWriter().WriteToWithOptions(&noRecompress, WriteOptions{
+		UseXRefStream:    true,
+		UseObjectStreams: true,
+	}); err != nil {
+		t.Fatalf("no recompress: %v", err)
+	}
+	if _, err := makeWriter().WriteToWithOptions(&withRecompress, WriteOptions{
+		UseXRefStream:     true,
+		UseObjectStreams:  true,
+		RecompressStreams: true,
+	}); err != nil {
+		t.Fatalf("with recompress: %v", err)
+	}
+	if withRecompress.Len() >= noRecompress.Len() {
+		t.Errorf("recompression did not shrink with xref+objstm: with=%d, without=%d",
+			withRecompress.Len(), noRecompress.Len())
+	}
+	if !bytes.Contains(withRecompress.Bytes(), []byte("/Type /XRef")) {
+		t.Error("missing /Type /XRef")
+	}
+	if !bytes.HasPrefix(withRecompress.Bytes(), []byte("%PDF-")) {
+		t.Error("missing PDF header")
+	}
+	if !bytes.HasSuffix(withRecompress.Bytes(), []byte("EOF\n")) {
+		t.Error("missing EOF marker")
+	}
+}
+
+func TestRecompressStreams_RewrittenStreamReinflatesToOriginal(t *testing.T) {
+	// Round-trip correctness: the bytes committed by recompression
+	// must inflate back to the original plaintext. A bug that emitted
+	// arbitrary bytes "of the right size" would silently corrupt the
+	// document; this test catches it.
+	w := minimalCatalogWriter(t)
+	plaintext := []byte("the quick brown fox jumps over the lazy dog. " + strings.Repeat("data ", 200))
+	s, _ := addRawStream(t, w, plaintext)
+
+	w.recompressStreams()
+
+	if s.Dict.Get("Filter") == nil {
+		t.Skip("recompression did not commit; nothing to verify")
+	}
+	roundTripped, err := core.InflateStreamData(s.Data)
+	if err != nil {
+		t.Fatalf("InflateStreamData on committed payload: %v", err)
+	}
+	if !bytes.Equal(roundTripped, plaintext) {
+		t.Errorf("recompressed payload does not round-trip: got %d bytes, want %d",
+			len(roundTripped), len(plaintext))
+	}
+}
+
+func TestRecompressStreams_FlateDecodeRoundTripCorrectness(t *testing.T) {
+	// Same correctness check on the FlateDecode-already-compressed
+	// path: the rewrite must inflate to the same plaintext as the
+	// original payload would.
+	w := minimalCatalogWriter(t)
+	plaintext := bytes.Repeat([]byte("preserve me "), 400)
+	s, _ := addFlateStream(t, w, plaintext, zlib.BestSpeed)
+	originalInflated, err := core.InflateStreamData(s.Data)
+	if err != nil {
+		t.Fatalf("setup: cannot inflate fixture: %v", err)
+	}
+
+	w.recompressStreams()
+
+	roundTripped, err := core.InflateStreamData(s.Data)
+	if err != nil {
+		t.Fatalf("InflateStreamData on committed payload: %v", err)
+	}
+	if !bytes.Equal(roundTripped, originalInflated) {
+		t.Errorf("re-Flate corrupted plaintext: got %d bytes, want %d",
+			len(roundTripped), len(originalInflated))
+	}
+}
+
+func TestRecompressStreams_SkipsBadFlatePayload(t *testing.T) {
+	// A stream that claims /Filter /FlateDecode but holds garbage
+	// must not crash the writer and must not be rewritten. The pass
+	// treats inflate failure as "skip" rather than aborting the entire
+	// write.
+	w := minimalCatalogWriter(t)
+	garbage := []byte("definitely not zlib-framed bytes")
+	s := core.NewPdfStream(garbage)
+	s.Dict.Set("Filter", core.NewPdfName("FlateDecode"))
+	ref := w.AddObject(s)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("Sample", ref)
+
+	w.recompressStreams()
+
+	if !bytes.Equal(s.Data, garbage) {
+		t.Error("garbage Flate stream was modified despite inflate failure")
+	}
+}
+
+func TestClassifyForRecompress_FilterShapes(t *testing.T) {
+	// Direct unit on the classifier so its eligibility table can be
+	// inspected without going through the full pass.
+	cases := []struct {
+		name      string
+		filterSet func(*core.PdfDictionary)
+		want      bool
+		mode      recompressMode
+	}{
+		{name: "no filter", filterSet: func(d *core.PdfDictionary) {}, want: true, mode: recompressRaw},
+		{name: "single FlateDecode", filterSet: func(d *core.PdfDictionary) {
+			d.Set("Filter", core.NewPdfName("FlateDecode"))
+		}, want: true, mode: recompressFlate},
+		{name: "single DCTDecode", filterSet: func(d *core.PdfDictionary) {
+			d.Set("Filter", core.NewPdfName("DCTDecode"))
+		}, want: false},
+		{name: "single ASCIIHexDecode", filterSet: func(d *core.PdfDictionary) {
+			d.Set("Filter", core.NewPdfName("ASCIIHexDecode"))
+		}, want: false},
+		{name: "array of one FlateDecode", filterSet: func(d *core.PdfDictionary) {
+			d.Set("Filter", core.NewPdfArray(core.NewPdfName("FlateDecode")))
+		}, want: true, mode: recompressFlate},
+		{name: "array of two", filterSet: func(d *core.PdfDictionary) {
+			d.Set("Filter", core.NewPdfArray(
+				core.NewPdfName("ASCII85Decode"),
+				core.NewPdfName("FlateDecode"),
+			))
+		}, want: false},
+		{name: "array containing non-name", filterSet: func(d *core.PdfDictionary) {
+			d.Set("Filter", core.NewPdfArray(core.NewPdfInteger(0)))
+		}, want: false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := core.NewPdfStream(nil)
+			c.filterSet(s.Dict)
+			mode, ok := classifyForRecompress(s)
+			if ok != c.want {
+				t.Errorf("eligible = %v, want %v", ok, c.want)
+			}
+			if ok && mode != c.mode {
+				t.Errorf("mode = %v, want %v", mode, c.mode)
+			}
+		})
+	}
+}
+
+func TestRecompressStreams_TripleGuardRefusalWithObjStmAndEncryption(t *testing.T) {
+	// All three trigger conditions are tripped simultaneously:
+	// UseObjectStreams + RecompressStreams + an encryptor. The current
+	// guard ordering reports the objstm-encryption refusal first
+	// because that check appears earlier in WriteToWithOptions. We
+	// pin "some refusal fired and nothing was mutated" rather than
+	// the specific message, since guard ordering is internal.
+	w := minimalCatalogWriter(t)
+	plaintext := bytes.Repeat([]byte("triple-guard "), 200)
+	s, _ := addRawStream(t, w, plaintext)
+	originalPayload := append([]byte(nil), s.Data...)
+
+	enc, err := core.NewEncryptor(core.RevisionAES128, "user", "owner", core.PermPrint)
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+	w.SetEncryption(enc)
+	preNumbers := snapshotObjectNumbers(w)
+
+	var buf bytes.Buffer
+	_, err = w.WriteToWithOptions(&buf, WriteOptions{
+		UseXRefStream:     true,
+		UseObjectStreams:  true,
+		RecompressStreams: true,
+	})
+	if err == nil {
+		t.Fatal("expected refusal with objstm + recompress + encryption")
+	}
+	if !sliceEqual(preNumbers, snapshotObjectNumbers(w)) {
+		t.Error("triple-guard refusal renumbered objects")
+	}
+	if !bytes.Equal(s.Data, originalPayload) {
+		t.Error("triple-guard refusal mutated stream payload")
+	}
+	if s.Dict.Get("Filter") != nil {
+		t.Error("triple-guard refusal added a /Filter to the stream")
+	}
+}
+
+func TestRecompressStreams_NearBreakevenPayload(t *testing.T) {
+	// Defends the size-regression guard's strict-less-than comparator
+	// (`<`, not `<=`). A payload engineered to land near the
+	// breakeven point would expose an off-by-one such that an
+	// equal-size candidate gets committed unnecessarily, perturbing
+	// a byte-stable artifact for zero benefit.
+	//
+	// We construct a payload whose Flate output is very close to (but
+	// strictly smaller than) the original size. The pass should
+	// commit. Then we check that re-running the pass on the now-Flate
+	// payload (which is at BestCompression) produces no further commit
+	// — the second-pass candidate would be equal-size, the guard must
+	// keep the baseline.
+	w := minimalCatalogWriter(t)
+	// 64 bytes of mixed structure — enough to compress, not so
+	// repetitive that it compresses dramatically.
+	payload := []byte("structured but not uniformly repetitive payload bytes here ABC")
+	s, _ := addRawStream(t, w, payload)
+
+	w.recompressStreams()
+	firstPassData := append([]byte(nil), s.Data...)
+
+	// If the first pass committed, /Filter is now /FlateDecode.
+	// Otherwise, the original payload was already too small to shrink.
+	if s.Dict.Get("Filter") == nil {
+		t.Skip("payload too small to shrink on first pass; near-breakeven guard not exercised")
+	}
+
+	w.recompressStreams()
+	if !bytes.Equal(s.Data, firstPassData) {
+		t.Errorf("second pass committed an equal-size candidate (guard `<` regressed to `<=`)")
+	}
+}
+
+func TestRecompressStreams_OverwritesStaleLength(t *testing.T) {
+	// A caller could set /Length explicitly in the stream dict to a
+	// value that no longer matches len(stream.Data) after recompress.
+	// PdfStream.WriteTo must overwrite /Length from the actual data
+	// length on every serialization, regardless of pre-set values.
+	// This test pins that contract from the recompression caller's
+	// perspective: a wrong /Length set before recompress must not
+	// survive into the serialized output.
+	w := minimalCatalogWriter(t)
+	plaintext := bytes.Repeat([]byte("overwrite my length "), 200)
+	s, _ := addRawStream(t, w, plaintext)
+	s.Dict.Set("Length", core.NewPdfInteger(99999)) // intentionally wrong
+
+	var buf bytes.Buffer
+	if _, err := w.WriteToWithOptions(&buf, WriteOptions{RecompressStreams: true}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	pdf := buf.String()
+
+	// The serialized length must equal len(s.Data) after recompress,
+	// not the wrong 99999 we planted.
+	wantLengthSubstr := fmt.Sprintf("/Length %d ", len(s.Data))
+	if !strings.Contains(pdf, wantLengthSubstr) {
+		t.Errorf("expected %q in output to confirm /Length was overwritten", wantLengthSubstr)
+	}
+	if strings.Contains(pdf, "/Length 99999") {
+		t.Error("stale /Length 99999 leaked into serialized output")
+	}
+}
+
+func TestClassifyForRecompress_NonNameNonArrayFilter(t *testing.T) {
+	// A /Filter set to something other than a name or an array of
+	// names is malformed per §7.4.2 and must classify as ineligible
+	// rather than fall through to the "no /Filter" branch.
+	cases := []struct {
+		name  string
+		value core.PdfObject
+	}{
+		{name: "PdfNull", value: core.NewPdfNull()},
+		{name: "PdfDictionary", value: core.NewPdfDictionary()},
+		{name: "PdfBoolean", value: core.NewPdfBoolean(true)},
+		{name: "PdfInteger", value: core.NewPdfInteger(0)},
+		{name: "PdfLiteralString", value: core.NewPdfLiteralString("FlateDecode")},
+		{name: "PdfIndirectReference", value: core.NewPdfIndirectReference(1, 0)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := core.NewPdfStream(nil)
+			s.Dict.Set("Filter", c.value)
+			if _, ok := classifyForRecompress(s); ok {
+				t.Errorf("/Filter of type %T classified as eligible", c.value)
+			}
+		})
+	}
+}
+
+func TestClassifyForRecompress_FlateFlateChain(t *testing.T) {
+	// /Filter [/FlateDecode /FlateDecode] is legal but unusual — two
+	// successive Flate passes. The classifier currently treats
+	// anything other than a single Flate name as ineligible, so this
+	// is a skip. Pin that explicitly.
+	s := core.NewPdfStream(nil)
+	s.Dict.Set("Filter", core.NewPdfArray(
+		core.NewPdfName("FlateDecode"),
+		core.NewPdfName("FlateDecode"),
+	))
+	if _, ok := classifyForRecompress(s); ok {
+		t.Error("[/FlateDecode /FlateDecode] chain classified as eligible")
+	}
+}
+
+func TestClassifyForRecompress_EmptyFilterArray(t *testing.T) {
+	// /Filter [] is not strictly forbidden by §7.4.2 (empty filter
+	// chain = no filtering applied) but is not standard. The
+	// classifier must not treat it as the "single FlateDecode" case.
+	s := core.NewPdfStream(nil)
+	s.Dict.Set("Filter", core.NewPdfArray())
+	if _, ok := classifyForRecompress(s); ok {
+		t.Error("/Filter [] (empty array) classified as eligible")
+	}
+}
+
+func TestRecompressStreams_OrphansDroppedBeforeRecompressVisit(t *testing.T) {
+	// When OrphanSweep + RecompressStreams are both enabled, the
+	// sweep must run first so the recompression pass does not waste
+	// effort on orphan streams. We invoke the passes directly (in
+	// order) and assert the orphan is gone before recompress visits.
+	w := minimalCatalogWriter(t)
+	addRawStream(t, w, bytes.Repeat([]byte("keep "), 200))
+	orphan := core.NewPdfStream(bytes.Repeat([]byte("drop "), 400))
+	w.AddObject(orphan)
+	preCount := len(w.objects)
+
+	w.sweepOrphans()
+	if len(w.objects) >= preCount {
+		t.Fatalf("sweep did not drop orphan: pre=%d, post=%d", preCount, len(w.objects))
+	}
+	for _, obj := range w.objects {
+		if obj.Object == orphan {
+			t.Fatal("orphan still present after sweep; recompress would visit it")
+		}
+	}
+
+	// Now recompress runs against the post-sweep object set — the
+	// orphan body cannot be visited because it is no longer in
+	// w.objects.
+	w.recompressStreams()
+}
+
+func TestRecompressStreams_DocumentAPIShrinksWithSyntheticOrphan(t *testing.T) {
+	// End-to-end through the public Document API. We can't easily
+	// build a real reader-imported document inside this package
+	// without a circular import, so this test uses ToBytesWithOptions
+	// on a layout-built Document and verifies the toggle does not
+	// enlarge or break the output. The reader-imported size win is
+	// asserted by the e2e test in writer_optimize_size_test.go.
+	doc := buildSampleDocument(5)
+	plain, err := doc.ToBytes()
+	if err != nil {
+		t.Fatalf("plain: %v", err)
+	}
+	doc2 := buildSampleDocument(5)
+	rec, err := doc2.ToBytesWithOptions(WriteOptions{RecompressStreams: true})
+	if err != nil {
+		t.Fatalf("recompressed: %v", err)
+	}
+	if len(rec) > len(plain) {
+		t.Errorf("RecompressStreams enlarged a layout-built document: plain=%d, rec=%d",
+			len(plain), len(rec))
+	}
+	if !bytes.HasPrefix(rec, []byte("%PDF-")) {
+		t.Error("missing PDF header")
+	}
+	if !bytes.HasSuffix(rec, []byte("EOF\n")) {
+		t.Error("missing EOF marker")
+	}
+}

--- a/document/writer_xref_stream.go
+++ b/document/writer_xref_stream.go
@@ -52,6 +52,38 @@ type WriteOptions struct {
 	// interaction with the standard security handler has not yet been
 	// implemented.
 	OrphanSweep bool
+
+	// RecompressStreams re-Flate-compresses eligible stream payloads
+	// at zlib.BestCompression and commits the rewrite only when it
+	// produces a strictly smaller payload (size-regression guarded).
+	// Eligibility (per ISO 32000-1 §7.4):
+	//
+	//   - Streams with no /Filter — payload is raw bytes; Flate is
+	//     applied and /Filter /FlateDecode is set.
+	//   - Streams whose /Filter is exactly /FlateDecode — payload is
+	//     inflated, re-deflated at higher effort, and committed only
+	//     on shrink. Useful when the original producer used a lower
+	//     zlib level than BestCompression.
+	//
+	// Streams whose filter chain contains /DCTDecode (§7.4.8),
+	// /JPXDecode (§7.4.9), /CCITTFaxDecode (§7.4.7), or /JBIG2Decode
+	// (§7.4.8) are skipped — those payloads are already specialized-
+	// compressed and Flate would inflate them. Multi-filter chains
+	// other than the eligible cases above are also skipped. FlateDecode
+	// streams that carry a /DecodeParms entry (most commonly a PNG or
+	// TIFF predictor per §7.4.4.4) are skipped because the inflated
+	// payload is predictor-filtered bytes, not plaintext, and a safe
+	// re-deflate would require re-applying the predictor inversion.
+	//
+	// Currently refused on encrypted documents: rewriting payload
+	// bytes after the encryption walk would emit ciphertext that
+	// decrypts to the wrong plaintext, and rewriting before the
+	// walk requires the encryption code to revisit each rewritten
+	// stream — both deferred until needed.
+	//
+	// Lossless and safe to combine with UseXRefStream,
+	// UseObjectStreams, and OrphanSweep.
+	RecompressStreams bool
 }
 
 // WriteToWithOptions is the option-aware variant of WriteTo. WriteTo is
@@ -83,11 +115,25 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 		// the keys for every renumbered entry.
 		return 0, fmt.Errorf("writer: orphan sweep is not supported on encrypted documents")
 	}
+	if opts.RecompressStreams && w.encryptor != nil {
+		// Same defense as the sweep refusal above: rewriting payload
+		// bytes interacts with the encryption walk in subtle ways
+		// (encrypted ciphertext decrypts only against the bytes that
+		// were encrypted). Refuse before any mutation so a retry
+		// without RecompressStreams is unaffected.
+		return 0, fmt.Errorf("writer: stream recompression is not supported on encrypted documents")
+	}
 	if opts.OrphanSweep {
 		// Sweep before the encryption walk so encryption uses the new
 		// numbers. With encryption refused above the order is currently
 		// moot, but the placement encodes the intended invariant.
 		w.sweepOrphans()
+	}
+	if opts.RecompressStreams {
+		// Recompress AFTER the sweep: orphan streams should not be
+		// recompressed only to be dropped. AFTER sweep also means
+		// after renumbering, but recompression is renumber-agnostic.
+		w.recompressStreams()
 	}
 
 	// Encrypt all user objects in place. Done before serialization so

--- a/examples/optimize/main.go
+++ b/examples/optimize/main.go
@@ -3,15 +3,17 @@
 
 // Optimize compares the default writer with the optimized writer
 // (cross-reference streams per ISO 32000-1 §7.5.8 plus object streams
-// per ISO 32000-1 §7.5.7) across several document shapes and reports
-// the byte-size delta for each.
+// per ISO 32000-1 §7.5.7, orphan sweep over §7.5.4 reachability, and
+// Flate recompression of eligible payloads per §7.4.4) across several
+// document shapes and reports the byte-size delta for each.
 //
 // The compression ratio depends heavily on what the document contains:
-// content streams are already Flate-compressed and ineligible for
-// object stream packing, so text-heavy documents save less than
-// metadata-heavy documents. The fixture set in this example is chosen
-// to surface that difference, so callers can decide whether the
-// optimizer is worth turning on for their workload.
+// content streams produced by Folio's writer are already at
+// zlib.BestCompression and cannot benefit from re-deflate, so layout-
+// built documents see most of their gains from object-stream packing
+// and the orphan sweep. Imported documents (built by parsing a source
+// PDF and copying pages into a new Document) carry their content
+// streams in raw plaintext form — that is where recompression wins big.
 //
 // Usage:
 //
@@ -19,12 +21,14 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
 	"github.com/carlos7ags/folio/document"
 	"github.com/carlos7ags/folio/font"
 	"github.com/carlos7ags/folio/layout"
+	"github.com/carlos7ags/folio/reader"
 )
 
 // fixture is one row of the comparison table.
@@ -86,23 +90,51 @@ func tableHeavy() *document.Document {
 	return doc
 }
 
+// importedTextHeavy builds the text-heavy document, writes it, parses
+// the result, and imports every page into a fresh Document. The output
+// document carries content streams in raw form — exactly the shape
+// where Flate recompression on write produces a large win.
+func importedTextHeavy() *document.Document {
+	src := textHeavy()
+	var buf bytes.Buffer
+	if _, err := src.WriteTo(&buf); err != nil {
+		panic(fmt.Errorf("source write: %w", err))
+	}
+	r, err := reader.Parse(buf.Bytes())
+	if err != nil {
+		panic(fmt.Errorf("source parse: %w", err))
+	}
+	out := document.NewDocument(document.PageSizeLetter)
+	out.Info.Title = "Imported text-heavy fixture"
+	for i := 0; i < r.PageCount(); i++ {
+		srcPage, _ := r.Page(i)
+		cs, _ := srcPage.ContentStream()
+		res, _ := srcPage.Resources()
+		p := out.AddPage()
+		p.ImportPage(cs, res, srcPage.Width, srcPage.Height)
+	}
+	return out
+}
+
 // writeAll serializes the fixture in each comparison mode:
 //
 //   - default: traditional xref table and trailer (§7.5.4 / §7.5.5).
 //   - xref+obj: cross-reference stream (§7.5.8) plus object streams (§7.5.7).
 //   - +sweep: also drops indirect objects unreachable from /Root, /Info,
 //     and /Encrypt before serialization.
-func writeAll(f fixture) (defaultBytes, packedBytes, sweptBytes []byte, err error) {
+//   - +recompress: also re-Flate-compresses eligible stream payloads
+//     (§7.4.4) at zlib.BestCompression.
+func writeAll(f fixture) (defaultBytes, packedBytes, sweptBytes, recompressBytes []byte, err error) {
 	defaultBytes, err = f.build().ToBytes()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("%s default: %w", f.name, err)
+		return nil, nil, nil, nil, fmt.Errorf("%s default: %w", f.name, err)
 	}
 	packedBytes, err = f.build().ToBytesWithOptions(document.WriteOptions{
 		UseXRefStream:    true,
 		UseObjectStreams: true,
 	})
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("%s xref+obj: %w", f.name, err)
+		return nil, nil, nil, nil, fmt.Errorf("%s xref+obj: %w", f.name, err)
 	}
 	sweptBytes, err = f.build().ToBytesWithOptions(document.WriteOptions{
 		UseXRefStream:    true,
@@ -110,9 +142,18 @@ func writeAll(f fixture) (defaultBytes, packedBytes, sweptBytes []byte, err erro
 		OrphanSweep:      true,
 	})
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("%s +sweep: %w", f.name, err)
+		return nil, nil, nil, nil, fmt.Errorf("%s +sweep: %w", f.name, err)
 	}
-	return defaultBytes, packedBytes, sweptBytes, nil
+	recompressBytes, err = f.build().ToBytesWithOptions(document.WriteOptions{
+		UseXRefStream:     true,
+		UseObjectStreams:  true,
+		OrphanSweep:       true,
+		RecompressStreams: true,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("%s +recompress: %w", f.name, err)
+	}
+	return defaultBytes, packedBytes, sweptBytes, recompressBytes, nil
 }
 
 func main() {
@@ -120,27 +161,29 @@ func main() {
 		{name: "text-heavy", build: textHeavy},
 		{name: "many empty pages", build: manyPages},
 		{name: "table-heavy", build: tableHeavy},
+		{name: "imported text-heavy", build: importedTextHeavy},
 	}
 
-	fmt.Printf("%-20s %12s %12s %12s %10s\n",
-		"fixture", "default", "xref+obj", "+sweep", "saved")
-	fmt.Println("-------------------- ------------ ------------ ------------ ----------")
+	fmt.Printf("%-22s %12s %12s %12s %12s %10s\n",
+		"fixture", "default", "xref+obj", "+sweep", "+recompress", "saved")
+	fmt.Println("---------------------- ------------ ------------ ------------ ------------ ----------")
 
 	for _, f := range fixtures {
-		def, packed, swept, err := writeAll(f)
+		def, packed, swept, recompress, err := writeAll(f)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
-		saved := len(def) - len(swept)
+		saved := len(def) - len(recompress)
 		pct := 100.0 * float64(saved) / float64(len(def))
-		fmt.Printf("%-20s %10d B %10d B %10d B %8.1f %%\n",
-			f.name, len(def), len(packed), len(swept), pct)
+		fmt.Printf("%-22s %10d B %10d B %10d B %10d B %8.1f %%\n",
+			f.name, len(def), len(packed), len(swept), len(recompress), pct)
 	}
 
-	// Write the text-heavy fixture to disk so the user has concrete
-	// files to inspect with qpdf or any PDF viewer.
-	def, _, swept, err := writeAll(fixtures[0])
+	// Write the imported fixture to disk so the user has concrete files
+	// to inspect with qpdf or any PDF viewer. The imported case is
+	// where the optimizer's win is most visible.
+	def, _, _, recompress, err := writeAll(fixtures[len(fixtures)-1])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -149,10 +192,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "write default file: %v\n", err)
 		os.Exit(1)
 	}
-	if err := os.WriteFile("optimize-compressed.pdf", swept, 0o644); err != nil {
+	if err := os.WriteFile("optimize-compressed.pdf", recompress, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "write optimized file: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Println()
-	fmt.Println("wrote optimize-default.pdf and optimize-compressed.pdf (text-heavy fixture)")
+	fmt.Println("wrote optimize-default.pdf and optimize-compressed.pdf (imported text-heavy fixture)")
 }

--- a/integration/recompress_import_test.go
+++ b/integration/recompress_import_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// TestRecompressShrinksImportedDocument verifies the headline use case
+// for WriteOptions.RecompressStreams: a document built by importing
+// pages from a parsed source PDF carries the source's content streams
+// in raw form (reader/import.go inflates and copies, but does not
+// re-Flate). Recompression on write must shrink the output.
+//
+// This is the only use case where the win is large enough to assert
+// numerically; layout-built documents already write streams at
+// BestCompression and would see ~0% improvement.
+func TestRecompressShrinksImportedDocument(t *testing.T) {
+	// Build a content-rich source document. Using NewParagraph repeatedly
+	// inflates the content stream past Flate's overhead so the test is
+	// robust to small per-stream overhead.
+	source := document.NewDocument(document.PageSizeLetter)
+	for i := 0; i < 5; i++ {
+		source.Add(layout.NewHeading(
+			fmt.Sprintf("Section %d", i+1),
+			layout.H1,
+		))
+		source.Add(layout.NewParagraph(
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do "+
+				"eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut "+
+				"enim ad minim veniam, quis nostrud exercitation ullamco laboris "+
+				"nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor "+
+				"in reprehenderit in voluptate velit esse cillum dolore eu fugiat "+
+				"nulla pariatur. Excepteur sint occaecat cupidatat non proident.",
+			font.Helvetica, 11,
+		))
+	}
+	var sourceBuf bytes.Buffer
+	if _, err := source.WriteTo(&sourceBuf); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	// Re-parse the source.
+	r, err := reader.Parse(sourceBuf.Bytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	if r.PageCount() == 0 {
+		t.Fatal("source has no pages")
+	}
+
+	// buildImportedDoc constructs a fresh Document by importing every
+	// page of the parsed source. The resulting Writer holds raw
+	// (uncompressed, no /Filter) content streams the recompression
+	// pass should be able to shrink.
+	buildImportedDoc := func() *document.Document {
+		imported := document.NewDocument(document.PageSizeLetter)
+		for i := 0; i < r.PageCount(); i++ {
+			srcPage, err := r.Page(i)
+			if err != nil {
+				t.Fatalf("source page %d: %v", i, err)
+			}
+			cs, err := srcPage.ContentStream()
+			if err != nil {
+				t.Fatalf("content stream %d: %v", i, err)
+			}
+			res, _ := srcPage.Resources()
+			p := imported.AddPage()
+			p.ImportPage(cs, res, srcPage.Width, srcPage.Height)
+		}
+		return imported
+	}
+
+	plain, err := buildImportedDoc().ToBytes()
+	if err != nil {
+		t.Fatalf("plain write: %v", err)
+	}
+	recompressed, err := buildImportedDoc().ToBytesWithOptions(document.WriteOptions{
+		RecompressStreams: true,
+	})
+	if err != nil {
+		t.Fatalf("recompressed write: %v", err)
+	}
+
+	if len(recompressed) >= len(plain) {
+		t.Errorf("RecompressStreams did not shrink imported document: plain=%d, recompressed=%d",
+			len(plain), len(recompressed))
+	}
+
+	// Round-trip the recompressed output to confirm it is still a
+	// well-formed PDF with the same page count. A bug that produced
+	// "smaller" but corrupt bytes (e.g., truncated content streams)
+	// would fail page-count and reparse.
+	rr, err := reader.Parse(recompressed)
+	if err != nil {
+		t.Fatalf("re-parse recompressed: %v", err)
+	}
+	if rr.PageCount() != r.PageCount() {
+		t.Errorf("recompressed page count = %d, want %d", rr.PageCount(), r.PageCount())
+	}
+
+	// Content-equality: a bug that produced "smaller" but text-
+	// corrupt bytes would survive page-count and reparse but fail
+	// here. We compare extracted text page-by-page against the
+	// pre-recompression import (which we already know preserves the
+	// original content correctly, since recompression is the only
+	// new variable between the two writes).
+	rPlain, err := reader.Parse(plain)
+	if err != nil {
+		t.Fatalf("re-parse plain: %v", err)
+	}
+	for i := 0; i < r.PageCount(); i++ {
+		plainPage, _ := rPlain.Page(i)
+		recPage, _ := rr.Page(i)
+		plainText, err := plainPage.ExtractText()
+		if err != nil {
+			t.Fatalf("ExtractText plain page %d: %v", i, err)
+		}
+		recText, err := recPage.ExtractText()
+		if err != nil {
+			t.Fatalf("ExtractText recompressed page %d: %v", i, err)
+		}
+		if plainText != recText {
+			t.Errorf("page %d text differs after recompression\n--- plain (%d chars) ---\n%s\n--- recompressed (%d chars) ---\n%s",
+				i, len(plainText), plainText, len(recText), recText)
+		}
+	}
+
+	t.Logf("imported document: plain=%d bytes, recompressed=%d bytes (saved %.1f%%)",
+		len(plain), len(recompressed),
+		100.0*float64(len(plain)-len(recompressed))/float64(len(plain)))
+}
+
+// TestRecompressComposesWithSweepOnImportedDocument verifies the full
+// optimizer stack on an imported document: orphan sweep + recompression
+// + xref/object streams together must produce strictly smaller output
+// than any subset, and the result must round-trip cleanly.
+func TestRecompressComposesWithSweepOnImportedDocument(t *testing.T) {
+	source := document.NewDocument(document.PageSizeLetter)
+	for i := 0; i < 8; i++ {
+		source.Add(layout.NewHeading(fmt.Sprintf("Heading %d", i+1), layout.H1))
+		source.Add(layout.NewParagraph(
+			"Body text body text body text body text body text body text body text. "+
+				"More body text here to give the content stream some real bulk.",
+			font.Helvetica, 11,
+		))
+	}
+	var sourceBuf bytes.Buffer
+	if _, err := source.WriteTo(&sourceBuf); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	r, err := reader.Parse(sourceBuf.Bytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+
+	buildImported := func() *document.Document {
+		imported := document.NewDocument(document.PageSizeLetter)
+		for i := 0; i < r.PageCount(); i++ {
+			srcPage, _ := r.Page(i)
+			cs, _ := srcPage.ContentStream()
+			res, _ := srcPage.Resources()
+			p := imported.AddPage()
+			p.ImportPage(cs, res, srcPage.Width, srcPage.Height)
+		}
+		return imported
+	}
+
+	plain, _ := buildImported().ToBytes()
+	full, err := buildImported().ToBytesWithOptions(document.WriteOptions{
+		UseXRefStream:     true,
+		UseObjectStreams:  true,
+		OrphanSweep:       true,
+		RecompressStreams: true,
+	})
+	if err != nil {
+		t.Fatalf("full optimizer: %v", err)
+	}
+
+	if len(full) >= len(plain) {
+		t.Errorf("full optimizer did not shrink: plain=%d, full=%d", len(plain), len(full))
+	}
+	if _, err := reader.Parse(full); err != nil {
+		t.Fatalf("re-parse full-optimizer output: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #203. Adds the second integration of the optimizer's lossless rewrite passes and the first real caller of the size-regression guard primitive shipped in #202.

- **\`WriteOptions.RecompressStreams\`** — walks every registered indirect object, finds eligible \`PdfStream\` payloads, and re-Flate-compresses them at \`zlib.BestCompression\`. The size-regression guard reverts any rewrite that fails to produce strictly smaller output.
- **Eligibility (ISO 32000-1 §7.4):**
  - No \`/Filter\`: deflate raw payload, set \`/Filter /FlateDecode\`. The headline use case — content streams imported from a parsed source PDF, which \`reader/import.go\` preserves in raw plaintext form.
  - Single \`/Filter /FlateDecode\` (without \`/DecodeParms\`): inflate, re-deflate at \`BestCompression\`. Useful when the original producer used a lower zlib level.
  - Skipped: \`/DCTDecode\` (§7.4.8), \`/JPXDecode\` (§7.4.9), \`/CCITTFaxDecode\` (§7.4.7), \`/JBIG2Decode\` (§7.4.8), multi-filter chains, malformed \`/Filter\`, FlateDecode with \`/DecodeParms\` (§7.4.4.4 predictor handling), and streams the writer is already going to compress at BestCompression (\`compress=true\`).
- **Refused on encrypted documents** — refusal runs before any mutation so a retry without the option is unaffected.
- **Composes** with \`UseXRefStream\`, \`UseObjectStreams\`, and \`OrphanSweep\`. Pass order: sweep → recompress → encrypt → serialize.

## Headline number

End-to-end on an imported text-heavy fixture: **40,569 → 6,376 bytes (84.3% saved)**. Verified text-equality round-trip across all extracted page text.

## Critical correctness fix from review

Both review subagents independently flagged that a Flate stream with \`/DecodeParms /Predictor\` (PNG/TIFF predictor per §7.4.4.4) carries predictor-filtered bytes after inflation, not plaintext. Re-deflating those bytes and dropping \`/DecodeParms\` would silently corrupt data in any reader that honors the predictor contract. Fixed by treating any FlateDecode stream with \`/DecodeParms\` as ineligible. Direct classifier test + pass-level test pin the contract.

## Other review findings addressed

- Triple-guard refusal (encrypt + UseObjectStreams + RecompressStreams) — added test pinning state-unmutated invariant.
- Orphan-dropped-before-recompress-visit ordering — added test inspecting \`w.objects\` between passes.
- Stale \`/Length\` overwrite — added test pinning that \`PdfStream.WriteTo\` overwrites a manually-set wrong \`/Length\`.
- Classifier coverage extended to non-name non-array \`/Filter\` shapes (Null, Dictionary, Boolean, Integer, String, IndirectReference), \`/Filter [/FlateDecode /FlateDecode]\` chains, and \`/Filter []\` empty arrays.
- E2E imported-document test now compares extracted text page-by-page in addition to page count + structural reparse.

## API additions

- \`document.WriteOptions.RecompressStreams bool\`
- \`core.DeflateStreamData([]byte) ([]byte, error)\` — exported (renamed from previously-unexported \`deflate\`).
- \`core.InflateStreamData([]byte) ([]byte, error)\` — symmetric inverse, the writer-side counterpart to the reader's size-bounded inflate.
- \`core.PdfStream.WillCompress() bool\` — getter matching the existing \`SetCompress(bool)\` setter, used by the recompress pass to skip streams the writer will already deflate.

## Test plan

- [x] \`go test ./...\` clean
- [x] \`go vet ./...\` clean
- [x] 28 unit tests in \`document/writer_recompress_test.go\` cover: shrink-on-raw, re-Flate-on-BestSpeed, guard reverts random bytes, all four specialized-filter skips, multi-filter skip, **predictor-bearing skip (the P0 fix)**, malformed \`/Filter\` shapes, empty/Flate-Flate arrays, encryption refusal with state invariants, triple-guard refusal, idempotence on serialized bytes, byte-identical zero-options output, composition with sweep + xref + objstm, structural reparse, round-trip-to-plaintext correctness on both raw and Flate paths, stale \`/Length\` overwrite.
- [x] 2 e2e tests in \`integration/\` round-trip an imported document and verify shrink + page-count + extracted-text equality.
- [x] \`go run ./examples/optimize\` shows the new \`+recompress\` column with 84.3% savings on the imported fixture.