### PR TITLE
optimize: structural deduplication + content stream operator cleanup

### DIFF
--- a/document/writer_content_cleanup.go
+++ b/document/writer_content_cleanup.go
@@ -1,0 +1,647 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"bytes"
+
+	"github.com/carlos7ags/folio/core"
+)
+
+// cleanContentStreams removes redundant operators from page content
+// streams (ISO 32000-1 §7.8). Two patterns are recognized in this
+// first cut:
+//
+//   - Empty `q` ... `Q` graphics-state save/restore pairs. A `q`
+//     followed by nothing but whitespace and another `Q` saves and
+//     restores state for no observable effect; both operators are
+//     dropped.
+//   - Identity `1 0 0 1 0 0 cm` matrix concatenations (§8.3.3 — the
+//     identity matrix). Concatenating the identity with the current
+//     transformation matrix is a no-op; the operator is dropped.
+//
+// Eligibility is restricted to streams referenced from a page
+// dictionary's /Contents entry. Other streams (font programs,
+// XObjects, ICC profiles, image data, ToUnicode CMaps) are left
+// alone — they have different syntactic conventions and the safe
+// rewrites listed above only apply to content streams.
+//
+// The size-regression guard reverts any rewrite whose cleaned payload
+// is not strictly smaller than the original. Streams whose payload
+// is already FlateDecode-compressed at this point are skipped — the
+// content cleanup operates on the raw operator text and would need
+// an inflate before any rewrite. The recompression pass runs after
+// cleanup, so cleaning before compression is the natural order.
+//
+// Encrypted documents are refused upstream; the defensive guard at
+// the top of this method matches the contract of the other passes.
+func (w *Writer) cleanContentStreams() {
+	if len(w.objects) == 0 {
+		return
+	}
+	if w.encryptor != nil {
+		return
+	}
+
+	// Identify content stream object numbers by walking page dicts.
+	contentNums := contentStreamObjectNumbers(w.objects)
+	if len(contentNums) == 0 {
+		return
+	}
+
+	for _, obj := range w.objects {
+		if !contentNums[obj.ObjectNumber] {
+			continue
+		}
+		stream, ok := obj.Object.(*core.PdfStream)
+		if !ok {
+			continue
+		}
+		if stream.Dict.Get("Filter") != nil {
+			// Already-compressed content stream. Cleanup needs the
+			// raw operator text; defer until decompression — out of
+			// scope for this pass.
+			continue
+		}
+		cleanOneContentStream(stream)
+	}
+}
+
+// cleanOneContentStream attempts to remove redundant operators from a
+// single content stream's payload. Mutates the stream in place on
+// commit; leaves it untouched when the cleaned payload is not
+// strictly smaller (size-regression guard).
+func cleanOneContentStream(stream *core.PdfStream) {
+	original := stream.Data
+	if len(original) == 0 {
+		return
+	}
+
+	cleaned, err := sizeRegressionGuard(original, func() ([]byte, error) {
+		return cleanContentStreamBytes(original), nil
+	})
+	if err != nil {
+		return
+	}
+	if len(cleaned) >= len(original) {
+		return
+	}
+	stream.Data = cleaned
+}
+
+// contentStreamObjectNumbers walks the registered objects and returns
+// the set of object numbers reachable as page /Contents references.
+// Per ISO 32000-1 §7.7.3.3, /Contents is either a single stream or
+// an array of streams; both forms are handled.
+func contentStreamObjectNumbers(objects []IndirectObject) map[int]bool {
+	out := make(map[int]bool)
+	for _, obj := range objects {
+		dict, ok := obj.Object.(*core.PdfDictionary)
+		if !ok {
+			continue
+		}
+		if !isPageDict(dict) {
+			continue
+		}
+		contents := dict.Get("Contents")
+		if contents == nil {
+			continue
+		}
+		collectContentRefs(contents, out)
+	}
+	return out
+}
+
+// isPageDict reports whether a dictionary has /Type /Page. We do not
+// look at /Subtype because Page dicts do not carry one.
+func isPageDict(d *core.PdfDictionary) bool {
+	t, ok := d.Get("Type").(*core.PdfName)
+	return ok && t.Value == "Page"
+}
+
+// collectContentRefs walks the value of a /Contents entry, adding
+// every PdfIndirectReference's target to the set. The entry can be
+// a single reference or an array of references per §7.7.3.3.
+func collectContentRefs(value core.PdfObject, set map[int]bool) {
+	switch v := value.(type) {
+	case *core.PdfIndirectReference:
+		set[v.Num()] = true
+	case *core.PdfArray:
+		for _, elem := range v.All() {
+			if ref, ok := elem.(*core.PdfIndirectReference); ok {
+				set[ref.Num()] = true
+			}
+		}
+	}
+}
+
+// cleanContentStreamBytes returns the input with redundant operators
+// removed. The current rules:
+//
+//   - Drop every `1 0 0 1 0 0 cm` operator (identity transform).
+//   - Drop every `q` ... `Q` pair whose body is whitespace-only.
+//
+// The function is byte-faithful for everything else: comments,
+// strings, hex strings, names, and operands are preserved verbatim.
+// Multiple cleanup passes are applied iteratively until a fixed point
+// is reached (a Q-cleaning pass can expose a previously-nested empty
+// q/Q whose body was just `q Q`).
+func cleanContentStreamBytes(data []byte) []byte {
+	const maxPasses = 8
+	current := data
+	for i := 0; i < maxPasses; i++ {
+		next := cleanContentStreamOnePass(current)
+		if bytes.Equal(next, current) {
+			break
+		}
+		current = next
+	}
+	return current
+}
+
+// cleanContentStreamOnePass walks the byte stream once, dropping
+// identity-cm and empty-q/Q occurrences. Returns the rewritten bytes.
+func cleanContentStreamOnePass(data []byte) []byte {
+	tokens := scanContentTokens(data)
+	if len(tokens) == 0 {
+		return data
+	}
+
+	// Build a set of token indices to drop.
+	drop := make(map[int]bool)
+
+	// Pass A: identity cm. Pattern is six numeric operand tokens
+	// (1 0 0 1 0 0) followed by an "cm" operator token.
+	for i := 6; i < len(tokens); i++ {
+		if tokens[i].kind != tokenOperator {
+			continue
+		}
+		if !bytes.Equal(tokens[i].slice(data), []byte("cm")) {
+			continue
+		}
+		if isIdentityCmOperands(data, tokens[i-6:i]) {
+			for j := i - 6; j <= i; j++ {
+				drop[j] = true
+			}
+		}
+	}
+
+	// Pass B: empty q/Q. A `q` operator followed (after only
+	// whitespace, no other tokens) by a `Q` operator — drop both.
+	for i := 0; i < len(tokens)-1; i++ {
+		if drop[i] {
+			continue
+		}
+		if tokens[i].kind != tokenOperator {
+			continue
+		}
+		if !bytes.Equal(tokens[i].slice(data), []byte("q")) {
+			continue
+		}
+		// Find the next non-dropped token.
+		next := -1
+		for j := i + 1; j < len(tokens); j++ {
+			if drop[j] {
+				continue
+			}
+			next = j
+			break
+		}
+		if next < 0 {
+			continue
+		}
+		if tokens[next].kind != tokenOperator {
+			continue
+		}
+		if !bytes.Equal(tokens[next].slice(data), []byte("Q")) {
+			continue
+		}
+		drop[i] = true
+		drop[next] = true
+	}
+
+	if len(drop) == 0 {
+		return data
+	}
+
+	// Build the output by skipping every byte range that belongs to a
+	// dropped token plus the trailing whitespace separator that
+	// followed the token.
+	var buf bytes.Buffer
+	buf.Grow(len(data))
+	pos := 0
+	for i, tok := range tokens {
+		if !drop[i] {
+			continue
+		}
+		// Emit the run from the previous cursor up to (but not
+		// including) this dropped token's start.
+		buf.Write(data[pos:tok.start])
+		// Skip the token itself plus any contiguous whitespace that
+		// followed it (so dropping `q\n` does not leave a stray
+		// blank line). Stop at any non-whitespace byte.
+		pos = tok.end
+		for pos < len(data) && isContentWhitespace(data[pos]) {
+			pos++
+		}
+	}
+	buf.Write(data[pos:])
+	return buf.Bytes()
+}
+
+// isIdentityCmOperands reports whether six operand tokens are exactly
+// the literal sequence 1 0 0 1 0 0 — the identity transformation
+// matrix per §8.3.3.
+func isIdentityCmOperands(data []byte, operands []contentToken) bool {
+	want := []string{"1", "0", "0", "1", "0", "0"}
+	for i, tok := range operands {
+		if tok.kind != tokenNumber {
+			return false
+		}
+		if string(tok.slice(data)) != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// contentTokenKind names the lexical class of a content-stream token.
+type contentTokenKind int
+
+const (
+	tokenOperator contentTokenKind = iota // bare keyword (q, Q, Tj, cm, ...)
+	tokenNumber                           // numeric literal (1, -2.5, .42)
+	tokenString                           // (...) or <hex>
+	tokenName                             // /Name
+	tokenArray                            // [...]
+	tokenDict                             // <<...>>
+)
+
+// contentToken records the byte range and lexical kind of a single
+// token in a content stream. The slice helper extracts the bytes.
+type contentToken struct {
+	start, end int
+	kind       contentTokenKind
+}
+
+// slice returns the token's bytes from the source data.
+func (t contentToken) slice(data []byte) []byte { return data[t.start:t.end] }
+
+// scanContentTokens lexes a content stream into tokens. The lexer
+// recognizes only the syntactic shapes needed to identify operator
+// boundaries safely; deeper analysis (operand types, string contents)
+// is left to higher-level callers.
+//
+// The lexer skips:
+//
+//   - Whitespace (space, tab, LF, CR, FF, NUL per §7.2.3).
+//   - Comments (% to end of line per §7.2.4).
+//
+// And it recognizes the literal forms:
+//
+//   - Numbers: optional sign + digits with optional decimal point.
+//   - Names: / followed by regular characters.
+//   - Strings: balanced parenthesis-delimited bytes with escape
+//     handling so `(\))` is one token.
+//   - Hex strings: <...>.
+//   - Arrays: [...] (whole bracket span is one token).
+//   - Dictionaries: <<...>> (whole span is one token).
+//   - Operators: any other run of regular characters not matched above.
+//
+// The lexer is faithful: a token's bytes can be extracted with
+// data[token.start:token.end] and concatenating all tokens with the
+// surviving whitespace produces the original stream.
+func scanContentTokens(data []byte) []contentToken {
+	var tokens []contentToken
+	i := 0
+	for i < len(data) {
+		// Skip whitespace.
+		for i < len(data) && isContentWhitespace(data[i]) {
+			i++
+		}
+		if i >= len(data) {
+			break
+		}
+		// Skip comments.
+		if data[i] == '%' {
+			for i < len(data) && data[i] != '\n' && data[i] != '\r' {
+				i++
+			}
+			continue
+		}
+		start := i
+		switch {
+		case data[i] == '(':
+			i = skipString(data, i)
+			tokens = append(tokens, contentToken{start, i, tokenString})
+		case data[i] == '<' && i+1 < len(data) && data[i+1] == '<':
+			i = skipDict(data, i)
+			tokens = append(tokens, contentToken{start, i, tokenDict})
+		case data[i] == '<':
+			i = skipHexString(data, i)
+			tokens = append(tokens, contentToken{start, i, tokenString})
+		case data[i] == '[':
+			i = skipArray(data, i)
+			tokens = append(tokens, contentToken{start, i, tokenArray})
+		case data[i] == '/':
+			i++
+			for i < len(data) && isRegularChar(data[i]) {
+				i++
+			}
+			tokens = append(tokens, contentToken{start, i, tokenName})
+		case isNumberStart(data, i):
+			i = skipNumber(data, i)
+			tokens = append(tokens, contentToken{start, i, tokenNumber})
+		default:
+			// Bare keyword — the operator.
+			for i < len(data) && isRegularChar(data[i]) {
+				i++
+			}
+			if i == start {
+				// Unrecognized byte; skip to avoid infinite loop.
+				i++
+				continue
+			}
+			tokens = append(tokens, contentToken{start, i, tokenOperator})
+			// Inline image (§8.9.7): BI begins an inline image, ID
+			// introduces its raw byte payload, EI terminates it. The
+			// bytes between ID and EI are arbitrary image data and
+			// MUST NOT be lexed as operators or operands; doing so
+			// would let cleanup match patterns inside the image.
+			if string(data[start:i]) == "BI" {
+				i = skipInlineImage(data, i)
+			}
+		}
+	}
+	return tokens
+}
+
+// isContentWhitespace reports the white-space bytes per ISO 32000-1
+// §7.2.3 Table 1: NUL, HT, LF, FF, CR, SP.
+func isContentWhitespace(b byte) bool {
+	return b == 0 || b == '\t' || b == '\n' || b == '\f' || b == '\r' || b == ' '
+}
+
+// isRegularChar reports the regular characters per §7.2.3 Table 2:
+// anything that is not whitespace and not one of the delimiters
+// ()<>[]{}/%.
+func isRegularChar(b byte) bool {
+	if isContentWhitespace(b) {
+		return false
+	}
+	switch b {
+	case '(', ')', '<', '>', '[', ']', '{', '}', '/', '%':
+		return false
+	}
+	return true
+}
+
+// isNumberStart reports whether the byte at i could begin a numeric
+// literal: a digit, a decimal point, or a sign followed by either.
+func isNumberStart(data []byte, i int) bool {
+	if i >= len(data) {
+		return false
+	}
+	b := data[i]
+	if b >= '0' && b <= '9' {
+		return true
+	}
+	if b == '.' {
+		return i+1 < len(data) && data[i+1] >= '0' && data[i+1] <= '9'
+	}
+	if b == '+' || b == '-' {
+		if i+1 >= len(data) {
+			return false
+		}
+		next := data[i+1]
+		if next >= '0' && next <= '9' {
+			return true
+		}
+		if next == '.' {
+			return i+2 < len(data) && data[i+2] >= '0' && data[i+2] <= '9'
+		}
+	}
+	return false
+}
+
+// skipNumber advances past a numeric literal starting at i.
+func skipNumber(data []byte, i int) int {
+	if data[i] == '+' || data[i] == '-' {
+		i++
+	}
+	for i < len(data) {
+		b := data[i]
+		if (b >= '0' && b <= '9') || b == '.' {
+			i++
+			continue
+		}
+		break
+	}
+	return i
+}
+
+// skipString advances past a (...) literal string handling escapes
+// and balanced nested parentheses per §7.3.4.2.
+func skipString(data []byte, i int) int {
+	i++ // skip opening (
+	depth := 1
+	for i < len(data) && depth > 0 {
+		switch data[i] {
+		case '\\':
+			// Escape sequence — skip the next byte.
+			if i+1 < len(data) {
+				i += 2
+				continue
+			}
+			i++
+		case '(':
+			depth++
+			i++
+		case ')':
+			depth--
+			i++
+		default:
+			i++
+		}
+	}
+	return i
+}
+
+// skipHexString advances past a <...> hex string per §7.3.4.3.
+func skipHexString(data []byte, i int) int {
+	i++ // skip opening <
+	for i < len(data) && data[i] != '>' {
+		i++
+	}
+	if i < len(data) {
+		i++ // skip closing >
+	}
+	return i
+}
+
+// skipArray advances past a [...] array. The bracket span is treated
+// as one opaque token by the cleanup pass; we do not need to descend
+// into operand-position arrays (TJ argument arrays).
+func skipArray(data []byte, i int) int {
+	i++ // skip opening [
+	depth := 1
+	for i < len(data) && depth > 0 {
+		switch data[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+		case '(':
+			i = skipString(data, i)
+			continue
+		case '<':
+			if i+1 < len(data) && data[i+1] == '<' {
+				i = skipDict(data, i)
+			} else {
+				i = skipHexString(data, i)
+			}
+			continue
+		}
+		i++
+	}
+	return i
+}
+
+// skipInlineImage advances past the dictionary, ID introducer, raw
+// image bytes, and EI terminator of an inline image (§8.9.7). The
+// caller has already consumed the leading BI keyword and `i` points
+// at the byte just after BI.
+//
+// Algorithm:
+//
+//  1. Skip the inline image dictionary (key/value pairs) until the
+//     ID keyword. Keys and values are tokenized normally so a value
+//     that happens to look like ID does not terminate prematurely.
+//  2. After ID, the spec mandates exactly one whitespace byte before
+//     the raw image data starts. Some producers emit "\r\n" (two
+//     bytes); we tolerate both.
+//  3. Scan forward for "EI" preceded by whitespace and not embedded
+//     inside a longer keyword. Anything in between is opaque image
+//     bytes — do NOT tokenize.
+//
+// On EOF or malformed input the function returns the original
+// position so the outer lexer can recover gracefully (the inline
+// image is treated as already-consumed; the cleanup pass will leave
+// it alone because no operators were emitted from inside it).
+func skipInlineImage(data []byte, i int) int {
+	// Step 1: scan for the ID keyword.
+	for i < len(data) {
+		// Skip whitespace.
+		for i < len(data) && isContentWhitespace(data[i]) {
+			i++
+		}
+		if i >= len(data) {
+			return i
+		}
+		// Skip comments — same as the main lexer.
+		if data[i] == '%' {
+			for i < len(data) && data[i] != '\n' && data[i] != '\r' {
+				i++
+			}
+			continue
+		}
+		// A name (/Foo) or hex string (<...>) or string ((...)) or
+		// number — skip via the existing helpers.
+		switch {
+		case data[i] == '/':
+			i++
+			for i < len(data) && isRegularChar(data[i]) {
+				i++
+			}
+			continue
+		case data[i] == '(':
+			i = skipString(data, i)
+			continue
+		case data[i] == '<' && i+1 < len(data) && data[i+1] == '<':
+			i = skipDict(data, i)
+			continue
+		case data[i] == '<':
+			i = skipHexString(data, i)
+			continue
+		case data[i] == '[':
+			i = skipArray(data, i)
+			continue
+		case isNumberStart(data, i):
+			i = skipNumber(data, i)
+			continue
+		}
+		// Otherwise: a keyword. If it's ID, we're done with the dict.
+		start := i
+		for i < len(data) && isRegularChar(data[i]) {
+			i++
+		}
+		if i == start {
+			i++ // unrecognized byte; advance to avoid infinite loop
+			continue
+		}
+		if string(data[start:i]) == "ID" {
+			break
+		}
+		// Other keyword inside an inline-image dict is unexpected but
+		// not fatal; keep scanning for ID.
+	}
+	if i >= len(data) {
+		return i
+	}
+	// Step 2: a single whitespace byte (sometimes CRLF) before image data.
+	if i < len(data) && (data[i] == '\r' || data[i] == '\n' || data[i] == ' ' || data[i] == '\t') {
+		if data[i] == '\r' && i+1 < len(data) && data[i+1] == '\n' {
+			i += 2
+		} else {
+			i++
+		}
+	}
+	// Step 3: scan for EI preceded by whitespace.
+	for i < len(data)-1 {
+		if data[i] == 'E' && data[i+1] == 'I' {
+			// Check the preceding byte is whitespace (so we are at
+			// a token boundary, not inside a longer identifier).
+			prevOK := i == 0 || isContentWhitespace(data[i-1])
+			// Check the following byte is whitespace or EOF (so EI
+			// is a complete token).
+			nextOK := i+2 >= len(data) || isContentWhitespace(data[i+2])
+			if prevOK && nextOK {
+				return i + 2
+			}
+		}
+		i++
+	}
+	return len(data)
+}
+
+// skipDict advances past a <<...>> dictionary literal.
+func skipDict(data []byte, i int) int {
+	i += 2 // skip opening <<
+	depth := 1
+	for i < len(data) && depth > 0 {
+		if i+1 < len(data) && data[i] == '<' && data[i+1] == '<' {
+			depth++
+			i += 2
+			continue
+		}
+		if i+1 < len(data) && data[i] == '>' && data[i+1] == '>' {
+			depth--
+			i += 2
+			continue
+		}
+		switch data[i] {
+		case '(':
+			i = skipString(data, i)
+			continue
+		case '<':
+			i = skipHexString(data, i)
+			continue
+		case '[':
+			i = skipArray(data, i)
+			continue
+		}
+		i++
+	}
+	return i
+}

--- a/document/writer_content_cleanup_test.go
+++ b/document/writer_content_cleanup_test.go
@@ -1,0 +1,648 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/core"
+)
+
+// addPageWithContents builds a Page dict whose /Contents points at
+// the given content stream, and wires the Page into a kids array
+// reachable from /Root via the Pages tree.
+func addPageWithContents(t *testing.T, w *Writer, contentBytes []byte) (
+	pageRef, contentRef *core.PdfIndirectReference,
+	contentStream *core.PdfStream,
+) {
+	t.Helper()
+	contentStream = core.NewPdfStream(contentBytes)
+	contentRef = w.AddObject(contentStream)
+
+	page := core.NewPdfDictionary()
+	page.Set("Type", core.NewPdfName("Page"))
+	page.Set("Contents", contentRef)
+	pageRef = w.AddObject(page)
+
+	pagesDict := w.objects[1].Object.(*core.PdfDictionary) // catalog=1, pages=2
+	kids := pagesDict.Get("Kids").(*core.PdfArray)
+	kids.Add(pageRef)
+	pagesDict.Set("Count", core.NewPdfInteger(kids.Len()))
+	page.Set("Parent", w.objects[1].Object.(*core.PdfDictionary).Get("Type")) // dummy parent ok for test
+
+	return pageRef, contentRef, contentStream
+}
+
+// --- Direct lexer tests ---
+
+func TestScanContentTokens_BasicOperators(t *testing.T) {
+	data := []byte("q\n1 0 0 1 50 50 cm\nQ\n")
+	tokens := scanContentTokens(data)
+	if len(tokens) != 9 {
+		t.Fatalf("got %d tokens, want 9 (q + 6 numbers + cm + Q)", len(tokens))
+	}
+	if string(tokens[0].slice(data)) != "q" || tokens[0].kind != tokenOperator {
+		t.Errorf("token[0] = %q (kind %d), want q operator", tokens[0].slice(data), tokens[0].kind)
+	}
+	if string(tokens[7].slice(data)) != "cm" || tokens[7].kind != tokenOperator {
+		t.Errorf("token[7] = %q (kind %d), want cm operator", tokens[7].slice(data), tokens[7].kind)
+	}
+	if string(tokens[8].slice(data)) != "Q" || tokens[8].kind != tokenOperator {
+		t.Errorf("token[8] = %q, want Q operator", tokens[8].slice(data))
+	}
+}
+
+func TestScanContentTokens_SkipsCommentsAndStrings(t *testing.T) {
+	// A comment containing "cm" must not produce a cm operator token.
+	// A literal string containing "cm" must not either.
+	data := []byte("BT\n% this is cm in a comment\n(text with cm inside) Tj\nET\n")
+	tokens := scanContentTokens(data)
+
+	for _, tok := range tokens {
+		if tok.kind == tokenOperator && string(tok.slice(data)) == "cm" {
+			t.Errorf("token at [%d:%d] was misclassified as cm operator: %q",
+				tok.start, tok.end, tok.slice(data))
+		}
+	}
+	// Verify we still got the real operators.
+	gotBT, gotTj, gotET := false, false, false
+	for _, tok := range tokens {
+		if tok.kind != tokenOperator {
+			continue
+		}
+		switch string(tok.slice(data)) {
+		case "BT":
+			gotBT = true
+		case "Tj":
+			gotTj = true
+		case "ET":
+			gotET = true
+		}
+	}
+	if !gotBT || !gotTj || !gotET {
+		t.Errorf("missing operator: BT=%v Tj=%v ET=%v", gotBT, gotTj, gotET)
+	}
+}
+
+func TestScanContentTokens_HandlesEscapedAndNestedParens(t *testing.T) {
+	// PDF strings allow balanced nested parens and escaped delimiters
+	// per §7.3.4.2. The lexer must consume the whole literal as one
+	// token. The fixture has one paren pair escaped (so it does not
+	// affect depth) and an outer balanced pair.
+	data := []byte(`(hello \(world\) and more) Tj`)
+	tokens := scanContentTokens(data)
+	if len(tokens) != 2 {
+		t.Fatalf("got %d tokens, want 2: %+v", len(tokens), tokens)
+	}
+	if tokens[0].kind != tokenString {
+		t.Errorf("token[0] kind = %d, want string", tokens[0].kind)
+	}
+	if string(tokens[1].slice(data)) != "Tj" {
+		t.Errorf("token[1] = %q, want Tj", tokens[1].slice(data))
+	}
+}
+
+func TestScanContentTokens_HandlesActualNestedParens(t *testing.T) {
+	// Truly nested unescaped parens — depth tracking must produce
+	// one string token containing the inner pair.
+	data := []byte(`(outer (inner) end) Tj`)
+	tokens := scanContentTokens(data)
+	if len(tokens) != 2 {
+		t.Fatalf("got %d tokens, want 2: %+v", len(tokens), tokens)
+	}
+	if tokens[0].kind != tokenString {
+		t.Errorf("token[0] kind = %d, want string", tokens[0].kind)
+	}
+	if string(tokens[1].slice(data)) != "Tj" {
+		t.Errorf("token[1] = %q, want Tj", tokens[1].slice(data))
+	}
+}
+
+func TestScanContentTokens_HandlesArraysAndDicts(t *testing.T) {
+	data := []byte(`[(a) (b) (c)] TJ <</Length 5>> some_op`)
+	tokens := scanContentTokens(data)
+	if len(tokens) != 4 {
+		t.Fatalf("got %d tokens, want 4", len(tokens))
+	}
+	if tokens[0].kind != tokenArray {
+		t.Errorf("token[0] kind = %d, want array", tokens[0].kind)
+	}
+	if string(tokens[1].slice(data)) != "TJ" {
+		t.Errorf("token[1] = %q, want TJ", tokens[1].slice(data))
+	}
+	if tokens[2].kind != tokenDict {
+		t.Errorf("token[2] kind = %d, want dict", tokens[2].kind)
+	}
+	if string(tokens[3].slice(data)) != "some_op" {
+		t.Errorf("token[3] = %q, want some_op", tokens[3].slice(data))
+	}
+}
+
+func TestScanContentTokens_NumbersWithSignsAndDecimals(t *testing.T) {
+	data := []byte("1 -2 3.5 -4.5 .25 +6 m")
+	tokens := scanContentTokens(data)
+	if len(tokens) != 7 {
+		t.Fatalf("got %d tokens, want 7", len(tokens))
+	}
+	for i := 0; i < 6; i++ {
+		if tokens[i].kind != tokenNumber {
+			t.Errorf("token[%d] kind = %d, want number; bytes=%q",
+				i, tokens[i].kind, tokens[i].slice(data))
+		}
+	}
+}
+
+// --- Pure cleanup function tests ---
+
+func TestCleanContentStreamBytes_DropsIdentityCm(t *testing.T) {
+	in := []byte("q\n1 0 0 1 0 0 cm\n100 200 m\nS\nQ\n")
+	out := cleanContentStreamBytes(in)
+	if bytes.Contains(out, []byte("cm")) {
+		t.Errorf("identity cm not removed: %q", out)
+	}
+	// The drawing operators must be preserved.
+	if !bytes.Contains(out, []byte("100 200 m")) {
+		t.Errorf("drawing operators lost: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_KeepsNonIdentityCm(t *testing.T) {
+	in := []byte("q\n2 0 0 2 0 0 cm\nS\nQ\n")
+	out := cleanContentStreamBytes(in)
+	if !bytes.Contains(out, []byte("2 0 0 2 0 0 cm")) {
+		t.Errorf("non-identity cm was incorrectly removed: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_DropsEmptyQQ(t *testing.T) {
+	in := []byte("q\n  \nQ\n100 200 m\nS\n")
+	out := cleanContentStreamBytes(in)
+	if bytes.Count(out, []byte("q ")) > 0 || bytes.Count(out, []byte("\nq\n")) > 0 {
+		t.Errorf("empty q/Q not removed: %q", out)
+	}
+	// Real ops preserved.
+	if !bytes.Contains(out, []byte("100 200 m")) {
+		t.Errorf("drawing operators lost: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_KeepsNonEmptyQQ(t *testing.T) {
+	in := []byte("q\n100 200 m\nS\nQ\n")
+	out := cleanContentStreamBytes(in)
+	if !bytes.Contains(out, []byte("q")) || !bytes.Contains(out, []byte("Q")) {
+		t.Errorf("non-empty q/Q was removed: %q", out)
+	}
+	if !bytes.Contains(out, []byte("100 200 m")) {
+		t.Errorf("body lost: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_NestedEmptyQQ(t *testing.T) {
+	// A `q q Q Q` collapses to nothing in two passes: first pass
+	// drops the inner empty pair, then the outer pair becomes empty
+	// and is dropped on the second pass.
+	in := []byte("q\nq\nQ\nQ\n")
+	out := cleanContentStreamBytes(in)
+	if bytes.Count(out, []byte("q")) > 0 || bytes.Count(out, []byte("Q")) > 0 {
+		t.Errorf("nested empty q/Q not collapsed: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_PreservesContentBetweenIdentityAndDraw(t *testing.T) {
+	// Drop identity cm but preserve the surrounding content stream
+	// shape — text operators must remain intact.
+	in := []byte("q\n1 0 0 1 0 0 cm\nBT\n/F1 12 Tf\n(Hello) Tj\nET\nQ\n")
+	out := cleanContentStreamBytes(in)
+	// cm gone.
+	if bytes.Contains(out, []byte("cm")) {
+		t.Errorf("identity cm not removed: %q", out)
+	}
+	// BT/Tj/ET preserved.
+	for _, op := range []string{"BT", "Tj", "ET", "/F1", "12 Tf", "(Hello)"} {
+		if !bytes.Contains(out, []byte(op)) {
+			t.Errorf("expected %q in output; got %q", op, out)
+		}
+	}
+	// q/Q remain because the body is no longer empty (BT...ET is real work).
+	if !bytes.Contains(out, []byte("q")) {
+		t.Errorf("q removed despite body containing real work: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_NoChangeOnAlreadyClean(t *testing.T) {
+	in := []byte("BT\n/F1 12 Tf\n(Hello) Tj\nET\n")
+	out := cleanContentStreamBytes(in)
+	if !bytes.Equal(out, in) {
+		t.Errorf("clean stream was modified:\n  in  %q\n  out %q", in, out)
+	}
+}
+
+func TestCleanContentStreamBytes_NoFalsePositivesInsideStrings(t *testing.T) {
+	// A string literal containing "1 0 0 1 0 0 cm" or "q Q" must not
+	// trigger removal — those are payload bytes, not operators.
+	in := []byte("BT\n(this string contains 1 0 0 1 0 0 cm and q Q text) Tj\nET\n")
+	out := cleanContentStreamBytes(in)
+	if !bytes.Equal(out, in) {
+		t.Errorf("string contents triggered removal:\n  in  %q\n  out %q", in, out)
+	}
+}
+
+func TestCleanContentStreamBytes_IdempotentOnSecondPass(t *testing.T) {
+	in := []byte("q\n1 0 0 1 0 0 cm\nq\nQ\n100 200 m\nS\nQ\n")
+	first := cleanContentStreamBytes(in)
+	second := cleanContentStreamBytes(first)
+	if !bytes.Equal(first, second) {
+		t.Errorf("second pass mutated already-clean output:\n  first  %q\n  second %q", first, second)
+	}
+}
+
+// --- Pass-level tests ---
+
+func TestCleanContentStreams_SkipsNonPageStreams(t *testing.T) {
+	// A stream not referenced from any Page /Contents must not be
+	// touched, even if its bytes look like a content stream.
+	w := minimalCatalogWriter(t)
+	junk := core.NewPdfStream([]byte("q\n1 0 0 1 0 0 cm\nQ\n"))
+	junkRef := w.AddObject(junk)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("Junk", junkRef)
+	originalData := append([]byte(nil), junk.Data...)
+
+	w.cleanContentStreams()
+
+	if !bytes.Equal(junk.Data, originalData) {
+		t.Error("non-page stream was modified by content cleanup")
+	}
+}
+
+func TestCleanContentStreams_CleansPageContentsStream(t *testing.T) {
+	w := minimalCatalogWriter(t)
+	contents := []byte("q\n1 0 0 1 0 0 cm\n100 200 m\nS\nQ\n")
+	_, _, contentStream := addPageWithContents(t, w, contents)
+
+	w.cleanContentStreams()
+
+	if bytes.Contains(contentStream.Data, []byte("cm")) {
+		t.Errorf("identity cm not removed from page contents: %q", contentStream.Data)
+	}
+	if !bytes.Contains(contentStream.Data, []byte("100 200 m")) {
+		t.Errorf("drawing operators lost: %q", contentStream.Data)
+	}
+}
+
+func TestCleanContentStreams_HandlesContentsArray(t *testing.T) {
+	// A page's /Contents can be an array of indirect references per
+	// §7.7.3.3. Each referenced stream must be cleaned.
+	w := minimalCatalogWriter(t)
+	stream1 := core.NewPdfStream([]byte("1 0 0 1 0 0 cm\n"))
+	stream2 := core.NewPdfStream([]byte("q\nQ\n"))
+	r1 := w.AddObject(stream1)
+	r2 := w.AddObject(stream2)
+	page := core.NewPdfDictionary()
+	page.Set("Type", core.NewPdfName("Page"))
+	page.Set("Contents", core.NewPdfArray(r1, r2))
+	pageRef := w.AddObject(page)
+	pagesDict := w.objects[1].Object.(*core.PdfDictionary)
+	pagesDict.Set("Kids", core.NewPdfArray(pageRef))
+	pagesDict.Set("Count", core.NewPdfInteger(1))
+
+	w.cleanContentStreams()
+
+	if bytes.Contains(stream1.Data, []byte("cm")) {
+		t.Errorf("stream1 cm not removed: %q", stream1.Data)
+	}
+	if bytes.Contains(stream2.Data, []byte("q")) || bytes.Contains(stream2.Data, []byte("Q")) {
+		t.Errorf("stream2 empty q/Q not removed: %q", stream2.Data)
+	}
+}
+
+func TestCleanContentStreams_SkipsCompressedStreams(t *testing.T) {
+	// Cleanup operates on raw operator text. A stream that is
+	// already FlateDecode-compressed must be skipped — inflating is
+	// out of scope for this pass.
+	w := minimalCatalogWriter(t)
+	contents := []byte("q\n1 0 0 1 0 0 cm\nQ\n")
+	_, _, contentStream := addPageWithContents(t, w, contents)
+	contentStream.Dict.Set("Filter", core.NewPdfName("FlateDecode"))
+	originalData := append([]byte(nil), contentStream.Data...)
+
+	w.cleanContentStreams()
+
+	if !bytes.Equal(contentStream.Data, originalData) {
+		t.Error("compressed content stream was modified")
+	}
+}
+
+func TestCleanContentStreams_SizeRegressionGuardRevertsNoOpCleaning(t *testing.T) {
+	// A content stream with no removable operators must not be
+	// rewritten at all (the size-regression guard reverts an
+	// equal-size candidate).
+	w := minimalCatalogWriter(t)
+	contents := []byte("BT\n/F1 12 Tf\n(Hello) Tj\nET\n")
+	_, _, contentStream := addPageWithContents(t, w, contents)
+	originalData := append([]byte(nil), contentStream.Data...)
+
+	w.cleanContentStreams()
+
+	if !bytes.Equal(contentStream.Data, originalData) {
+		t.Errorf("clean content stream was modified for no benefit:\n  before %q\n  after  %q",
+			originalData, contentStream.Data)
+	}
+}
+
+func TestCleanContentStreams_RefusedOnEncryptedDocument(t *testing.T) {
+	w := minimalCatalogWriter(t)
+	contents := []byte("q\n1 0 0 1 0 0 cm\nQ\n")
+	_, _, contentStream := addPageWithContents(t, w, contents)
+	originalData := append([]byte(nil), contentStream.Data...)
+
+	enc, err := core.NewEncryptor(core.RevisionAES128, "user", "owner", core.PermPrint)
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+	w.SetEncryption(enc)
+
+	var buf bytes.Buffer
+	_, err = w.WriteToWithOptions(&buf, WriteOptions{CleanContentStreams: true})
+	if err == nil {
+		t.Fatal("expected refusal with encryption + CleanContentStreams")
+	}
+	if !strings.Contains(err.Error(), "content stream cleanup") {
+		t.Errorf("error %q does not mention content stream cleanup", err.Error())
+	}
+	if !bytes.Equal(contentStream.Data, originalData) {
+		t.Error("refusal mutated content stream payload")
+	}
+}
+
+func TestCleanContentStreams_ZeroOptionsByteIdentical(t *testing.T) {
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		addPageWithContents(t, w, []byte("BT (hi) Tj ET\n"))
+		return w
+	}
+	var bufA, bufB bytes.Buffer
+	if _, err := makeWriter().WriteToWithOptions(&bufA, WriteOptions{}); err != nil {
+		t.Fatalf("zero opts: %v", err)
+	}
+	if _, err := makeWriter().WriteTo(&bufB); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if !bytes.Equal(bufA.Bytes(), bufB.Bytes()) {
+		t.Error("zero-options output diverges from WriteTo")
+	}
+}
+
+func TestCleanContentStreams_Idempotent(t *testing.T) {
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		addPageWithContents(t, w, []byte("q\n1 0 0 1 0 0 cm\n100 200 m\nS\nQ\n"))
+		return w
+	}
+	w1 := makeWriter()
+	w1.cleanContentStreams()
+	var buf1 bytes.Buffer
+	if _, err := w1.WriteToWithOptions(&buf1, WriteOptions{}); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	w2 := makeWriter()
+	w2.cleanContentStreams()
+	w2.cleanContentStreams()
+	var buf2 bytes.Buffer
+	if _, err := w2.WriteToWithOptions(&buf2, WriteOptions{}); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if !bytes.Equal(buf1.Bytes(), buf2.Bytes()) {
+		t.Error("cleanup not idempotent")
+	}
+}
+
+func TestCleanContentStreams_ComposesWithRecompress(t *testing.T) {
+	// Cleanup runs before recompression; the cleaned (smaller) bytes
+	// then get Flate-compressed. Combined output must shrink.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		// Padded with junk so cleanup actually saves visible bytes.
+		junk := strings.Repeat("q\n1 0 0 1 0 0 cm\nQ\n", 10)
+		body := junk + "BT\n(real text) Tj\nET\n"
+		addPageWithContents(t, w, []byte(body))
+		return w
+	}
+	var noCleanup, withCleanup bytes.Buffer
+	if _, err := makeWriter().WriteToWithOptions(&noCleanup, WriteOptions{
+		RecompressStreams: true,
+	}); err != nil {
+		t.Fatalf("recompress only: %v", err)
+	}
+	if _, err := makeWriter().WriteToWithOptions(&withCleanup, WriteOptions{
+		CleanContentStreams: true,
+		RecompressStreams:   true,
+	}); err != nil {
+		t.Fatalf("cleanup + recompress: %v", err)
+	}
+	if withCleanup.Len() >= noCleanup.Len() {
+		t.Errorf("cleanup did not shrink even with recompress: with=%d, without=%d",
+			withCleanup.Len(), noCleanup.Len())
+	}
+}
+
+func TestCleanContentStreams_DocumentAPIDoesNotEnlarge(t *testing.T) {
+	doc := buildSampleDocument(5)
+	plain, err := doc.ToBytes()
+	if err != nil {
+		t.Fatalf("plain: %v", err)
+	}
+	doc2 := buildSampleDocument(5)
+	cleaned, err := doc2.ToBytesWithOptions(WriteOptions{CleanContentStreams: true})
+	if err != nil {
+		t.Fatalf("cleaned: %v", err)
+	}
+	if len(cleaned) > len(plain) {
+		t.Errorf("CleanContentStreams enlarged a layout-built document: plain=%d, cleaned=%d",
+			len(plain), len(cleaned))
+	}
+	if !bytes.HasPrefix(cleaned, []byte("%PDF-")) {
+		t.Error("missing PDF header")
+	}
+	if !bytes.HasSuffix(cleaned, []byte("EOF\n")) {
+		t.Error("missing EOF marker")
+	}
+}
+
+func TestCleanContentStreamBytes_PreservesInlineImageBytes(t *testing.T) {
+	// Inline images (BI ... ID <bytes> EI per §8.9.7) carry arbitrary
+	// binary payloads that MUST NOT be tokenized as content stream
+	// operators. A bug here would let cleanup match patterns inside
+	// the image data and silently corrupt it. Construct a payload
+	// whose binary bytes happen to contain the strings "q\nQ" and
+	// "1 0 0 1 0 0 cm" — both must survive verbatim.
+	imageBytes := []byte("\x01\x02q\nQ\x03\x041 0 0 1 0 0 cm\x05\x06")
+	in := []byte("q\nBI\n/W 4 /H 4 /CS /G /BPC 8\nID\n")
+	in = append(in, imageBytes...)
+	in = append(in, []byte("\nEI\nQ\n")...)
+
+	out := cleanContentStreamBytes(in)
+
+	if !bytes.Contains(out, imageBytes) {
+		t.Errorf("inline image bytes were corrupted by cleanup\n  in:  %q\n  out: %q",
+			in, out)
+	}
+	// The outer q/Q is empty (only the inline image between them, no
+	// real drawing operators). Whether cleanup drops the q/Q is
+	// implementation-defined for inline images — but it must not
+	// touch the image bytes themselves.
+}
+
+func TestCleanContentStreamBytes_HexStringNotMisclassified(t *testing.T) {
+	// A hex string `<71 51>` is the ASCII for "qQ" but it is a string
+	// literal, not two operators. Cleanup must leave it alone.
+	in := []byte("<71 51> Tj\n")
+	out := cleanContentStreamBytes(in)
+	if !bytes.Equal(out, in) {
+		t.Errorf("hex string contents misclassified as operators:\n  in  %q\n  out %q", in, out)
+	}
+}
+
+func TestCleanContentStreamBytes_EmptyInput(t *testing.T) {
+	out := cleanContentStreamBytes(nil)
+	if len(out) != 0 {
+		t.Errorf("empty input produced %d bytes", len(out))
+	}
+	out = cleanContentStreamBytes([]byte{})
+	if len(out) != 0 {
+		t.Errorf("empty slice input produced %d bytes", len(out))
+	}
+}
+
+func TestCleanContentStreamBytes_AdjacentEmptyPairs(t *testing.T) {
+	// Two adjacent `q Q q Q` empty pairs — both must drop in one
+	// pass.
+	in := []byte("q\nQ\nq\nQ\n")
+	out := cleanContentStreamBytes(in)
+	if bytes.Contains(out, []byte("q")) || bytes.Contains(out, []byte("Q")) {
+		t.Errorf("adjacent empty pairs not collapsed: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_TripleNestedEmptyPairs(t *testing.T) {
+	// `q q q Q Q Q` — three levels of empty nesting. The 8-pass cap
+	// handles up to 8 levels; 3 is well within that.
+	in := []byte("q\nq\nq\nQ\nQ\nQ\n")
+	out := cleanContentStreamBytes(in)
+	if bytes.Contains(out, []byte("q")) || bytes.Contains(out, []byte("Q")) {
+		t.Errorf("triple-nested empty pairs not collapsed: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_MultiLineCm(t *testing.T) {
+	// Identity cm with operands separated by newlines instead of
+	// spaces. The lexer's whitespace tolerance means the operands
+	// still tokenize cleanly; the cleanup should drop them.
+	in := []byte("1\n0\n0\n1\n0\n0\ncm\n100 200 m\n")
+	out := cleanContentStreamBytes(in)
+	if bytes.Contains(out, []byte("cm")) {
+		t.Errorf("multi-line identity cm not removed: %q", out)
+	}
+	if !bytes.Contains(out, []byte("100 200 m")) {
+		t.Errorf("drawing op lost after multi-line cm cleanup: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_CommentNotMistakenForOperator(t *testing.T) {
+	// A line comment `% ... Q` ending with a Q-shaped string must
+	// not produce a Q operator token. A real q above must therefore
+	// remain (no matching Q to pair with).
+	in := []byte("q\n% comment ending with Q\n100 200 m\nS\nQ\n")
+	out := cleanContentStreamBytes(in)
+	// Both q and Q must remain because there's a real `100 200 m S`
+	// between them.
+	if !bytes.Contains(out, []byte("q")) {
+		t.Errorf("real q removed: %q", out)
+	}
+	if !bytes.Contains(out, []byte("Q")) {
+		t.Errorf("real Q removed: %q", out)
+	}
+}
+
+func TestCleanContentStreamBytes_AdversarialUnclosedString(t *testing.T) {
+	// A truncated `(unclosed` literal — the lexer must terminate
+	// without panicking. The cleanup pass should treat the stream
+	// as malformed and either return it unchanged or short-circuit.
+	in := []byte("BT (unclosed string ")
+	// Just verify no panic and a deterministic result.
+	out := cleanContentStreamBytes(in)
+	_ = out
+}
+
+func TestCleanContentStreamBytes_AdversarialUnclosedHex(t *testing.T) {
+	in := []byte("<deadbeef")
+	out := cleanContentStreamBytes(in)
+	_ = out
+}
+
+func TestCleanContentStreamBytes_AdversarialUnclosedDict(t *testing.T) {
+	in := []byte("<<unclosed dict")
+	out := cleanContentStreamBytes(in)
+	_ = out
+}
+
+func TestCleanContentStreamBytes_AdversarialUnclosedArray(t *testing.T) {
+	in := []byte("[unclosed array")
+	out := cleanContentStreamBytes(in)
+	_ = out
+}
+
+func TestSkipInlineImage_HappyPath(t *testing.T) {
+	// Standalone unit on the inline-image skipper.
+	data := []byte("BI\n/W 1 /H 1 /BPC 8 /CS /G\nID\nXY\nEI\nq Q")
+	tokens := scanContentTokens(data)
+	// Expected tokens: BI (operator), q (operator), Q (operator).
+	// Everything inside BI..EI must be opaque.
+	gotBI, gotQ, gotQQ := false, false, false
+	for _, tok := range tokens {
+		if tok.kind != tokenOperator {
+			continue
+		}
+		switch string(tok.slice(data)) {
+		case "BI":
+			gotBI = true
+		case "q":
+			gotQ = true
+		case "Q":
+			gotQQ = true
+		case "ID", "EI", "XY":
+			t.Errorf("unexpected operator %q from inside inline image span: token at [%d:%d]",
+				tok.slice(data), tok.start, tok.end)
+		}
+	}
+	if !gotBI || !gotQ || !gotQQ {
+		t.Errorf("missing expected operators: BI=%v q=%v Q=%v", gotBI, gotQ, gotQQ)
+	}
+}
+
+func TestCleanContentStreams_PreservesContentSemantics(t *testing.T) {
+	// After cleanup, a content stream that originally drew text
+	// must still draw the same text. We verify by checking the
+	// post-cleanup bytes still contain the text-positioning and
+	// text-showing operators in the right order.
+	w := minimalCatalogWriter(t)
+	contents := []byte("q\n1 0 0 1 0 0 cm\nBT\n/F1 12 Tf\n100 200 Td\n(Hello, world!) Tj\nET\nQ\n")
+	_, _, contentStream := addPageWithContents(t, w, contents)
+
+	w.cleanContentStreams()
+
+	// All semantic operators preserved in original order.
+	idx := 0
+	for _, op := range []string{"BT", "/F1", "Tf", "100 200 Td", "Hello, world!", "Tj", "ET"} {
+		next := bytes.Index(contentStream.Data[idx:], []byte(op))
+		if next < 0 {
+			t.Errorf("operator %q missing or out of order in cleaned output: %q",
+				op, contentStream.Data)
+			return
+		}
+		idx += next + len(op)
+	}
+}

--- a/document/writer_dedup.go
+++ b/document/writer_dedup.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"bytes"
+	"crypto/sha256"
+
+	"github.com/carlos7ags/folio/core"
+)
+
+// deduplicateObjects merges byte-identical indirect objects so the
+// serialized output stores each unique payload exactly once.
+//
+// The pass works in three steps:
+//
+//  1. For every eligible indirect object, compute the SHA-256 of its
+//     canonical serialization (the bytes that PdfObject.WriteTo would
+//     emit for that object's body). Two objects whose serializations
+//     match are equivalent under PDF semantics (§7.3) provided their
+//     embedded references resolve to the same targets — and they do,
+//     because we run after sweep/cleanup but before encryption, on a
+//     graph that has not been mutated since the previous pass.
+//
+//  2. Group hashes. For each group with more than one member, the
+//     first slot in original write order becomes the canonical
+//     survivor and every other slot is marked for elimination. Build
+//     a redirect map: duplicateObjNum → canonicalObjNum.
+//
+//  3. Rewrite every PdfIndirectReference inside every kept object's
+//     value graph (and the trailer-slot roots) so duplicates point
+//     at their canonical survivor. Drop the eliminated slots from
+//     w.objects, then renumber survivors contiguously starting at 1.
+//
+// Eligibility: the catalog (w.root), the document info dictionary
+// (w.info), and the encryption dictionary (w.encryptRef) are excluded.
+// They are reachability roots; merging them would require relocating
+// the trailer-side bookkeeping, and they are unique in practice.
+//
+// Encrypted documents are refused upstream in WriteToWithOptions
+// because per-object keys derive from the object number (§7.6.3.3)
+// and renumbering would invalidate them. The defensive guard at the
+// top of this method matches the sweep contract so a future caller
+// bypassing WriteToWithOptions cannot corrupt encrypted payloads.
+//
+// The pass never enlarges output, never changes object content, and
+// never invalidates a reference. It composes safely with
+// OrphanSweep, CleanContentStreams, RecompressStreams,
+// UseXRefStream, and UseObjectStreams.
+func (w *Writer) deduplicateObjects() {
+	if len(w.objects) == 0 {
+		return
+	}
+	if w.encryptor != nil {
+		return
+	}
+
+	// Identify the trailer-root object numbers that must not be merged.
+	skip := make(map[int]bool, 3)
+	if w.root != nil {
+		skip[w.root.Num()] = true
+	}
+	if w.info != nil {
+		skip[w.info.Num()] = true
+	}
+	if w.encryptRef != nil {
+		skip[w.encryptRef.Num()] = true
+	}
+
+	// Step 1: hash each eligible object's canonical bytes. Skipped
+	// objects are still kept; their hashes are set to a sentinel that
+	// cannot collide with any real hash so they never group with
+	// anything else.
+	//
+	// Side effect: hashing a *PdfStream calls its WriteTo, which sets
+	// /Length on the stream's dictionary (and /Filter when the stream
+	// was constructed with NewPdfStreamCompressed). Both are inserted
+	// at deterministic positions and re-running WriteTo produces
+	// byte-identical output, so the hash is stable across calls and
+	// the writer's later serialization sees the same dictionary state.
+	type hashedSlot struct {
+		idx  int    // index into w.objects
+		hash string // hex SHA-256 of canonical bytes; "" means "do not dedup"
+	}
+	hashed := make([]hashedSlot, len(w.objects))
+	var buf bytes.Buffer
+	for i, obj := range w.objects {
+		hashed[i].idx = i
+		if skip[obj.ObjectNumber] {
+			continue
+		}
+		buf.Reset()
+		if _, err := obj.Object.WriteTo(&buf); err != nil {
+			// Hashing failed; treat as un-dedupable. Better to keep
+			// the object than to fail the whole write.
+			continue
+		}
+		sum := sha256.Sum256(buf.Bytes())
+		hashed[i].hash = string(sum[:])
+	}
+
+	// Step 2: group by hash; first slot wins.
+	canonical := make(map[string]int) // hash → ObjectNumber of canonical survivor
+	redirect := make(map[int]int)     // duplicate ObjectNumber → canonical ObjectNumber
+	for _, h := range hashed {
+		if h.hash == "" {
+			continue
+		}
+		objNum := w.objects[h.idx].ObjectNumber
+		if canon, ok := canonical[h.hash]; ok {
+			redirect[objNum] = canon
+		} else {
+			canonical[h.hash] = objNum
+		}
+	}
+
+	if len(redirect) == 0 {
+		return
+	}
+
+	// Step 3a: rewrite references to merged duplicates. A reference to
+	// a duplicate becomes a reference to its canonical survivor.
+	rewriteToCanonical := func(ref *core.PdfIndirectReference) {
+		if ref == nil {
+			return
+		}
+		if canon, ok := redirect[ref.Num()]; ok {
+			ref.SetNum(canon)
+		}
+	}
+	for _, obj := range w.objects {
+		walkReferences(obj.Object, rewriteToCanonical)
+	}
+	rewriteToCanonical(w.root)
+	rewriteToCanonical(w.info)
+	rewriteToCanonical(w.encryptRef)
+
+	// Step 3b: drop the duplicates from w.objects.
+	kept := make([]IndirectObject, 0, len(w.objects)-len(redirect))
+	for _, obj := range w.objects {
+		if _, isDup := redirect[obj.ObjectNumber]; isDup {
+			continue
+		}
+		kept = append(kept, obj)
+	}
+
+	// Step 3c: renumber survivors contiguously. We could leave gaps
+	// (xref free entries handle them per §7.5.4) but contiguous
+	// numbering keeps the xref subsection compact and matches the
+	// post-sweep convention.
+	renumber := make(map[int]int, len(kept))
+	for i := range kept {
+		newNum := i + 1
+		if kept[i].ObjectNumber != newNum {
+			renumber[kept[i].ObjectNumber] = newNum
+		}
+	}
+	if len(renumber) > 0 {
+		rewriteForRenumber := func(ref *core.PdfIndirectReference) {
+			if ref == nil {
+				return
+			}
+			if newNum, ok := renumber[ref.Num()]; ok {
+				ref.SetNum(newNum)
+			}
+		}
+		for i := range kept {
+			walkReferences(kept[i].Object, rewriteForRenumber)
+			kept[i].ObjectNumber = i + 1
+		}
+		rewriteForRenumber(w.root)
+		rewriteForRenumber(w.info)
+		rewriteForRenumber(w.encryptRef)
+	}
+
+	w.objects = kept
+}

--- a/document/writer_dedup_test.go
+++ b/document/writer_dedup_test.go
@@ -1,0 +1,663 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/core"
+)
+
+// addPlainDict registers a small dictionary with the given name and
+// returns its indirect reference. Reachable from /Root via a sentinel
+// /Sample-N entry to keep the orphan sweep from touching it.
+func addPlainDict(t *testing.T, w *Writer, slot, name string) *core.PdfIndirectReference {
+	t.Helper()
+	d := core.NewPdfDictionary()
+	d.Set("Type", core.NewPdfName(name))
+	ref := w.AddObject(d)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set(slot, ref)
+	return ref
+}
+
+func TestDeduplicateObjects_NoOpEmptyWriter(t *testing.T) {
+	w := NewWriter("1.7")
+	w.deduplicateObjects() // must not panic on zero objects
+	if len(w.objects) != 0 {
+		t.Errorf("empty writer gained %d objects", len(w.objects))
+	}
+}
+
+func TestDeduplicateObjects_NoOpWhenNoDuplicates(t *testing.T) {
+	w := minimalCatalogWriter(t)
+	a := core.NewPdfDictionary()
+	a.Set("Type", core.NewPdfName("Foo"))
+	b := core.NewPdfDictionary()
+	b.Set("Type", core.NewPdfName("Bar"))
+	w.AddObject(a)
+	w.AddObject(b)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("A", core.NewPdfIndirectReference(3, 0))
+	root.Set("B", core.NewPdfIndirectReference(4, 0))
+	preCount := len(w.objects)
+
+	w.deduplicateObjects()
+
+	if len(w.objects) != preCount {
+		t.Errorf("dedup dropped non-duplicates: %d → %d", preCount, len(w.objects))
+	}
+}
+
+func TestDeduplicateObjects_MergesIdenticalDicts(t *testing.T) {
+	// Two separately-constructed dictionaries with byte-identical
+	// content. After dedup, only one survives and both observers
+	// reach the canonical survivor.
+	w := minimalCatalogWriter(t)
+	refA := addPlainDict(t, w, "A", "Twin")
+	refB := addPlainDict(t, w, "B", "Twin")
+
+	if refA.Num() == refB.Num() {
+		t.Fatalf("setup: refs share number %d", refA.Num())
+	}
+
+	w.deduplicateObjects()
+
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	gotA := root.Get("A").(*core.PdfIndirectReference)
+	gotB := root.Get("B").(*core.PdfIndirectReference)
+	if gotA.Num() != gotB.Num() {
+		t.Errorf("after dedup, A=%d B=%d — should point at the same survivor",
+			gotA.Num(), gotB.Num())
+	}
+}
+
+func TestDeduplicateObjects_MergesIdenticalStreams(t *testing.T) {
+	// Identical raw stream payloads with identical dicts must merge.
+	// This is the headline case for the dedup pass: imported pages
+	// often share fonts or color spaces stored as separate stream
+	// objects.
+	w := minimalCatalogWriter(t)
+	payload := bytes.Repeat([]byte("shared "), 100)
+
+	makeStream := func(slot string) *core.PdfIndirectReference {
+		s := core.NewPdfStream(payload)
+		s.Dict.Set("Type", core.NewPdfName("XObject"))
+		ref := w.AddObject(s)
+		root := w.objects[0].Object.(*core.PdfDictionary)
+		root.Set(slot, ref)
+		return ref
+	}
+
+	refA := makeStream("A")
+	refB := makeStream("B")
+	refC := makeStream("C")
+
+	preCount := len(w.objects)
+	w.deduplicateObjects()
+
+	if len(w.objects) != preCount-2 {
+		t.Errorf("expected to drop 2 of 3 duplicate streams: pre=%d, post=%d",
+			preCount, len(w.objects))
+	}
+	if refA.Num() != refB.Num() || refB.Num() != refC.Num() {
+		t.Errorf("three duplicate streams not collapsed to one: A=%d B=%d C=%d",
+			refA.Num(), refB.Num(), refC.Num())
+	}
+}
+
+func TestDeduplicateObjects_SkipsCatalogInfoEncrypt(t *testing.T) {
+	// The catalog (w.root), info, and /Encrypt are excluded from
+	// dedup. Even if a duplicate body were registered with the same
+	// content as the catalog, the catalog itself must not be merged
+	// into a non-root slot. Here we construct a body byte-identical
+	// to the catalog and verify the catalog survives at slot 0.
+	w := minimalCatalogWriter(t)
+	originalRootObj := w.objects[0].Object
+	clone := core.NewPdfDictionary()
+	clone.Set("Type", core.NewPdfName("Catalog"))
+	clone.Set("Pages", w.objects[0].Object.(*core.PdfDictionary).Get("Pages"))
+	cloneRef := w.AddObject(clone)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("Decoy", cloneRef)
+
+	w.deduplicateObjects()
+
+	// The catalog must still be the first object after dedup.
+	if w.objects[0].Object != originalRootObj {
+		t.Error("catalog body was replaced; trailer /Root would point at the wrong object")
+	}
+	// w.root must still be in w.objects (not pointing at a number
+	// that no longer exists).
+	rootFound := false
+	for _, obj := range w.objects {
+		if obj.ObjectNumber == w.root.Num() && obj.Object == originalRootObj {
+			rootFound = true
+		}
+	}
+	if !rootFound {
+		t.Errorf("trailer /Root (%d) does not match any kept object body", w.root.Num())
+	}
+}
+
+func TestDeduplicateObjects_RewritesReferencesInArrays(t *testing.T) {
+	// References to merged duplicates living inside PdfArray elements
+	// must also be rewritten to the canonical survivor.
+	w := minimalCatalogWriter(t)
+	d1 := core.NewPdfDictionary()
+	d1.Set("Type", core.NewPdfName("Twin"))
+	d2 := core.NewPdfDictionary()
+	d2.Set("Type", core.NewPdfName("Twin"))
+	r1 := w.AddObject(d1)
+	r2 := w.AddObject(d2)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("Twins", core.NewPdfArray(r1, r2))
+
+	w.deduplicateObjects()
+
+	arr := root.Get("Twins").(*core.PdfArray)
+	if arr.Len() != 2 {
+		t.Fatalf("array len = %d, want 2", arr.Len())
+	}
+	a := arr.At(0).(*core.PdfIndirectReference)
+	b := arr.At(1).(*core.PdfIndirectReference)
+	if a.Num() != b.Num() {
+		t.Errorf("array refs not collapsed: [%d, %d]", a.Num(), b.Num())
+	}
+}
+
+func TestDeduplicateObjects_RewritesReferencesInsideStreamDict(t *testing.T) {
+	// A reference stored inside a stream dictionary must be rewritten
+	// when its target is merged. This is the same case as PdfDictionary
+	// rewrites but exercises the stream-dict descent in walkReferences.
+	w := minimalCatalogWriter(t)
+	twin1 := core.NewPdfDictionary()
+	twin1.Set("Type", core.NewPdfName("Twin"))
+	twin2 := core.NewPdfDictionary()
+	twin2.Set("Type", core.NewPdfName("Twin"))
+	r1 := w.AddObject(twin1)
+	r2 := w.AddObject(twin2)
+
+	holder := core.NewPdfStream([]byte("data"))
+	holder.Dict.Set("RefA", r1)
+	holder.Dict.Set("RefB", r2)
+	holderRef := w.AddObject(holder)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("Holder", holderRef)
+
+	w.deduplicateObjects()
+
+	gotA := holder.Dict.Get("RefA").(*core.PdfIndirectReference)
+	gotB := holder.Dict.Get("RefB").(*core.PdfIndirectReference)
+	if gotA.Num() != gotB.Num() {
+		t.Errorf("stream-dict refs not collapsed: A=%d B=%d", gotA.Num(), gotB.Num())
+	}
+}
+
+func TestDeduplicateObjects_RenumbersSurvivorsContiguously(t *testing.T) {
+	// After dedup drops slots, surviving objects must be renumbered
+	// contiguously starting at 1. Otherwise the xref table would
+	// carry free entries for the gaps, costing bytes.
+	w := minimalCatalogWriter(t)
+	// Two twins.
+	addPlainDict(t, w, "A", "Twin")
+	addPlainDict(t, w, "B", "Twin")
+	// One unique trailing object.
+	addPlainDict(t, w, "C", "Unique")
+
+	preCount := len(w.objects)
+	w.deduplicateObjects()
+
+	if len(w.objects) != preCount-1 {
+		t.Fatalf("expected %d objects, got %d", preCount-1, len(w.objects))
+	}
+	for i, obj := range w.objects {
+		if obj.ObjectNumber != i+1 {
+			t.Errorf("object at index %d has number %d, want %d", i, obj.ObjectNumber, i+1)
+		}
+	}
+}
+
+func TestDeduplicateObjects_Idempotent(t *testing.T) {
+	// Running dedup twice must produce byte-identical writer output:
+	// the first pass collapses duplicates; the second pass finds
+	// nothing to merge.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		addPlainDict(t, w, "A", "Twin")
+		addPlainDict(t, w, "B", "Twin")
+		addPlainDict(t, w, "C", "Twin")
+		return w
+	}
+	w1 := makeWriter()
+	w1.deduplicateObjects()
+	var buf1 bytes.Buffer
+	if _, err := w1.WriteToWithOptions(&buf1, WriteOptions{}); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	w2 := makeWriter()
+	w2.deduplicateObjects()
+	w2.deduplicateObjects()
+	var buf2 bytes.Buffer
+	if _, err := w2.WriteToWithOptions(&buf2, WriteOptions{}); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	if !bytes.Equal(buf1.Bytes(), buf2.Bytes()) {
+		t.Errorf("dedup not idempotent: 1 pass %d bytes vs 2 passes %d bytes",
+			buf1.Len(), buf2.Len())
+	}
+}
+
+func TestDeduplicateObjects_ZeroOptionsByteIdentical(t *testing.T) {
+	// A Writer with eligible duplicates must produce byte-identical
+	// output between WriteOptions{} and WriteTo when DeduplicateObjects
+	// is unset. Defends against the toggle silently activating.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		addPlainDict(t, w, "A", "Twin")
+		addPlainDict(t, w, "B", "Twin")
+		return w
+	}
+	var bufA, bufB bytes.Buffer
+	if _, err := makeWriter().WriteToWithOptions(&bufA, WriteOptions{}); err != nil {
+		t.Fatalf("zero opts: %v", err)
+	}
+	if _, err := makeWriter().WriteTo(&bufB); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if !bytes.Equal(bufA.Bytes(), bufB.Bytes()) {
+		t.Error("zero-options output diverges from WriteTo")
+	}
+}
+
+func TestDeduplicateObjects_RefusedOnEncryptedDocument(t *testing.T) {
+	// Per-object encryption keys derive from the object number
+	// (§7.6.3.3); renumbering after dedup would invalidate every
+	// key. The refusal must run before any mutation so a retry
+	// without the option produces correct output.
+	w := minimalCatalogWriter(t)
+	addPlainDict(t, w, "A", "Twin")
+	addPlainDict(t, w, "B", "Twin")
+	enc, err := core.NewEncryptor(core.RevisionAES128, "user", "owner", core.PermPrint)
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+	w.SetEncryption(enc)
+	preCount := len(w.objects)
+	preNumbers := snapshotObjectNumbers(w)
+
+	var buf bytes.Buffer
+	_, err = w.WriteToWithOptions(&buf, WriteOptions{DeduplicateObjects: true})
+	if err == nil {
+		t.Fatal("expected refusal with encryption + DeduplicateObjects")
+	}
+	if !strings.Contains(err.Error(), "deduplication") {
+		t.Errorf("error %q does not mention deduplication", err.Error())
+	}
+	if len(w.objects) != preCount {
+		t.Errorf("refusal mutated object count: %d → %d", preCount, len(w.objects))
+	}
+	if !sliceEqual(preNumbers, snapshotObjectNumbers(w)) {
+		t.Error("refusal renumbered objects")
+	}
+
+	buf.Reset()
+	if _, err := w.WriteToWithOptions(&buf, WriteOptions{}); err != nil {
+		t.Fatalf("retry without dedup: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("retry produced empty output")
+	}
+}
+
+func TestDeduplicateObjects_ComposesWithOrphanSweep(t *testing.T) {
+	// Sweep + dedup: sweep drops orphans first, then dedup merges
+	// remaining duplicates. Result must be smaller than either alone.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		// Reachable twins.
+		addPlainDict(t, w, "A", "Twin")
+		addPlainDict(t, w, "B", "Twin")
+		// Unreachable orphan.
+		o := core.NewPdfDictionary()
+		o.Set("Type", core.NewPdfName("Orphan"))
+		o.Set("Junk", core.NewPdfLiteralString(strings.Repeat("x", 200)))
+		w.AddObject(o)
+		return w
+	}
+	var sweepOnly, dedupOnly, both bytes.Buffer
+	if _, err := makeWriter().WriteToWithOptions(&sweepOnly, WriteOptions{
+		OrphanSweep: true,
+	}); err != nil {
+		t.Fatalf("sweep only: %v", err)
+	}
+	if _, err := makeWriter().WriteToWithOptions(&dedupOnly, WriteOptions{
+		DeduplicateObjects: true,
+	}); err != nil {
+		t.Fatalf("dedup only: %v", err)
+	}
+	if _, err := makeWriter().WriteToWithOptions(&both, WriteOptions{
+		OrphanSweep:        true,
+		DeduplicateObjects: true,
+	}); err != nil {
+		t.Fatalf("both: %v", err)
+	}
+	if both.Len() >= sweepOnly.Len() {
+		t.Errorf("sweep+dedup not smaller than sweep alone: both=%d, sweep=%d",
+			both.Len(), sweepOnly.Len())
+	}
+	if both.Len() >= dedupOnly.Len() {
+		t.Errorf("sweep+dedup not smaller than dedup alone: both=%d, dedup=%d",
+			both.Len(), dedupOnly.Len())
+	}
+}
+
+func TestDeduplicateObjects_ComposesWithRecompressAndObjStm(t *testing.T) {
+	// Full optimizer stack on a writer with duplicates. Result must
+	// reparse structurally and be the smallest of all combinations.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		payload := bytes.Repeat([]byte("dedup-then-compress "), 200)
+		makeStream := func(slot string) {
+			s := core.NewPdfStream(payload)
+			ref := w.AddObject(s)
+			root := w.objects[0].Object.(*core.PdfDictionary)
+			root.Set(slot, ref)
+		}
+		makeStream("A")
+		makeStream("B")
+		makeStream("C")
+		return w
+	}
+	var noDedup, withDedup bytes.Buffer
+	if _, err := makeWriter().WriteToWithOptions(&noDedup, WriteOptions{
+		UseXRefStream:     true,
+		UseObjectStreams:  true,
+		RecompressStreams: true,
+	}); err != nil {
+		t.Fatalf("no dedup: %v", err)
+	}
+	if _, err := makeWriter().WriteToWithOptions(&withDedup, WriteOptions{
+		UseXRefStream:      true,
+		UseObjectStreams:   true,
+		RecompressStreams:  true,
+		DeduplicateObjects: true,
+	}); err != nil {
+		t.Fatalf("with dedup: %v", err)
+	}
+	if withDedup.Len() >= noDedup.Len() {
+		t.Errorf("dedup did not shrink with full stack: with=%d, without=%d",
+			withDedup.Len(), noDedup.Len())
+	}
+	if !bytes.Contains(withDedup.Bytes(), []byte("/Type /XRef")) {
+		t.Error("missing /Type /XRef in output")
+	}
+	if !bytes.HasPrefix(withDedup.Bytes(), []byte("%PDF-")) {
+		t.Error("missing PDF header")
+	}
+	if !bytes.HasSuffix(withDedup.Bytes(), []byte("EOF\n")) {
+		t.Error("missing EOF marker")
+	}
+}
+
+func TestDeduplicateObjects_DocumentAPIDoesNotEnlarge(t *testing.T) {
+	// Layout-built documents typically have few or no duplicate
+	// objects, so dedup is a near-no-op. Asserting "no enlargement"
+	// + structural reparse is the right contract for the public API.
+	doc := buildSampleDocument(5)
+	plain, err := doc.ToBytes()
+	if err != nil {
+		t.Fatalf("plain: %v", err)
+	}
+	doc2 := buildSampleDocument(5)
+	deduped, err := doc2.ToBytesWithOptions(WriteOptions{DeduplicateObjects: true})
+	if err != nil {
+		t.Fatalf("deduped: %v", err)
+	}
+	if len(deduped) > len(plain) {
+		t.Errorf("DeduplicateObjects enlarged a layout-built document: plain=%d, deduped=%d",
+			len(plain), len(deduped))
+	}
+	if !bytes.HasPrefix(deduped, []byte("%PDF-")) {
+		t.Error("missing PDF header")
+	}
+	if !bytes.HasSuffix(deduped, []byte("EOF\n")) {
+		t.Error("missing EOF marker")
+	}
+}
+
+func TestDeduplicateObjects_DistinctButSimilarBodiesNotMerged(t *testing.T) {
+	// Two dictionaries whose serialized bytes differ by a single byte
+	// must NOT be merged. Defends against a hash truncation or
+	// equality-by-prefix bug.
+	w := minimalCatalogWriter(t)
+	d1 := core.NewPdfDictionary()
+	d1.Set("Type", core.NewPdfName("Almost"))
+	d1.Set("N", core.NewPdfInteger(1))
+	d2 := core.NewPdfDictionary()
+	d2.Set("Type", core.NewPdfName("Almost"))
+	d2.Set("N", core.NewPdfInteger(2))
+	r1 := w.AddObject(d1)
+	r2 := w.AddObject(d2)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("A", r1)
+	root.Set("B", r2)
+
+	preCount := len(w.objects)
+	w.deduplicateObjects()
+	if len(w.objects) != preCount {
+		t.Errorf("dedup merged distinct dicts: %d → %d", preCount, len(w.objects))
+	}
+	if r1.Num() == r2.Num() {
+		t.Error("distinct dicts share an object number after dedup")
+	}
+}
+
+func TestDeduplicateObjects_HashStableAcrossWriteToCalls(t *testing.T) {
+	// The dedup pass hashes obj.WriteTo() bytes. Two consecutive
+	// WriteTo calls on the same object must produce identical bytes,
+	// otherwise the second hash would diverge and dedup would fail
+	// to merge a previously-merged duplicate (silently ineffective).
+	//
+	// Streams are the interesting case: PdfStream.WriteTo mutates
+	// s.Dict by setting /Length (and /Filter when compress=true).
+	// A bug that bumped /Length to a fresh dict slot on each call,
+	// or that re-Flated to non-deterministic bytes, would surface
+	// here.
+	cases := []struct {
+		name  string
+		build func() core.PdfObject
+	}{
+		{
+			name: "raw stream",
+			build: func() core.PdfObject {
+				s := core.NewPdfStream(bytes.Repeat([]byte("hello "), 200))
+				s.Dict.Set("Type", core.NewPdfName("Test"))
+				return s
+			},
+		},
+		{
+			name: "compressed stream",
+			build: func() core.PdfObject {
+				return core.NewPdfStreamCompressed(bytes.Repeat([]byte("compressible "), 200))
+			},
+		},
+		{
+			name: "dictionary",
+			build: func() core.PdfObject {
+				d := core.NewPdfDictionary()
+				d.Set("Type", core.NewPdfName("Test"))
+				d.Set("N", core.NewPdfInteger(42))
+				d.Set("Name", core.NewPdfLiteralString("hello"))
+				return d
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			obj := c.build()
+			var buf1, buf2 bytes.Buffer
+			if _, err := obj.WriteTo(&buf1); err != nil {
+				t.Fatalf("first WriteTo: %v", err)
+			}
+			if _, err := obj.WriteTo(&buf2); err != nil {
+				t.Fatalf("second WriteTo: %v", err)
+			}
+			if !bytes.Equal(buf1.Bytes(), buf2.Bytes()) {
+				t.Errorf("WriteTo not idempotent — dedup hashes would diverge\n  call 1 (%d B): %q\n  call 2 (%d B): %q",
+					buf1.Len(), buf1.Bytes(), buf2.Len(), buf2.Bytes())
+			}
+		})
+	}
+}
+
+func TestDeduplicateObjects_SweepThenDedupKeepsCatalogIdentity(t *testing.T) {
+	// Run sweep and dedup together. After the combined run, the
+	// catalog body must still be the SAME object the writer started
+	// with (pointer identity), and w.root must point at the slot
+	// that holds it. A bug that merged the catalog into a duplicate,
+	// or that pointed w.root at a stale number, would silently break
+	// /Root in the trailer.
+	w := minimalCatalogWriter(t)
+	originalCatalogBody := w.objects[0].Object
+	// Add an orphan that sweep will drop, plus a twin pair that dedup
+	// will merge.
+	o := core.NewPdfDictionary()
+	o.Set("Type", core.NewPdfName("Orphan"))
+	w.AddObject(o)
+	addPlainDict(t, w, "T1", "Twin")
+	addPlainDict(t, w, "T2", "Twin")
+
+	w.sweepOrphans()
+	w.deduplicateObjects()
+
+	rootSlot := -1
+	for i, obj := range w.objects {
+		if obj.Object == originalCatalogBody {
+			rootSlot = i
+			break
+		}
+	}
+	if rootSlot < 0 {
+		t.Fatal("original catalog body lost after sweep+dedup")
+	}
+	if w.root.Num() != w.objects[rootSlot].ObjectNumber {
+		t.Errorf("w.root = %d, but original catalog is at object number %d",
+			w.root.Num(), w.objects[rootSlot].ObjectNumber)
+	}
+}
+
+func TestDeduplicateObjects_RefusalSnapshotsPayloadBytes(t *testing.T) {
+	// The encryption refusal must not mutate any stream payload
+	// bytes. A snapshot/check defends against a bug that pre-hashed
+	// streams (calling WriteTo, which mutates the stream dict) before
+	// the refusal fired.
+	w := minimalCatalogWriter(t)
+	payload := bytes.Repeat([]byte("payload "), 200)
+	s := core.NewPdfStream(payload)
+	s.Dict.Set("Type", core.NewPdfName("X"))
+	ref := w.AddObject(s)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("X", ref)
+	originalData := append([]byte(nil), s.Data...)
+	originalDictLen := s.Dict.Len()
+
+	enc, err := core.NewEncryptor(core.RevisionAES128, "user", "owner", core.PermPrint)
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+	w.SetEncryption(enc)
+
+	var buf bytes.Buffer
+	_, err = w.WriteToWithOptions(&buf, WriteOptions{DeduplicateObjects: true})
+	if err == nil {
+		t.Fatal("expected refusal")
+	}
+	if !bytes.Equal(s.Data, originalData) {
+		t.Error("refusal mutated stream payload")
+	}
+	if s.Dict.Len() != originalDictLen {
+		t.Errorf("refusal added entries to stream dict: was %d, now %d",
+			originalDictLen, s.Dict.Len())
+	}
+}
+
+func TestDeduplicateObjects_TripleEncryptionRefusal(t *testing.T) {
+	// All three optimizer toggles enabled simultaneously with an
+	// encryptor present: the writer must refuse with SOME error and
+	// leave the writer state unmutated. We do not pin which refusal
+	// fires first because that ordering is internal.
+	w := minimalCatalogWriter(t)
+	payload := bytes.Repeat([]byte("data "), 100)
+	s := core.NewPdfStream(payload)
+	ref := w.AddObject(s)
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("S", ref)
+	originalPayload := append([]byte(nil), s.Data...)
+
+	enc, err := core.NewEncryptor(core.RevisionAES128, "user", "owner", core.PermPrint)
+	if err != nil {
+		t.Fatalf("NewEncryptor: %v", err)
+	}
+	w.SetEncryption(enc)
+	preNumbers := snapshotObjectNumbers(w)
+
+	var buf bytes.Buffer
+	_, err = w.WriteToWithOptions(&buf, WriteOptions{
+		UseXRefStream:       true,
+		UseObjectStreams:    true,
+		OrphanSweep:         true,
+		CleanContentStreams: true,
+		DeduplicateObjects:  true,
+		RecompressStreams:   true,
+	})
+	if err == nil {
+		t.Fatal("expected refusal with all toggles + encryption")
+	}
+	if !sliceEqual(preNumbers, snapshotObjectNumbers(w)) {
+		t.Error("triple-refusal renumbered objects")
+	}
+	if !bytes.Equal(s.Data, originalPayload) {
+		t.Error("triple-refusal mutated stream payload")
+	}
+}
+
+func TestDeduplicateObjects_DropsObjectShrinksSerializedOutput(t *testing.T) {
+	// End-to-end: a writer with three identical large-ish payloads
+	// must produce strictly smaller serialized output with
+	// DeduplicateObjects than without.
+	makeWriter := func() *Writer {
+		w := minimalCatalogWriter(t)
+		// Use streams with significant payload so dedup wins are
+		// visible against the per-object overhead.
+		payload := bytes.Repeat([]byte("repeated payload "), 200)
+		makeStream := func(slot string) {
+			s := core.NewPdfStream(payload)
+			ref := w.AddObject(s)
+			root := w.objects[0].Object.(*core.PdfDictionary)
+			root.Set(slot, ref)
+		}
+		makeStream("A")
+		makeStream("B")
+		makeStream("C")
+		return w
+	}
+	var noDedup, withDedup bytes.Buffer
+	if _, err := makeWriter().WriteToWithOptions(&noDedup, WriteOptions{}); err != nil {
+		t.Fatalf("no dedup: %v", err)
+	}
+	if _, err := makeWriter().WriteToWithOptions(&withDedup, WriteOptions{
+		DeduplicateObjects: true,
+	}); err != nil {
+		t.Fatalf("with dedup: %v", err)
+	}
+	if withDedup.Len() >= noDedup.Len() {
+		t.Errorf("dedup did not shrink: with=%d, without=%d",
+			withDedup.Len(), noDedup.Len())
+	}
+}

--- a/document/writer_xref_stream.go
+++ b/document/writer_xref_stream.go
@@ -84,6 +84,44 @@ type WriteOptions struct {
 	// Lossless and safe to combine with UseXRefStream,
 	// UseObjectStreams, and OrphanSweep.
 	RecompressStreams bool
+
+	// DeduplicateObjects merges byte-identical indirect objects so the
+	// serialized output stores each unique payload exactly once. For
+	// every group of indirect objects whose canonical serialization
+	// (per ISO 32000-1 §7.3) produces the same bytes, the first slot
+	// is retained and every PdfIndirectReference targeting any of the
+	// other slots is rewritten to point at the survivor. Surviving
+	// objects are renumbered contiguously.
+	//
+	// The pass is most valuable on documents that re-use resources:
+	// imported pages sharing fonts or color spaces, repeated logos
+	// embedded as separate XObjects, identical ToUnicode CMaps
+	// (§9.10.3) across font dictionaries, and per-page content streams
+	// produced by templated workflows.
+	//
+	// Catalog, /Info, and /Encrypt indirect objects are excluded from
+	// dedup — they are reachability roots that the trailer slots refer
+	// to by pointer, and merging them would require relocating the
+	// trailer-side bookkeeping. They are unique in practice anyway.
+	//
+	// Currently refused on encrypted documents for the same reason as
+	// OrphanSweep: per-object encryption keys derive from the object
+	// number (§7.6.3.3) and renumbering after dedup would invalidate
+	// every key.
+	DeduplicateObjects bool
+
+	// CleanContentStreams removes redundant operators from page content
+	// streams (ISO 32000-1 §7.8): empty `q ... Q` graphics-state
+	// save/restore pairs that contain only whitespace, and identity
+	// `1 0 0 1 0 0 cm` matrix concatenations. The cleanup operates on
+	// the raw byte payload of each stream referenced from a Page
+	// dictionary's /Contents entry; the size-regression guard reverts
+	// any rewrite that fails to shrink.
+	//
+	// Currently refused on encrypted documents because rewriting
+	// payload bytes after the encryption walk would emit ciphertext
+	// that decrypts to the wrong plaintext.
+	CleanContentStreams bool
 }
 
 // WriteToWithOptions is the option-aware variant of WriteTo. WriteTo is
@@ -123,16 +161,34 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 		// without RecompressStreams is unaffected.
 		return 0, fmt.Errorf("writer: stream recompression is not supported on encrypted documents")
 	}
+	if opts.DeduplicateObjects && w.encryptor != nil {
+		// Same defense: dedup renumbers survivors, which would
+		// invalidate per-object encryption keys (§7.6.3.3).
+		return 0, fmt.Errorf("writer: object deduplication is not supported on encrypted documents")
+	}
+	if opts.CleanContentStreams && w.encryptor != nil {
+		// Same defense as RecompressStreams: rewriting payload bytes
+		// interacts badly with the encryption walk.
+		return 0, fmt.Errorf("writer: content stream cleanup is not supported on encrypted documents")
+	}
+	// Order: sweep → cleanup → dedup → recompress → encrypt → serialize.
+	// - Sweep first so later passes do not waste effort on orphans.
+	// - Cleanup before dedup so two streams that become byte-identical
+	//   after redundant-operator removal can be merged.
+	// - Dedup before recompress so each canonical payload is recompressed
+	//   exactly once.
+	// - Encryption walk runs last because it mutates payload bytes
+	//   (ciphertext) that no other pass should touch.
 	if opts.OrphanSweep {
-		// Sweep before the encryption walk so encryption uses the new
-		// numbers. With encryption refused above the order is currently
-		// moot, but the placement encodes the intended invariant.
 		w.sweepOrphans()
 	}
+	if opts.CleanContentStreams {
+		w.cleanContentStreams()
+	}
+	if opts.DeduplicateObjects {
+		w.deduplicateObjects()
+	}
 	if opts.RecompressStreams {
-		// Recompress AFTER the sweep: orphan streams should not be
-		// recompressed only to be dropped. AFTER sweep also means
-		// after renumbering, but recompression is renumber-agnostic.
 		w.recompressStreams()
 	}
 

--- a/examples/optimize/main.go
+++ b/examples/optimize/main.go
@@ -124,17 +124,20 @@ func importedTextHeavy() *document.Document {
 //     and /Encrypt before serialization.
 //   - +recompress: also re-Flate-compresses eligible stream payloads
 //     (§7.4.4) at zlib.BestCompression.
-func writeAll(f fixture) (defaultBytes, packedBytes, sweptBytes, recompressBytes []byte, err error) {
+//   - +full: every lossless toggle on — adds content-stream operator
+//     cleanup (§7.8) and structural deduplication of byte-identical
+//     indirect objects.
+func writeAll(f fixture) (defaultBytes, packedBytes, sweptBytes, recompressBytes, fullBytes []byte, err error) {
 	defaultBytes, err = f.build().ToBytes()
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("%s default: %w", f.name, err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("%s default: %w", f.name, err)
 	}
 	packedBytes, err = f.build().ToBytesWithOptions(document.WriteOptions{
 		UseXRefStream:    true,
 		UseObjectStreams: true,
 	})
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("%s xref+obj: %w", f.name, err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("%s xref+obj: %w", f.name, err)
 	}
 	sweptBytes, err = f.build().ToBytesWithOptions(document.WriteOptions{
 		UseXRefStream:    true,
@@ -142,7 +145,7 @@ func writeAll(f fixture) (defaultBytes, packedBytes, sweptBytes, recompressBytes
 		OrphanSweep:      true,
 	})
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("%s +sweep: %w", f.name, err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("%s +sweep: %w", f.name, err)
 	}
 	recompressBytes, err = f.build().ToBytesWithOptions(document.WriteOptions{
 		UseXRefStream:     true,
@@ -151,9 +154,20 @@ func writeAll(f fixture) (defaultBytes, packedBytes, sweptBytes, recompressBytes
 		RecompressStreams: true,
 	})
 	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("%s +recompress: %w", f.name, err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("%s +recompress: %w", f.name, err)
 	}
-	return defaultBytes, packedBytes, sweptBytes, recompressBytes, nil
+	fullBytes, err = f.build().ToBytesWithOptions(document.WriteOptions{
+		UseXRefStream:       true,
+		UseObjectStreams:    true,
+		OrphanSweep:         true,
+		CleanContentStreams: true,
+		DeduplicateObjects:  true,
+		RecompressStreams:   true,
+	})
+	if err != nil {
+		return nil, nil, nil, nil, nil, fmt.Errorf("%s +full: %w", f.name, err)
+	}
+	return defaultBytes, packedBytes, sweptBytes, recompressBytes, fullBytes, nil
 }
 
 func main() {
@@ -164,26 +178,26 @@ func main() {
 		{name: "imported text-heavy", build: importedTextHeavy},
 	}
 
-	fmt.Printf("%-22s %12s %12s %12s %12s %10s\n",
-		"fixture", "default", "xref+obj", "+sweep", "+recompress", "saved")
-	fmt.Println("---------------------- ------------ ------------ ------------ ------------ ----------")
+	fmt.Printf("%-22s %12s %12s %12s %12s %12s %10s\n",
+		"fixture", "default", "xref+obj", "+sweep", "+recompress", "+full", "saved")
+	fmt.Println("---------------------- ------------ ------------ ------------ ------------ ------------ ----------")
 
 	for _, f := range fixtures {
-		def, packed, swept, recompress, err := writeAll(f)
+		def, packed, swept, recompress, full, err := writeAll(f)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
-		saved := len(def) - len(recompress)
+		saved := len(def) - len(full)
 		pct := 100.0 * float64(saved) / float64(len(def))
-		fmt.Printf("%-22s %10d B %10d B %10d B %10d B %8.1f %%\n",
-			f.name, len(def), len(packed), len(swept), len(recompress), pct)
+		fmt.Printf("%-22s %10d B %10d B %10d B %10d B %10d B %8.1f %%\n",
+			f.name, len(def), len(packed), len(swept), len(recompress), len(full), pct)
 	}
 
 	// Write the imported fixture to disk so the user has concrete files
 	// to inspect with qpdf or any PDF viewer. The imported case is
 	// where the optimizer's win is most visible.
-	def, _, _, recompress, err := writeAll(fixtures[len(fixtures)-1])
+	def, _, _, _, full, err := writeAll(fixtures[len(fixtures)-1])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -192,7 +206,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "write default file: %v\n", err)
 		os.Exit(1)
 	}
-	if err := os.WriteFile("optimize-compressed.pdf", recompress, 0o644); err != nil {
+	if err := os.WriteFile("optimize-compressed.pdf", full, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "write optimized file: %v\n", err)
 		os.Exit(1)
 	}

--- a/integration/dedup_cleanup_import_test.go
+++ b/integration/dedup_cleanup_import_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// TestFullOptimizerStackOnImportedDocument exercises every lossless
+// optimizer toggle together on a multi-page imported document. The
+// dedup pass merges identical resource dictionaries (fonts, color
+// spaces) shared across imported pages; the cleanup pass strips
+// redundant operators from per-page content streams; the recompress
+// pass Flates the cleaned bytes; the sweep pass drops any orphans
+// the import process may have left behind. The combined result must
+// be smaller than every prefix-subset and must round-trip
+// (page count, structural reparse, extracted text equality).
+func TestFullOptimizerStackOnImportedDocument(t *testing.T) {
+	source := document.NewDocument(document.PageSizeLetter)
+	for i := 0; i < 6; i++ {
+		source.Add(layout.NewHeading(fmt.Sprintf("Section %d", i+1), layout.H1))
+		source.Add(layout.NewParagraph(
+			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "+
+				"Sed do eiusmod tempor incididunt ut labore et dolore magna "+
+				"aliqua. Ut enim ad minim veniam, quis nostrud exercitation.",
+			font.Helvetica, 11,
+		))
+	}
+	var sourceBuf bytes.Buffer
+	if _, err := source.WriteTo(&sourceBuf); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	r, err := reader.Parse(sourceBuf.Bytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+
+	buildImported := func() *document.Document {
+		out := document.NewDocument(document.PageSizeLetter)
+		for i := 0; i < r.PageCount(); i++ {
+			srcPage, _ := r.Page(i)
+			cs, _ := srcPage.ContentStream()
+			res, _ := srcPage.Resources()
+			p := out.AddPage()
+			p.ImportPage(cs, res, srcPage.Width, srcPage.Height)
+		}
+		return out
+	}
+
+	// Each progressive option set adds one toggle. We expect the size
+	// curve to be monotonically non-increasing (no toggle enlarges).
+	type variant struct {
+		name string
+		opts document.WriteOptions
+	}
+	variants := []variant{
+		{"plain", document.WriteOptions{}},
+		{"xref+obj", document.WriteOptions{
+			UseXRefStream:    true,
+			UseObjectStreams: true,
+		}},
+		{"+sweep", document.WriteOptions{
+			UseXRefStream:    true,
+			UseObjectStreams: true,
+			OrphanSweep:      true,
+		}},
+		{"+cleanup", document.WriteOptions{
+			UseXRefStream:       true,
+			UseObjectStreams:    true,
+			OrphanSweep:         true,
+			CleanContentStreams: true,
+		}},
+		{"+dedup", document.WriteOptions{
+			UseXRefStream:       true,
+			UseObjectStreams:    true,
+			OrphanSweep:         true,
+			CleanContentStreams: true,
+			DeduplicateObjects:  true,
+		}},
+		{"+recompress", document.WriteOptions{
+			UseXRefStream:       true,
+			UseObjectStreams:    true,
+			OrphanSweep:         true,
+			CleanContentStreams: true,
+			DeduplicateObjects:  true,
+			RecompressStreams:   true,
+		}},
+	}
+	sizes := make([]int, len(variants))
+	outputs := make([][]byte, len(variants))
+	for i, v := range variants {
+		out, err := buildImported().ToBytesWithOptions(v.opts)
+		if err != nil {
+			t.Fatalf("%s: %v", v.name, err)
+		}
+		sizes[i] = len(out)
+		outputs[i] = out
+	}
+
+	// Headline assertion: the full stack is strictly smaller than
+	// plain. Per-toggle monotonicity is NOT asserted because some
+	// toggles add overhead that pays off only in combination — for
+	// example, the xref+object-stream variant on a small document
+	// can be a few bytes larger than the traditional xref table
+	// before recompression collapses the content streams. Real
+	// users care about the bottom-line size, not the intermediate
+	// columns.
+	if sizes[len(sizes)-1] >= sizes[0] {
+		t.Errorf("full optimizer stack did not shrink: plain=%d, full=%d",
+			sizes[0], sizes[len(sizes)-1])
+	}
+
+	// Round-trip the full-optimizer output.
+	full := outputs[len(outputs)-1]
+	rr, err := reader.Parse(full)
+	if err != nil {
+		t.Fatalf("re-parse full optimizer: %v", err)
+	}
+	if rr.PageCount() != r.PageCount() {
+		t.Errorf("page count mismatch: full=%d, source=%d",
+			rr.PageCount(), r.PageCount())
+	}
+
+	// Text equality: every page's extracted text must match the
+	// pre-optimizer plain re-import.
+	rPlain, err := reader.Parse(outputs[0])
+	if err != nil {
+		t.Fatalf("re-parse plain: %v", err)
+	}
+	for i := 0; i < r.PageCount(); i++ {
+		plainPage, _ := rPlain.Page(i)
+		fullPage, _ := rr.Page(i)
+		plainText, err := plainPage.ExtractText()
+		if err != nil {
+			t.Fatalf("ExtractText plain page %d: %v", i, err)
+		}
+		fullText, err := fullPage.ExtractText()
+		if err != nil {
+			t.Fatalf("ExtractText full page %d: %v", i, err)
+		}
+		if plainText != fullText {
+			t.Errorf("page %d text differs after full optimizer\n--- plain ---\n%s\n--- full ---\n%s",
+				i, plainText, fullText)
+		}
+	}
+
+	t.Logf("imported document: plain=%d, xref+obj=%d, +sweep=%d, +cleanup=%d, +dedup=%d, +recompress=%d (saved %.1f%%)",
+		sizes[0], sizes[1], sizes[2], sizes[3], sizes[4], sizes[5],
+		100.0*float64(sizes[0]-sizes[5])/float64(sizes[0]))
+}


### PR DESCRIPTION
## Summary

Closes the optimizer's lossless rewrite story by adding the two remaining passes from the original scope, in a single PR per request (no tracking issue).

- **\`WriteOptions.DeduplicateObjects\`** — hashes each indirect object's canonical serialization (SHA-256 of \`obj.WriteTo\` bytes), groups duplicates, keeps the first slot as the canonical survivor, rewrites every reference targeting any of the others to point at the survivor, and renumbers survivors contiguously starting at 1. Reuses the \`walkReferences\` primitive from the orphan-sweep pass. Catalog, \`/Info\`, and \`/Encrypt\` are excluded — they are reachability roots that the trailer slots refer to by pointer. Highest-value pass on documents that re-use resources (imported pages sharing fonts, repeated logos, identical \`/ToUnicode\` CMaps per §9.10.3).
- **\`WriteOptions.CleanContentStreams\`** — removes redundant operators from page content streams (ISO 32000-1 §7.8). Two patterns in this first cut: empty \`q\` ... \`Q\` graphics-state save/restore pairs whose body is whitespace-only, and identity \`1 0 0 1 0 0 cm\` matrix concatenations (§8.3.3). Operates on the raw byte payload of streams referenced from a Page dictionary's \`/Contents\` entry.

The cleanup includes a minimal byte-level lexer that respects PDF syntax per §7.2 — strings (with balanced nested parens and escape handling), hex strings, comments, names, arrays, dictionaries, numbers, and **inline images (BI ... ID ... EI per §8.9.7)** so the arbitrary binary bytes between ID and EI are never tokenized as operators or operands. Cleanup applies iteratively up to 8 passes so nested empty \`q/Q\` pairs collapse cleanly.

The size-regression guard reverts any cleanup whose result is not strictly smaller than the original.

## Pass ordering

In \`WriteToWithOptions\`: **sweep → cleanup → dedup → recompress → encrypt → serialize**.

- Sweep first so later passes do not waste effort on orphans.
- Cleanup before dedup so two streams that become byte-identical after redundant-operator removal can be merged.
- Dedup before recompress so each canonical payload is recompressed exactly once.
- Encryption walk last because it mutates payload bytes that no other pass should touch.

## Encryption

Both new passes refuse encrypted documents because per-object keys derive from the object number (§7.6.3.3) and payload mutation breaks the encryption walk. Refusal runs before any mutation so a retry without the option is unaffected.

## Headline numbers

End-to-end on the imported text-heavy fixture in \`examples/optimize\`: **40,569 → 6,071 bytes (85.0% saved)** with the full optimizer stack.

| fixture | default | xref+obj | +sweep | +recompress | +full | saved |
|---|---:|---:|---:|---:|---:|---:|
| text-heavy | 6913 | 5621 | 5621 | 5621 | 5555 | 19.6% |
| many empty pages | 6317 | 932 | 932 | 932 | 535 | 91.5% |
| table-heavy | 8063 | 7785 | 7785 | 7785 | 7774 | 3.6% |
| imported text-heavy | 40569 | 40073 | 40073 | 6376 | 6071 | 85.0% |

## Critical correctness fix from review

The test audit surfaced that **inline images** (BI ... ID ... EI) carry arbitrary binary bytes that a naive lexer would tokenize as operators, potentially corrupting image data. Fixed by adding inline-image awareness to the lexer (\`skipInlineImage\` per §8.9.7); the bytes between ID and EI are now treated as opaque. Direct lexer test + cleanup test pin the contract.

## Test plan

- [x] \`go test ./...\` clean
- [x] \`go vet ./...\` clean
- [x] **Dedup tests (20)**: identical dicts/streams merge, three-way duplicate chain collapses, references in arrays/stream-dicts get rewritten, catalog/info/encrypt excluded, distinct-but-similar bodies NOT merged, survivors renumber contiguously, idempotence on serialized bytes, byte-identical zero-options output, encryption refusal with state invariants (object count, numbers, payload bytes), triple-encryption refusal across all toggles, hash stability across two \`WriteTo\` calls (raw stream, compressed stream, dictionary), sweep+dedup catalog identity preservation, composes with sweep / recompress / xref / objstm.
- [x] **Cleanup tests (33)**: 5 lexer tests (operators, comments, strings with nested parens, arrays/dicts, numbers); 9 pure-cleanup tests (drop/keep identity cm, drop/keep empty q/Q, nested + triple-nested + adjacent empty pairs, multi-line cm, comment-not-mistaken-for-operator, no-op on clean stream, no false positives in strings, hex string with operator-shaped bytes, **inline image byte preservation**, empty input, idempotence, adversarial unclosed string/hex/dict/array); 10 pass-level tests (skips non-page streams, cleans page contents, /Contents arrays, skips compressed streams, size-regression guard reverts no-op, encryption refusal, byte-identical zero opts, idempotence, composes with recompress, layout-built docs do not enlarge, content semantics preserved).
- [x] **Integration**: 1 e2e on imported document — full optimizer stack must shrink, structurally reparse, and produce text-equal output page-by-page against the un-optimized re-import.