### PR TITLE
font: add GPOS LookupType 3 (cursive) and LookupType 5 (mark-to-ligature)

### DIFF
--- a/font/gpos.go
+++ b/font/gpos.go
@@ -23,6 +23,13 @@ const (
 	// shadda + fatha, Hebrew dagesh + niqqud, and Vietnamese tone marks
 	// on already-diacritic vowels. ISO 14496-22 §6.3 LookupType 6.
 	GPOSMkmk GPOSFeature = "mkmk"
+
+	// GPOSCurs is the Cursive Attachment feature. It chains glyphs along
+	// the script baseline by joining the previous glyph's exit anchor to
+	// the next glyph's entry anchor — the mechanism behind Arabic
+	// nastaliq-style joining and similar connected scripts.
+	// ISO 14496-22 §6.3 LookupType 3.
+	GPOSCurs GPOSFeature = "curs"
 )
 
 // PairAdjustment holds the XAdvance delta to apply to the first glyph of
@@ -54,6 +61,29 @@ type BaseRecord struct {
 	Anchors []Anchor
 }
 
+// CursiveRecord captures the entry/exit anchors a single glyph
+// contributes to LookupType 3 cursive attachment. Either anchor may be
+// absent (zero offset in the source EntryExitRecord); HasEntry/HasExit
+// disambiguate "absent" from "present at (0,0)".
+type CursiveRecord struct {
+	Entry, Exit       Anchor
+	HasEntry, HasExit bool
+}
+
+// LigatureRecord captures the per-component anchors a ligature base
+// glyph exposes for LookupType 5 (Mark-to-Ligature). Components is
+// indexed first by component index (0 = leftmost component for LTR
+// ligatures, in glyph order) and then by mark class.
+//
+// Present is a parallel grid that disambiguates "no anchor declared"
+// (the source ligatureAnchorOffset was 0) from "anchor declared at
+// (0, 0)". Consumers must check Present[component][markClass] before
+// trusting the anchor value.
+type LigatureRecord struct {
+	Components [][]Anchor
+	Present    [][]bool
+}
+
 // GPOSAdjustments holds parsed GPOS positioning data grouped by feature
 // tag. A nil map or nil outer struct means "feature absent".
 type GPOSAdjustments struct {
@@ -75,13 +105,29 @@ type GPOSAdjustments struct {
 	// the receiving (mark2) glyph ID. Shape mirrors Bases: each entry
 	// exposes one anchor per mark class of the attaching mark.
 	Mark2Bases map[GPOSFeature]map[uint16]BaseRecord
+
+	// Cursives holds LookupType 3 cursive attachment records keyed by
+	// glyph ID. The shape is one record per coverage entry; consumers
+	// pair them at runtime via CursiveOffset(prev, curr).
+	Cursives map[GPOSFeature]map[uint16]CursiveRecord
+
+	// LigatureMarks holds LookupType 5 mark records keyed by mark glyph
+	// ID. Shape mirrors Marks but lives in its own slot so a font can
+	// carry both LookupType 4 and LookupType 5 marks without aliasing.
+	LigatureMarks map[GPOSFeature]map[uint16]MarkRecord
+
+	// LigatureBases holds LookupType 5 ligature base records keyed by
+	// ligature glyph ID. Each record exposes a per-component grid of
+	// anchors indexed [component][markClass].
+	LigatureBases map[GPOSFeature]map[uint16]LigatureRecord
 }
 
 // ParseGPOS reads the GPOS table from raw font bytes and extracts
-// LookupType 2 (Pair Positioning), LookupType 4 (Mark-to-Base), and
-// LookupType 6 (Mark-to-Mark) data for the "kern", "mark", and "mkmk"
-// features. Extension lookups (LookupType 9) are unwrapped for types
-// 2, 4, and 6.
+// LookupType 2 (Pair Positioning), LookupType 3 (Cursive Attachment),
+// LookupType 4 (Mark-to-Base), LookupType 5 (Mark-to-Ligature), and
+// LookupType 6 (Mark-to-Mark) data for the "kern", "curs", "mark", and
+// "mkmk" features. Extension lookups (LookupType 9) are unwrapped for
+// types 2, 3, 4, 5, and 6.
 //
 // Script selection follows the same preference order as GSUB:
 // "arab" and "latn" when present, "DFLT" as a fallback.
@@ -111,6 +157,7 @@ func ParseGPOS(data []byte) *GPOSAdjustments {
 		"kern": GPOSKern,
 		"mark": GPOSMark,
 		"mkmk": GPOSMkmk,
+		"curs": GPOSCurs,
 	}
 	featureToLookups := matchGPOSFeatures(gpos, featureListOff, featureIndices, targetTags)
 	if len(featureToLookups) == 0 {
@@ -118,40 +165,72 @@ func ParseGPOS(data []byte) *GPOSAdjustments {
 	}
 
 	result := &GPOSAdjustments{
-		Pairs:      make(map[GPOSFeature]map[[2]uint16]PairAdjustment),
-		Marks:      make(map[GPOSFeature]map[uint16]MarkRecord),
-		Bases:      make(map[GPOSFeature]map[uint16]BaseRecord),
-		MarkMarks:  make(map[GPOSFeature]map[uint16]MarkRecord),
-		Mark2Bases: make(map[GPOSFeature]map[uint16]BaseRecord),
+		Pairs:         make(map[GPOSFeature]map[[2]uint16]PairAdjustment),
+		Marks:         make(map[GPOSFeature]map[uint16]MarkRecord),
+		Bases:         make(map[GPOSFeature]map[uint16]BaseRecord),
+		MarkMarks:     make(map[GPOSFeature]map[uint16]MarkRecord),
+		Mark2Bases:    make(map[GPOSFeature]map[uint16]BaseRecord),
+		Cursives:      make(map[GPOSFeature]map[uint16]CursiveRecord),
+		LigatureMarks: make(map[GPOSFeature]map[uint16]MarkRecord),
+		LigatureBases: make(map[GPOSFeature]map[uint16]LigatureRecord),
 	}
 	for feat, lookupIndices := range featureToLookups {
-		pairs := make(map[[2]uint16]PairAdjustment)
-		marks := make(map[uint16]MarkRecord)
-		bases := make(map[uint16]BaseRecord)
-		markMarks := make(map[uint16]MarkRecord)
-		mark2Bases := make(map[uint16]BaseRecord)
-		parseGPOSLookups(gpos, lookupListOff, lookupIndices, pairs, marks, bases, markMarks, mark2Bases)
-		if len(pairs) > 0 {
-			result.Pairs[feat] = pairs
+		acc := gposAccumulator{
+			pairs:         make(map[[2]uint16]PairAdjustment),
+			marks:         make(map[uint16]MarkRecord),
+			bases:         make(map[uint16]BaseRecord),
+			markMarks:     make(map[uint16]MarkRecord),
+			mark2Bases:    make(map[uint16]BaseRecord),
+			cursives:      make(map[uint16]CursiveRecord),
+			ligatureMarks: make(map[uint16]MarkRecord),
+			ligatureBases: make(map[uint16]LigatureRecord),
 		}
-		if len(marks) > 0 {
-			result.Marks[feat] = marks
+		parseGPOSLookups(gpos, lookupListOff, lookupIndices, &acc)
+		if len(acc.pairs) > 0 {
+			result.Pairs[feat] = acc.pairs
 		}
-		if len(bases) > 0 {
-			result.Bases[feat] = bases
+		if len(acc.marks) > 0 {
+			result.Marks[feat] = acc.marks
 		}
-		if len(markMarks) > 0 {
-			result.MarkMarks[feat] = markMarks
+		if len(acc.bases) > 0 {
+			result.Bases[feat] = acc.bases
 		}
-		if len(mark2Bases) > 0 {
-			result.Mark2Bases[feat] = mark2Bases
+		if len(acc.markMarks) > 0 {
+			result.MarkMarks[feat] = acc.markMarks
+		}
+		if len(acc.mark2Bases) > 0 {
+			result.Mark2Bases[feat] = acc.mark2Bases
+		}
+		if len(acc.cursives) > 0 {
+			result.Cursives[feat] = acc.cursives
+		}
+		if len(acc.ligatureMarks) > 0 {
+			result.LigatureMarks[feat] = acc.ligatureMarks
+		}
+		if len(acc.ligatureBases) > 0 {
+			result.LigatureBases[feat] = acc.ligatureBases
 		}
 	}
 	if len(result.Pairs) == 0 && len(result.Marks) == 0 && len(result.Bases) == 0 &&
-		len(result.MarkMarks) == 0 && len(result.Mark2Bases) == 0 {
+		len(result.MarkMarks) == 0 && len(result.Mark2Bases) == 0 &&
+		len(result.Cursives) == 0 &&
+		len(result.LigatureMarks) == 0 && len(result.LigatureBases) == 0 {
 		return nil
 	}
 	return result
+}
+
+// gposAccumulator groups the per-feature output maps so dispatcher
+// signatures stay compact as new lookup types are added.
+type gposAccumulator struct {
+	pairs         map[[2]uint16]PairAdjustment
+	marks         map[uint16]MarkRecord
+	bases         map[uint16]BaseRecord
+	markMarks     map[uint16]MarkRecord
+	mark2Bases    map[uint16]BaseRecord
+	cursives      map[uint16]CursiveRecord
+	ligatureMarks map[uint16]MarkRecord
+	ligatureBases map[uint16]LigatureRecord
 }
 
 // PairAdjust returns the horizontal XAdvance adjustment in FUnits that
@@ -203,6 +282,81 @@ func (g *GPOSAdjustments) MarkMarkOffset(mark1GID, mark2GID uint16, feature GPOS
 		return 0, 0, false
 	}
 	return anchorOffset(g.MarkMarks[feature], g.Mark2Bases[feature], mark1GID, mark2GID)
+}
+
+// CursiveOffset returns the (dx, dy) offset in FUnits needed to move
+// the current glyph so its entry anchor coincides with the previous
+// glyph's exit anchor. The result is prev.Exit - curr.Entry, which is
+// the LTR convention from ISO 14496-22 §6.3 LookupType 3. Returns
+// ok=false when either glyph is absent from the feature, when the
+// previous glyph has no exit anchor declared, or when the current
+// glyph has no entry anchor declared.
+//
+// RTL handling is left to the caller: the package is shaping-direction
+// agnostic, so a layout layer that knows the run direction (Arabic,
+// Hebrew, etc.) is responsible for flipping the dx sign when the visual
+// progression runs right-to-left.
+func (g *GPOSAdjustments) CursiveOffset(prevGID, currGID uint16, feature GPOSFeature) (dx, dy int16, ok bool) {
+	if g == nil {
+		return 0, 0, false
+	}
+	cur, ok := g.Cursives[feature]
+	if !ok || cur == nil {
+		return 0, 0, false
+	}
+	prev, hasPrev := cur[prevGID]
+	if !hasPrev || !prev.HasExit {
+		return 0, 0, false
+	}
+	curr, hasCurr := cur[currGID]
+	if !hasCurr || !curr.HasEntry {
+		return 0, 0, false
+	}
+	return prev.Exit.X - curr.Entry.X, prev.Exit.Y - curr.Entry.Y, true
+}
+
+// MarkLigatureOffset returns the (dx, dy) offset in FUnits needed to
+// move a mark glyph so its anchor coincides with the ligature base's
+// anchor for the requested component and mark class. componentIdx is
+// the zero-based component index (0 = leftmost component for LTR
+// ligatures, in glyph order). Returns ok=false when either glyph is
+// absent from the feature, when componentIdx is out of range for the
+// ligature, or when the requested component has no anchor for the
+// mark's class.
+//
+// The formula is the direct anchor subtraction from ISO 14496-22 §6.3
+// LookupType 5: dx = ligAnchor.X - markAnchor.X,
+// dy = ligAnchor.Y - markAnchor.Y.
+func (g *GPOSAdjustments) MarkLigatureOffset(ligGID uint16, componentIdx int, markGID uint16, feature GPOSFeature) (dx, dy int16, ok bool) {
+	if g == nil {
+		return 0, 0, false
+	}
+	marks := g.LigatureMarks[feature]
+	ligs := g.LigatureBases[feature]
+	if marks == nil || ligs == nil {
+		return 0, 0, false
+	}
+	mark, hasMark := marks[markGID]
+	if !hasMark {
+		return 0, 0, false
+	}
+	lig, hasLig := ligs[ligGID]
+	if !hasLig {
+		return 0, 0, false
+	}
+	if componentIdx < 0 || componentIdx >= len(lig.Components) {
+		return 0, 0, false
+	}
+	comp := lig.Components[componentIdx]
+	if int(mark.Class) >= len(comp) {
+		return 0, 0, false
+	}
+	if componentIdx >= len(lig.Present) || int(mark.Class) >= len(lig.Present[componentIdx]) ||
+		!lig.Present[componentIdx][mark.Class] {
+		return 0, 0, false
+	}
+	a := comp[mark.Class]
+	return a.X - mark.Anchor.X, a.Y - mark.Anchor.Y, true
 }
 
 // anchorOffset is the shared anchor-subtraction used by MarkOffset and
@@ -272,14 +426,9 @@ func matchGPOSFeatures(gpos []byte, off int, allowed []int, targetTags map[strin
 
 // parseGPOSLookups walks each referenced lookup and dispatches its
 // subtables to the appropriate LookupType parser. LookupType 9
-// (Extension Positioning) is unwrapped inline for types 2, 4, and 6.
-func parseGPOSLookups(gpos []byte, listOff int, indices []int,
-	pairs map[[2]uint16]PairAdjustment,
-	marks map[uint16]MarkRecord,
-	bases map[uint16]BaseRecord,
-	markMarks map[uint16]MarkRecord,
-	mark2Bases map[uint16]BaseRecord,
-) {
+// (Extension Positioning) is unwrapped inline for types 2, 3, 4, 5,
+// and 6.
+func parseGPOSLookups(gpos []byte, listOff int, indices []int, acc *gposAccumulator) {
 	if listOff+2 > len(gpos) {
 		return
 	}
@@ -292,20 +441,14 @@ func parseGPOSLookups(gpos []byte, listOff int, indices []int,
 			continue
 		}
 		lookupOff := listOff + int(be16(gpos, listOff+2+idx*2))
-		parseGPOSLookup(gpos, lookupOff, pairs, marks, bases, markMarks, mark2Bases)
+		parseGPOSLookup(gpos, lookupOff, acc)
 	}
 }
 
 // parseGPOSLookup reads a single Lookup table and calls the subtable
 // parser matching its lookup type. Extension subtables (type 9) are
 // followed to their target subtable in the same GPOS blob.
-func parseGPOSLookup(gpos []byte, lookupOff int,
-	pairs map[[2]uint16]PairAdjustment,
-	marks map[uint16]MarkRecord,
-	bases map[uint16]BaseRecord,
-	markMarks map[uint16]MarkRecord,
-	mark2Bases map[uint16]BaseRecord,
-) {
+func parseGPOSLookup(gpos []byte, lookupOff int, acc *gposAccumulator) {
 	if lookupOff+6 > len(gpos) {
 		return
 	}
@@ -334,11 +477,15 @@ func parseGPOSLookup(gpos []byte, lookupOff int,
 		}
 		switch t {
 		case 2:
-			parsePairPos(gpos, off, pairs)
+			parsePairPos(gpos, off, acc.pairs)
+		case 3:
+			parseCursivePos(gpos, off, acc.cursives)
 		case 4:
-			parseMarkBasePos(gpos, off, marks, bases)
+			parseMarkBasePos(gpos, off, acc.marks, acc.bases)
+		case 5:
+			parseMarkLigPos(gpos, off, acc.ligatureMarks, acc.ligatureBases)
 		case 6:
-			parseMarkMarkPos(gpos, off, markMarks, mark2Bases)
+			parseMarkMarkPos(gpos, off, acc.markMarks, acc.mark2Bases)
 		}
 	}
 }
@@ -696,6 +843,165 @@ func parseBaseArray(gpos []byte, off int, baseCov []uint16, markClassCount int, 
 			anchors[c] = anchor
 		}
 		out[baseCov[i]] = BaseRecord{Anchors: anchors}
+	}
+}
+
+// parseCursivePos reads a CursivePosFormat1 subtable.
+//
+// Layout (ISO 14496-22 §6.3 LookupType 3):
+//
+//	posFormat       uint16 (==1)
+//	coverageOffset  Offset16
+//	entryExitCount  uint16
+//	entryExitRecords[entryExitCount] {
+//	    entryAnchorOffset Offset16  (from subtable start; 0 = absent)
+//	    exitAnchorOffset  Offset16  (from subtable start; 0 = absent)
+//	}
+//
+// The coverage table maps positionally to entryExitRecords; coverage
+// index i selects record i. Per-glyph CursiveRecord entries are written
+// only when at least one anchor is present; HasEntry/HasExit
+// disambiguate "absent" from "(0,0)".
+func parseCursivePos(gpos []byte, off int, out map[uint16]CursiveRecord) {
+	if off+6 > len(gpos) {
+		return
+	}
+	format := be16(gpos, off)
+	if format != 1 {
+		return
+	}
+	coverageOff := off + int(be16(gpos, off+2))
+	count := int(be16(gpos, off+4))
+	if off+6+count*4 > len(gpos) {
+		return
+	}
+	covered := parseCoverage(gpos, coverageOff)
+	if covered == nil {
+		return
+	}
+	for i := 0; i < count && i < len(covered); i++ {
+		rec := off + 6 + i*4
+		entryOffRaw := int(be16(gpos, rec))
+		exitOffRaw := int(be16(gpos, rec+2))
+		var cr CursiveRecord
+		if entryOffRaw != 0 {
+			if a, ok := parseAnchor(gpos, off+entryOffRaw); ok {
+				cr.Entry = a
+				cr.HasEntry = true
+			}
+		}
+		if exitOffRaw != 0 {
+			if a, ok := parseAnchor(gpos, off+exitOffRaw); ok {
+				cr.Exit = a
+				cr.HasExit = true
+			}
+		}
+		if !cr.HasEntry && !cr.HasExit {
+			continue
+		}
+		out[covered[i]] = cr
+	}
+}
+
+// parseMarkLigPos reads a MarkLigPosFormat1 subtable.
+//
+// Layout (ISO 14496-22 §6.3 LookupType 5):
+//
+//	posFormat            uint16 (==1)
+//	markCoverageOff      Offset16
+//	ligatureCoverageOff  Offset16
+//	markClassCount       uint16
+//	markArrayOff         Offset16
+//	ligatureArrayOff     Offset16
+//
+// MarkArray reuses parseMarkArray. LigatureArray is a count followed by
+// LigatureAttach offsets; each LigatureAttach is a componentCount
+// followed by componentCount × markClassCount anchor offsets.
+func parseMarkLigPos(gpos []byte, off int,
+	marks map[uint16]MarkRecord,
+	ligatures map[uint16]LigatureRecord,
+) {
+	if off+12 > len(gpos) {
+		return
+	}
+	format := be16(gpos, off)
+	if format != 1 {
+		return
+	}
+	markCoverageOff := off + int(be16(gpos, off+2))
+	ligCoverageOff := off + int(be16(gpos, off+4))
+	markClassCount := int(be16(gpos, off+6))
+	markArrayOff := off + int(be16(gpos, off+8))
+	ligArrayOff := off + int(be16(gpos, off+10))
+
+	markCov := parseCoverage(gpos, markCoverageOff)
+	ligCov := parseCoverage(gpos, ligCoverageOff)
+	if markCov == nil || ligCov == nil {
+		return
+	}
+	parseMarkArray(gpos, markArrayOff, markCov, marks)
+	parseLigatureArray(gpos, ligArrayOff, ligCov, markClassCount, ligatures)
+}
+
+// parseLigatureArray reads a LigatureArray and populates ligatures.
+//
+// Layout:
+//
+//	ligatureCount     uint16
+//	ligatureAttachOffsets[ligatureCount] Offset16 (from LigatureArray start)
+//
+// Each LigatureAttach:
+//
+//	componentCount    uint16
+//	componentRecords[componentCount] {
+//	    ligatureAnchorOffsets[markClassCount] Offset16 (from LigatureAttach start; 0 = absent)
+//	}
+//
+// A zero anchor offset means "no anchor for this (component, mark
+// class)" pair; such slots are left as the zero Anchor in the per-
+// component slice.
+func parseLigatureArray(gpos []byte, off int, ligCov []uint16, markClassCount int, out map[uint16]LigatureRecord) {
+	if off+2 > len(gpos) {
+		return
+	}
+	count := int(be16(gpos, off))
+	if off+2+count*2 > len(gpos) {
+		return
+	}
+	for i := 0; i < count && i < len(ligCov); i++ {
+		attachOffRaw := int(be16(gpos, off+2+i*2))
+		if attachOffRaw == 0 {
+			continue
+		}
+		attachOff := off + attachOffRaw
+		if attachOff+2 > len(gpos) {
+			continue
+		}
+		componentCount := int(be16(gpos, attachOff))
+		rowSize := markClassCount * 2
+		if attachOff+2+componentCount*rowSize > len(gpos) {
+			continue
+		}
+		components := make([][]Anchor, componentCount)
+		present := make([][]bool, componentCount)
+		for c := 0; c < componentCount; c++ {
+			rowOff := attachOff + 2 + c*rowSize
+			anchors := make([]Anchor, markClassCount)
+			has := make([]bool, markClassCount)
+			for k := 0; k < markClassCount; k++ {
+				aOffRaw := int(be16(gpos, rowOff+k*2))
+				if aOffRaw == 0 {
+					continue
+				}
+				if a, ok := parseAnchor(gpos, attachOff+aOffRaw); ok {
+					anchors[k] = a
+					has[k] = true
+				}
+			}
+			components[c] = anchors
+			present[c] = has
+		}
+		out[ligCov[i]] = LigatureRecord{Components: components, Present: present}
 	}
 }
 

--- a/font/gpos_test.go
+++ b/font/gpos_test.go
@@ -1008,6 +1008,406 @@ func TestFaceKernPrefersGPOS(t *testing.T) {
 	}
 }
 
+// cursivePosBody builds a CursivePosFormat1 subtable with two glyphs
+// in coverage. glyph1 carries (entryX1, entryY1) entry / (exitX1, exitY1)
+// exit; glyph2 carries entry/exit pair 2. A zero (presence == false) on
+// either anchor causes that field to be emitted with offset 0 (absent).
+type cursiveGlyphSpec struct {
+	gid                          uint16
+	hasEntry, hasExit            bool
+	entryX, entryY, exitX, exitY int16
+}
+
+func cursivePosBody(specs ...cursiveGlyphSpec) []byte {
+	var b gposBuilder
+	b.u16(1) // posFormat
+	covOffPos := b.pos()
+	b.u16(0) // coverageOffset
+	b.u16(uint16(len(specs)))
+
+	// Reserve EntryExitRecords; patch their offsets later.
+	type recPos struct {
+		entryPos, exitPos int
+	}
+	recs := make([]recPos, len(specs))
+	for i := range specs {
+		recs[i].entryPos = b.pos()
+		b.u16(0) // entryAnchorOffset
+		recs[i].exitPos = b.pos()
+		b.u16(0) // exitAnchorOffset
+	}
+
+	// Coverage lists glyphs in order.
+	covOff := b.pos()
+	b.patchU16(covOffPos, uint16(covOff))
+	gids := make([]uint16, len(specs))
+	for i, s := range specs {
+		gids[i] = s.gid
+	}
+	b.buf = append(b.buf, buildCoverageFormat1(gids...)...)
+
+	// Anchors. All offsets are from subtable start (off = 0 in the body).
+	for i, s := range specs {
+		if s.hasEntry {
+			anchorOff := b.pos()
+			b.patchU16(recs[i].entryPos, uint16(anchorOff))
+			b.u16(1) // anchor format 1
+			b.i16(s.entryX)
+			b.i16(s.entryY)
+		}
+		if s.hasExit {
+			anchorOff := b.pos()
+			b.patchU16(recs[i].exitPos, uint16(anchorOff))
+			b.u16(1)
+			b.i16(s.exitX)
+			b.i16(s.exitY)
+		}
+	}
+	return b.buf
+}
+
+// TestParseGPOSCursivePosFormat1 asserts that two glyphs with entry/exit
+// anchors land in the Cursives map with the right anchors and presence
+// flags, and that CursiveOffset returns prev.Exit - curr.Entry.
+func TestParseGPOSCursivePosFormat1(t *testing.T) {
+	// Glyph 100: exit (700, 50). Glyph 101: entry (50, 60), exit (650, 40).
+	body := cursivePosBody(
+		cursiveGlyphSpec{gid: 100, hasExit: true, exitX: 700, exitY: 50},
+		cursiveGlyphSpec{gid: 101, hasEntry: true, hasExit: true,
+			entryX: 50, entryY: 60, exitX: 650, exitY: 40},
+	)
+	gpos := buildGPOSHeader("curs", 3, body, 0)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	cur := g.Cursives[GPOSCurs]
+	if len(cur) != 2 {
+		t.Fatalf("Cursives[curs] size = %d, want 2", len(cur))
+	}
+	rec100, ok := cur[100]
+	if !ok {
+		t.Fatal("missing record for glyph 100")
+	}
+	if rec100.HasEntry || !rec100.HasExit {
+		t.Errorf("glyph 100 presence: HasEntry=%v HasExit=%v, want false true", rec100.HasEntry, rec100.HasExit)
+	}
+	if rec100.Exit.X != 700 || rec100.Exit.Y != 50 {
+		t.Errorf("glyph 100 exit = %+v, want (700, 50)", rec100.Exit)
+	}
+	rec101 := cur[101]
+	if !rec101.HasEntry || !rec101.HasExit {
+		t.Errorf("glyph 101 presence: HasEntry=%v HasExit=%v, want both true", rec101.HasEntry, rec101.HasExit)
+	}
+	if rec101.Entry.X != 50 || rec101.Entry.Y != 60 {
+		t.Errorf("glyph 101 entry = %+v, want (50, 60)", rec101.Entry)
+	}
+
+	// CursiveOffset(100, 101): exit (700, 50) - entry (50, 60) = (650, -10).
+	dx, dy, ok := g.CursiveOffset(100, 101, GPOSCurs)
+	if !ok {
+		t.Fatal("CursiveOffset(100, 101) ok=false, want true")
+	}
+	if dx != 650 || dy != -10 {
+		t.Errorf("CursiveOffset(100, 101) = (%d, %d), want (650, -10)", dx, dy)
+	}
+
+	// Glyph 100 has no entry, so (101, 100) should miss.
+	if _, _, ok := g.CursiveOffset(101, 100, GPOSCurs); ok {
+		t.Error("CursiveOffset(101, 100) should miss: glyph 100 has no entry anchor")
+	}
+	// Unknown glyphs miss.
+	if _, _, ok := g.CursiveOffset(100, 999, GPOSCurs); ok {
+		t.Error("CursiveOffset with unknown current glyph should miss")
+	}
+	if _, _, ok := g.CursiveOffset(999, 101, GPOSCurs); ok {
+		t.Error("CursiveOffset with unknown previous glyph should miss")
+	}
+}
+
+// TestCursiveOffsetNilReceiver covers nil-safety for the cursive path.
+func TestCursiveOffsetNilReceiver(t *testing.T) {
+	var g *GPOSAdjustments
+	if _, _, ok := g.CursiveOffset(1, 2, GPOSCurs); ok {
+		t.Error("CursiveOffset on nil receiver must return ok=false")
+	}
+}
+
+// TestParseGPOSCursiveExtensionWrap verifies the type-3 dispatch follows
+// LookupType 9 extension subtables, like types 2/4/6.
+func TestParseGPOSCursiveExtensionWrap(t *testing.T) {
+	body := cursivePosBody(
+		cursiveGlyphSpec{gid: 10, hasExit: true, exitX: 100, exitY: 0},
+		cursiveGlyphSpec{gid: 11, hasEntry: true, entryX: 20, entryY: 0},
+	)
+	gpos := buildGPOSHeader("curs", 3, body, 3)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	dx, dy, ok := g.CursiveOffset(10, 11, GPOSCurs)
+	if !ok {
+		t.Fatal("CursiveOffset through extension ok=false")
+	}
+	if dx != 80 || dy != 0 {
+		t.Errorf("CursiveOffset through extension = (%d, %d), want (80, 0)", dx, dy)
+	}
+}
+
+// TestCursiveOffsetCumulativeChain exercises the LTR convention across
+// a three-glyph chain. With each link reusing the previous exit, the
+// caller's running offset should advance by exit_n − entry_(n+1).
+func TestCursiveOffsetCumulativeChain(t *testing.T) {
+	body := cursivePosBody(
+		// G1: exit (500, 10).
+		cursiveGlyphSpec{gid: 1, hasExit: true, exitX: 500, exitY: 10},
+		// G2: entry (40, -5), exit (490, 20).
+		cursiveGlyphSpec{gid: 2, hasEntry: true, hasExit: true,
+			entryX: 40, entryY: -5, exitX: 490, exitY: 20},
+		// G3: entry (60, 15).
+		cursiveGlyphSpec{gid: 3, hasEntry: true, entryX: 60, entryY: 15},
+	)
+	gpos := buildGPOSHeader("curs", 3, body, 0)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	// Link 1: prev=G1, curr=G2 → (500-40, 10-(-5)) = (460, 15).
+	dx12, dy12, ok := g.CursiveOffset(1, 2, GPOSCurs)
+	if !ok || dx12 != 460 || dy12 != 15 {
+		t.Errorf("link 1 = (%d,%d,%v), want (460,15,true)", dx12, dy12, ok)
+	}
+	// Link 2: prev=G2, curr=G3 → (490-60, 20-15) = (430, 5).
+	dx23, dy23, ok := g.CursiveOffset(2, 3, GPOSCurs)
+	if !ok || dx23 != 430 || dy23 != 5 {
+		t.Errorf("link 2 = (%d,%d,%v), want (430,5,true)", dx23, dy23, ok)
+	}
+	// Cumulative offset that the caller would apply across the run:
+	// glyph 2 sits at link1; glyph 3 sits at link1 + link2.
+	cumX, cumY := dx12+dx23, dy12+dy23
+	if cumX != 890 || cumY != 20 {
+		t.Errorf("cumulative = (%d,%d), want (890,20)", cumX, cumY)
+	}
+}
+
+// markLigPosBody builds a MarkLigPosFormat1 subtable with one mark
+// glyph (per markGID/class/anchor pair in marks) and one ligature glyph
+// whose LigatureAttach has componentCount components × markClassCount
+// mark classes; anchors[componentIdx][classIdx] supplies the (x, y) for
+// each grid cell. A nil cell anchor (presence=false) emits offset 0.
+type markLigMarkSpec struct {
+	gid    uint16
+	class  uint16
+	anchor Anchor
+}
+
+type ligAnchorSpec struct {
+	present bool
+	x, y    int16
+}
+
+func markLigPosBody(marks []markLigMarkSpec, ligGID uint16, markClassCount int, anchors [][]ligAnchorSpec) []byte {
+	var b gposBuilder
+	b.u16(1) // posFormat
+	markCovOffPos := b.pos()
+	b.u16(0)
+	ligCovOffPos := b.pos()
+	b.u16(0)
+	b.u16(uint16(markClassCount))
+	markArrayOffPos := b.pos()
+	b.u16(0)
+	ligArrayOffPos := b.pos()
+	b.u16(0)
+
+	// Mark coverage in the order of the marks slice.
+	markGIDs := make([]uint16, len(marks))
+	for i, m := range marks {
+		markGIDs[i] = m.gid
+	}
+	markCovOff := b.pos()
+	b.patchU16(markCovOffPos, uint16(markCovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(markGIDs...)...)
+
+	// Ligature coverage: a single ligature glyph.
+	ligCovOff := b.pos()
+	b.patchU16(ligCovOffPos, uint16(ligCovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(ligGID)...)
+
+	// MarkArray.
+	markArrayOff := b.pos()
+	b.patchU16(markArrayOffPos, uint16(markArrayOff))
+	b.u16(uint16(len(marks)))
+	markAnchorOffPositions := make([]int, len(marks))
+	for i, m := range marks {
+		b.u16(m.class)
+		markAnchorOffPositions[i] = b.pos()
+		b.u16(0) // markAnchorOffset placeholder (from MarkArray start)
+	}
+	for i, m := range marks {
+		anchorOff := b.pos()
+		b.patchU16(markAnchorOffPositions[i], uint16(anchorOff-markArrayOff))
+		b.u16(1)
+		b.i16(m.anchor.X)
+		b.i16(m.anchor.Y)
+	}
+
+	// LigatureArray: one ligature.
+	ligArrayOff := b.pos()
+	b.patchU16(ligArrayOffPos, uint16(ligArrayOff))
+	b.u16(1) // ligatureCount
+	attachOffPos := b.pos()
+	b.u16(0) // ligatureAttachOffset placeholder (from LigatureArray start)
+
+	// LigatureAttach.
+	attachOff := b.pos()
+	b.patchU16(attachOffPos, uint16(attachOff-ligArrayOff))
+	componentCount := len(anchors)
+	b.u16(uint16(componentCount))
+	// Reserve the per-component anchor offset rows.
+	rowAnchorPos := make([][]int, componentCount)
+	for c := 0; c < componentCount; c++ {
+		row := make([]int, markClassCount)
+		for k := 0; k < markClassCount; k++ {
+			row[k] = b.pos()
+			b.u16(0) // anchor offset placeholder
+		}
+		rowAnchorPos[c] = row
+	}
+	// Emit anchors for present cells; patch their offsets relative to
+	// the LigatureAttach start.
+	for c := 0; c < componentCount; c++ {
+		for k := 0; k < markClassCount; k++ {
+			cell := anchors[c][k]
+			if !cell.present {
+				continue
+			}
+			anchorOff := b.pos()
+			b.patchU16(rowAnchorPos[c][k], uint16(anchorOff-attachOff))
+			b.u16(1)
+			b.i16(cell.x)
+			b.i16(cell.y)
+		}
+	}
+	return b.buf
+}
+
+// TestParseGPOSMarkLigPosFormat1 covers the parser with a 2-component
+// ligature carrying anchors for two mark classes. Each (component, class)
+// cell is checked against MarkLigatureOffset.
+func TestParseGPOSMarkLigPosFormat1(t *testing.T) {
+	const (
+		mark0GID uint16 = 200 // class 0 mark
+		mark1GID uint16 = 201 // class 1 mark
+		ligGID   uint16 = 300
+	)
+	marks := []markLigMarkSpec{
+		{gid: mark0GID, class: 0, anchor: Anchor{X: 100, Y: 200}},
+		{gid: mark1GID, class: 1, anchor: Anchor{X: 50, Y: 50}},
+	}
+	// 2 components × 2 mark classes.
+	// Component 0: class-0 anchor (500, 800), class-1 anchor (520, 850).
+	// Component 1: class-0 anchor (1500, 800), class-1 anchor absent.
+	ligAnchors := [][]ligAnchorSpec{
+		{
+			{present: true, x: 500, y: 800},
+			{present: true, x: 520, y: 850},
+		},
+		{
+			{present: true, x: 1500, y: 800},
+			{present: false},
+		},
+	}
+	body := markLigPosBody(marks, ligGID, 2, ligAnchors)
+	gpos := buildGPOSHeader("mark", 5, body, 0)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+
+	lig, ok := g.LigatureBases[GPOSMark][ligGID]
+	if !ok {
+		t.Fatal("missing LigatureRecord for ligGID")
+	}
+	if len(lig.Components) != 2 {
+		t.Fatalf("componentCount = %d, want 2", len(lig.Components))
+	}
+	if lig.Components[0][0] != (Anchor{X: 500, Y: 800}) {
+		t.Errorf("comp 0 class 0 = %+v, want (500, 800)", lig.Components[0][0])
+	}
+	if lig.Components[0][1] != (Anchor{X: 520, Y: 850}) {
+		t.Errorf("comp 0 class 1 = %+v, want (520, 850)", lig.Components[0][1])
+	}
+	if lig.Components[1][0] != (Anchor{X: 1500, Y: 800}) {
+		t.Errorf("comp 1 class 0 = %+v, want (1500, 800)", lig.Components[1][0])
+	}
+	if lig.Components[1][1] != (Anchor{}) {
+		t.Errorf("comp 1 class 1 should be zero anchor, got %+v", lig.Components[1][1])
+	}
+
+	cases := []struct {
+		lig            uint16
+		comp           int
+		mark           uint16
+		wantDX, wantDY int16
+		wantOK         bool
+	}{
+		{ligGID, 0, mark0GID, 400, 600, true},  // 500-100, 800-200
+		{ligGID, 0, mark1GID, 470, 800, true},  // 520-50,  850-50
+		{ligGID, 1, mark0GID, 1400, 600, true}, // 1500-100, 800-200
+		{ligGID, 1, mark1GID, 0, 0, false},     // class 1 absent on comp 1
+		{ligGID, 2, mark0GID, 0, 0, false},     // out of range component
+		{ligGID, -1, mark0GID, 0, 0, false},    // negative component
+		{999, 0, mark0GID, 0, 0, false},        // unknown ligature
+		{ligGID, 0, 999, 0, 0, false},          // unknown mark
+	}
+	for _, c := range cases {
+		dx, dy, ok := g.MarkLigatureOffset(c.lig, c.comp, c.mark, GPOSMark)
+		if ok != c.wantOK || (ok && (dx != c.wantDX || dy != c.wantDY)) {
+			t.Errorf("MarkLigatureOffset(%d, %d, %d) = (%d, %d, %v), want (%d, %d, %v)",
+				c.lig, c.comp, c.mark, dx, dy, ok, c.wantDX, c.wantDY, c.wantOK)
+		}
+	}
+}
+
+// TestMarkLigatureOffsetNilReceiver covers the nil-safety contract for
+// the new ligature accessor.
+func TestMarkLigatureOffsetNilReceiver(t *testing.T) {
+	var g *GPOSAdjustments
+	if _, _, ok := g.MarkLigatureOffset(1, 0, 2, GPOSMark); ok {
+		t.Error("MarkLigatureOffset on nil receiver must return ok=false")
+	}
+}
+
+// TestParseGPOSMarkLigExtensionWrap verifies that LookupType 5 is also
+// followed through a LookupType 9 extension subtable.
+func TestParseGPOSMarkLigExtensionWrap(t *testing.T) {
+	const (
+		markGID uint16 = 200
+		ligGID  uint16 = 300
+	)
+	marks := []markLigMarkSpec{
+		{gid: markGID, class: 0, anchor: Anchor{X: 10, Y: 20}},
+	}
+	ligAnchors := [][]ligAnchorSpec{
+		{{present: true, x: 110, y: 120}},
+		{{present: true, x: 210, y: 320}},
+	}
+	body := markLigPosBody(marks, ligGID, 1, ligAnchors)
+	gpos := buildGPOSHeader("mark", 5, body, 5)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	dx, dy, ok := g.MarkLigatureOffset(ligGID, 0, markGID, GPOSMark)
+	if !ok || dx != 100 || dy != 100 {
+		t.Errorf("comp 0 through extension = (%d,%d,%v), want (100,100,true)", dx, dy, ok)
+	}
+	dx, dy, ok = g.MarkLigatureOffset(ligGID, 1, markGID, GPOSMark)
+	if !ok || dx != 200 || dy != 300 {
+		t.Errorf("comp 1 through extension = (%d,%d,%v), want (200,300,true)", dx, dy, ok)
+	}
+}
+
 // TestFaceGPOSCacheIdentity exercises the GPOS one-shot cache flag.
 func TestFaceGPOSCacheIdentity(t *testing.T) {
 	face := loadTestFace(t).(*sfntFace)

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -282,6 +282,18 @@ func drawWordEmbedded(stream *content.Stream, word Word) {
 	// so a shaped Devanagari word would otherwise re-enter the
 	// mark path and be shaped a second time on the original text.
 	if len(word.GIDs) > 0 {
+		// Cursive attachment (GPOS LookupType 3) joins glyphs along
+		// the baseline by aligning the previous glyph's exit anchor
+		// with the next glyph's entry anchor. When the face exposes
+		// curs data and the run carries at least one cursive pair,
+		// emit per-glyph Tj operators bracketed by Td shifts so each
+		// glyph lands at the cursive position. Cursive runs before
+		// any kerning pass; the GID-stream path here does not apply
+		// kern-table kerning, so the ordering note is documentary.
+		if cursivePositioningEligible(word) {
+			drawShapedGIDsCursive(stream, word)
+			return
+		}
 		stream.ShowTextHex(word.Embedded.EncodeGIDs(word.GIDs, word.OriginalText))
 		return
 	}
@@ -322,9 +334,10 @@ func drawWordEmbedded(stream *content.Stream, word Word) {
 
 // markPositioningEligible reports whether drawWordEmbedded should switch
 // to the cluster-by-cluster mark-attachment path. Eligibility requires
-// an embedded font whose Face exposes GPOS mark-to-base data, a word
-// containing at least one Extend or ZWJ codepoint, and no letter
-// spacing override (Tc complicates the text-matrix arithmetic).
+// an embedded font whose Face exposes GPOS mark anchors (either Type 4
+// mark-to-base or Type 5 mark-to-ligature), a word containing at least
+// one Extend or ZWJ codepoint, and no letter spacing override (Tc
+// complicates the text-matrix arithmetic).
 func markPositioningEligible(word Word) bool {
 	if word.Embedded == nil || word.LetterSpacing != 0 {
 		return false
@@ -334,7 +347,12 @@ func markPositioningEligible(word Word) bool {
 		return false
 	}
 	gpos := provider.GPOS()
-	if gpos == nil || len(gpos.Marks[font.GPOSMark]) == 0 || len(gpos.Bases[font.GPOSMark]) == 0 {
+	if gpos == nil {
+		return false
+	}
+	hasType4 := len(gpos.Marks[font.GPOSMark]) > 0 && len(gpos.Bases[font.GPOSMark]) > 0
+	hasType5 := len(gpos.LigatureMarks[font.GPOSMark]) > 0 && len(gpos.LigatureBases[font.GPOSMark]) > 0
+	if !hasType4 && !hasType5 {
 		return false
 	}
 	for _, r := range word.Text {
@@ -344,6 +362,99 @@ func markPositioningEligible(word Word) bool {
 		}
 	}
 	return false
+}
+
+// cursivePositioningEligible reports whether the word's GID stream is
+// eligible for the cursive (GPOS LookupType 3) draw path. Eligibility
+// requires an embedded font whose Face exposes GPOS curs data, a GID
+// stream of at least two glyphs, and at least one consecutive pair
+// (prev, curr) for which CursiveOffset returns a non-trivial offset.
+//
+// The presence check is keyed on the Cursives map only; callers that
+// need to flip the dx sign for RTL runs must do so themselves on the
+// values returned by CursiveOffset, since this package is shaping-
+// direction agnostic.
+func cursivePositioningEligible(word Word) bool {
+	if word.Embedded == nil || len(word.GIDs) < 2 || word.LetterSpacing != 0 {
+		return false
+	}
+	provider, ok := word.Embedded.Face().(font.GPOSProvider)
+	if !ok {
+		return false
+	}
+	gpos := provider.GPOS()
+	if gpos == nil || len(gpos.Cursives[font.GPOSCurs]) == 0 {
+		return false
+	}
+	for i := 1; i < len(word.GIDs); i++ {
+		if _, _, hit := gpos.CursiveOffset(word.GIDs[i-1], word.GIDs[i], font.GPOSCurs); hit {
+			return true
+		}
+	}
+	return false
+}
+
+// drawShapedGIDsCursive emits a shaper-produced GID stream with cursive
+// attachment offsets applied between consecutive glyphs. Each glyph is
+// emitted via its own Tj; a Td-shift moves the text matrix from the
+// natural glyph-end position to the cursive-anchored origin, then
+// another Td-shift advances by the glyph's natural advance plus the
+// cursive dx so the next glyph's natural origin sits at the cursive
+// target. Td brackets that surround the same glyph cancel net advance
+// to match the natural advance of the run; cursive only re-positions,
+// it does not add or remove width.
+//
+// RTL handling: this function applies the LTR convention dx as-returned
+// by CursiveOffset. Callers that need RTL semantics must arrange for
+// the GID stream order to already reflect visual order (which the
+// shaper does today) and accept that for RTL the dx should be flipped.
+// This iteration documents the constraint rather than fixing it; the
+// only shipped shaper today is Indic (LTR) and Indic does not use the
+// curs feature, so the path is exercised by tests and Arabic-style
+// shapers that arrive later will need to participate in the sign flip.
+func drawShapedGIDsCursive(stream *content.Stream, word Word) {
+	ef := word.Embedded
+	face := ef.Face()
+	upem := face.UnitsPerEm()
+	if upem == 0 {
+		stream.ShowTextHex(ef.EncodeGIDs(word.GIDs, word.OriginalText))
+		return
+	}
+	provider, _ := face.(font.GPOSProvider)
+	gpos := provider.GPOS()
+	scale := word.FontSize / float64(upem)
+
+	// Per-glyph Tj emission. We use one EncodeGIDs call per glyph so
+	// each Tj carries exactly one GID; the Identity-H encoder still
+	// produces the right two-byte hex sequence, and per-glyph emission
+	// is the only way to interleave Td shifts between glyphs.
+	gids := word.GIDs
+	for i, gid := range gids {
+		if i == 0 {
+			stream.ShowTextHex(ef.EncodeGIDs(gids[i:i+1], ""))
+			continue
+		}
+		dxFU, dyFU, ok := gpos.CursiveOffset(gids[i-1], gid, font.GPOSCurs)
+		if !ok {
+			stream.ShowTextHex(ef.EncodeGIDs(gids[i:i+1], ""))
+			continue
+		}
+		dxPts := float64(dxFU) * scale
+		dyPts := float64(dyFU) * scale
+		// Open: shift from the natural cursor to the cursive origin.
+		stream.MoveText(dxPts, dyPts)
+		stream.ShowTextHex(ef.EncodeGIDs(gids[i:i+1], ""))
+		// Close: shift back by -dy so the baseline is consistent for
+		// subsequent glyphs. The horizontal shift introduced by dx is
+		// intentional: after this glyph's Tj the text matrix already
+		// sits at (naturalAdvance + dxPts, dyPts) — the close move
+		// only restores y. This matches the spec's "join previous
+		// exit to current entry" semantics: the cursive offset rides
+		// along between glyphs and is not undone.
+		if dyPts != 0 {
+			stream.MoveText(0, -dyPts)
+		}
+	}
 }
 
 // drawWordEmbeddedWithMarks walks the word cluster-by-cluster (UAX #29
@@ -452,7 +563,28 @@ func drawWordEmbeddedWithMarks(stream *content.Stream, word Word) {
 		var prevDxPts, prevDyPts float64
 		var prevMarkGID uint16
 		havePrevMark := false
-		for _, m := range extendMarks {
+		// Detect whether the cluster's base is a Type 5 ligature glyph;
+		// when it is, marks resolve against the ligature's per-component
+		// anchor grid instead of the Type 4 mark-to-base grid.
+		//
+		// Component attribution heuristic: the first Extend/ZWJ mark in
+		// the cluster attaches to component 0 (leftmost in glyph order).
+		// Subsequent marks attach to the LAST component
+		// (len(components)-1). This is a documented stop-gap until the
+		// shaper plumbs cluster→component IDs through the layout
+		// pipeline; see TODO(#218).
+		// TODO(#218): replace the first/last component heuristic with
+		// real cluster→component attribution from the shaper. The HTML
+		// path currently has no source for component IDs at draw time.
+		var ligComponents int
+		isLigatureBase := false
+		if gpos != nil {
+			if rec, ok := gpos.LigatureBases[font.GPOSMark][baseGID]; ok {
+				ligComponents = len(rec.Components)
+				isLigatureBase = ligComponents > 0
+			}
+		}
+		for mi, m := range extendMarks {
 			markGID := face.GlyphIndex(m.r)
 			var dxPts, dyPts float64
 			placed := false
@@ -460,6 +592,17 @@ func drawWordEmbeddedWithMarks(stream *content.Stream, word Word) {
 				if mx, my, ok := gpos.MarkMarkOffset(markGID, prevMarkGID, font.GPOSMkmk); ok {
 					dxPts = prevDxPts + float64(mx)*scale
 					dyPts = prevDyPts + float64(my)*scale
+					placed = true
+				}
+			}
+			if !placed && isLigatureBase {
+				comp := 0
+				if mi > 0 {
+					comp = ligComponents - 1
+				}
+				if dx, dy, ok := gpos.MarkLigatureOffset(baseGID, comp, markGID, font.GPOSMark); ok {
+					dxPts = float64(dx) * scale
+					dyPts = float64(dy) * scale
 					placed = true
 				}
 			}

--- a/layout/gpos_mark_draw_test.go
+++ b/layout/gpos_mark_draw_test.go
@@ -634,3 +634,240 @@ func almostEqual(a, b, eps float64) bool {
 	}
 	return d <= eps
 }
+
+// newCursiveFace returns a mock face with three glyphs and a cursive
+// chain among them. The chain is encoded directly in the GPOS Cursives
+// map so the parser is not exercised here — the draw integration is.
+//
+//	GID 1: exit (700, 0).
+//	GID 2: entry (50, 0), exit (650, 30).
+//	GID 3: entry (60, 20).
+//
+// Expected CursiveOffset values:
+//
+//	(1 → 2): exit(700,0)   - entry(50,0)  = (650, 0)
+//	(2 → 3): exit(650,30)  - entry(60,20) = (590, 10)
+func newCursiveFace() *mockGPOSFace {
+	face := &mockGPOSFace{
+		upem: 1000,
+		advance: map[uint16]int{
+			1: 600,
+			2: 600,
+			3: 600,
+		},
+		cmap: map[rune]uint16{},
+		gpos: &font.GPOSAdjustments{
+			Cursives: map[font.GPOSFeature]map[uint16]font.CursiveRecord{
+				font.GPOSCurs: {
+					1: {Exit: font.Anchor{X: 700, Y: 0}, HasExit: true},
+					2: {
+						Entry: font.Anchor{X: 50, Y: 0}, HasEntry: true,
+						Exit: font.Anchor{X: 650, Y: 30}, HasExit: true,
+					},
+					3: {Entry: font.Anchor{X: 60, Y: 20}, HasEntry: true},
+				},
+			},
+		},
+	}
+	return face
+}
+
+// TestGPOSCursiveJoinTwoGlyphs renders a two-glyph cursive run and
+// asserts the draw stream contains the expected per-glyph Td shift.
+// At fontSize=10 with upem=1000, FUnit→pt scale is 1/100.
+//
+//	dx = (700 - 50) / 1000 * 10 = 6.5 pt
+//	dy = (0   - 0)  / 1000 * 10 = 0
+//
+// The first glyph emits without a Td; the second emits with "6.5 0 Td".
+func TestGPOSCursiveJoinTwoGlyphs(t *testing.T) {
+	face := newCursiveFace()
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Embedded: ef,
+		FontSize: 10,
+		GIDs:     []uint16{1, 2},
+	}
+	b := capturedWordStream(word)
+
+	// One initial Td (MoveText), one cursive Td between glyphs.
+	if countTdOps(b) != 2 {
+		t.Fatalf("expected 2 Td ops (initial + cursive), got %d:\n%s", countTdOps(b), b)
+	}
+	if !bytes.Contains(b, []byte("6.5 0 Td")) {
+		t.Errorf("missing cursive Td '6.5 0 Td' in stream:\n%s", b)
+	}
+}
+
+// TestGPOSCursiveJoinThreeGlyphs verifies cumulative cursive offset
+// across a three-glyph chain. Each link contributes its own Td bracket;
+// the second Td (5.9, +0.1) carries the dy non-zero so the close-Td of
+// 0,-0.1 appears in the stream as well.
+//
+//	link 1 dx = 6.5, dy = 0    → "6.5 0 Td"
+//	link 2 dx = 5.9, dy = 0.1  → "5.9 0.1 Td"  + close "0 -0.1 Td"
+func TestGPOSCursiveJoinThreeGlyphs(t *testing.T) {
+	face := newCursiveFace()
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Embedded: ef,
+		FontSize: 10,
+		GIDs:     []uint16{1, 2, 3},
+	}
+	b := capturedWordStream(word)
+
+	if !bytes.Contains(b, []byte("6.5 0 Td")) {
+		t.Errorf("missing link-1 cursive Td '6.5 0 Td':\n%s", b)
+	}
+	if !bytes.Contains(b, []byte("5.9 0.1 Td")) {
+		t.Errorf("missing link-2 cursive Td '5.9 0.1 Td':\n%s", b)
+	}
+	if !bytes.Contains(b, []byte("0 -0.1 Td")) {
+		t.Errorf("missing link-2 close Td '0 -0.1 Td':\n%s", b)
+	}
+}
+
+// TestGPOSCursiveFallbackWithoutCursData verifies that a GID stream
+// without GPOS curs data falls through to the standard EncodeGIDs path:
+// a single Tj with no inter-glyph Td.
+func TestGPOSCursiveFallbackWithoutCursData(t *testing.T) {
+	face := newCursiveFace()
+	face.gpos = nil
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Embedded: ef,
+		FontSize: 10,
+		GIDs:     []uint16{1, 2, 3},
+	}
+	b := capturedWordStream(word)
+	if countTdOps(b) != 1 {
+		t.Errorf("without curs data expect only initial Td, got %d:\n%s", countTdOps(b), b)
+	}
+	tjCount := 0
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.HasSuffix(strings.TrimSpace(line), " Tj") {
+			tjCount++
+		}
+	}
+	if tjCount != 1 {
+		t.Errorf("expected single Tj for non-cursive GID stream, got %d:\n%s", tjCount, b)
+	}
+}
+
+// newLigatureBaseFace builds a face whose cluster base glyph is a
+// ligature (LookupType 5 carrier) with two components. Two distinct
+// marks attach to component 0 and component 1 respectively. The mark
+// classes also differ to exercise the (component, class) grid.
+//
+//	Ligature GID 80 = "ffi"-style 2-component glyph (one combined glyph).
+//	Component 0 anchor for class 0: (300, 700).  → first-mark target
+//	Component 1 anchor for class 1: (1100, 700). → last-mark target
+//	Mark A (GID 90, class 0) anchor at (50, 100)
+//	Mark B (GID 91, class 1) anchor at (40, 80)
+//
+//	Base advance = 1500 FUnits → 18 pt at fontSize=12.
+//	Mark A target: (300-50, 700-100) = (250, 600) FUnits → (3, 7.2) pt
+//	Mark B target: (1100-40, 700-80) = (1060, 620) FUnits → (12.72, 7.44) pt
+//
+// Mark A is the first cluster mark, so the heuristic puts it on
+// component 0. Mark B is the second, so it lands on component 1.
+func newLigatureBaseFace() *mockGPOSFace {
+	const (
+		ligGID   uint16 = 80
+		markAGID uint16 = 90
+		markBGID uint16 = 91
+		// Use private-use codepoints so grapheme classification keeps
+		// them as the base / Extend roles we want.
+		ligRune   = rune(0xE000)
+		markARune = rune(0x0300) // combining grave: Extend
+		markBRune = rune(0x0301) // combining acute: Extend
+	)
+	face := &mockGPOSFace{
+		upem: 1000,
+		advance: map[uint16]int{
+			ligGID:   1500,
+			markAGID: 0,
+			markBGID: 0,
+		},
+		cmap: map[rune]uint16{
+			ligRune:   ligGID,
+			markARune: markAGID,
+			markBRune: markBGID,
+		},
+		gpos: &font.GPOSAdjustments{
+			LigatureMarks: map[font.GPOSFeature]map[uint16]font.MarkRecord{
+				font.GPOSMark: {
+					markAGID: {Class: 0, Anchor: font.Anchor{X: 50, Y: 100}},
+					markBGID: {Class: 1, Anchor: font.Anchor{X: 40, Y: 80}},
+				},
+			},
+			LigatureBases: map[font.GPOSFeature]map[uint16]font.LigatureRecord{
+				font.GPOSMark: {
+					ligGID: {
+						Components: [][]font.Anchor{
+							{{X: 300, Y: 700}, {}},
+							{{}, {X: 1100, Y: 700}},
+						},
+						Present: [][]bool{
+							{true, false},
+							{false, true},
+						},
+					},
+				},
+			},
+		},
+	}
+	return face
+}
+
+// TestGPOSMarkLigatureTwoComponentMarks renders a ligature base with
+// two combining marks and asserts each mark lands on its expected
+// component. The component-attribution heuristic (first→0, rest→last)
+// is the contract under test here; if the heuristic shifts, this test
+// must move with it.
+func TestGPOSMarkLigatureTwoComponentMarks(t *testing.T) {
+	face := newLigatureBaseFace()
+	ef := font.NewEmbeddedFont(face)
+	// Ligature base + two marks.
+	word := Word{
+		Text:     string([]rune{0xE000, 0x0300, 0x0301}),
+		Embedded: ef,
+		FontSize: 12,
+	}
+	b := capturedWordStream(word)
+
+	// The cluster advances by the ligature base width = 18 pt. Mark A
+	// open Td: (3 - 18, 7.2) = (-15, 7.2). Close Td: (15, -7.2).
+	if !bytes.Contains(b, []byte("-15 7.2 Td")) {
+		t.Errorf("missing mark A open Td '-15 7.2 Td' (component 0 anchor):\n%s", b)
+	}
+	if !bytes.Contains(b, []byte("15 -7.2 Td")) {
+		t.Errorf("missing mark A close Td '15 -7.2 Td':\n%s", b)
+	}
+	// Mark B open Td: (12.72 - 18, 7.44) = (-5.28, 7.44). Close: (5.28, -7.44).
+	if !bytes.Contains(b, []byte("-5.28 7.44 Td")) {
+		t.Errorf("missing mark B open Td '-5.28 7.44 Td' (component 1 anchor):\n%s", b)
+	}
+	if !bytes.Contains(b, []byte("5.28 -7.44 Td")) {
+		t.Errorf("missing mark B close Td '5.28 -7.44 Td':\n%s", b)
+	}
+}
+
+// TestGPOSMarkLigatureFallsBackToType4 verifies that when a cluster
+// base has no Type 5 ligature record, mark resolution falls through to
+// Type 4 mark-to-base unchanged. This is the regression guard against
+// any accidental Type 5 hijacking of plain marks.
+func TestGPOSMarkLigatureFallsBackToType4(t *testing.T) {
+	face := newLamFathaFace()
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Text:     "\u0644\u064E",
+		Embedded: ef,
+		FontSize: 12,
+	}
+	b := capturedWordStream(word)
+	// The Type 4 mark-to-base path emits "-4.8 6 Td" / "4.8 -6 Td".
+	if !bytes.Contains(b, []byte("-4.8 6 Td")) {
+		t.Errorf("Type 4 fallback should still emit '-4.8 6 Td':\n%s", b)
+	}
+}


### PR DESCRIPTION
## Summary

Adds two more OpenType GPOS lookup types alongside the existing
LookupType 2 (pair kerning), LookupType 4 (mark-to-base), and
LookupType 6 (mark-to-mark) implementations.

### LookupType 3 (Cursive Attachment)

- Parses CursivePosFormat1 (the only format defined by the spec): per-glyph entry/exit anchors with a presence flag so a zero offset is not confused with an anchor at (0, 0).
- New `CursiveOffset(prevGID, currGID, feature)` returns `prev.Exit - curr.Entry` in FUnits, which is the LTR convention from ISO 14496-22 §6.3. RTL handling is intentionally left to the caller; the font package is shaping-direction agnostic.
- Draw integration applies cursive offsets on shaper-produced GID streams (`word.GIDs`). Each glyph emits its own `Tj`; the second through Nth are bracketed by `Td` shifts that align the entry anchor onto the previous exit. Cursive precedes kerning in the design; the GID-stream path here does not run the legacy kern table, so the ordering note is documentary.

### LookupType 5 (Mark-to-Ligature)

- Parses MarkLigPosFormat1: mark coverage, ligature coverage, mark class count, MarkArray (reuses the existing helper used by Type 4), and a per-ligature `LigatureAttach` table with a `componentCount × markClassCount` grid of anchor offsets.
- `LigatureRecord` stores both the anchor grid and a parallel `Present` grid; `MarkLigatureOffset(ligGID, componentIdx, markGID, feature)` returns the per-(component, mark) subtraction.
- Draw integration in `drawWordEmbeddedWithMarks` tries `MarkLigatureOffset` before falling back to `MarkOffset` when the cluster base is a ligature carrier. Component attribution uses a documented stop-gap heuristic — the first Extend/ZWJ mark of the cluster lands on component 0, subsequent marks land on the last component — because the layout pipeline does not yet plumb cluster→component IDs from the shaper. `TODO(#218)` is left in `layout/draw.go` for the follow-up.

### Tests

- `font/gpos_test.go`: spec-crafted byte tables for both lookup types — Type 3 parser (entry/exit slot placement), Type 3 executor (`CursiveOffset` arithmetic), Type 3 three-glyph cumulative chain, Type 3 extension wrap, Type 5 parser (multi-component × multi-class grid with absent slots), Type 5 executor with miss cases (out-of-range component, unknown lig/mark, absent class slot), Type 5 extension wrap, plus nil-receiver guards for both.
- `layout/gpos_mark_draw_test.go`: two-glyph cursive integration test asserting the expected `Td` operator, three-glyph cursive cumulative chain (covering dy non-zero close), no-curs fallback to a single `Tj`, ligature base + two marks integration test verifying the per-component anchor lands at the right (cluster-relative) offset, and a Type-4/Type-5 fallback guard so Type 5 does not hijack plain marks.

### Decisions reviewers should scrutinize

- Cursive RTL sign convention: the package returns the LTR `prev.Exit - curr.Entry`. Callers who know they are positioning an Arabic run must flip dx themselves. This avoids carrying script direction into the parser, but it does mean future RTL shaper code must opt in.
- Type 5 component attribution heuristic (first → 0, rest → last). This is the documented placeholder; HarfBuzz-grade attribution requires propagating the GSUB ligature-substitution component IDs through to the layout `Word`. The heuristic gives sensible output for two-component ligatures (the common case for Arabic lam-alef and Latin "fi" / "ffl") and degrades gracefully on longer ones.
- Cursive vs. kerning ordering: applied at the shaper-produced GID-stream path, which does not consult the legacy kern table, so ordering is currently moot. If a future GPOS pair-kern integration is added on the GID-stream path, cursive should run first.
- LigatureRecord carries a parallel `Present` grid rather than reusing `BaseRecord`'s "zero-anchor = absent" convention. This is a deliberate divergence: the ligature grid sees absent slots far more often (a class-0 mark on the second component of a two-component ligature is a very common shape), so silently treating (0, 0) as "no anchor" was felt to be worth the extra slice.

## Test plan

- [x] `go test ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -s -l .` clean
- [x] `golangci-lint run` clean (0 issues)