### PR TITLE
html: add Options.BaseFS and Options.Client (#85)

### DIFF
--- a/html/converter.go
+++ b/html/converter.go
@@ -5,7 +5,11 @@ package html
 
 import (
 	"fmt"
+	"io/fs"
 	"math"
+	"net/http"
+	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -21,7 +25,19 @@ type Options struct {
 	// DefaultFontSize is the root font size in points (default 12).
 	DefaultFontSize float64
 	// BasePath is the base directory for resolving relative image/font/CSS paths.
+	// Used when BaseFS is nil. Paths are forwarded with filepath.Join, so
+	// OS-native separators and absolute references both work.
 	BasePath string
+	// BaseFS is the filesystem used to resolve relative paths for images,
+	// fonts, and linked stylesheets. When non-nil, it takes precedence over
+	// BasePath for relative paths. Absolute paths still fall through to the
+	// OS filesystem so existing absolute path references keep working.
+	// System-font fallback lookup in FallbackFontPath / hardcoded candidates
+	// is unaffected and always reads from the OS filesystem.
+	// Typical uses: embed.FS for embedded assets, fstest.MapFS in tests,
+	// os.DirFS(dir) or (*os.Root).FS() for sandboxed directory access.
+	// BaseFS paths must be forward-slash separated (fs.FS convention).
+	BaseFS fs.FS
 	// PageWidth is the page width in points (default 612 = US Letter).
 	PageWidth float64
 	// PageHeight is the page height in points (default 792 = US Letter).
@@ -35,6 +51,9 @@ type Options struct {
 	// Return nil to allow the fetch, or an error to block it.
 	// If nil, all URLs are allowed.
 	URLPolicy URLPolicy
+	// Client is the HTTP client used to fetch remote images and stylesheets.
+	// If nil, http.DefaultClient is used.
+	Client *http.Client
 }
 
 // URLPolicy controls whether the HTML converter may fetch a remote URL.
@@ -50,17 +69,62 @@ func (o *Options) defaults() Options {
 			out.DefaultFontSize = o.DefaultFontSize
 		}
 		out.BasePath = o.BasePath
+		out.BaseFS = o.BaseFS
 		if o.PageWidth > 0 {
 			out.PageWidth = o.PageWidth
 		}
 		if o.PageHeight > 0 {
 			out.PageHeight = o.PageHeight
 		}
+		if o.FallbackFontPath != "" {
+			out.FallbackFontPath = o.FallbackFontPath
+		}
 		if o.URLPolicy != nil {
 			out.URLPolicy = o.URLPolicy
 		}
+		if o.Client != nil {
+			out.Client = o.Client
+		}
 	}
 	return out
+}
+
+// readAsset reads a relative or absolute path using BaseFS / BasePath rules.
+// Resolution order:
+//  1. Absolute paths → os.ReadFile (bypasses BaseFS so existing absolute-path
+//     references in CSS/HTML keep working even when BaseFS is set).
+//  2. BaseFS != nil → fs.ReadFile(BaseFS, normalized-p). The path is normalized
+//     to fs.FS form: backslashes → slashes, a leading "/" is stripped, and the
+//     result must satisfy fs.ValidPath (so ".." escapes are rejected up front
+//     rather than relying on each fs.FS implementation to enforce it).
+//  3. BasePath != "" → os.ReadFile(filepath.Join(BasePath, p)).
+//  4. Fallback → os.ReadFile(p) (cwd-relative).
+func readAsset(baseFS fs.FS, basePath, p string) ([]byte, error) {
+	if filepath.IsAbs(p) {
+		return os.ReadFile(p)
+	}
+	if baseFS != nil {
+		fsPath := filepath.ToSlash(p)
+		fsPath = strings.TrimPrefix(fsPath, "./")
+		fsPath = strings.TrimPrefix(fsPath, "/")
+		fsPath = path.Clean(fsPath)
+		if !fs.ValidPath(fsPath) {
+			return nil, fmt.Errorf("invalid path for BaseFS: %q", p)
+		}
+		return fs.ReadFile(baseFS, fsPath)
+	}
+	if basePath != "" {
+		return os.ReadFile(filepath.Join(basePath, p))
+	}
+	return os.ReadFile(p)
+}
+
+// httpClientOrDefault returns the configured HTTP client or http.DefaultClient.
+func httpClientOrDefault(c *http.Client) *http.Client {
+	if c != nil {
+		return c
+	}
+	return http.DefaultClient
 }
 
 // ConvertResult holds the full result of an HTML → layout conversion,
@@ -168,7 +232,7 @@ func ConvertFull(htmlStr string, opts *Options) (*ConvertResult, error) {
 	style := defaultStyle()
 	style.FontSize = o.DefaultFontSize
 
-	ss := parseStyleBlocks(doc, o.BasePath, makeCSSFetcher(o.URLPolicy))
+	ss := parseStyleBlocks(doc, o.BaseFS, o.BasePath, makeCSSFetcher(o.URLPolicy, o.Client))
 
 	c := &converter{opts: o, rootFontSize: o.DefaultFontSize, sheet: ss, embeddedFonts: make(map[string]*font.EmbeddedFont), containerWidth: o.PageWidth, counters: make(map[string][]int), urlPolicy: o.URLPolicy}
 
@@ -185,7 +249,7 @@ func ConvertFull(htmlStr string, opts *Options) (*ConvertResult, error) {
 	}
 
 	// Load @font-face fonts.
-	c.loadFontFaces(ss.fontFaces, o.BasePath)
+	c.loadFontFaces(ss.fontFaces)
 
 	elems := c.walkChildren(doc, style)
 	result := &ConvertResult{Elements: elems, Absolutes: c.absolutes, Metadata: c.metadata}
@@ -216,7 +280,7 @@ func Convert(htmlStr string, opts *Options) ([]layout.Element, error) {
 	style := defaultStyle()
 	style.FontSize = o.DefaultFontSize
 
-	ss := parseStyleBlocks(doc, o.BasePath, makeCSSFetcher(o.URLPolicy))
+	ss := parseStyleBlocks(doc, o.BaseFS, o.BasePath, makeCSSFetcher(o.URLPolicy, o.Client))
 
 	c := &converter{opts: o, rootFontSize: o.DefaultFontSize, sheet: ss, embeddedFonts: make(map[string]*font.EmbeddedFont), containerWidth: o.PageWidth, counters: make(map[string][]int), urlPolicy: o.URLPolicy}
 
@@ -230,7 +294,7 @@ func Convert(htmlStr string, opts *Options) ([]layout.Element, error) {
 	}
 
 	// Load @font-face fonts.
-	c.loadFontFaces(ss.fontFaces, o.BasePath)
+	c.loadFontFaces(ss.fontFaces)
 
 	return c.walkChildren(doc, style), nil
 }
@@ -279,8 +343,8 @@ type pendingOverlay struct {
 // loadFontFaces loads @font-face fonts into the converter's embeddedFonts map.
 // Supports both file paths and base64-encoded data URIs (data:font/truetype;base64,...).
 // Data URI support enables fully self-contained HTML templates without external
-// font file dependencies.
-func (c *converter) loadFontFaces(faces []fontFaceRule, basePath string) {
+// font file dependencies. File paths are resolved through BaseFS/BasePath.
+func (c *converter) loadFontFaces(faces []fontFaceRule) {
 	for _, ff := range faces {
 		src := ff.src
 		if src == "" {
@@ -294,12 +358,11 @@ func (c *converter) loadFontFaces(faces []fontFaceRule, basePath string) {
 			// Data URI: decode base64 font data inline.
 			face, err = decodeFontDataURI(src)
 		} else {
-			// File path: resolve relative to basePath.
-			path := src
-			if !filepath.IsAbs(path) && basePath != "" {
-				path = filepath.Join(basePath, path)
+			var data []byte
+			data, err = readAsset(c.opts.BaseFS, c.opts.BasePath, src)
+			if err == nil {
+				face, err = font.ParseFont(data)
 			}
-			face, err = font.LoadFont(path)
 		}
 
 		if err != nil {

--- a/html/converter_helpers.go
+++ b/html/converter_helpers.go
@@ -5,7 +5,6 @@ package html
 
 import (
 	"math"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -572,10 +571,7 @@ func (c *converter) resolveBackgroundImage(style computedStyle) *layout.Backgrou
 			}
 			img = loaded
 		} else {
-			if !filepath.IsAbs(imgPath) && c.opts.BasePath != "" {
-				imgPath = filepath.Join(c.opts.BasePath, imgPath)
-			}
-			loaded, err := loadImage(imgPath)
+			loaded, err := c.loadLocalImage(imgPath)
 			if err != nil {
 				return nil
 			}

--- a/html/converter_image.go
+++ b/html/converter_image.go
@@ -6,7 +6,6 @@ package html
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -44,11 +43,7 @@ func (c *converter) convertImage(n *html.Node, style computedStyle) []layout.Ele
 	} else if isURL(src) {
 		img, err = c.fetchImage(src)
 	} else {
-		imgPath := src
-		if !filepath.IsAbs(imgPath) && c.opts.BasePath != "" {
-			imgPath = filepath.Join(c.opts.BasePath, imgPath)
-		}
-		img, err = loadImage(imgPath)
+		img, err = c.loadLocalImage(src)
 	}
 	if err != nil {
 		if alt != "" {
@@ -259,12 +254,8 @@ func (c *converter) convertImgSVG(src string, style computedStyle) []layout.Elem
 			return nil
 		}
 	} else {
-		// Local file path.
-		imgPath := src
-		if !filepath.IsAbs(imgPath) && c.opts.BasePath != "" {
-			imgPath = filepath.Join(c.opts.BasePath, imgPath)
-		}
-		svgData, err = os.ReadFile(imgPath)
+		// Local file path resolved through BaseFS / BasePath.
+		svgData, err = readAsset(c.opts.BaseFS, c.opts.BasePath, src)
 		if err != nil {
 			return nil
 		}
@@ -298,36 +289,47 @@ func isURL(s string) bool {
 // fetchImage is implemented in fetch_image.go (with net/http)
 // and fetch_image_wasm.go (stub for WASM builds).
 
-// loadImage attempts to load an image file (JPEG, PNG, TIFF, WebP, GIF).
-func loadImage(path string) (*folioimage.Image, error) {
-	ext := strings.ToLower(filepath.Ext(path))
-	switch ext {
+// loadLocalImage loads an image referenced by a relative or absolute path,
+// resolving through BaseFS / BasePath. The image format is detected from
+// the file extension first, then by magic bytes.
+func (c *converter) loadLocalImage(p string) (*folioimage.Image, error) {
+	data, err := readAsset(c.opts.BaseFS, c.opts.BasePath, p)
+	if err != nil {
+		return nil, err
+	}
+	return decodeImageBytes(data, filepath.Ext(p))
+}
+
+// decodeImageBytes decodes image bytes to a folio Image. ext is a hint like
+// ".png" / ".jpg"; content sniffing is used when the extension is unknown.
+func decodeImageBytes(data []byte, ext string) (*folioimage.Image, error) {
+	switch strings.ToLower(ext) {
 	case ".jpg", ".jpeg":
-		return folioimage.LoadJPEG(path)
+		return folioimage.NewJPEG(data)
 	case ".png":
-		return folioimage.LoadPNG(path)
+		return folioimage.NewPNG(data)
 	case ".tif", ".tiff":
-		return folioimage.LoadTIFF(path)
+		return folioimage.NewTIFF(data)
 	case ".webp":
-		return folioimage.LoadWebP(path)
+		return folioimage.NewWebP(data)
 	case ".gif":
-		return folioimage.LoadGIF(path)
-	default:
-		// Try reading raw bytes and detecting format.
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil, err
-		}
-		// Content sniffing: try formats by magic bytes.
-		if len(data) >= 4 && string(data[:4]) == "RIFF" && len(data) >= 12 && string(data[8:12]) == "WEBP" {
-			return folioimage.NewWebP(data)
-		}
-		if len(data) >= 6 && (string(data[:6]) == "GIF87a" || string(data[:6]) == "GIF89a") {
-			return folioimage.NewGIF(data)
-		}
-		if img, err := folioimage.NewJPEG(data); err == nil {
-			return img, nil
-		}
+		return folioimage.NewGIF(data)
+	}
+	// Content sniffing: try formats by magic bytes.
+	if len(data) >= 4 && string(data[:4]) == "RIFF" && len(data) >= 12 && string(data[8:12]) == "WEBP" {
+		return folioimage.NewWebP(data)
+	}
+	if len(data) >= 6 && (string(data[:6]) == "GIF87a" || string(data[:6]) == "GIF89a") {
+		return folioimage.NewGIF(data)
+	}
+	if len(data) >= 2 && data[0] == 0xFF && data[1] == 0xD8 {
+		return folioimage.NewJPEG(data)
+	}
+	if len(data) >= 4 && string(data[:4]) == "\x89PNG" {
 		return folioimage.NewPNG(data)
 	}
+	if img, err := folioimage.NewJPEG(data); err == nil {
+		return img, nil
+	}
+	return folioimage.NewPNG(data)
 }

--- a/html/css.go
+++ b/html/css.go
@@ -4,8 +4,7 @@
 package html
 
 import (
-	"os"
-	"path/filepath"
+	"io/fs"
 	"strings"
 
 	"golang.org/x/net/html"
@@ -77,8 +76,9 @@ type cssDecl struct {
 // document and parses their CSS. Linked stylesheets are processed before <style>
 // blocks so that inline styles override external ones by source order.
 // fetchURL, if non-nil, is called for HTTP/HTTPS hrefs; it should return the
-// CSS bytes or an error. Local file paths are resolved against basePath.
-func parseStyleBlocks(doc *html.Node, basePath string, fetchURL func(string) ([]byte, error)) *styleSheet {
+// CSS bytes or an error. Local file paths are resolved against baseFS (if
+// non-nil), else against basePath.
+func parseStyleBlocks(doc *html.Node, baseFS fs.FS, basePath string, fetchURL func(string) ([]byte, error)) *styleSheet {
 	ss := &styleSheet{}
 
 	// First pass: collect <link rel="stylesheet"> elements and load them.
@@ -101,11 +101,7 @@ func parseStyleBlocks(doc *html.Node, basePath string, fetchURL func(string) ([]
 				if isURL(href) && fetchURL != nil {
 					data, err = fetchURL(href)
 				} else {
-					path := href
-					if !filepath.IsAbs(path) && basePath != "" {
-						path = filepath.Join(basePath, path)
-					}
-					data, err = os.ReadFile(path)
+					data, err = readAsset(baseFS, basePath, href)
 				}
 				if err == nil {
 					ss.parseCSS(string(data))

--- a/html/fetch_image.go
+++ b/html/fetch_image.go
@@ -16,15 +16,20 @@ import (
 )
 
 // makeCSSFetcher returns a function that fetches CSS from a URL, protected
-// by the given URLPolicy. Returns nil if no URL fetching should be attempted.
-func makeCSSFetcher(policy URLPolicy) func(string) ([]byte, error) {
+// by the given URLPolicy and using the given HTTP client. Returns nil if
+// no URL fetching should be attempted. A nil client falls back to
+// http.DefaultClient.
+func makeCSSFetcher(policy URLPolicy, client *http.Client) func(string) ([]byte, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	return func(url string) ([]byte, error) {
 		if policy != nil {
 			if err := policy(url); err != nil {
 				return nil, err
 			}
 		}
-		resp, err := http.Get(url)
+		resp, err := client.Get(url)
 		if err != nil {
 			return nil, fmt.Errorf("fetch stylesheet %s: %w", url, err)
 		}
@@ -47,7 +52,7 @@ func (c *converter) fetchImage(url string) (*folioimage.Image, error) {
 		}
 	}
 
-	resp, err := http.Get(url)
+	resp, err := httpClientOrDefault(c.opts.Client).Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("fetch image %s: %w", url, err)
 	}

--- a/html/fetch_image_wasm.go
+++ b/html/fetch_image_wasm.go
@@ -7,12 +7,13 @@ package html
 
 import (
 	"fmt"
+	"net/http"
 
 	folioimage "github.com/carlos7ags/folio/image"
 )
 
 // makeCSSFetcher is a stub for WASM builds — returns nil (no HTTP fetching).
-func makeCSSFetcher(_ URLPolicy) func(string) ([]byte, error) {
+func makeCSSFetcher(_ URLPolicy, _ *http.Client) func(string) ([]byte, error) {
 	return nil
 }
 

--- a/html/options_fs_client_test.go
+++ b/html/options_fs_client_test.go
@@ -1,0 +1,347 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"testing/fstest"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// makeJPEGBytes returns a small encoded JPEG for tests.
+func makeJPEGBytes(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for y := 0; y < 4; y++ {
+		for x := 0; x < 4; x++ {
+			img.SetRGBA(x, y, color.RGBA{R: 200, G: 100, B: 50, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, nil); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// TestBaseFSLoadsImage verifies that <img> with a relative src is loaded
+// from Options.BaseFS instead of the OS filesystem. We assert both that the
+// BaseFS was read and that the decoded image made it into the layout.
+func TestBaseFSLoadsImage(t *testing.T) {
+	jpegData := makeJPEGBytes(t)
+	fsys := &countingFS{inner: fstest.MapFS{
+		"assets/photo.jpg": {Data: jpegData},
+	}}
+
+	elems, err := Convert(`<img src="assets/photo.jpg"/>`, &Options{BaseFS: fsys})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
+	if _, ok := elems[0].(*layout.ImageElement); !ok {
+		t.Fatalf("expected ImageElement from BaseFS, got %T (alt-text fallback means FS load failed)", elems[0])
+	}
+	if fsys.count("assets/photo.jpg") == 0 {
+		t.Errorf("expected BaseFS to be read; opens = %v", fsys.snapshot())
+	}
+}
+
+// TestBaseFSLoadsLinkedStylesheet verifies that <link rel="stylesheet"> resolves
+// through BaseFS. We check that the stylesheet file was actually read by
+// wrapping MapFS in a counting FS.
+func TestBaseFSLoadsLinkedStylesheet(t *testing.T) {
+	fsys := &countingFS{inner: fstest.MapFS{
+		"styles/site.css": {Data: []byte(`p { color: red; }`)},
+	}}
+	html := `<html><head><link rel="stylesheet" href="styles/site.css"/></head><body><p>hi</p></body></html>`
+
+	if _, err := ConvertFull(html, &Options{BaseFS: fsys}); err != nil {
+		t.Fatal(err)
+	}
+	if fsys.count("styles/site.css") == 0 {
+		t.Errorf("expected stylesheet to be read from BaseFS; opens = %v", fsys.snapshot())
+	}
+}
+
+// TestBaseFSLoadsBackgroundImage verifies the background-image: url() resolver
+// routes through BaseFS. This path goes through resolveBackgroundImage →
+// loadLocalImage, a different code path from <img> and linked stylesheet.
+func TestBaseFSLoadsBackgroundImage(t *testing.T) {
+	jpegData := makeJPEGBytes(t)
+	fsys := &countingFS{inner: fstest.MapFS{
+		"bg.jpg": {Data: jpegData},
+	}}
+	html := `<div style="background-image: url('bg.jpg'); width:100px; height:100px;"><p>x</p></div>`
+	if _, err := Convert(html, &Options{BaseFS: fsys}); err != nil {
+		t.Fatal(err)
+	}
+	if fsys.count("bg.jpg") == 0 {
+		t.Errorf("expected background-image to be read from BaseFS; opens = %v", fsys.snapshot())
+	}
+}
+
+// TestBaseFSTakesPrecedenceOverBasePath verifies that when both BaseFS and
+// BasePath are set, BaseFS wins for relative paths.
+func TestBaseFSTakesPrecedenceOverBasePath(t *testing.T) {
+	jpegData := makeJPEGBytes(t)
+	fsys := fstest.MapFS{
+		"photo.jpg": {Data: jpegData},
+	}
+	elems, err := Convert(`<img src="photo.jpg"/>`, &Options{
+		BaseFS:   fsys,
+		BasePath: "/this/path/does/not/exist",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := elems[0].(*layout.ImageElement); !ok {
+		t.Fatalf("BaseFS should win over BasePath; got %T", elems[0])
+	}
+}
+
+// TestBaseFSAbsolutePathFallsThrough verifies that absolute paths bypass BaseFS
+// and go to the OS filesystem. This preserves backward compatibility for
+// absolute references in CSS/HTML.
+func TestBaseFSAbsolutePathFallsThrough(t *testing.T) {
+	dir := t.TempDir()
+	osPath := dir + "/abs.jpg"
+	if err := writeFile(osPath, makeJPEGBytes(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty BaseFS — absolute paths should go to OS.
+	fsys := fstest.MapFS{}
+	elems, err := Convert(fmt.Sprintf(`<img src="%s"/>`, osPath), &Options{BaseFS: fsys})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := elems[0].(*layout.ImageElement); !ok {
+		t.Fatalf("absolute path should bypass BaseFS; got %T", elems[0])
+	}
+}
+
+// TestClientUsedForImageFetch verifies that Options.Client is used for HTTP
+// image fetches.
+func TestClientUsedForImageFetch(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(makeJPEGBytes(t))
+	}))
+	defer srv.Close()
+
+	// Wrap the transport so we can also assert our client is the one making the call.
+	seen := 0
+	client := &http.Client{
+		Transport: &countingTransport{inner: http.DefaultTransport, counter: &seen},
+	}
+
+	elems, err := Convert(fmt.Sprintf(`<img src="%s/photo.jpg"/>`, srv.URL), &Options{
+		Client: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("test server was not hit")
+	}
+	if seen == 0 {
+		t.Error("Options.Client transport was not used for image fetch")
+	}
+	if _, ok := elems[0].(*layout.ImageElement); !ok {
+		t.Fatalf("expected ImageElement, got %T", elems[0])
+	}
+}
+
+// TestClientUsedForStylesheetFetch verifies that Options.Client is used for
+// HTTP <link rel="stylesheet"> loads.
+func TestClientUsedForStylesheetFetch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/css")
+		_, _ = io.WriteString(w, `p { color: red; }`)
+	}))
+	defer srv.Close()
+
+	seen := 0
+	client := &http.Client{
+		Transport: &countingTransport{inner: http.DefaultTransport, counter: &seen},
+	}
+	html := fmt.Sprintf(`<html><head><link rel="stylesheet" href="%s/s.css"/></head><body><p>hi</p></body></html>`, srv.URL)
+
+	if _, err := ConvertFull(html, &Options{Client: client}); err != nil {
+		t.Fatal(err)
+	}
+	if seen == 0 {
+		t.Error("Options.Client transport was not used for stylesheet fetch")
+	}
+}
+
+// TestURLPolicyStillBlocksWithCustomClient confirms that URLPolicy short-circuits
+// the fetch before the custom Client is ever consulted.
+func TestURLPolicyStillBlocksWithCustomClient(t *testing.T) {
+	seen := 0
+	client := &http.Client{
+		Transport: &countingTransport{inner: http.DefaultTransport, counter: &seen},
+	}
+	_, err := Convert(`<img src="http://example.invalid/x.jpg"/>`, &Options{
+		Client:    client,
+		URLPolicy: func(string) error { return fmt.Errorf("denied") },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen != 0 {
+		t.Errorf("Client should not have been used when URLPolicy denies: got %d transport calls", seen)
+	}
+}
+
+// TestBaseFSLoadsFontFace verifies that @font-face src resolves through BaseFS.
+// The font bytes are invalid so loadFontFaces silently skips embedding — but
+// the counting FS proves readAsset routed the read through BaseFS.
+func TestBaseFSLoadsFontFace(t *testing.T) {
+	fsys := &countingFS{inner: fstest.MapFS{
+		"fonts/fake.ttf": {Data: []byte("not a real font")},
+	}}
+	html := `<html><head><style>
+		@font-face { font-family: "X"; src: url("fonts/fake.ttf"); }
+		p { font-family: "X"; }
+	</style></head><body><p>hi</p></body></html>`
+
+	if _, err := Convert(html, &Options{BaseFS: fsys}); err != nil {
+		t.Fatal(err)
+	}
+	if fsys.count("fonts/fake.ttf") == 0 {
+		t.Errorf("expected @font-face src to be read from BaseFS; opens = %v", fsys.snapshot())
+	}
+}
+
+// TestBaseFSRejectsParentEscape verifies that a "../" traversal attempt in
+// <img src> against BaseFS fails cleanly (rejected by fs.ValidPath in
+// readAsset) and falls back to alt text, not to an OS read outside the FS.
+func TestBaseFSRejectsParentEscape(t *testing.T) {
+	fsys := &countingFS{inner: fstest.MapFS{
+		"safe.jpg": {Data: makeJPEGBytes(t)},
+	}}
+	elems, err := Convert(`<img src="../etc/passwd" alt="blocked"/>`, &Options{BaseFS: fsys})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
+	if _, ok := elems[0].(*layout.Paragraph); !ok {
+		t.Fatalf("expected alt-text Paragraph fallback, got %T", elems[0])
+	}
+	if fsys.count("../etc/passwd") != 0 {
+		t.Errorf("fs should not have been opened with traversal path; opens = %v", fsys.snapshot())
+	}
+}
+
+// TestReadAssetInvalidPath directly exercises readAsset's path handling
+// for fs.FS inputs: traversal rejected, leading ./ stripped, not-found is
+// a clean fs.ErrNotExist rather than a panic.
+func TestReadAssetInvalidPath(t *testing.T) {
+	fsys := fstest.MapFS{"dir/a.txt": {Data: []byte("ok")}}
+
+	// ".." traversal must not reach fs.ReadFile.
+	if _, err := readAsset(fsys, "", "dir/../../escape"); err == nil {
+		t.Error("expected error for traversal path, got nil")
+	}
+
+	// Leading "./" is normalized and the read succeeds.
+	data, err := readAsset(fsys, "", "./dir/a.txt")
+	if err != nil {
+		t.Errorf("./ prefix should be stripped: %v", err)
+	}
+	if string(data) != "ok" {
+		t.Errorf("unexpected data: %q", data)
+	}
+
+	// Missing file surfaces as fs.ErrNotExist (not a panic, not a different error).
+	if _, err := readAsset(fsys, "", "dir/nope.txt"); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("expected fs.ErrNotExist, got %v", err)
+	}
+}
+
+// TestBasePathStillWorksWithoutBaseFS verifies the legacy path behavior is
+// unchanged when BaseFS is nil.
+func TestBasePathStillWorksWithoutBaseFS(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFile(dir+"/legacy.jpg", makeJPEGBytes(t)); err != nil {
+		t.Fatal(err)
+	}
+	elems, err := Convert(`<img src="legacy.jpg"/>`, &Options{BasePath: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := elems[0].(*layout.ImageElement); !ok {
+		t.Fatalf("BasePath (without BaseFS) should still load image; got %T", elems[0])
+	}
+}
+
+// countingTransport wraps an http.RoundTripper and counts invocations.
+type countingTransport struct {
+	inner   http.RoundTripper
+	counter *int
+}
+
+func (c *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	*c.counter++
+	return c.inner.RoundTrip(req)
+}
+
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o644)
+}
+
+// countingFS wraps an fs.FS and records which paths were opened, so a test
+// can assert BaseFS was actually the source of a read. Safe for concurrent
+// use by Open; snapshots are independent copies.
+type countingFS struct {
+	inner fstest.MapFS
+	mu    sync.Mutex
+	opens map[string]int
+}
+
+func (c *countingFS) Open(name string) (fs.File, error) {
+	c.mu.Lock()
+	if c.opens == nil {
+		c.opens = map[string]int{}
+	}
+	c.opens[name]++
+	c.mu.Unlock()
+	return c.inner.Open(name)
+}
+
+func (c *countingFS) count(name string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.opens[name]
+}
+
+func (c *countingFS) snapshot() map[string]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]int, len(c.opens))
+	for k, v := range c.opens {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
Closes #85.

## Summary

- Adds `html.Options.BaseFS` (`fs.FS`) so relative image / font / linked-stylesheet paths can be served from any filesystem — `embed.FS`, `os.DirFS`, `fstest.MapFS`, `(*os.Root).FS()`.
- Adds `html.Options.Client` (`*http.Client`) so every HTTP fetch (images, stylesheets) goes through a caller-supplied client. Defaults to `http.DefaultClient`.
- Keeps `BasePath` working unchanged — BaseFS is opt-in, backward compat is preserved for every existing caller.

## Resolution rules

`readAsset` in `html/converter.go`:

1. Absolute paths → `os.ReadFile` (existing absolute references keep working).
2. `BaseFS != nil` → `fs.ReadFile(BaseFS, p)`; path normalized and validated with `fs.ValidPath`, so `..` traversal attempts are rejected up front.
3. `BasePath != ""` → `os.ReadFile(filepath.Join(BasePath, p))`.
4. Otherwise → `os.ReadFile(p)` (cwd-relative).

`URLPolicy` still runs before the `Client`, so a denying policy short-circuits the fetch regardless of the client supplied.

## What changed

- `html/converter.go`: Options fields, `readAsset`, `httpClientOrDefault`, `loadFontFaces` via `font.ParseFont`.
- `html/css.go`: `parseStyleBlocks` now takes `fs.FS`.
- `html/converter_image.go`: `convertImage` / `convertImgSVG` use `readAsset`; `loadImage` replaced by `decodeImageBytes` + `converter.loadLocalImage`.
- `html/converter_helpers.go`: background-image path uses `loadLocalImage`.
- `html/fetch_image.go`: `makeCSSFetcher` and `fetchImage` use the configured `*http.Client`.
- `html/fetch_image_wasm.go`: stub signature updated.

## Out of scope

- C ABI unchanged. `fs.FS` and `*http.Client` are Go-only interfaces and can't cross the C boundary. C callers continue to use `BasePath`. Header stays in sync at 388 exports.
- `tmpl.RenderFile` still sets only `BasePath`. Candidate follow-up.
- `@font-face` inside a linked stylesheet still resolves relative to the document, not the stylesheet. Pre-existing behavior; would be a semantic change.

## Test plan

- [x] `go test ./...` (all packages)
- [x] `go test -race ./html/ -run 'TestBaseFS|TestClient'`
- [x] `GOOS=js GOARCH=wasm go build ./html/ ./layout/ ./font/ ./image/`
- [x] New test file `html/options_fs_client_test.go` covers: image via BaseFS, linked stylesheet via BaseFS, background-image via BaseFS, @font-face via BaseFS (asserted via counting FS), BaseFS precedence over BasePath, absolute path falls through to OS, custom Client for images and stylesheets, URLPolicy short-circuits a custom Client, `..` traversal rejected and falls back to alt text, direct unit test of `readAsset` path normalization and `fs.ErrNotExist` propagation, legacy BasePath still works without BaseFS.