### PR TITLE
document: extend PDF/A to A-3a and the PDF/A-4 family

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -186,8 +186,24 @@ func renderHTML(_ js.Value, args []js.Value) any {
 	switch settings.PdfProfile {
 	case "pdfa1b":
 		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA1B})
+	case "pdfa1a":
+		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA1A})
 	case "pdfa2b":
 		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA2B})
+	case "pdfa2u":
+		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA2U})
+	case "pdfa2a":
+		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA2A})
+	case "pdfa3b":
+		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA3B})
+	case "pdfa3a":
+		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA3A})
+	case "pdfa4":
+		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA4})
+	case "pdfa4f":
+		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA4F})
+	case "pdfa4e":
+		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA4E})
 	case "pdfua1":
 		doc.SetTagged(true)
 	}

--- a/document/document.go
+++ b/document/document.go
@@ -598,6 +598,13 @@ func (d *Document) WriteToWithOptions(w io.Writer, opts WriteOptions) (int64, er
 	catalog := core.NewPdfDictionary()
 	catalog.Set("Type", core.NewPdfName("Catalog"))
 
+	// /Lang declares the document's default natural language
+	// (ISO 32000-2 §14.9.2). Required for PDF/A Level A
+	// (ISO 19005-2 §6.7.2) when per-structure Lang is not set.
+	if d.Info.Language != "" {
+		catalog.Set("Lang", core.NewPdfLiteralString(d.Info.Language))
+	}
+
 	pagesDict := core.NewPdfDictionary()
 	pagesDict.Set("Type", core.NewPdfName("Pages"))
 	pagesDict.Set("Count", core.NewPdfInteger(len(allPages)))

--- a/document/info.go
+++ b/document/info.go
@@ -21,6 +21,14 @@ type Info struct {
 	Producer     string // application that produced the PDF
 	CreationDate time.Time
 	ModDate      time.Time
+
+	// Language is the default natural language of all text in the
+	// document, expressed as a BCP 47 / RFC 3066 language tag
+	// (e.g. "en-US", "es", "fr-CA"). When non-empty it is written
+	// to the document catalog as /Lang (ISO 32000-2 §14.9.2) and
+	// declared in the XMP dc:language property. PDF/A Level A
+	// (accessibility-conformance) requires this entry.
+	Language string
 }
 
 // toDict converts Info to a PdfDictionary. Only non-zero fields are included.
@@ -56,6 +64,9 @@ func (info *Info) toDict() *core.PdfDictionary {
 }
 
 // isEmpty reports whether all fields are zero-valued.
+// Language is intentionally excluded: it is written to the catalog,
+// not the /Info dictionary, and a document with only Language set
+// should still produce no /Info entry.
 func (info *Info) isEmpty() bool {
 	return info.Title == "" && info.Author == "" && info.Subject == "" &&
 		info.Keywords == "" && info.Creator == "" && info.Producer == "" &&

--- a/document/pdfa.go
+++ b/document/pdfa.go
@@ -16,6 +16,8 @@ import (
 // PdfALevel specifies the PDF/A conformance level.
 type PdfALevel int
 
+// New PdfALevel constants must be appended to this block. The numeric
+// values are part of the C ABI surface (see export/folio.h FOLIO_PDFA_*).
 const (
 	// PdfA2B is PDF/A-2b (ISO 19005-2:2011, Level B).
 	// Based on PDF 1.7. Allows transparency. Requires font embedding,
@@ -28,7 +30,8 @@ const (
 	// PdfA2A is PDF/A-2a (Level A). Adds structure tagging requirement.
 	PdfA2A
 
-	// PdfA3B is PDF/A-3b. Like A-2b but allows file attachments.
+	// PdfA3B is PDF/A-3b (ISO 19005-3:2012, Level B). Like A-2b but
+	// allows associated file attachments (§6.4).
 	PdfA3B
 
 	// PdfA1B is PDF/A-1b (ISO 19005-1:2005, Level B).
@@ -38,6 +41,24 @@ const (
 
 	// PdfA1A is PDF/A-1a (Level A). Like 1b but adds structure tagging.
 	PdfA1A
+
+	// PdfA3A is PDF/A-3a (ISO 19005-3:2012, Level A). Adds structure
+	// tagging on top of A-3b; inherits attachment support from part 3.
+	PdfA3A
+
+	// PdfA4 is PDF/A-4 (ISO 19005-4:2020). Based on PDF 2.0. Has no
+	// conformance level letter; XMP carries pdfaid:rev = "2020"
+	// (§6.5). Forbids embedded files unless the level is PdfA4F or
+	// PdfA4E.
+	PdfA4
+
+	// PdfA4F is PDF/A-4f (ISO 19005-4:2020). Like PdfA4 but permits
+	// embedded files. Successor to PDF/A-3 for invoice/data carriers.
+	PdfA4F
+
+	// PdfA4E is PDF/A-4e (ISO 19005-4:2020). Engineering profile;
+	// permits 3D, RichMedia, and embedded files. Successor to PDF/E-1.
+	PdfA4E
 )
 
 // PdfAConfig holds PDF/A conformance settings.
@@ -112,11 +133,12 @@ type XMPProperty struct {
 // or via [Document.ValidatePdfA].
 func (d *Document) SetPdfA(config PdfAConfig) {
 	d.pdfA = &config
-	// Level A (any part) requires tagged PDF.
-	if config.Level == PdfA2A || config.Level == PdfA1A {
+	// Level A (any part) requires tagged PDF (ISO 19005-1 §6.8,
+	// ISO 19005-2 §6.7.3, ISO 19005-3 §6.7.3). PDF/A-4 has no Level A.
+	if isLevelA(config.Level) {
 		d.tagged = true
 	}
-	// PDF/A disallows encryption.
+	// PDF/A disallows encryption (ISO 19005-1 §6.1.3, etc.).
 	d.encryption = nil
 }
 
@@ -131,15 +153,23 @@ func (d *Document) ValidatePdfA() error {
 	return d.validatePdfA(d.pages)
 }
 
-// pdfALevelString returns the conformance level letter.
+// pdfALevelString returns the conformance level letter for the
+// pdfaid:conformance XMP property. Returns "" when the level has no
+// conformance letter (PDF/A-4 base profile, ISO 19005-4 §6.5).
 func pdfALevelString(level PdfALevel) string {
 	switch level {
 	case PdfA1B, PdfA2B, PdfA3B:
 		return "B"
 	case PdfA2U:
 		return "U"
-	case PdfA1A, PdfA2A:
+	case PdfA1A, PdfA2A, PdfA3A:
 		return "A"
+	case PdfA4F:
+		return "F"
+	case PdfA4E:
+		return "E"
+	case PdfA4:
+		return ""
 	default:
 		return "B"
 	}
@@ -150,8 +180,10 @@ func pdfAPartNumber(level PdfALevel) int {
 	switch level {
 	case PdfA1B, PdfA1A:
 		return 1
-	case PdfA3B:
+	case PdfA3B, PdfA3A:
 		return 3
+	case PdfA4, PdfA4F, PdfA4E:
+		return 4
 	default:
 		return 2
 	}
@@ -162,13 +194,42 @@ func isPdfA1(level PdfALevel) bool {
 	return level == PdfA1B || level == PdfA1A
 }
 
-// pdfVersionForPdfA returns the PDF version string for the given level.
-// PDF/A-1 is based on PDF 1.4; PDF/A-2 and later on PDF 1.7.
-func pdfVersionForPdfA(level PdfALevel) string {
-	if isPdfA1(level) {
-		return "1.4"
+// isPdfA4 returns true if the level is a PDF/A-4 variant.
+func isPdfA4(level PdfALevel) bool {
+	return level == PdfA4 || level == PdfA4F || level == PdfA4E
+}
+
+// isLevelA returns true if the level is an accessibility-conformance
+// (Level A) variant. PDF/A-4 has no Level A equivalent.
+func isLevelA(level PdfALevel) bool {
+	return level == PdfA1A || level == PdfA2A || level == PdfA3A
+}
+
+// allowsAttachments returns true if the level permits embedded files
+// in the /EmbeddedFiles name tree (ISO 19005-3 §6.4 for part 3;
+// ISO 19005-4 §6.8 for A-4f / A-4e).
+func allowsAttachments(level PdfALevel) bool {
+	switch level {
+	case PdfA3B, PdfA3A, PdfA4F, PdfA4E:
+		return true
+	default:
+		return false
 	}
-	return "1.7"
+}
+
+// pdfVersionForPdfA returns the PDF version string for the given level.
+// PDF/A-1 is based on PDF 1.4 (ISO 19005-1 §6.1.2);
+// PDF/A-2 and PDF/A-3 on PDF 1.7 (ISO 19005-2 §6.1.2);
+// PDF/A-4 on PDF 2.0 (ISO 19005-4 §6.1).
+func pdfVersionForPdfA(level PdfALevel) string {
+	switch {
+	case isPdfA1(level):
+		return "1.4"
+	case isPdfA4(level):
+		return "2.0"
+	default:
+		return "1.7"
+	}
 }
 
 // validatePdfA checks that the document meets PDF/A requirements.
@@ -202,14 +263,24 @@ func (d *Document) validatePdfA(allPages []*Page) error {
 		}
 	}
 
-	// File attachments are only permitted in PDF/A-3B (ISO 19005-3 §6.4).
-	if len(d.attachments) > 0 && d.pdfA.Level != PdfA3B {
-		return fmt.Errorf("pdfa: file attachments are only permitted in PDF/A-3B; current level does not allow them")
+	// File attachments are only permitted in parts/levels that explicitly
+	// allow them: PDF/A-3 (ISO 19005-3 §6.4) and PDF/A-4f / PDF/A-4e
+	// (ISO 19005-4 §6.8). Plain PDF/A-4 forbids them.
+	if len(d.attachments) > 0 && !allowsAttachments(d.pdfA.Level) {
+		return fmt.Errorf("pdfa: file attachments are only permitted in PDF/A-3 (a/b) or PDF/A-4f / PDF/A-4e; current level does not allow them")
 	}
 
 	// Title is required.
 	if d.Info.Title == "" {
 		return fmt.Errorf("pdfa: document Title is required for PDF/A conformance")
+	}
+
+	// Level A (accessibility-conformance) requires a declared natural
+	// language for all text (ISO 19005-2 §6.7.2 / 19005-3 §6.7.2).
+	// Folio satisfies this via the catalog /Lang entry, populated from
+	// Info.Language. Per-structure Lang is not yet exposed.
+	if isLevelA(d.pdfA.Level) && d.Info.Language == "" {
+		return fmt.Errorf("pdfa: Info.Language is required for Level A (accessibility-conformance) variants; set Info.Language to a BCP 47 / RFC 3066 tag (e.g. \"en-US\")")
 	}
 
 	return nil
@@ -228,6 +299,7 @@ func buildXMPMetadata(info Info, level PdfALevel, xmpSchemas []XMPSchema, xmpPro
 
 	title := xmlEscape(info.Title)
 	author := xmlEscape(info.Author)
+	language := xmlEscape(info.Language)
 	creator := xmlEscape(info.Creator)
 	if creator == "" {
 		creator = "Folio"
@@ -245,7 +317,7 @@ func buildXMPMetadata(info Info, level PdfALevel, xmpSchemas []XMPSchema, xmpPro
 	b.WriteString(`<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">`)
 	b.WriteString("\n")
 
-	// Dublin Core (title, creator)
+	// Dublin Core (title, creator, language)
 	b.WriteString(`<rdf:Description rdf:about=""`)
 	b.WriteString(` xmlns:dc="http://purl.org/dc/elements/1.1/">`)
 	b.WriteString("\n")
@@ -255,6 +327,12 @@ func buildXMPMetadata(info Info, level PdfALevel, xmpSchemas []XMPSchema, xmpPro
 	}
 	if author != "" {
 		b.WriteString(`<dc:creator><rdf:Seq><rdf:li>` + author + `</rdf:li></rdf:Seq></dc:creator>`)
+		b.WriteString("\n")
+	}
+	if language != "" {
+		// dc:language mirrors the catalog /Lang entry. PDF/A Level A
+		// (ISO 19005-2 §6.7.2) and PDF/UA-1 conformance check for it.
+		b.WriteString(`<dc:language><rdf:Bag><rdf:li>` + language + `</rdf:li></rdf:Bag></dc:language>`)
 		b.WriteString("\n")
 	}
 	b.WriteString(`</rdf:Description>`)
@@ -282,21 +360,36 @@ func buildXMPMetadata(info Info, level PdfALevel, xmpSchemas []XMPSchema, xmpPro
 	b.WriteString(`</rdf:Description>`)
 	b.WriteString("\n")
 
-	// PDF/A identification
+	// PDF/A identification (ISO 19005-1 §6.7.11, 19005-2 §6.7.11,
+	// 19005-3 §6.7.11, 19005-4 §6.5).
+	//
+	// Parts 1–3 carry pdfaid:part + pdfaid:conformance.
+	// Part 4 carries pdfaid:part + pdfaid:rev = "2020"; conformance is
+	// only present for the A-4f / A-4e profiles (values "F" / "E").
 	b.WriteString(`<rdf:Description rdf:about=""`)
 	b.WriteString(` xmlns:pdfaid="http://www.aiim.org/pdfa/ns/id/">`)
 	b.WriteString("\n")
 	fmt.Fprintf(&b, `<pdfaid:part>%d</pdfaid:part>`, part)
 	b.WriteString("\n")
-	b.WriteString(`<pdfaid:conformance>` + conf + `</pdfaid:conformance>`)
-	b.WriteString("\n")
+	if isPdfA4(level) {
+		b.WriteString(`<pdfaid:rev>2020</pdfaid:rev>`)
+		b.WriteString("\n")
+	}
+	if conf != "" {
+		b.WriteString(`<pdfaid:conformance>` + conf + `</pdfaid:conformance>`)
+		b.WriteString("\n")
+	}
 	b.WriteString(`</rdf:Description>`)
 	b.WriteString("\n")
 
-	// PDF/A-3 requires a single pdfaExtension:schemas block. The built-in pdfaf
-	// schema (for /AF) and any caller-supplied schemas (e.g. Factur-X fx:) are
-	// merged into one <rdf:Bag> to avoid the "duplicate property" XMP parse error.
-	if level == PdfA3B || len(xmpSchemas) > 0 {
+	// Any level that allows associated files (PDF/A-3 a/b, PDF/A-4f,
+	// PDF/A-4e) needs the pdfaf extension schema declared so that
+	// validators recognise the AFRelationship key on filespecs.
+	// The built-in pdfaf schema and any caller-supplied schemas
+	// (e.g. Factur-X fx:) are merged into one <rdf:Bag> to keep a
+	// single pdfaExtension:schemas block.
+	emitAFSchema := allowsAttachments(level)
+	if emitAFSchema || len(xmpSchemas) > 0 {
 		b.WriteString(`<rdf:Description rdf:about=""`)
 		b.WriteString(` xmlns:pdfaExtension="http://www.aiim.org/pdfa/ns/extension/"`)
 		b.WriteString(` xmlns:pdfaSchema="http://www.aiim.org/pdfa/ns/schema#"`)
@@ -305,10 +398,11 @@ func buildXMPMetadata(info Info, level PdfALevel, xmpSchemas []XMPSchema, xmpPro
 		b.WriteString(`<pdfaExtension:schemas><rdf:Bag>`)
 		b.WriteString("\n")
 
-		// Built-in pdfaf schema (AF associated files, PDF/A-3 §6.4).
-		if level == PdfA3B {
+		// Built-in pdfaf schema (AF associated files, ISO 19005-3 §6.4
+		// and ISO 19005-4 §6.8).
+		if emitAFSchema {
 			b.WriteString(`<rdf:li rdf:parseType="Resource">`)
-			b.WriteString(`<pdfaSchema:schema>PDF/A-3 Association File Attachment</pdfaSchema:schema>`)
+			b.WriteString(`<pdfaSchema:schema>PDF/A Associated File Attachment</pdfaSchema:schema>`)
 			b.WriteString(`<pdfaSchema:namespaceURI>http://www.aiim.org/pdfa/ns/f#</pdfaSchema:namespaceURI>`)
 			b.WriteString(`<pdfaSchema:prefix>pdfaf</pdfaSchema:prefix>`)
 			b.WriteString(`<pdfaSchema:property><rdf:Seq><rdf:li rdf:parseType="Resource">`)

--- a/document/pdfa_test.go
+++ b/document/pdfa_test.go
@@ -392,8 +392,8 @@ func TestPdfA2bRejectsAttachment(t *testing.T) {
 	if err == nil {
 		t.Error("expected error when attaching file to PDF/A-2B document")
 	}
-	if err != nil && !strings.Contains(err.Error(), "PDF/A-3B") {
-		t.Errorf("expected error mentioning PDF/A-3B, got: %v", err)
+	if err != nil && !strings.Contains(err.Error(), "PDF/A-3") {
+		t.Errorf("expected error mentioning PDF/A-3, got: %v", err)
 	}
 }
 
@@ -771,5 +771,267 @@ func TestXMPPropertyBlockNamespaceEscaping(t *testing.T) {
 	}
 	if !strings.Contains(pdf, `xmlns:edge="urn:edge:ns&amp;v2#"`) {
 		t.Error("expected XML-escaped namespace URI in xmlns attribute")
+	}
+}
+
+// --- PDF/A-3a (ISO 19005-3:2012, Level A) ---
+
+func TestPdfA3aBasic(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "PDF/A-3a Test"
+	doc.Info.Language = "en-US"
+	doc.SetPdfA(PdfAConfig{Level: PdfA3A})
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	pdf := buf.String()
+
+	if !strings.Contains(pdf, "<pdfaid:part>3</pdfaid:part>") {
+		t.Error("expected PDF/A part 3")
+	}
+	if !strings.Contains(pdf, "<pdfaid:conformance>A</pdfaid:conformance>") {
+		t.Error("expected PDF/A conformance A")
+	}
+}
+
+func TestPdfA3aEnablesTagging(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "Tagged A-3a"
+	doc.Info.Language = "en"
+	doc.SetPdfA(PdfAConfig{Level: PdfA3A})
+
+	if !doc.tagged {
+		t.Error("PDF/A-3a should enable tagged PDF automatically")
+	}
+}
+
+func TestPdfA3aAllowsAttachment(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "A-3a Attachment"
+	doc.Info.Language = "en"
+	doc.SetPdfA(PdfAConfig{Level: PdfA3A})
+
+	doc.AttachFile(FileAttachment{
+		FileName: "data.xml",
+		MIMEType: "application/xml",
+		Data:     []byte(`<data/>`),
+	})
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("PDF/A-3a should permit attachments: %v", err)
+	}
+
+	pdf := buf.String()
+	if !strings.Contains(pdf, "/EmbeddedFiles") {
+		t.Error("expected /EmbeddedFiles in A-3a output")
+	}
+	// pdfaExtension AF schema must also be declared for A-3a.
+	if !strings.Contains(pdf, "http://www.aiim.org/pdfa/ns/f#") {
+		t.Error("expected pdfaf schema declaration in A-3a XMP")
+	}
+}
+
+// --- PDF/A-4 (ISO 19005-4:2020) ---
+
+func TestPdfA4Basic(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "PDF/A-4 Test"
+	doc.SetPdfA(PdfAConfig{Level: PdfA4})
+	doc.AddPage()
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	pdf := buf.String()
+
+	if !strings.HasPrefix(pdf, "%PDF-2.0") {
+		t.Error("expected PDF 2.0 header for PDF/A-4")
+	}
+	if !strings.Contains(pdf, "<pdfaid:part>4</pdfaid:part>") {
+		t.Error("expected PDF/A part 4")
+	}
+	if !strings.Contains(pdf, "<pdfaid:rev>2020</pdfaid:rev>") {
+		t.Error("expected pdfaid:rev 2020 for PDF/A-4")
+	}
+	// Plain PDF/A-4 must NOT carry a pdfaid:conformance element.
+	if strings.Contains(pdf, "<pdfaid:conformance>") {
+		t.Error("plain PDF/A-4 must not emit pdfaid:conformance")
+	}
+}
+
+func TestPdfA4DoesNotEnableTagging(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "A-4"
+	doc.SetPdfA(PdfAConfig{Level: PdfA4})
+
+	if doc.tagged {
+		t.Error("PDF/A-4 has no Level A and should not auto-enable tagging")
+	}
+}
+
+func TestPdfA4RejectsAttachment(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "A-4 Attachment Rejection"
+	doc.SetPdfA(PdfAConfig{Level: PdfA4})
+
+	doc.AttachFile(FileAttachment{
+		FileName: "data.xml",
+		MIMEType: "application/xml",
+		Data:     []byte(`<data/>`),
+	})
+
+	var buf bytes.Buffer
+	_, err := doc.WriteTo(&buf)
+	if err == nil {
+		t.Error("plain PDF/A-4 must not allow embedded files")
+	}
+}
+
+func TestPdfA4fAllowsAttachment(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "A-4f Attachment"
+	doc.SetPdfA(PdfAConfig{Level: PdfA4F})
+
+	doc.AttachFile(FileAttachment{
+		FileName: "invoice.xml",
+		MIMEType: "application/xml",
+		Data:     []byte(`<invoice/>`),
+	})
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("PDF/A-4f must permit attachments: %v", err)
+	}
+
+	pdf := buf.String()
+	if !strings.Contains(pdf, "<pdfaid:part>4</pdfaid:part>") {
+		t.Error("expected PDF/A part 4")
+	}
+	if !strings.Contains(pdf, "<pdfaid:conformance>F</pdfaid:conformance>") {
+		t.Error("expected pdfaid:conformance F for PDF/A-4f")
+	}
+	if !strings.Contains(pdf, "<pdfaid:rev>2020</pdfaid:rev>") {
+		t.Error("expected pdfaid:rev 2020")
+	}
+	if !strings.Contains(pdf, "/EmbeddedFiles") {
+		t.Error("expected /EmbeddedFiles in A-4f output")
+	}
+	if !strings.Contains(pdf, "http://www.aiim.org/pdfa/ns/f#") {
+		t.Error("expected pdfaf schema declaration in A-4f XMP")
+	}
+}
+
+func TestPdfA4eConformance(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "A-4e"
+	doc.SetPdfA(PdfAConfig{Level: PdfA4E})
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	pdf := buf.String()
+	if !strings.Contains(pdf, "<pdfaid:conformance>E</pdfaid:conformance>") {
+		t.Error("expected pdfaid:conformance E for PDF/A-4e")
+	}
+	if !strings.HasPrefix(pdf, "%PDF-2.0") {
+		t.Error("expected PDF 2.0 header for PDF/A-4e")
+	}
+}
+
+// --- Level A language requirement (ISO 19005-2 §6.7.2) ---
+
+func TestPdfALevelARequiresLanguage(t *testing.T) {
+	cases := []struct {
+		name  string
+		level PdfALevel
+	}{
+		{"PdfA1A", PdfA1A},
+		{"PdfA2A", PdfA2A},
+		{"PdfA3A", PdfA3A},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := NewDocument(PageSizeLetter)
+			doc.Info.Title = "Level A No Lang"
+			// Info.Language intentionally omitted.
+			doc.SetPdfA(PdfAConfig{Level: tc.level})
+
+			var buf bytes.Buffer
+			_, err := doc.WriteTo(&buf)
+			if err == nil {
+				t.Errorf("%s should require Info.Language", tc.name)
+			}
+			if err != nil && !strings.Contains(err.Error(), "Language") {
+				t.Errorf("expected language error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestPdfALevelBNoLanguageRequired(t *testing.T) {
+	// Level B variants must still write successfully with no Language set.
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "Level B No Lang"
+	doc.SetPdfA(PdfAConfig{Level: PdfA2B})
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("Level B must not require Language: %v", err)
+	}
+}
+
+func TestPdfALanguageInCatalog(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "Lang Test"
+	doc.Info.Language = "fr-CA"
+	doc.SetPdfA(PdfAConfig{Level: PdfA2A})
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	pdf := buf.String()
+	if !strings.Contains(pdf, "/Lang (fr-CA)") {
+		t.Error("expected /Lang (fr-CA) in catalog")
+	}
+	// dc:language mirrors the catalog /Lang in XMP.
+	if !strings.Contains(pdf, "<rdf:li>fr-CA</rdf:li>") {
+		t.Error("expected dc:language entry in XMP")
+	}
+}
+
+func TestPdfA4UsesPdf2(t *testing.T) {
+	cases := []struct {
+		name  string
+		level PdfALevel
+	}{
+		{"PdfA4", PdfA4},
+		{"PdfA4F", PdfA4F},
+		{"PdfA4E", PdfA4E},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := NewDocument(PageSizeLetter)
+			doc.Info.Title = "Version Check"
+			doc.SetPdfA(PdfAConfig{Level: tc.level})
+			doc.AddPage()
+
+			var buf bytes.Buffer
+			if _, err := doc.WriteTo(&buf); err != nil {
+				t.Fatalf("WriteTo failed: %v", err)
+			}
+			if !strings.HasPrefix(buf.String(), "%PDF-2.0") {
+				t.Errorf("%s expected PDF 2.0 header", tc.name)
+			}
+		})
 	}
 }

--- a/export/cabi_document.go
+++ b/export/cabi_document.go
@@ -68,6 +68,21 @@ func folio_document_set_author(docH C.uint64_t, author *C.char) C.int32_t {
 	return errOK
 }
 
+// folio_document_set_language sets the document's default natural
+// language as a BCP 47 / RFC 3066 tag (e.g. "en-US"). When non-empty
+// it is written to the catalog /Lang entry (ISO 32000-2 §14.9.2) and
+// is required for PDF/A Level A conformance (ISO 19005-2 §6.7.2).
+//
+//export folio_document_set_language
+func folio_document_set_language(docH C.uint64_t, lang *C.char) C.int32_t {
+	doc, errCode := loadDoc(docH)
+	if errCode != errOK {
+		return errCode
+	}
+	doc.Info.Language = C.GoString(lang)
+	return errOK
+}
+
 // folio_document_set_margins sets the page margins in points (top, right, bottom, left).
 //
 //export folio_document_set_margins

--- a/export/folio.h
+++ b/export/folio.h
@@ -87,6 +87,10 @@ extern "C" {
 #define FOLIO_PDFA_3B          3
 #define FOLIO_PDFA_1B          4
 #define FOLIO_PDFA_1A          5
+#define FOLIO_PDFA_3A          6   /* ISO 19005-3:2012 Level A */
+#define FOLIO_PDFA_4           7   /* ISO 19005-4:2020 base, PDF 2.0 */
+#define FOLIO_PDFA_4F          8   /* ISO 19005-4:2020 with files */
+#define FOLIO_PDFA_4E          9   /* ISO 19005-4:2020 engineering */
 
 /* Encryption algorithms (document.EncryptionAlgorithm) */
 #define FOLIO_ENCRYPT_RC4_128  0
@@ -165,6 +169,7 @@ void     folio_document_free(uint64_t doc);
 
 int32_t  folio_document_set_title(uint64_t doc, const char *title);
 int32_t  folio_document_set_author(uint64_t doc, const char *author);
+int32_t  folio_document_set_language(uint64_t doc, const char *lang);
 int32_t  folio_document_set_margins(uint64_t doc, double top, double right, double bottom, double left);
 
 uint64_t folio_document_add_page(uint64_t doc);


### PR DESCRIPTION
## Summary
Closes the PDF/A coverage gap. Folio now supports the full ISO 19005 matrix:

- **PDF/A-3a** (ISO 19005-3:2012, Level A) — accessibility-conformance with attachment support.
- **PDF/A-4 family** (ISO 19005-4:2020, PDF 2.0):
  - `PdfA4` — base profile
  - `PdfA4F` — embedded files (Factur-X successor)
  - `PdfA4E` — engineering profile (replaces PDF/E-1)

Per-standard behavior:
- PDF version selected per part (1.4 / 1.7 / 2.0).
- `pdfaid:rev = "2020"` emitted for part 4 (ISO 19005-4 §6.5); `pdfaid:conformance` omitted for plain A-4 and present (`F` / `E`) for the A-4f / A-4e profiles.
- Embedded files now permitted in A-3 (a/b) and A-4 (f/e); rejected elsewhere. The `pdfaf` extension schema is declared for every level allowing associated files.
- New `Info.Language` field (BCP 47 / RFC 3066) writes catalog `/Lang` (ISO 32000-2 §14.9.2) and `dc:language`. Required for any Level A variant per ISO 19005-2 §6.7.2 / 19005-3 §6.7.2.

## C ABI
- New constants: `FOLIO_PDFA_3A`, `FOLIO_PDFA_4`, `FOLIO_PDFA_4F`, `FOLIO_PDFA_4E`. Existing constant numeric values are preserved.
- New setter: `folio_document_set_language(doc, lang)`.

## WASM CLI
Exposes the new profile keys (`pdfa3a`, `pdfa4`, `pdfa4f`, `pdfa4e`) and fills in profile keys that the Go API already supported but the playground did not (`pdfa1a`, `pdfa2u`, `pdfa2a`, `pdfa3b`).

## Test plan
- [x] `go test ./document/ -run TestPdfA -v` — 35 tests pass (22 pre-existing + 13 new).
- [x] `go test ./...` — full suite green.
- [x] `go vet ./...` clean.
- [x] `go build ./...` and `GOOS=js GOARCH=wasm go build ./cmd/wasm` both clean.
- [x] Existing `qpdf --check` test (`TestPdfA2bQpdfCheck`, `TestPdfA1bQpdfCheck`) still passes.

New tests cover: A-3a basics / tagging / attachment + AF schema; A-4 PDF 2.0 header + `pdfaid:rev` + no conformance letter; A-4 attachment rejection; A-4f attachment + conformance F + AF schema; A-4e conformance E; Level A `Info.Language` requirement (table-driven across A-1a/A-2a/A-3a); Level B no-language regression; `/Lang` in catalog + `dc:language` in XMP; PDF 2.0 header across all A-4 variants.