### PR TITLE
core: anchor deprecations to v0.7.0, reframe RC4 as discouraged

### DIFF
--- a/core/array.go
+++ b/core/array.go
@@ -14,10 +14,10 @@ import (
 type PdfArray struct {
 	// Elements is the underlying slice of array elements.
 	//
-	// Deprecated: direct field access is retained for backward compatibility.
-	// Prefer [PdfArray.All], [PdfArray.At], [PdfArray.Len], and [PdfArray.Add]
-	// for new code so that internal representation changes remain invisible
-	// to callers.
+	// Deprecated: since v0.7.0, scheduled for removal at v1.0. Use
+	// [PdfArray.All], [PdfArray.At], [PdfArray.Len], [PdfArray.Add],
+	// [PdfArray.Set], [PdfArray.RemoveAt], and [PdfArray.Replace] so
+	// internal representation changes remain invisible to callers.
 	Elements []PdfObject
 }
 

--- a/core/dictionary.go
+++ b/core/dictionary.go
@@ -26,9 +26,10 @@ type DictEntry struct {
 type PdfDictionary struct {
 	// Entries is the ordered list of key-value pairs.
 	//
-	// Deprecated: direct field access is retained for backward compatibility.
-	// Prefer [PdfDictionary.All] or [PdfDictionary.Get] in new code so that
-	// the internal index stays consistent with any mutations.
+	// Deprecated: since v0.7.0, scheduled for removal at v1.0. Use
+	// [PdfDictionary.All], [PdfDictionary.Get], [PdfDictionary.Set],
+	// and [PdfDictionary.Remove] so the internal index stays consistent
+	// with mutations.
 	Entries []DictEntry
 
 	// index maps key name → position in Entries. It is lazily built on

--- a/core/encrypt.go
+++ b/core/encrypt.go
@@ -48,9 +48,9 @@ type EncryptionRevision int
 
 const (
 	// RevisionRC4128 selects the RC4-128 Standard Security Handler (V=2, R=3).
-	//
-	// Deprecated: RC4 is cryptographically broken and kept only for backward
-	// compatibility with legacy readers. Use [RevisionAES256] for new documents.
+	// RC4 is cryptographically broken; prefer [RevisionAES256] for new
+	// documents. The constant remains supported for reading and writing
+	// legacy RC4-encrypted PDFs and is not scheduled for removal.
 	RevisionRC4128 EncryptionRevision = 3
 	RevisionAES128 EncryptionRevision = 4 // AES-128-CBC (V=4, R=4)
 	RevisionAES256 EncryptionRevision = 6 // AES-256-CBC (V=5, R=6)

--- a/core/reference.go
+++ b/core/reference.go
@@ -14,14 +14,15 @@ import (
 type PdfIndirectReference struct {
 	// ObjectNumber is the object number of the referenced indirect object.
 	//
-	// Deprecated: direct field access is retained for backward compatibility.
-	// Prefer [PdfIndirectReference.Num] in new code.
+	// Deprecated: since v0.7.0, scheduled for removal at v1.0. Use
+	// [PdfIndirectReference.Num] for reads and [PdfIndirectReference.SetNum]
+	// for writes.
 	ObjectNumber int
 
 	// GenerationNumber is the generation number of the referenced object.
 	//
-	// Deprecated: direct field access is retained for backward compatibility.
-	// Prefer [PdfIndirectReference.Gen] in new code.
+	// Deprecated: since v0.7.0, scheduled for removal at v1.0. Use
+	// [PdfIndirectReference.Gen] in new code.
 	GenerationNumber int
 }
 
@@ -42,10 +43,9 @@ func (r *PdfIndirectReference) Num() int { return r.ObjectNumber }
 // Gen returns the generation number of the referenced object.
 func (r *PdfIndirectReference) Gen() int { return r.GenerationNumber }
 
-// SetNum updates the object number this reference points to. Used by
-// writer-side passes that renumber objects (e.g., the orphan-sweep
-// renumbering in package document) without forcing callers to touch
-// the deprecated ObjectNumber field directly.
+// SetNum updates the object number this reference points to. Writer-side
+// passes that renumber objects (e.g., orphan sweep, deduplication) use
+// this in place of mutating the deprecated ObjectNumber field directly.
 func (r *PdfIndirectReference) SetNum(objNum int) { r.ObjectNumber = objNum }
 
 // WriteTo serializes the indirect reference as "objNum genNum R" to w.


### PR DESCRIPTION
## Summary

Release-prep cleanup for v0.7.0. Two changes:

- **Anchor existing deprecations** with since-v0.7.0 markers and a v1.0 removal target. Lists the concrete replacement API for each accessor:
  - \`core.PdfDictionary.Entries\` → \`All\` / \`Get\` / \`Set\` / \`Remove\`
  - \`core.PdfArray.Elements\` → \`All\` / \`At\` / \`Len\` / \`Add\` / \`Set\` / \`RemoveAt\` / \`Replace\`
  - \`core.PdfIndirectReference.ObjectNumber\` → \`Num\` / \`SetNum\`
  - \`core.PdfIndirectReference.GenerationNumber\` → \`Gen\`
- **Reframe \`core.RevisionRC4128\`** from \`Deprecated:\` to discouraged. RC4 is cryptographically broken and unsuitable for new documents, but the constant must remain for reading and writing legacy RC4-encrypted PDFs and is not scheduled for removal. The previous \`Deprecated:\` tag caused staticcheck and gopls to flag legitimate reader-side use.

Also tightens the \`SetNum\` doc-comment to name the writer-side passes that consume it (orphan sweep, deduplication).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./core/ ./document/\` clean
- [x] No production code changes — only doc-comments