### PR TITLE
svg: clip to viewport under preserveAspectRatio slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **SVG `preserveAspectRatio` slice viewport clip** — when an SVG is drawn with `slice` meet-or-slice, the renderer now emits a PDF clip path on the target rectangle before the viewport transform. Previously the uniform scale was applied correctly but content outside the target rectangle leaked onto the page. Callers that already clipped externally will continue to work (#196)
+
 ## [0.7.1] - 2026-04-22
 
 C ABI follow-up to v0.7.0. No Go-side behavior changes; every addition is in `export/`. C ABI exports grow from 372 to 388 (+16). The header `export/folio.h` is updated in lockstep — `scripts/audit-cabi.sh` reports Go and header in sync.
@@ -45,7 +51,6 @@ Handle-based builder so future toggles compose without renaming existing calls. 
 ### Not exposed
 
 Internal-only v0.7.0 additions remain unexported from the C ABI: `core.PdfIndirectReference.SetNum` and `core.PdfStream.WillCompress` (writer-internal); `core.DeflateStreamData` / `core.InflateStreamData` (callers can use any host-language zlib); `core.PdfArray` / `PdfDictionary` / `PdfNumber` / `PdfBoolean` / `PdfString` Go-style accessors; `font.ParseGPOS` / `ParseGSUB` / `ParseKern` and `face.GSUB` / `GPOS` / `GIDToUnicode` (font parser internals); `font.CanEncodeWinAnsiRune`, `EmbeddedFont.EncodeGIDs` / `MeasureGIDs` (shaper-internal); `layout.ShapeArabic` / `ShapeArabicWithFont` / `ShapeDevanagari*`, `ScriptOf` / `SegmentByScript`, `GraphemeBreaks` / `NextGraphemeBreak` / `GraphemeCount`, `FindKashidaCandidates` / `InsertKashidas` (run inside the layout pipeline); `layout.GSUBProvider` / `GPOSProvider` (Go interfaces); `tmpl` package (Go-specific templating). RTL and shaping for HTML-driven workflows continue to flow through `folio_document_add_html` unchanged.
-
 ## [0.7.0] - 2026-04-21
 
 No breaking API changes. Every new field, method, and package is additive; zero-value `WriteOptions` and existing constructors produce byte-identical output to v0.6.2. Several bug fixes change the visible output of affected documents — see Visual changes before regression-diffing PDFs.

--- a/svg/aspect.go
+++ b/svg/aspect.go
@@ -33,8 +33,8 @@ const (
 	// aspect ratio differs from the viewBox aspect ratio.
 	ScaleMeet AspectMeetOrSlice = iota
 	// ScaleSlice scales uniformly so the viewport is completely covered
-	// by the viewBox; content outside the viewport is not clipped by
-	// this package, so callers should clip externally when using slice.
+	// by the viewBox. Content outside the target rectangle is clipped
+	// by [DrawWithOptions] before the scale transform is applied.
 	ScaleSlice
 )
 

--- a/svg/doc.go
+++ b/svg/doc.go
@@ -36,9 +36,9 @@
 // filter, switch, foreignObject. Per-character text positioning via
 // x/y/dx/dy attribute lists is not supported; text rotate, textPath,
 // and lengthAdjust are not supported. Stroke gradients collapse to the
-// first stop color. Slice mode under preserveAspectRatio scales content
-// correctly but this package does not emit a PDF clip path, so callers
-// that need strict viewport clipping with slice should clip externally.
+// first stop color because painting a stroke with an arbitrary gradient
+// requires PDF tiling/shading patterns, which this package does not
+// emit today.
 //
 // # Usage
 //

--- a/svg/issue196_test.go
+++ b/svg/issue196_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package svg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/content"
+)
+
+// TestSliceEmitsViewportClip verifies that slice mode emits a clip
+// path on the target rectangle so content scaled to cover the
+// viewport is not rendered outside it. Regression guard for #196.
+func TestSliceEmitsViewportClip(t *testing.T) {
+	svgXML := `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50" preserveAspectRatio="xMidYMid slice">
+		<rect width="50" height="50" fill="red"/>
+	</svg>`
+	doc, err := Parse(svgXML)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	stream := content.NewStream()
+	doc.DrawWithOptions(stream, 0, 0, 200, 100, RenderOptions{})
+
+	out := string(stream.Bytes())
+	// The clip should be the target rectangle (0, 0, 200, 100) in the
+	// translated coordinate space, followed by W (clip) and n (end path).
+	if !strings.Contains(out, "0 0 200 100 re") {
+		t.Errorf("expected slice viewport clip rectangle, got:\n%s", out)
+	}
+	// The re must be followed by W and n operators to establish the clip.
+	idx := strings.Index(out, "0 0 200 100 re")
+	if idx < 0 {
+		t.Fatal("rectangle not found")
+	}
+	tail := out[idx:]
+	if !strings.Contains(tail, "\nW\n") && !strings.Contains(tail, " W ") {
+		t.Errorf("expected W operator after slice clip rectangle, got:\n%s", tail)
+	}
+	if !strings.Contains(tail, "\nn\n") && !strings.Contains(tail, " n") {
+		t.Errorf("expected n operator after W for slice clip, got:\n%s", tail)
+	}
+}
+
+// TestMeetDoesNotEmitViewportClip confirms the clip is limited to
+// slice mode. Meet aligns content inside the viewport by construction,
+// so emitting a viewport clip there would be dead code that bloats the
+// content stream.
+func TestMeetDoesNotEmitViewportClip(t *testing.T) {
+	svgXML := `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
+		<rect width="50" height="50" fill="red"/>
+	</svg>`
+	doc, err := Parse(svgXML)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	stream := content.NewStream()
+	doc.DrawWithOptions(stream, 0, 0, 200, 100, RenderOptions{})
+
+	out := string(stream.Bytes())
+	if strings.Contains(out, "0 0 200 100 re") {
+		t.Errorf("meet mode must not emit a target-rect clip, got:\n%s", out)
+	}
+}
+
+// TestNoneDoesNotEmitViewportClip confirms the same guard for the
+// legacy non-uniform scaling path.
+func TestNoneDoesNotEmitViewportClip(t *testing.T) {
+	svgXML := `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50" preserveAspectRatio="none">
+		<rect width="50" height="50" fill="red"/>
+	</svg>`
+	doc, err := Parse(svgXML)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	stream := content.NewStream()
+	doc.DrawWithOptions(stream, 0, 0, 200, 100, RenderOptions{})
+
+	out := string(stream.Bytes())
+	if strings.Contains(out, "0 0 200 100 re") {
+		t.Errorf("none mode must not emit a target-rect clip, got:\n%s", out)
+	}
+}
+
+// TestSliceWithoutViewBoxStillClips covers the fallback path where the
+// SVG has no explicit viewBox; the renderer uses width/height instead.
+// If those differ in aspect ratio from the target rectangle, slice
+// still overflows and must still clip.
+func TestSliceWithoutViewBoxStillClips(t *testing.T) {
+	svgXML := `<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" preserveAspectRatio="xMidYMid slice">
+		<rect width="50" height="50" fill="red"/>
+	</svg>`
+	doc, err := Parse(svgXML)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	stream := content.NewStream()
+	doc.DrawWithOptions(stream, 0, 0, 200, 100, RenderOptions{})
+
+	out := string(stream.Bytes())
+	if !strings.Contains(out, "0 0 200 100 re") {
+		t.Errorf("expected slice clip even without a viewBox, got:\n%s", out)
+	}
+}
+
+// TestZeroViewBoxDoesNotLeakClip guards against a future refactor
+// moving the clip emission above the zero-viewBox early return. A
+// zero-sized viewBox must produce an empty render (matched Save/
+// Restore) with no orphan clip operators that would persist to
+// subsequent page content.
+func TestZeroViewBoxDoesNotLeakClip(t *testing.T) {
+	svgXML := `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 0 0" preserveAspectRatio="xMidYMid slice">
+		<rect width="10" height="10" fill="red"/>
+	</svg>`
+	doc, err := Parse(svgXML)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	stream := content.NewStream()
+	doc.DrawWithOptions(stream, 0, 0, 200, 100, RenderOptions{})
+
+	out := string(stream.Bytes())
+	if strings.Contains(out, " re") {
+		t.Errorf("zero viewBox must not emit any rectangle, got:\n%s", out)
+	}
+	if strings.Contains(out, "\nW\n") || strings.Contains(out, " W ") {
+		t.Errorf("zero viewBox must not emit a clip, got:\n%s", out)
+	}
+}
+
+// TestSliceClipHonorsFloatDimensions checks that the substring-based
+// regression assertions remain correct when callers pass non-integer
+// target dimensions. `content.formatNum` trims trailing zeros, so a
+// half-point target prints as "150.5" rather than "150.500000".
+func TestSliceClipHonorsFloatDimensions(t *testing.T) {
+	svgXML := `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" preserveAspectRatio="xMidYMid slice">
+		<rect width="10" height="10" fill="red"/>
+	</svg>`
+	doc, err := Parse(svgXML)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	stream := content.NewStream()
+	doc.DrawWithOptions(stream, 0, 0, 150.5, 100.25, RenderOptions{})
+
+	out := string(stream.Bytes())
+	if !strings.Contains(out, "0 0 150.5 100.25 re") {
+		t.Errorf("expected float dimensions in clip rectangle, got:\n%s", out)
+	}
+}

