### PR TITLE
font: GPOS LookupType 6 (Mark-to-Mark Positioning)

### DIFF
--- a/font/gpos.go
+++ b/font/gpos.go
@@ -17,8 +17,11 @@ const (
 	// an explicit anchor of a base glyph. ISO 14496-22 §6.3 LookupType 4.
 	GPOSMark GPOSFeature = "mark"
 
-	// GPOSMkmk is the Mark-to-Mark Positioning feature. Recognized for
-	// future use; LookupType 6 is not implemented in this iteration.
+	// GPOSMkmk is the Mark-to-Mark Positioning feature. It positions a
+	// combining mark glyph on an explicit anchor of another combining
+	// mark — the mechanism behind stacked diacritics such as Arabic
+	// shadda + fatha, Hebrew dagesh + niqqud, and Vietnamese tone marks
+	// on already-diacritic vowels. ISO 14496-22 §6.3 LookupType 6.
 	GPOSMkmk GPOSFeature = "mkmk"
 )
 
@@ -63,12 +66,22 @@ type GPOSAdjustments struct {
 
 	// Bases holds LookupType 4 base records keyed by base glyph ID.
 	Bases map[GPOSFeature]map[uint16]BaseRecord
+
+	// MarkMarks holds LookupType 6 top-mark records keyed by the
+	// attaching (mark1) glyph ID. Shape mirrors Marks.
+	MarkMarks map[GPOSFeature]map[uint16]MarkRecord
+
+	// Mark2Bases holds LookupType 6 underlying-mark records keyed by
+	// the receiving (mark2) glyph ID. Shape mirrors Bases: each entry
+	// exposes one anchor per mark class of the attaching mark.
+	Mark2Bases map[GPOSFeature]map[uint16]BaseRecord
 }
 
 // ParseGPOS reads the GPOS table from raw font bytes and extracts
-// LookupType 2 (Pair Positioning) and LookupType 4 (Mark-to-Base
-// Positioning) data for the "kern" and "mark" features. Extension
-// lookups (LookupType 9) are unwrapped for types 2 and 4.
+// LookupType 2 (Pair Positioning), LookupType 4 (Mark-to-Base), and
+// LookupType 6 (Mark-to-Mark) data for the "kern", "mark", and "mkmk"
+// features. Extension lookups (LookupType 9) are unwrapped for types
+// 2, 4, and 6.
 //
 // Script selection follows the same preference order as GSUB:
 // "arab" and "latn" when present, "DFLT" as a fallback.
@@ -105,15 +118,19 @@ func ParseGPOS(data []byte) *GPOSAdjustments {
 	}
 
 	result := &GPOSAdjustments{
-		Pairs: make(map[GPOSFeature]map[[2]uint16]PairAdjustment),
-		Marks: make(map[GPOSFeature]map[uint16]MarkRecord),
-		Bases: make(map[GPOSFeature]map[uint16]BaseRecord),
+		Pairs:      make(map[GPOSFeature]map[[2]uint16]PairAdjustment),
+		Marks:      make(map[GPOSFeature]map[uint16]MarkRecord),
+		Bases:      make(map[GPOSFeature]map[uint16]BaseRecord),
+		MarkMarks:  make(map[GPOSFeature]map[uint16]MarkRecord),
+		Mark2Bases: make(map[GPOSFeature]map[uint16]BaseRecord),
 	}
 	for feat, lookupIndices := range featureToLookups {
 		pairs := make(map[[2]uint16]PairAdjustment)
 		marks := make(map[uint16]MarkRecord)
 		bases := make(map[uint16]BaseRecord)
-		parseGPOSLookups(gpos, lookupListOff, lookupIndices, pairs, marks, bases)
+		markMarks := make(map[uint16]MarkRecord)
+		mark2Bases := make(map[uint16]BaseRecord)
+		parseGPOSLookups(gpos, lookupListOff, lookupIndices, pairs, marks, bases, markMarks, mark2Bases)
 		if len(pairs) > 0 {
 			result.Pairs[feat] = pairs
 		}
@@ -123,8 +140,15 @@ func ParseGPOS(data []byte) *GPOSAdjustments {
 		if len(bases) > 0 {
 			result.Bases[feat] = bases
 		}
+		if len(markMarks) > 0 {
+			result.MarkMarks[feat] = markMarks
+		}
+		if len(mark2Bases) > 0 {
+			result.Mark2Bases[feat] = mark2Bases
+		}
 	}
-	if len(result.Pairs) == 0 && len(result.Marks) == 0 && len(result.Bases) == 0 {
+	if len(result.Pairs) == 0 && len(result.Marks) == 0 && len(result.Bases) == 0 &&
+		len(result.MarkMarks) == 0 && len(result.Mark2Bases) == 0 {
 		return nil
 	}
 	return result
@@ -158,16 +182,38 @@ func (g *GPOSAdjustments) MarkOffset(baseGID, markGID uint16, feature GPOSFeatur
 	if g == nil {
 		return 0, 0, false
 	}
-	marks, mok := g.Marks[feature]
-	if !mok {
+	return anchorOffset(g.Marks[feature], g.Bases[feature], markGID, baseGID)
+}
+
+// MarkMarkOffset returns the (dx, dy) offset in FUnits that positions
+// the attaching mark1 glyph so its anchor coincides with mark2's anchor
+// for the same class. mark1 is the mark riding on top; mark2 is the
+// already-placed mark playing the "base" role. Returns ok=false when
+// either glyph is absent from the feature's mark1/mark2 arrays, or when
+// mark2 has no anchor declared for mark1's class.
+//
+// Note: the parameter order is (mark1, mark2) to match the ISO 14496-22
+// §6.3 spec naming, which is the reverse of MarkOffset(base, mark).
+// Callers porting from MarkOffset must swap the operands.
+//
+// The formula mirrors LookupType 4: dx = mark2Anchor.X - mark1Anchor.X,
+// dy = mark2Anchor.Y - mark1Anchor.Y.
+func (g *GPOSAdjustments) MarkMarkOffset(mark1GID, mark2GID uint16, feature GPOSFeature) (dx, dy int16, ok bool) {
+	if g == nil {
+		return 0, 0, false
+	}
+	return anchorOffset(g.MarkMarks[feature], g.Mark2Bases[feature], mark1GID, mark2GID)
+}
+
+// anchorOffset is the shared anchor-subtraction used by MarkOffset and
+// MarkMarkOffset. markGID selects the attaching mark (Class + Anchor);
+// baseGID selects the receiving glyph (one anchor per mark class).
+func anchorOffset(marks map[uint16]MarkRecord, bases map[uint16]BaseRecord, markGID, baseGID uint16) (int16, int16, bool) {
+	if marks == nil || bases == nil {
 		return 0, 0, false
 	}
 	mark, hasMark := marks[markGID]
 	if !hasMark {
-		return 0, 0, false
-	}
-	bases, bok := g.Bases[feature]
-	if !bok {
 		return 0, 0, false
 	}
 	base, hasBase := bases[baseGID]
@@ -226,11 +272,13 @@ func matchGPOSFeatures(gpos []byte, off int, allowed []int, targetTags map[strin
 
 // parseGPOSLookups walks each referenced lookup and dispatches its
 // subtables to the appropriate LookupType parser. LookupType 9
-// (Extension Positioning) is unwrapped inline for types 2 and 4.
+// (Extension Positioning) is unwrapped inline for types 2, 4, and 6.
 func parseGPOSLookups(gpos []byte, listOff int, indices []int,
 	pairs map[[2]uint16]PairAdjustment,
 	marks map[uint16]MarkRecord,
 	bases map[uint16]BaseRecord,
+	markMarks map[uint16]MarkRecord,
+	mark2Bases map[uint16]BaseRecord,
 ) {
 	if listOff+2 > len(gpos) {
 		return
@@ -244,7 +292,7 @@ func parseGPOSLookups(gpos []byte, listOff int, indices []int,
 			continue
 		}
 		lookupOff := listOff + int(be16(gpos, listOff+2+idx*2))
-		parseGPOSLookup(gpos, lookupOff, pairs, marks, bases)
+		parseGPOSLookup(gpos, lookupOff, pairs, marks, bases, markMarks, mark2Bases)
 	}
 }
 
@@ -255,6 +303,8 @@ func parseGPOSLookup(gpos []byte, lookupOff int,
 	pairs map[[2]uint16]PairAdjustment,
 	marks map[uint16]MarkRecord,
 	bases map[uint16]BaseRecord,
+	markMarks map[uint16]MarkRecord,
+	mark2Bases map[uint16]BaseRecord,
 ) {
 	if lookupOff+6 > len(gpos) {
 		return
@@ -287,6 +337,8 @@ func parseGPOSLookup(gpos []byte, lookupOff int,
 			parsePairPos(gpos, off, pairs)
 		case 4:
 			parseMarkBasePos(gpos, off, marks, bases)
+		case 6:
+			parseMarkMarkPos(gpos, off, markMarks, mark2Bases)
 		}
 	}
 }
@@ -532,6 +584,49 @@ func parseMarkBasePos(gpos []byte, off int,
 
 	parseMarkArray(gpos, markArrayOff, markCov, marks)
 	parseBaseArray(gpos, baseArrayOff, baseCov, markClassCount, bases)
+}
+
+// parseMarkMarkPos reads a MarkMarkPosFormat1 subtable.
+//
+// Layout (ISO 14496-22 §6.3 LookupType 6):
+//
+//	posFormat         uint16 (==1)
+//	mark1CoverageOff  Offset16
+//	mark2CoverageOff  Offset16
+//	markClassCount    uint16
+//	mark1ArrayOff     Offset16
+//	mark2ArrayOff     Offset16
+//
+// The Mark1Array is a MarkArray of attaching (top) marks: each entry
+// carries a class and an anchor. The Mark2Array is structurally
+// identical to BaseArray — a matrix of anchors indexed by mark class —
+// so parseBaseArray is reused verbatim. Lookup combines a mark1's
+// class with the mark2's anchor at that class.
+func parseMarkMarkPos(gpos []byte, off int,
+	markMarks map[uint16]MarkRecord,
+	mark2Bases map[uint16]BaseRecord,
+) {
+	if off+12 > len(gpos) {
+		return
+	}
+	format := be16(gpos, off)
+	if format != 1 {
+		return
+	}
+	mark1CoverageOff := off + int(be16(gpos, off+2))
+	mark2CoverageOff := off + int(be16(gpos, off+4))
+	markClassCount := int(be16(gpos, off+6))
+	mark1ArrayOff := off + int(be16(gpos, off+8))
+	mark2ArrayOff := off + int(be16(gpos, off+10))
+
+	mark1Cov := parseCoverage(gpos, mark1CoverageOff)
+	mark2Cov := parseCoverage(gpos, mark2CoverageOff)
+	if mark1Cov == nil || mark2Cov == nil {
+		return
+	}
+
+	parseMarkArray(gpos, mark1ArrayOff, mark1Cov, markMarks)
+	parseBaseArray(gpos, mark2ArrayOff, mark2Cov, markClassCount, mark2Bases)
 }
 
 // parseMarkArray reads a MarkArray and populates marks.

--- a/font/gpos_test.go
+++ b/font/gpos_test.go
@@ -524,6 +524,427 @@ func TestParseGPOSAnchorFormats2And3(t *testing.T) {
 	}
 }
 
+// TestParseGPOSMarkMarkPosFormat1 checks the LookupType 6 parser: a
+// mark1 whose anchor sits at (100, 400) attaching to a mark2 whose
+// anchor sits at (150, 900) must yield an offset of (50, 500), i.e.
+// mark2.X - mark1.X, mark2.Y - mark1.Y. The byte layout of a
+// MarkMarkPosFormat1 subtable is identical to MarkBasePosFormat1, so
+// markBasePosBody is reused here with the mark1/mark2 glyph IDs
+// standing in for mark/base.
+func TestParseGPOSMarkMarkPosFormat1(t *testing.T) {
+	const (
+		mark1GID uint16 = 61 // attaching mark (e.g. shadda on top)
+		mark2GID uint16 = 60 // underlying mark (e.g. fatha)
+	)
+	body := markBasePosBody(mark1GID, mark2GID, 100, 400, 150, 900, 1)
+	gpos := buildGPOSHeader("mkmk", 6, body, 0)
+	font := wrapTTF(gpos)
+
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	dx, dy, ok := g.MarkMarkOffset(mark1GID, mark2GID, GPOSMkmk)
+	if !ok {
+		t.Fatal("MarkMarkOffset returned ok=false, want true")
+	}
+	if dx != 50 || dy != 500 {
+		t.Errorf("MarkMarkOffset = (%d, %d), want (50, 500)", dx, dy)
+	}
+	// The reverse pair must miss: mark2 is not in the mark1 array.
+	if _, _, okMiss := g.MarkMarkOffset(mark2GID, mark1GID, GPOSMkmk); okMiss {
+		t.Error("MarkMarkOffset with swapped operands should return ok=false")
+	}
+	if _, _, okMiss := g.MarkMarkOffset(999, mark2GID, GPOSMkmk); okMiss {
+		t.Error("MarkMarkOffset for unknown mark1 should return ok=false")
+	}
+	if _, _, okMiss := g.MarkMarkOffset(mark1GID, 999, GPOSMkmk); okMiss {
+		t.Error("MarkMarkOffset for unknown mark2 should return ok=false")
+	}
+	// Mark-to-base storage must remain independent: mkmk data must not
+	// bleed into the mark feature.
+	if _, _, okMiss := g.MarkOffset(mark2GID, mark1GID, GPOSMark); okMiss {
+		t.Error("mkmk data must not populate the mark feature's MarkOffset path")
+	}
+}
+
+// TestParseGPOSMarkMarkExtensionWrap verifies that LookupType 6 is
+// followed through a LookupType 9 extension subtable, matching the
+// treatment of LookupType 2 and 4.
+func TestParseGPOSMarkMarkExtensionWrap(t *testing.T) {
+	body := markBasePosBody(61, 60, 10, 40, 30, 90, 1)
+	gpos := buildGPOSHeader("mkmk", 6, body, 6)
+	font := wrapTTF(gpos)
+
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	dx, dy, ok := g.MarkMarkOffset(61, 60, GPOSMkmk)
+	if !ok {
+		t.Fatal("MarkMarkOffset through extension returned ok=false")
+	}
+	if dx != 20 || dy != 50 {
+		t.Errorf("MarkMarkOffset through extension = (%d, %d), want (20, 50)", dx, dy)
+	}
+}
+
+// TestMarkMarkOffsetNilReceiver covers the nil-safety contract; the
+// draw pipeline relies on a zero-value return when GPOS parsing
+// yielded nothing.
+func TestMarkMarkOffsetNilReceiver(t *testing.T) {
+	var g *GPOSAdjustments
+	if _, _, ok := g.MarkMarkOffset(1, 2, GPOSMkmk); ok {
+		t.Error("MarkMarkOffset on nil receiver must return ok=false")
+	}
+}
+
+// markMarkPosBodyMultiClass assembles a MarkMarkPosFormat1 subtable
+// with markClassCount=2, two mark1 glyphs in different classes, and
+// one mark2 that carries two anchors (one per class). The returned
+// body exercises the class-indexed anchor lookup which is invisible
+// under the single-class test.
+//
+// Layout reminder (same as MarkBasePosFormat1):
+//
+//	posFormat(2) mark1CovOff(2) mark2CovOff(2) markClassCount(2)
+//	mark1ArrayOff(2) mark2ArrayOff(2)
+//	... Mark1Coverage, Mark2Coverage, Mark1Array, Mark2Array, Anchors
+func markMarkPosBodyMultiClass() []byte {
+	const (
+		mark1GIDA uint16 = 70 // class 0 attaching mark
+		mark1GIDB uint16 = 71 // class 1 attaching mark
+		mark2GID  uint16 = 72 // underlying mark with two anchors
+	)
+	_ = mark1GIDA
+	_ = mark1GIDB
+	_ = mark2GID
+
+	var b gposBuilder
+	b.u16(1) // posFormat
+	mark1CovOffPos := b.pos()
+	b.u16(0) // mark1CoverageOffset
+	mark2CovOffPos := b.pos()
+	b.u16(0) // mark2CoverageOffset
+	b.u16(2) // markClassCount
+	mark1ArrayOffPos := b.pos()
+	b.u16(0)
+	mark2ArrayOffPos := b.pos()
+	b.u16(0)
+
+	// Mark1 coverage: {70, 71}.
+	mark1CovOff := b.pos()
+	b.patchU16(mark1CovOffPos, uint16(mark1CovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(70, 71)...)
+
+	// Mark2 coverage: {72}.
+	mark2CovOff := b.pos()
+	b.patchU16(mark2CovOffPos, uint16(mark2CovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(72)...)
+
+	// Mark1Array: two entries, (class 0, anchor offset A), (class 1, anchor offset B).
+	mark1ArrayOff := b.pos()
+	b.patchU16(mark1ArrayOffPos, uint16(mark1ArrayOff))
+	b.u16(2)                // markCount
+	b.u16(0)                // mark1GIDA class
+	mark1AOffPos := b.pos() // anchor A offset
+	b.u16(0)
+	b.u16(1)                // mark1GIDB class
+	mark1BOffPos := b.pos() // anchor B offset
+	b.u16(0)
+
+	// Mark2Array: one entry with 2 anchor offsets (one per class).
+	mark2ArrayOff := b.pos()
+	b.patchU16(mark2ArrayOffPos, uint16(mark2ArrayOff))
+	b.u16(1) // mark2Count
+	mark2AOffPos := b.pos()
+	b.u16(0) // mark2 class-0 anchor offset
+	mark2BOffPos := b.pos()
+	b.u16(0) // mark2 class-1 anchor offset
+
+	// Anchors. Mark1A = (10, 20), Mark1B = (30, 40);
+	// Mark2 class-0 = (100, 200), Mark2 class-1 = (300, 400).
+	// Expected offsets:
+	//   (mark1A, mark2) class 0 → (100-10, 200-20) = (90, 180)
+	//   (mark1B, mark2) class 1 → (300-30, 400-40) = (270, 360)
+	mark1AOff := b.pos()
+	b.patchU16(mark1AOffPos, uint16(mark1AOff-mark1ArrayOff))
+	b.u16(1) // Anchor format 1
+	b.i16(10)
+	b.i16(20)
+
+	mark1BOff := b.pos()
+	b.patchU16(mark1BOffPos, uint16(mark1BOff-mark1ArrayOff))
+	b.u16(1)
+	b.i16(30)
+	b.i16(40)
+
+	mark2AOff := b.pos()
+	b.patchU16(mark2AOffPos, uint16(mark2AOff-mark2ArrayOff))
+	b.u16(1)
+	b.i16(100)
+	b.i16(200)
+
+	mark2BOff := b.pos()
+	b.patchU16(mark2BOffPos, uint16(mark2BOff-mark2ArrayOff))
+	b.u16(1)
+	b.i16(300)
+	b.i16(400)
+
+	return b.buf
+}
+
+// TestParseGPOSMarkMarkMultiClass locks down the class-indexed anchor
+// lookup: mark1A (class 0) must resolve against mark2's class-0 anchor,
+// and mark1B (class 1) against mark2's class-1 anchor. A regression
+// that hard-coded class 0 would be caught here.
+func TestParseGPOSMarkMarkMultiClass(t *testing.T) {
+	body := markMarkPosBodyMultiClass()
+	gpos := buildGPOSHeader("mkmk", 6, body, 0)
+	font := wrapTTF(gpos)
+
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+
+	dx, dy, ok := g.MarkMarkOffset(70, 72, GPOSMkmk)
+	if !ok {
+		t.Fatal("MarkMarkOffset(70,72) ok=false")
+	}
+	if dx != 90 || dy != 180 {
+		t.Errorf("MarkMarkOffset(70,72) class 0 = (%d,%d), want (90,180)", dx, dy)
+	}
+
+	dx, dy, ok = g.MarkMarkOffset(71, 72, GPOSMkmk)
+	if !ok {
+		t.Fatal("MarkMarkOffset(71,72) ok=false")
+	}
+	if dx != 270 || dy != 360 {
+		t.Errorf("MarkMarkOffset(71,72) class 1 = (%d,%d), want (270,360)", dx, dy)
+	}
+}
+
+// TestParseGPOSMarkMarkClassOverflow covers the defensive branch in
+// anchorOffset: a mark1 whose Class is out of range for the mark2's
+// anchor slice returns ok=false rather than panicking.
+func TestParseGPOSMarkMarkClassOverflow(t *testing.T) {
+	// Build a mkmk body with markClassCount=1 but force the mark1
+	// record to claim class 5. The parser stores the class verbatim;
+	// lookup must refuse to index past the mark2 anchor slice.
+	var b gposBuilder
+	b.u16(1) // posFormat
+	mark1CovOffPos := b.pos()
+	b.u16(0)
+	mark2CovOffPos := b.pos()
+	b.u16(0)
+	b.u16(1) // markClassCount
+	mark1ArrayOffPos := b.pos()
+	b.u16(0)
+	mark2ArrayOffPos := b.pos()
+	b.u16(0)
+
+	mark1CovOff := b.pos()
+	b.patchU16(mark1CovOffPos, uint16(mark1CovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(80)...)
+	mark2CovOff := b.pos()
+	b.patchU16(mark2CovOffPos, uint16(mark2CovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(81)...)
+
+	mark1ArrayOff := b.pos()
+	b.patchU16(mark1ArrayOffPos, uint16(mark1ArrayOff))
+	b.u16(1)
+	b.u16(5) // out-of-range mark class
+	mark1AOffPos := b.pos()
+	b.u16(0)
+
+	mark2ArrayOff := b.pos()
+	b.patchU16(mark2ArrayOffPos, uint16(mark2ArrayOff))
+	b.u16(1)
+	mark2AOffPos := b.pos()
+	b.u16(0)
+
+	mark1AOff := b.pos()
+	b.patchU16(mark1AOffPos, uint16(mark1AOff-mark1ArrayOff))
+	b.u16(1)
+	b.i16(0)
+	b.i16(0)
+
+	mark2AOff := b.pos()
+	b.patchU16(mark2AOffPos, uint16(mark2AOff-mark2ArrayOff))
+	b.u16(1)
+	b.i16(10)
+	b.i16(20)
+
+	gpos := buildGPOSHeader("mkmk", 6, b.buf, 0)
+	font := wrapTTF(gpos)
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	if _, _, ok := g.MarkMarkOffset(80, 81, GPOSMkmk); ok {
+		t.Error("MarkMarkOffset with out-of-range class must return ok=false")
+	}
+}
+
+// buildGPOSHeaderDualFeature builds a GPOS table exposing two features
+// (tag1 → lookupType1 body1, tag2 → lookupType2 body2) both wired
+// through the default LangSys of a "DFLT" script. Exists to exercise
+// the mark + mkmk coexistence path.
+func buildGPOSHeaderDualFeature(tag1 string, lt1 uint16, body1 []byte, tag2 string, lt2 uint16, body2 []byte) []byte {
+	var b gposBuilder
+	b.u32(0x00010000)
+	scriptListPos := b.pos()
+	b.u16(0)
+	featureListPos := b.pos()
+	b.u16(0)
+	lookupListPos := b.pos()
+	b.u16(0)
+
+	// ScriptList.
+	scriptListOff := b.pos()
+	b.patchU16(scriptListPos, uint16(scriptListOff))
+	b.u16(1) // scriptCount
+	b.buf = append(b.buf, []byte("DFLT")...)
+	scriptRecordOffPos := b.pos()
+	b.u16(0)
+
+	scriptTableOff := b.pos()
+	b.patchU16(scriptRecordOffPos, uint16(scriptTableOff-scriptListOff))
+	defaultLangSysPos := b.pos()
+	b.u16(0)
+	b.u16(0) // langSysCount
+
+	defaultLangSysOff := b.pos()
+	b.patchU16(defaultLangSysPos, uint16(defaultLangSysOff-scriptTableOff))
+	b.u16(0)      // lookupOrder
+	b.u16(0xFFFF) // requiredFeatureIndex
+	b.u16(2)      // featureIndexCount
+	b.u16(0)      // feature 0
+	b.u16(1)      // feature 1
+
+	// FeatureList.
+	featureListOff := b.pos()
+	b.patchU16(featureListPos, uint16(featureListOff))
+	b.u16(2) // featureCount
+	b.buf = append(b.buf, []byte(tag1)...)
+	f1OffPos := b.pos()
+	b.u16(0)
+	b.buf = append(b.buf, []byte(tag2)...)
+	f2OffPos := b.pos()
+	b.u16(0)
+
+	feat1Off := b.pos()
+	b.patchU16(f1OffPos, uint16(feat1Off-featureListOff))
+	b.u16(0) // featureParams
+	b.u16(1) // lookupIndexCount
+	b.u16(0) // lookup 0
+
+	feat2Off := b.pos()
+	b.patchU16(f2OffPos, uint16(feat2Off-featureListOff))
+	b.u16(0)
+	b.u16(1)
+	b.u16(1) // lookup 1
+
+	// LookupList.
+	lookupListOff := b.pos()
+	b.patchU16(lookupListPos, uint16(lookupListOff))
+	b.u16(2) // lookupCount
+	l1OffPos := b.pos()
+	b.u16(0)
+	l2OffPos := b.pos()
+	b.u16(0)
+
+	// Lookup 0 (feature 1).
+	lookup1Off := b.pos()
+	b.patchU16(l1OffPos, uint16(lookup1Off-lookupListOff))
+	b.u16(lt1)
+	b.u16(0) // lookupFlag
+	b.u16(1) // subTableCount
+	sub1OffPos := b.pos()
+	b.u16(0)
+
+	sub1Off := b.pos()
+	b.patchU16(sub1OffPos, uint16(sub1Off-lookup1Off))
+	b.buf = append(b.buf, body1...)
+
+	// Lookup 1 (feature 2).
+	lookup2Off := b.pos()
+	b.patchU16(l2OffPos, uint16(lookup2Off-lookupListOff))
+	b.u16(lt2)
+	b.u16(0)
+	b.u16(1)
+	sub2OffPos := b.pos()
+	b.u16(0)
+
+	sub2Off := b.pos()
+	b.patchU16(sub2OffPos, uint16(sub2Off-lookup2Off))
+	b.buf = append(b.buf, body2...)
+
+	return b.buf
+}
+
+// TestParseGPOSMarkAndMkmkCoexist builds a GPOS blob that carries both
+// a mark (LookupType 4) subtable and an mkmk (LookupType 6) subtable.
+// Each must populate its own storage slot; neither must bleed into
+// the other's maps. Catches any accidental shared accumulator.
+func TestParseGPOSMarkAndMkmkCoexist(t *testing.T) {
+	markBody := markBasePosBody(50, 100, 200, 300, 500, 800, 1)
+	mkmkBody := markBasePosBody(61, 60, 100, 400, 150, 950, 1)
+
+	gpos := buildGPOSHeaderDualFeature("mark", 4, markBody, "mkmk", 6, mkmkBody)
+	font := wrapTTF(gpos)
+	g := ParseGPOS(font)
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+
+	// Mark feature resolves.
+	dx, dy, ok := g.MarkOffset(100, 50, GPOSMark)
+	if !ok || dx != 300 || dy != 500 {
+		t.Errorf("MarkOffset = (%d,%d,%v), want (300,500,true)", dx, dy, ok)
+	}
+	// Mkmk feature resolves independently.
+	dx, dy, ok = g.MarkMarkOffset(61, 60, GPOSMkmk)
+	if !ok || dx != 50 || dy != 550 {
+		t.Errorf("MarkMarkOffset = (%d,%d,%v), want (50,550,true)", dx, dy, ok)
+	}
+	// Mark data must not leak into mkmk storage and vice versa.
+	if len(g.MarkMarks[GPOSMark]) != 0 {
+		t.Errorf("MarkMarks[GPOSMark] should be empty, got %v", g.MarkMarks[GPOSMark])
+	}
+	if len(g.Mark2Bases[GPOSMark]) != 0 {
+		t.Errorf("Mark2Bases[GPOSMark] should be empty, got %v", g.Mark2Bases[GPOSMark])
+	}
+	if len(g.Marks[GPOSMkmk]) != 0 {
+		t.Errorf("Marks[GPOSMkmk] should be empty, got %v", g.Marks[GPOSMkmk])
+	}
+	if len(g.Bases[GPOSMkmk]) != 0 {
+		t.Errorf("Bases[GPOSMkmk] should be empty, got %v", g.Bases[GPOSMkmk])
+	}
+}
+
+// TestParseGPOSMkmkOnlyReturnsNonNil pins the nil-guard at the bottom
+// of ParseGPOS: a font whose GPOS table carries only an mkmk feature
+// (no kern, no mark) must still produce a non-nil result. A regression
+// that forgot to include MarkMarks/Mark2Bases in the guard would make
+// mkmk-only fonts silently lose their positioning data.
+func TestParseGPOSMkmkOnlyReturnsNonNil(t *testing.T) {
+	body := markBasePosBody(61, 60, 100, 400, 150, 950, 1)
+	gpos := buildGPOSHeader("mkmk", 6, body, 0)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS with only mkmk feature returned nil")
+	}
+	if len(g.Pairs) != 0 || len(g.Marks) != 0 || len(g.Bases) != 0 {
+		t.Errorf("mkmk-only font populated non-mkmk maps: pairs=%d marks=%d bases=%d",
+			len(g.Pairs), len(g.Marks), len(g.Bases))
+	}
+	if len(g.MarkMarks[GPOSMkmk]) == 0 || len(g.Mark2Bases[GPOSMkmk]) == 0 {
+		t.Error("mkmk-only font did not populate MarkMarks/Mark2Bases")
+	}
+}
+
 // TestParseGPOSExtensionWrap wraps a PairPosFormat1 subtable inside a
 // LookupType 9 Extension and verifies it still resolves.
 func TestParseGPOSExtensionWrap(t *testing.T) {

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -432,25 +432,52 @@ func drawWordEmbeddedWithMarks(stream *content.Stream, word Word) {
 
 		// Emit each Extend/ZWJ mark bracketed by Td moves that shift
 		// the text matrix from the cluster-end position back to the
-		// base origin plus the GPOS offset, and then back to the
-		// cluster-end position for the next mark or next cluster.
+		// mark's target origin, and then back to the cluster-end
+		// position for the next mark or next cluster.
 		//
 		// After Tj of the base (plus SpacingMarks), the text matrix is
 		// at clusterEnd = (clusterAdvance, 0) relative to the cluster
-		// start. A mark's origin must sit at (markDx, markDy) relative
-		// to the base's origin (the cluster start), so the first Td
-		// moves by (markDx - clusterAdvance, markDy) and the closing
-		// Td moves by (clusterAdvance - markDx, -markDy). Marks have
-		// zero advance, so Tj of the mark does not shift the matrix.
+		// start. Mark 0 anchors against the base via LookupType 4; its
+		// origin sits at (dx, dy) relative to the cluster start. Marks
+		// 1..n-1 consult LookupType 6 against the previously-placed
+		// mark: given the (prevDx, prevDy) origin of the previous
+		// mark and a mark-to-mark delta (mkmkDx, mkmkDy), the new
+		// mark's origin is (prevDx + mkmkDx, prevDy + mkmkDy). This
+		// is how Arabic shadda+fatha, Hebrew dagesh+niqqud, and
+		// Vietnamese ế-style stacks avoid collisions. On miss (no
+		// LookupType 6 anchor for the pair) the mark falls back to
+		// mark-to-base against the cluster base, matching the
+		// single-mark path above. Marks have zero advance, so Tj of
+		// the mark does not shift the matrix.
+		var prevDxPts, prevDyPts float64
+		var prevMarkGID uint16
+		havePrevMark := false
 		for _, m := range extendMarks {
 			markGID := face.GlyphIndex(m.r)
-			dx, dy, ok := gpos.MarkOffset(baseGID, markGID, font.GPOSMark)
-			if ok {
-				dxPts := float64(dx) * scale
-				dyPts := float64(dy) * scale
+			var dxPts, dyPts float64
+			placed := false
+			if havePrevMark {
+				if mx, my, ok := gpos.MarkMarkOffset(markGID, prevMarkGID, font.GPOSMkmk); ok {
+					dxPts = prevDxPts + float64(mx)*scale
+					dyPts = prevDyPts + float64(my)*scale
+					placed = true
+				}
+			}
+			if !placed {
+				if dx, dy, ok := gpos.MarkOffset(baseGID, markGID, font.GPOSMark); ok {
+					dxPts = float64(dx) * scale
+					dyPts = float64(dy) * scale
+					placed = true
+				}
+			}
+			if placed {
 				stream.MoveText(dxPts-clusterAdvance, dyPts)
 				stream.ShowTextHex(ef.EncodeString(string(m.r)))
 				stream.MoveText(clusterAdvance-dxPts, -dyPts)
+				prevDxPts = dxPts
+				prevDyPts = dyPts
+				prevMarkGID = markGID
+				havePrevMark = true
 			} else {
 				stream.ShowTextHex(ef.EncodeString(string(m.r)))
 			}

--- a/layout/gpos_mark_draw_test.go
+++ b/layout/gpos_mark_draw_test.go
@@ -342,6 +342,291 @@ func TestGPOSMarkAttachmentMeasureAgreesWithDraw(t *testing.T) {
 	}
 }
 
+// addStackedShadda extends the lam+fatha fixture with a shadda (U+0651)
+// that carries LookupType 6 data saying it stacks on top of the fatha
+// rather than anchoring against the lam base. Mark1 (attaching) =
+// shadda with anchor (100, 400); Mark2 (underlying) = fatha with
+// anchor (150, 950) for class 0. LookupType 6 offset =
+// (150-100, 950-400) = (50, 550) FUnits relative to the fatha's origin.
+// Y differs from the mark-to-base offset (500 FUnits) so that any
+// bug swapping mkmk for mark-to-base fails on both axes.
+func addStackedShadda(face *mockGPOSFace) uint16 {
+	const shaddaGID uint16 = 61
+	face.cmap[0x0651] = shaddaGID
+	face.advance[shaddaGID] = 0
+	if face.gpos.MarkMarks == nil {
+		face.gpos.MarkMarks = map[font.GPOSFeature]map[uint16]font.MarkRecord{}
+	}
+	if face.gpos.Mark2Bases == nil {
+		face.gpos.Mark2Bases = map[font.GPOSFeature]map[uint16]font.BaseRecord{}
+	}
+	face.gpos.MarkMarks[font.GPOSMkmk] = map[uint16]font.MarkRecord{
+		shaddaGID: {Class: 0, Anchor: font.Anchor{X: 100, Y: 400}},
+	}
+	face.gpos.Mark2Bases[font.GPOSMkmk] = map[uint16]font.BaseRecord{
+		60: {Anchors: []font.Anchor{{X: 150, Y: 950}}}, // fatha GID 60
+	}
+	return shaddaGID
+}
+
+// TestGPOSMarkMarkAttachmentStacksSecondMark verifies that when mkmk
+// data is present for the (mark2 = mark[i-1], mark1 = mark[i]) pair,
+// the second mark's Td bracket opens at (prevDx + mkmkDx - clusterAdv,
+// prevDy + mkmkDy) rather than at the plain mark-to-base offset. With
+// the fixture above:
+//
+//	fatha origin (mark-to-base) = (300, 500) FUnits → (3.6, 6.0) pt
+//	shadda origin (stacked)     = (300+50, 500+550) FUnits → (4.2, 12.6) pt
+//	clusterAdvance = 8.4 pt
+//
+// First mark open Td:  (3.6 - 8.4, 6) = (-4.8, 6)
+// Second mark open Td: (4.2 - 8.4, 12.6) = (-4.2, 12.6)
+// Second mark close Td: (8.4 - 4.2, -12.6) = (4.2, -12.6)
+func TestGPOSMarkMarkAttachmentStacksSecondMark(t *testing.T) {
+	face := newLamFathaFace()
+	_ = addStackedShadda(face)
+	ef := font.NewEmbeddedFont(face)
+
+	word := Word{
+		Text:     "\u0644\u064E\u0651", // lam + fatha + shadda
+		Embedded: ef,
+		FontSize: 12,
+	}
+	b := capturedWordStream(word)
+
+	// Collect every Td after the initial MoveText.
+	var tds []string
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasSuffix(line, " Td") {
+			tds = append(tds, line)
+		}
+	}
+	// Initial + two open + two close = 5 Tds total.
+	if len(tds) != 5 {
+		t.Fatalf("expected 5 Td ops, got %d:\n%s", len(tds), b)
+	}
+	// tds[0]: MoveText(0, 0).
+	// tds[1]: fatha open  -> "-4.8 6 Td"
+	// tds[2]: fatha close -> "4.8 -6 Td"
+	// tds[3]: shadda open (stacked) -> "-4.2 12.6 Td"
+	// tds[4]: shadda close           -> "4.2 -12.6 Td"
+	if !strings.Contains(tds[3], "-4.2 12.6 Td") {
+		t.Errorf("shadda open Td = %q, want stacked offset -4.2 12.6 Td:\n%s", tds[3], b)
+	}
+	if !strings.Contains(tds[4], "4.2 -12.6 Td") {
+		t.Errorf("shadda close Td = %q, want 4.2 -12.6 Td:\n%s", tds[4], b)
+	}
+}
+
+// TestGPOSMarkMarkAttachmentThreeStackedMarks exercises transitive
+// stacking: a fourth glyph (dammatan, U+064C) stacks on shadda, which
+// itself stacks on fatha, which anchors to lam. This confirms that
+// prevDxPts/prevDyPts accumulate across marks rather than collapsing
+// to the previous mark's mkmk delta only.
+//
+//	lam      class-0 anchor (500, 800)
+//	fatha    class 0, anchor (200, 300)   → origin (300, 500) = (3.6, 6.0)
+//	shadda   mkmk class 0 on fatha's (150, 950) with mark1 anchor
+//	         (100, 400) → delta (50, 550) → origin (350, 1050) = (4.2, 12.6)
+//	dammatan mkmk class 0 on shadda's (120, 1100) with mark1 anchor
+//	         (80, 500) → delta (40, 600) → origin (390, 1650) = (4.68, 19.8)
+func TestGPOSMarkMarkAttachmentThreeStackedMarks(t *testing.T) {
+	face := newLamFathaFace()
+	_ = addStackedShadda(face)
+	const dammatanGID uint16 = 62
+	face.cmap[0x064C] = dammatanGID // dammatan
+	face.advance[dammatanGID] = 0
+	face.gpos.MarkMarks[font.GPOSMkmk][dammatanGID] = font.MarkRecord{
+		Class:  0,
+		Anchor: font.Anchor{X: 80, Y: 500},
+	}
+	face.gpos.Mark2Bases[font.GPOSMkmk][61 /* shadda */] = font.BaseRecord{
+		Anchors: []font.Anchor{{X: 120, Y: 1100}},
+	}
+
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Text:     "\u0644\u064E\u0651\u064C", // lam + fatha + shadda + dammatan
+		Embedded: ef,
+		FontSize: 12,
+	}
+	b := capturedWordStream(word)
+
+	var tds []string
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasSuffix(line, " Td") {
+			tds = append(tds, line)
+		}
+	}
+	// Initial + three open + three close = 7 Tds total.
+	if len(tds) != 7 {
+		t.Fatalf("expected 7 Td ops (initial + 3*(open+close)), got %d:\n%s", len(tds), b)
+	}
+	// tds[5]: dammatan open  -> want "-3.72 19.8 Td"
+	// tds[6]: dammatan close -> want "3.72 -19.8 Td"
+	if !strings.Contains(tds[5], "-3.72 19.8 Td") {
+		t.Errorf("dammatan open Td = %q, want -3.72 19.8 Td (prevDx + mkmkDx accumulation):\n%s", tds[5], b)
+	}
+	if !strings.Contains(tds[6], "3.72 -19.8 Td") {
+		t.Errorf("dammatan close Td = %q, want 3.72 -19.8 Td:\n%s", tds[6], b)
+	}
+	// Open/close pairs must sum to zero on both axes.
+	var netX, netY float64
+	for i, td := range tds {
+		if i == 0 {
+			continue // initial MoveText(0, 0)
+		}
+		var tx, ty float64
+		n, err := fmt.Sscanf(td, "%f %f Td", &tx, &ty)
+		if err != nil || n != 2 {
+			t.Fatalf("unparseable Td %q: %v", td, err)
+		}
+		netX += tx
+		netY += ty
+	}
+	if !almostEqual(netX, 0, 1e-9) || !almostEqual(netY, 0, 1e-9) {
+		t.Errorf("Td bracket pairs must cancel; net = (%v, %v)", netX, netY)
+	}
+}
+
+// TestGPOSMarkMarkFallbackWithWrongGID verifies the mkmk miss path is
+// keyed by glyph ID, not by feature-presence. The font carries mkmk
+// data for a *different* mark1 GID than the one being placed; the
+// current mark must fall back to mark-to-base against the cluster
+// base, not silently reuse whatever mkmk state is nearby.
+func TestGPOSMarkMarkFallbackWithWrongGID(t *testing.T) {
+	face := newLamFathaFace()
+	const shaddaGID uint16 = 61
+	face.cmap[0x0651] = shaddaGID
+	face.advance[shaddaGID] = 0
+	// Shadda has mark-to-base data sharing class 0 with fatha, so lam's
+	// existing class-0 anchor positions it.
+	face.gpos.Marks[font.GPOSMark][shaddaGID] = font.MarkRecord{
+		Class:  0,
+		Anchor: font.Anchor{X: 200, Y: 300},
+	}
+	// Populate mkmk, but only for an unrelated GID 99 as mark1 — the
+	// actual shadda glyph (GID 61) must miss.
+	face.gpos.MarkMarks = map[font.GPOSFeature]map[uint16]font.MarkRecord{
+		font.GPOSMkmk: {99: {Class: 0, Anchor: font.Anchor{X: 100, Y: 400}}},
+	}
+	face.gpos.Mark2Bases = map[font.GPOSFeature]map[uint16]font.BaseRecord{
+		font.GPOSMkmk: {60: {Anchors: []font.Anchor{{X: 150, Y: 950}}}},
+	}
+
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Text:     "\u0644\u064E\u0651",
+		Embedded: ef,
+		FontSize: 12,
+	}
+	b := capturedWordStream(word)
+
+	var tds []string
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasSuffix(line, " Td") {
+			tds = append(tds, line)
+		}
+	}
+	if len(tds) != 5 {
+		t.Fatalf("expected 5 Td ops, got %d:\n%s", len(tds), b)
+	}
+	// Shadda must land at mark-to-base offset (-4.8, 6), not at the
+	// mkmk-stacked offset (-4.2, 12.6).
+	if !strings.Contains(tds[3], "-4.8 6 Td") {
+		t.Errorf("shadda open Td = %q, want mark-to-base fallback -4.8 6 Td (wrong-GID mkmk miss):\n%s", tds[3], b)
+	}
+}
+
+// TestGPOSMarkMarkFallsBackWhenPairUnknown verifies that when LookupType
+// 6 has no entry for (mark[i], mark[i-1]), the mark falls back to
+// mark-to-base against the cluster base. Here shadda declares a
+// mark-to-base anchor (class 0 on lam) but no mkmk relation to fatha:
+// the shadda must land at its mark-to-base offset, not stacked.
+func TestGPOSMarkMarkFallsBackWhenPairUnknown(t *testing.T) {
+	face := newLamFathaFace()
+	const shaddaGID uint16 = 61
+	face.cmap[0x0651] = shaddaGID
+	face.advance[shaddaGID] = 0
+	// Give shadda a mark-to-base record sharing class 0 so lam's
+	// existing class-0 anchor serves it. Expected offset equals the
+	// fatha offset: (300, 500) FUnits → (3.6, 6.0) pt.
+	face.gpos.Marks[font.GPOSMark][shaddaGID] = font.MarkRecord{
+		Class:  0,
+		Anchor: font.Anchor{X: 200, Y: 300},
+	}
+	// No MarkMarks / Mark2Bases populated: mkmk lookup must miss.
+
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Text:     "\u0644\u064E\u0651",
+		Embedded: ef,
+		FontSize: 12,
+	}
+	b := capturedWordStream(word)
+
+	var tds []string
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasSuffix(line, " Td") {
+			tds = append(tds, line)
+		}
+	}
+	if len(tds) != 5 {
+		t.Fatalf("expected 5 Td ops, got %d:\n%s", len(tds), b)
+	}
+	// Both marks should land at the same (-4.8, 6) open because both
+	// resolve to the lam class-0 anchor via mark-to-base fallback.
+	if !strings.Contains(tds[3], "-4.8") || !strings.Contains(tds[3], "6 Td") {
+		t.Errorf("fallback shadda open Td = %q, want mark-to-base -4.8 6 Td:\n%s", tds[3], b)
+	}
+}
+
+// TestGPOSMarkMarkMeasureAgreesWithDraw locks down the invariant for
+// stacked marks: mkmk positioning is purely visual (zero-advance marks,
+// paired Td brackets that cancel), so MeasureString must still equal
+// the net horizontal advance of the draw stream.
+func TestGPOSMarkMarkMeasureAgreesWithDraw(t *testing.T) {
+	face := newLamFathaFace()
+	_ = addStackedShadda(face)
+	ef := font.NewEmbeddedFont(face)
+
+	word := Word{
+		Text:     "\u0644\u064E\u0651",
+		Embedded: ef,
+		FontSize: 12,
+	}
+	measured := ef.MeasureString(word.Text, word.FontSize)
+
+	b := capturedWordStream(word)
+	netTdX := 0.0
+	seenInitial := false
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasSuffix(line, " Td") {
+			continue
+		}
+		if !seenInitial {
+			seenInitial = true
+			continue
+		}
+		var tx, ty float64
+		n, err := fmt.Sscanf(line, "%f %f Td", &tx, &ty)
+		if err != nil || n != 2 {
+			t.Fatalf("unparseable Td line %q: %v", line, err)
+		}
+		netTdX += tx
+	}
+	baseAdv := float64(face.advance[50]) / float64(face.upem) * word.FontSize
+	drawAdvance := baseAdv + netTdX
+	if !almostEqual(drawAdvance, measured, 1e-9) {
+		t.Errorf("mkmk draw advance = %v, MeasureString = %v — must agree", drawAdvance, measured)
+	}
+}
+
 func almostEqual(a, b, eps float64) bool {
 	d := a - b
 	if d < 0 {


### PR DESCRIPTION
## Summary

Implements ISO 14496-22 §6.3 LookupType 6 (MarkMarkPosFormat1) so combining marks anchor to the previously placed mark instead of stacking on the same base anchor. Closes #206.

Use cases unblocked:
- Arabic shadda + harakat stacks
- Hebrew dagesh + niqqud combinations
- Vietnamese tone marks on already-diacritic vowels (ế)
- IPA stacked tone / length marks

## Implementation

- `font/gpos.go`
  - `GPOSAdjustments` gains `MarkMarks` and `Mark2Bases` maps, keyed by feature tag, mirroring the existing `Marks` / `Bases` shape.
  - `parseMarkMarkPos` parses `MarkMarkPosFormat1`. Byte layout is identical to `MarkBasePosFormat1`, so `parseMarkArray` and `parseBaseArray` are reused.
  - `parseGPOSLookup` dispatch gains case `6`; LookupType 9 (Extension) unwrapping already routes through the same switch.
  - `MarkMarkOffset(mark1GID, mark2GID, feature)` accessor. Anchor subtraction is factored into a shared `anchorOffset` helper with `MarkOffset`. Parameter order follows the spec's mark1/mark2 naming (attaching, receiving) — reverse of `MarkOffset(base, mark)`; godoc flags the inversion.
- `layout/draw.go`
  - In `drawWordEmbeddedWithMarks`, marks after the first consult `MarkMarkOffset(markGID, prevMarkGID, GPOSMkmk)`. On hit, the new mark's origin is `(prevDx + mkmkDx, prevDy + mkmkDy)`. On miss, falls back to mark-to-base against the cluster base.
  - Td brackets remain paired; marks stay zero-advance, so `MeasureString` continues to equal the draw advance.

## Test plan

- [x] `font/gpos_test.go`
  - Parser happy path (`TestParseGPOSMarkMarkPosFormat1`).
  - LookupType 9 extension wrap around LookupType 6.
  - Multi-class anchor lookup (`markClassCount=2`) plus out-of-range-class defensive branch.
  - `mark` and `mkmk` features coexisting in one GPOS blob populate independently (no cross-contamination).
  - Mkmk-only font still yields a non-nil `GPOSAdjustments`.
  - Nil-receiver safety for `MarkMarkOffset`.
- [x] `layout/gpos_mark_draw_test.go`
  - Stacked shadda on fatha emits Td bracket at the compounded offset, not the mark-to-base offset.
  - Transitive stacking across three marks (lam + fatha + shadda + dammatan) — accumulated offsets + zero-sum Td brackets on both axes.
  - Fallback to mark-to-base when mkmk has no entry for the pair.
  - Fallback keyed by glyph ID: mkmk data for an unrelated mark1 GID must not shadow the correct fallback path.
  - `MeasureString` / draw-advance invariant preserved under stacking.
- [x] Full `go test ./...` passes.