--- a/svg/render.go
+++ b/svg/render.go
@@ -92,6 +92,19 @@ func (s *SVG) DrawWithOptions(stream *content.Stream, x, y, w, h float64, opts R
 	// other setting the scale is uniform and a translation offset is
 	// folded in so the scaled viewBox is aligned within (w, h).
 	sx, sy, tx, ty := computeViewportTransform(s.aspectRatio, w, h, vbW, vbH)
+
+	// Slice mode scales uniformly so the viewport is fully covered,
+	// which means content overflows on one axis. Clip to the target
+	// rectangle in its own coordinate space (i.e. after the translate
+	// to (x, y), before the scale is applied) so the overflow is not
+	// visible. Meet and none modes keep content inside the target by
+	// construction, so no clip is needed there.
+	if !s.aspectRatio.None && s.aspectRatio.MeetOrSlice == ScaleSlice {
+		stream.Rectangle(0, 0, w, h)
+		stream.ClipNonZero()
+		stream.EndPath()
+	}
+
 	stream.ConcatMatrix(sx, 0, 0, sy, tx, ty)
 
 	// Flip Y axis: SVG is top-down, PDF is bottom-up.


### PR DESCRIPTION
## Summary

- Emits a PDF clip path on the target rectangle in \`DrawWithOptions\` before the viewport scale is applied, but only when \`preserveAspectRatio\` selects \`slice\`. Fixes half of #196.
- Meet and none keep byte-identical output: the fix is scoped to the only mode that actually overflows.
- Updates the \`ScaleSlice\` godoc and \`svg/doc.go\` \"Unsupported\" note; rewords the stroke-gradient note to explain why that half needs Pattern infrastructure (tracked in #210).
- Filed #209 for nested \`<svg>\` viewport clipping (same class of bug, different recursion path).

## Why the clip is slice-only

Spec-faithful behavior would clip in meet and none too (SVG 1.1 §7.8 — content outside the viewport is hidden regardless of mode). But meet and none contain content by construction, and emitting a clip unconditionally would break byte-identical output for every existing 0.7.0 caller (violates ARCHITECTURE.md §5). Slice is the only mode where overflow is observable, so that is the only mode where the clip is added.

## Test plan

- [x] \`TestSliceEmitsViewportClip\` — slice emits \`0 0 w h re\` + \`W\` + \`n\` in the right coordinate space.
- [x] \`TestMeetDoesNotEmitViewportClip\` and \`TestNoneDoesNotEmitViewportClip\` — deterministic-output regression guards.
- [x] \`TestSliceWithoutViewBoxStillClips\` — width/height fallback path also clips.
- [x] \`TestZeroViewBoxDoesNotLeakClip\` — guards against a future refactor moving the clip above the zero-viewBox early return.
- [x] \`TestSliceClipHonorsFloatDimensions\` — substring assertions hold for non-integer target sizes (\`content.formatNum\` trims trailing zeros).
- [x] \`go test ./...\` and \`go vet ./...\` clean.

## Follow-ups (filed as separate issues)

- #209 — nested \`<svg>\` elements should establish their own viewport.
- #210 — stroke gradients via tiling/shading patterns (Option A or B).

Closes half of #196; stroke-gradient portion moved to #210.