### PR TITLE
font: fix GPOS cursive horizontal placement and tighten Type 5

### DIFF
--- a/font/gpos.go
+++ b/font/gpos.go
@@ -65,9 +65,19 @@ type BaseRecord struct {
 // contributes to LookupType 3 cursive attachment. Either anchor may be
 // absent (zero offset in the source EntryExitRecord); HasEntry/HasExit
 // disambiguate "absent" from "present at (0,0)".
+//
+// LookupFlag carries the parent Lookup table's lookupFlag uint16 so
+// downstream consumers can interpret bits the draw path does not yet
+// act on. Currently only the RIGHT_TO_LEFT bit (0x0001) is meaningful
+// for cursive; ISO 14496-22 §5.2 also defines IGNORE_BASE_GLYPHS
+// (0x0002), IGNORE_LIGATURES (0x0004), IGNORE_MARKS (0x0008),
+// USE_MARK_FILTERING_SET (0x0010), and a MarkAttachmentType byte in
+// the upper 8 bits. None of these are consumed yet; they are persisted
+// here so a future fix can read them without re-parsing.
 type CursiveRecord struct {
 	Entry, Exit       Anchor
 	HasEntry, HasExit bool
+	LookupFlag        uint16
 }
 
 // LigatureRecord captures the per-component anchors a ligature base
@@ -292,10 +302,13 @@ func (g *GPOSAdjustments) MarkMarkOffset(mark1GID, mark2GID uint16, feature GPOS
 // previous glyph has no exit anchor declared, or when the current
 // glyph has no entry anchor declared.
 //
-// RTL handling is left to the caller: the package is shaping-direction
-// agnostic, so a layout layer that knows the run direction (Arabic,
-// Hebrew, etc.) is responsible for flipping the dx sign when the visual
-// progression runs right-to-left.
+// Returns the LTR-convention join delta. RTL handling requires reading
+// the parent Lookup's RIGHT_TO_LEFT flag bit (0x0001), which inverts
+// which anchor (entry vs exit) is the "joining" anchor and changes the
+// Y-alignment rule. That flag is not yet parsed by ParseGPOS, so RTL
+// cursive (Arabic and similar) will not render correctly until the
+// lookup flag is consumed. TODO: plumb the lookup flag through the
+// parser and apply it here.
 func (g *GPOSAdjustments) CursiveOffset(prevGID, currGID uint16, feature GPOSFeature) (dx, dy int16, ok bool) {
 	if g == nil {
 		return 0, 0, false
@@ -347,12 +360,16 @@ func (g *GPOSAdjustments) MarkLigatureOffset(ligGID uint16, componentIdx int, ma
 	if componentIdx < 0 || componentIdx >= len(lig.Components) {
 		return 0, 0, false
 	}
+	// parseLigatureArray builds Components and Present row-by-row in
+	// lockstep, so len(Components[c]) == len(Present[c]) == markClassCount
+	// for every component. A single class-bound check on Components is
+	// enough; an explicit re-check against Present[componentIdx] would
+	// be unreachable.
 	comp := lig.Components[componentIdx]
 	if int(mark.Class) >= len(comp) {
 		return 0, 0, false
 	}
-	if componentIdx >= len(lig.Present) || int(mark.Class) >= len(lig.Present[componentIdx]) ||
-		!lig.Present[componentIdx][mark.Class] {
+	if !lig.Present[componentIdx][mark.Class] {
 		return 0, 0, false
 	}
 	a := comp[mark.Class]
@@ -448,11 +465,22 @@ func parseGPOSLookups(gpos []byte, listOff int, indices []int, acc *gposAccumula
 // parseGPOSLookup reads a single Lookup table and calls the subtable
 // parser matching its lookup type. Extension subtables (type 9) are
 // followed to their target subtable in the same GPOS blob.
+//
+// The Lookup table's lookupFlag uint16 is read once and forwarded to
+// subtable parsers that need it. Per ISO 14496-22 §5.2, lookupFlag
+// carries semantically important bits — RIGHT_TO_LEFT (0x0001) for
+// cursive, IGNORE_BASE_GLYPHS (0x0002), IGNORE_LIGATURES (0x0004),
+// IGNORE_MARKS (0x0008), USE_MARK_FILTERING_SET (0x0010), and a
+// MarkAttachmentType byte in the upper 8 bits. Only the flag value is
+// persisted today (on CursiveRecord); none of the bits are acted on by
+// the draw path yet. TODO: consume RIGHT_TO_LEFT in the cursive draw
+// path; consume IGNORE_* in mark and ligature placement.
 func parseGPOSLookup(gpos []byte, lookupOff int, acc *gposAccumulator) {
 	if lookupOff+6 > len(gpos) {
 		return
 	}
 	lookupType := be16(gpos, lookupOff)
+	lookupFlag := be16(gpos, lookupOff+2)
 	subCount := int(be16(gpos, lookupOff+4))
 	if lookupOff+6+subCount*2 > len(gpos) {
 		return
@@ -479,7 +507,7 @@ func parseGPOSLookup(gpos []byte, lookupOff int, acc *gposAccumulator) {
 		case 2:
 			parsePairPos(gpos, off, acc.pairs)
 		case 3:
-			parseCursivePos(gpos, off, acc.cursives)
+			parseCursivePos(gpos, off, lookupFlag, acc.cursives)
 		case 4:
 			parseMarkBasePos(gpos, off, acc.marks, acc.bases)
 		case 5:
@@ -862,7 +890,7 @@ func parseBaseArray(gpos []byte, off int, baseCov []uint16, markClassCount int, 
 // index i selects record i. Per-glyph CursiveRecord entries are written
 // only when at least one anchor is present; HasEntry/HasExit
 // disambiguate "absent" from "(0,0)".
-func parseCursivePos(gpos []byte, off int, out map[uint16]CursiveRecord) {
+func parseCursivePos(gpos []byte, off int, lookupFlag uint16, out map[uint16]CursiveRecord) {
 	if off+6 > len(gpos) {
 		return
 	}
@@ -884,6 +912,7 @@ func parseCursivePos(gpos []byte, off int, out map[uint16]CursiveRecord) {
 		entryOffRaw := int(be16(gpos, rec))
 		exitOffRaw := int(be16(gpos, rec+2))
 		var cr CursiveRecord
+		cr.LookupFlag = lookupFlag
 		if entryOffRaw != 0 {
 			if a, ok := parseAnchor(gpos, off+entryOffRaw); ok {
 				cr.Entry = a
@@ -982,6 +1011,11 @@ func parseLigatureArray(gpos []byte, off int, ligCov []uint16, markClassCount in
 		if attachOff+2+componentCount*rowSize > len(gpos) {
 			continue
 		}
+		// Invariant maintained by this constructor: Components[c] and
+		// Present[c] are allocated with the same length (markClassCount)
+		// for every component c. MarkLigatureOffset relies on this so a
+		// single bounds check against Components[c] also covers
+		// Present[c][mark.Class].
 		components := make([][]Anchor, componentCount)
 		present := make([][]bool, componentCount)
 		for c := 0; c < componentCount; c++ {

--- a/font/gpos_test.go
+++ b/font/gpos_test.go
@@ -1421,3 +1421,359 @@ func TestFaceGPOSCacheIdentity(t *testing.T) {
 		t.Error("second GPOS call rebuilt the cached result")
 	}
 }
+
+// cursivePosBodyAnchorFormat builds a CursivePosFormat1 subtable where
+// every anchor is emitted in the requested format. Formats 2 and 3 add
+// trailing fields beyond (x, y) that parseAnchor must skip past.
+func cursivePosBodyAnchorFormat(format uint16) []byte {
+	specs := []cursiveGlyphSpec{
+		{gid: 100, hasExit: true, exitX: 700, exitY: 50},
+		{gid: 101, hasEntry: true, hasExit: true,
+			entryX: 50, entryY: 60, exitX: 650, exitY: 40},
+	}
+	var b gposBuilder
+	b.u16(1) // posFormat
+	covOffPos := b.pos()
+	b.u16(0) // coverageOffset
+	b.u16(uint16(len(specs)))
+
+	type recPos struct {
+		entryPos, exitPos int
+	}
+	recs := make([]recPos, len(specs))
+	for i := range specs {
+		recs[i].entryPos = b.pos()
+		b.u16(0)
+		recs[i].exitPos = b.pos()
+		b.u16(0)
+	}
+
+	covOff := b.pos()
+	b.patchU16(covOffPos, uint16(covOff))
+	gids := make([]uint16, len(specs))
+	for i, s := range specs {
+		gids[i] = s.gid
+	}
+	b.buf = append(b.buf, buildCoverageFormat1(gids...)...)
+
+	emit := func(x, y int16) {
+		b.u16(format)
+		b.i16(x)
+		b.i16(y)
+		switch format {
+		case 2:
+			b.u16(0) // anchor point index
+		case 3:
+			b.u16(0) // xDeviceOffset
+			b.u16(0) // yDeviceOffset
+		}
+	}
+	for i, s := range specs {
+		if s.hasEntry {
+			anchorOff := b.pos()
+			b.patchU16(recs[i].entryPos, uint16(anchorOff))
+			emit(s.entryX, s.entryY)
+		}
+		if s.hasExit {
+			anchorOff := b.pos()
+			b.patchU16(recs[i].exitPos, uint16(anchorOff))
+			emit(s.exitX, s.exitY)
+		}
+	}
+	return b.buf
+}
+
+// TestParseGPOSCursiveAnchorFormats2And3 mirrors
+// TestParseGPOSAnchorFormats2And3 for LookupType 3: anchors emitted in
+// formats 2 and 3 must yield the same X, Y as format 1, since the
+// trailing anchor-point index and Device offsets are deliberately
+// ignored.
+func TestParseGPOSCursiveAnchorFormats2And3(t *testing.T) {
+	for _, fmt := range []uint16{1, 2, 3} {
+		body := cursivePosBodyAnchorFormat(fmt)
+		gpos := buildGPOSHeader("curs", 3, body, 0)
+		g := ParseGPOS(wrapTTF(gpos))
+		if g == nil {
+			t.Fatalf("format %d: ParseGPOS returned nil", fmt)
+		}
+		rec100 := g.Cursives[GPOSCurs][100]
+		if rec100.Exit.X != 700 || rec100.Exit.Y != 50 {
+			t.Errorf("format %d: glyph 100 exit = %+v, want (700, 50)", fmt, rec100.Exit)
+		}
+		rec101 := g.Cursives[GPOSCurs][101]
+		if rec101.Entry.X != 50 || rec101.Entry.Y != 60 {
+			t.Errorf("format %d: glyph 101 entry = %+v, want (50, 60)", fmt, rec101.Entry)
+		}
+		if rec101.Exit.X != 650 || rec101.Exit.Y != 40 {
+			t.Errorf("format %d: glyph 101 exit = %+v, want (650, 40)", fmt, rec101.Exit)
+		}
+	}
+}
+
+// TestParseGPOSCursiveBothAnchorsAbsentOmitted covers the skip branch
+// in parseCursivePos: a coverage entry whose EntryExitRecord has both
+// offsets equal to zero must NOT appear in the Cursives map.
+func TestParseGPOSCursiveBothAnchorsAbsentOmitted(t *testing.T) {
+	body := cursivePosBody(
+		cursiveGlyphSpec{gid: 50}, // both offsets 0
+		cursiveGlyphSpec{gid: 51, hasExit: true, exitX: 200, exitY: 0},
+	)
+	gpos := buildGPOSHeader("curs", 3, body, 0)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	if _, ok := g.Cursives[GPOSCurs][50]; ok {
+		t.Errorf("glyph 50 should be absent from Cursives (both anchors absent), got entry %+v", g.Cursives[GPOSCurs][50])
+	}
+	if _, ok := g.Cursives[GPOSCurs][51]; !ok {
+		t.Error("glyph 51 should be present (one anchor declared)")
+	}
+}
+
+// TestGPOSCursiveLTRContractDoc pins the LTR-convention contract on
+// CursiveOffset: the package is shaping-direction agnostic and always
+// returns the LTR delta (prev.Exit - curr.Entry). Any RTL handling is
+// the layout layer's responsibility.
+func TestGPOSCursiveLTRContractDoc(t *testing.T) {
+	body := cursivePosBody(
+		cursiveGlyphSpec{gid: 1, hasExit: true, exitX: 800, exitY: 5},
+		cursiveGlyphSpec{gid: 2, hasEntry: true, entryX: 30, entryY: -5},
+	)
+	gpos := buildGPOSHeader("curs", 3, body, 0)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	dx, dy, ok := g.CursiveOffset(1, 2, GPOSCurs)
+	if !ok {
+		t.Fatal("CursiveOffset returned ok=false")
+	}
+	// LTR: dx = 800 - 30 = 770; dy = 5 - (-5) = 10. Sign is positive
+	// regardless of which run direction the caller intends.
+	if dx != 770 || dy != 10 {
+		t.Errorf("CursiveOffset = (%d, %d), want (770, 10) (LTR convention)", dx, dy)
+	}
+}
+
+// TestParseGPOSCursiveStoresLookupFlag verifies that the lookup-table
+// flag uint16 is persisted on every CursiveRecord. Today the flag is
+// not consumed by the draw path; persisting it lets a future RTL fix
+// or IGNORE_* fix read the bits without re-parsing.
+func TestParseGPOSCursiveStoresLookupFlag(t *testing.T) {
+	body := cursivePosBody(
+		cursiveGlyphSpec{gid: 1, hasExit: true, exitX: 100, exitY: 0},
+		cursiveGlyphSpec{gid: 2, hasEntry: true, entryX: 20, entryY: 0},
+	)
+	// Build a GPOS table by hand so we can inject a non-zero
+	// lookupFlag (0x0001 = RIGHT_TO_LEFT). buildGPOSHeader hard-codes
+	// the flag to 0; we patch it post-construction.
+	gpos := buildGPOSHeader("curs", 3, body, 0)
+	// Walk the lookup list and overwrite the lookupFlag field of the
+	// single Lookup table. The header layout is: GPOS header (10),
+	// then ScriptList, FeatureList, LookupList. Locate the lookup via
+	// the LookupList offset stored at GPOS+8.
+	lookupListOff := int(be16(gpos, 8))
+	// LookupList: count(2) lookupOffset(2). Single lookup.
+	lookupOff := lookupListOff + int(be16(gpos, lookupListOff+2))
+	// Lookup: lookupType(2), lookupFlag(2), subTableCount(2). Patch
+	// flag with RIGHT_TO_LEFT (0x0001).
+	gpos[lookupOff+2] = 0x00
+	gpos[lookupOff+3] = 0x01
+
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	rec1, ok := g.Cursives[GPOSCurs][1]
+	if !ok {
+		t.Fatal("glyph 1 missing from Cursives")
+	}
+	if rec1.LookupFlag != 0x0001 {
+		t.Errorf("glyph 1 LookupFlag = %#x, want 0x0001", rec1.LookupFlag)
+	}
+	rec2 := g.Cursives[GPOSCurs][2]
+	if rec2.LookupFlag != 0x0001 {
+		t.Errorf("glyph 2 LookupFlag = %#x, want 0x0001", rec2.LookupFlag)
+	}
+}
+
+// markLigPosBodyAnchorFormat is a variant of markLigPosBody whose
+// every anchor (mark and ligature) is emitted in the requested format.
+// Used to exercise the format-2/3 read path on Type 5 anchors.
+func markLigPosBodyAnchorFormat(format uint16) []byte {
+	const (
+		markGID uint16 = 200
+		ligGID  uint16 = 300
+	)
+	var b gposBuilder
+	b.u16(1) // posFormat
+	markCovOffPos := b.pos()
+	b.u16(0)
+	ligCovOffPos := b.pos()
+	b.u16(0)
+	b.u16(1) // markClassCount
+	markArrayOffPos := b.pos()
+	b.u16(0)
+	ligArrayOffPos := b.pos()
+	b.u16(0)
+
+	markCovOff := b.pos()
+	b.patchU16(markCovOffPos, uint16(markCovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(markGID)...)
+
+	ligCovOff := b.pos()
+	b.patchU16(ligCovOffPos, uint16(ligCovOff))
+	b.buf = append(b.buf, buildCoverageFormat1(ligGID)...)
+
+	markArrayOff := b.pos()
+	b.patchU16(markArrayOffPos, uint16(markArrayOff))
+	b.u16(1) // markCount
+	b.u16(0) // class 0
+	markAnchorOffPos := b.pos()
+	b.u16(0)
+
+	ligArrayOff := b.pos()
+	b.patchU16(ligArrayOffPos, uint16(ligArrayOff))
+	b.u16(1) // ligatureCount
+	attachOffPos := b.pos()
+	b.u16(0)
+
+	attachOff := b.pos()
+	b.patchU16(attachOffPos, uint16(attachOff-ligArrayOff))
+	b.u16(2) // componentCount
+	c0AnchorPos := b.pos()
+	b.u16(0)
+	c1AnchorPos := b.pos()
+	b.u16(0)
+
+	emit := func(x, y int16) {
+		b.u16(format)
+		b.i16(x)
+		b.i16(y)
+		switch format {
+		case 2:
+			b.u16(0)
+		case 3:
+			b.u16(0)
+			b.u16(0)
+		}
+	}
+
+	// Mark anchor at (10, 20).
+	markAnchorOff := b.pos()
+	b.patchU16(markAnchorOffPos, uint16(markAnchorOff-markArrayOff))
+	emit(10, 20)
+	// Component 0 anchor at (110, 220).
+	c0AnchorOff := b.pos()
+	b.patchU16(c0AnchorPos, uint16(c0AnchorOff-attachOff))
+	emit(110, 220)
+	// Component 1 anchor at (310, 420).
+	c1AnchorOff := b.pos()
+	b.patchU16(c1AnchorPos, uint16(c1AnchorOff-attachOff))
+	emit(310, 420)
+	return b.buf
+}
+
+// TestParseGPOSMarkLigAnchorFormats2And3 mirrors the cursive variant
+// for LookupType 5: mark and ligature anchors in formats 2 and 3 must
+// resolve identically to format 1.
+func TestParseGPOSMarkLigAnchorFormats2And3(t *testing.T) {
+	for _, fmt := range []uint16{1, 2, 3} {
+		body := markLigPosBodyAnchorFormat(fmt)
+		gpos := buildGPOSHeader("mark", 5, body, 0)
+		g := ParseGPOS(wrapTTF(gpos))
+		if g == nil {
+			t.Fatalf("format %d: ParseGPOS returned nil", fmt)
+		}
+		dx, dy, ok := g.MarkLigatureOffset(300, 0, 200, GPOSMark)
+		if !ok || dx != 100 || dy != 200 {
+			t.Errorf("format %d comp 0: (%d, %d, %v), want (100, 200, true)", fmt, dx, dy, ok)
+		}
+		dx, dy, ok = g.MarkLigatureOffset(300, 1, 200, GPOSMark)
+		if !ok || dx != 300 || dy != 400 {
+			t.Errorf("format %d comp 1: (%d, %d, %v), want (300, 400, true)", fmt, dx, dy, ok)
+		}
+	}
+}
+
+// TestParseGPOSMarkLigDoesNotPopulateType4Marks is the storage-isolation
+// regression for LookupType 5: a pure-Type-5 GPOS table must populate
+// LigatureMarks/LigatureBases without bleeding into the Type 4
+// Marks/Bases maps. A regression that aliased the two sets of maps
+// would be caught here.
+func TestParseGPOSMarkLigDoesNotPopulateType4Marks(t *testing.T) {
+	const (
+		markGID uint16 = 200
+		ligGID  uint16 = 300
+	)
+	marks := []markLigMarkSpec{
+		{gid: markGID, class: 0, anchor: Anchor{X: 10, Y: 20}},
+	}
+	ligAnchors := [][]ligAnchorSpec{
+		{{present: true, x: 110, y: 220}},
+		{{present: true, x: 310, y: 420}},
+	}
+	body := markLigPosBody(marks, ligGID, 1, ligAnchors)
+	gpos := buildGPOSHeader("mark", 5, body, 0)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	if len(g.Marks[GPOSMark]) != 0 {
+		t.Errorf("Marks[GPOSMark] should be empty for pure Type 5, got %v", g.Marks[GPOSMark])
+	}
+	if len(g.Bases[GPOSMark]) != 0 {
+		t.Errorf("Bases[GPOSMark] should be empty for pure Type 5, got %v", g.Bases[GPOSMark])
+	}
+	if len(g.LigatureMarks[GPOSMark]) == 0 {
+		t.Error("LigatureMarks[GPOSMark] should be populated")
+	}
+	if len(g.LigatureBases[GPOSMark]) == 0 {
+		t.Error("LigatureBases[GPOSMark] should be populated")
+	}
+}
+
+// TestParseGPOSMarkType4AndType5Coexist builds a multi-lookup GPOS
+// blob where one Type 4 lookup and one Type 5 lookup both belong to
+// the "mark" feature. Both MarkOffset and MarkLigatureOffset must
+// resolve simultaneously.
+func TestParseGPOSMarkType4AndType5Coexist(t *testing.T) {
+	const (
+		baseGID  uint16 = 100
+		mark4GID uint16 = 50
+		ligGID   uint16 = 300
+		mark5GID uint16 = 200
+	)
+	type4Body := markBasePosBody(mark4GID, baseGID, 5, 10, 105, 110, 1)
+	marks := []markLigMarkSpec{
+		{gid: mark5GID, class: 0, anchor: Anchor{X: 10, Y: 20}},
+	}
+	ligAnchors := [][]ligAnchorSpec{
+		{{present: true, x: 110, y: 220}},
+		{{present: true, x: 310, y: 420}},
+	}
+	type5Body := markLigPosBody(marks, ligGID, 1, ligAnchors)
+
+	// buildGPOSHeaderDualFeature pairs two lookups via two features;
+	// reuse it with both features set to "mark" so they share a
+	// feature tag. The parser keys subtables by lookup type, so the
+	// shared tag does not collide with Type 4 storage.
+	gpos := buildGPOSHeaderDualFeature("mark", 4, type4Body, "mark", 5, type5Body)
+	g := ParseGPOS(wrapTTF(gpos))
+	if g == nil {
+		t.Fatal("ParseGPOS returned nil")
+	}
+	dx, dy, ok := g.MarkOffset(baseGID, mark4GID, GPOSMark)
+	if !ok || dx != 100 || dy != 100 {
+		t.Errorf("Type 4 MarkOffset = (%d, %d, %v), want (100, 100, true)", dx, dy, ok)
+	}
+	dx, dy, ok = g.MarkLigatureOffset(ligGID, 0, mark5GID, GPOSMark)
+	if !ok || dx != 100 || dy != 200 {
+		t.Errorf("Type 5 MarkLigatureOffset comp 0 = (%d, %d, %v), want (100, 200, true)", dx, dy, ok)
+	}
+	dx, dy, ok = g.MarkLigatureOffset(ligGID, 1, mark5GID, GPOSMark)
+	if !ok || dx != 300 || dy != 400 {
+		t.Errorf("Type 5 MarkLigatureOffset comp 1 = (%d, %d, %v), want (300, 400, true)", dx, dy, ok)
+	}
+}

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -367,13 +367,15 @@ func markPositioningEligible(word Word) bool {
 // cursivePositioningEligible reports whether the word's GID stream is
 // eligible for the cursive (GPOS LookupType 3) draw path. Eligibility
 // requires an embedded font whose Face exposes GPOS curs data, a GID
-// stream of at least two glyphs, and at least one consecutive pair
-// (prev, curr) for which CursiveOffset returns a non-trivial offset.
+// stream of at least two glyphs, and a non-empty Cursives map for the
+// curs feature.
 //
-// The presence check is keyed on the Cursives map only; callers that
-// need to flip the dx sign for RTL runs must do so themselves on the
-// values returned by CursiveOffset, since this package is shaping-
-// direction agnostic.
+// This is a presence check only; the per-pair join data is consumed by
+// drawShapedGIDsCursive on the same walk that emits the Tj operators,
+// so a separate eligibility probe would re-walk the run for no benefit.
+// Callers that ship RTL cursive scripts (Arabic) must additionally
+// consult the Lookup table's RIGHT_TO_LEFT flag, which is not yet
+// plumbed through the parser; see CursiveOffset for the documented gap.
 func cursivePositioningEligible(word Word) bool {
 	if word.Embedded == nil || len(word.GIDs) < 2 || word.LetterSpacing != 0 {
 		return false
@@ -383,35 +385,31 @@ func cursivePositioningEligible(word Word) bool {
 		return false
 	}
 	gpos := provider.GPOS()
-	if gpos == nil || len(gpos.Cursives[font.GPOSCurs]) == 0 {
+	if gpos == nil {
 		return false
 	}
-	for i := 1; i < len(word.GIDs); i++ {
-		if _, _, hit := gpos.CursiveOffset(word.GIDs[i-1], word.GIDs[i], font.GPOSCurs); hit {
-			return true
-		}
-	}
-	return false
+	return len(gpos.Cursives[font.GPOSCurs]) > 0
 }
 
 // drawShapedGIDsCursive emits a shaper-produced GID stream with cursive
-// attachment offsets applied between consecutive glyphs. Each glyph is
-// emitted via its own Tj; a Td-shift moves the text matrix from the
-// natural glyph-end position to the cursive-anchored origin, then
-// another Td-shift advances by the glyph's natural advance plus the
-// cursive dx so the next glyph's natural origin sits at the cursive
-// target. Td brackets that surround the same glyph cancel net advance
-// to match the natural advance of the run; cursive only re-positions,
-// it does not add or remove width.
+// attachment offsets applied between consecutive glyphs. In horizontal
+// text the OpenType spec §6.3 LookupType 3 join is a Y-only alignment:
+// the X delta between previous-exit and current-entry is already
+// encoded by the glyph's hmtx advance, so the cursive feature's job is
+// to align baselines / connecting points vertically. Each glyph is
+// emitted via its own Tj; when CursiveOffset reports a non-zero dy,
+// a Td(0, dy) opens before the Tj and a Td(0, -dy) closes after it so
+// the baseline is consistent for subsequent glyphs.
 //
-// RTL handling: this function applies the LTR convention dx as-returned
-// by CursiveOffset. Callers that need RTL semantics must arrange for
-// the GID stream order to already reflect visual order (which the
-// shaper does today) and accept that for RTL the dx should be flipped.
-// This iteration documents the constraint rather than fixing it; the
+// RTL handling: this function applies the LTR-convention join. Real
+// RTL cursive (Arabic, etc.) requires consulting the parent Lookup's
+// RIGHT_TO_LEFT flag (0x0001), which inverts which anchor (entry vs
+// exit) plays the joining role and changes the Y-alignment rule. The
+// flag is not yet parsed (see TODO in font/gpos.go), so RTL cursive
+// will not render correctly until that data is plumbed through. The
 // only shipped shaper today is Indic (LTR) and Indic does not use the
-// curs feature, so the path is exercised by tests and Arabic-style
-// shapers that arrive later will need to participate in the sign flip.
+// curs feature, so the path is exercised by tests rather than real
+// runs.
 func drawShapedGIDsCursive(stream *content.Stream, word Word) {
 	ef := word.Embedded
 	face := ef.Face()
@@ -434,26 +432,24 @@ func drawShapedGIDsCursive(stream *content.Stream, word Word) {
 			stream.ShowTextHex(ef.EncodeGIDs(gids[i:i+1], ""))
 			continue
 		}
-		dxFU, dyFU, ok := gpos.CursiveOffset(gids[i-1], gid, font.GPOSCurs)
+		_, dyFU, ok := gpos.CursiveOffset(gids[i-1], gid, font.GPOSCurs)
 		if !ok {
 			stream.ShowTextHex(ef.EncodeGIDs(gids[i:i+1], ""))
 			continue
 		}
-		dxPts := float64(dxFU) * scale
 		dyPts := float64(dyFU) * scale
-		// Open: shift from the natural cursor to the cursive origin.
-		stream.MoveText(dxPts, dyPts)
-		stream.ShowTextHex(ef.EncodeGIDs(gids[i:i+1], ""))
-		// Close: shift back by -dy so the baseline is consistent for
-		// subsequent glyphs. The horizontal shift introduced by dx is
-		// intentional: after this glyph's Tj the text matrix already
-		// sits at (naturalAdvance + dxPts, dyPts) — the close move
-		// only restores y. This matches the spec's "join previous
-		// exit to current entry" semantics: the cursive offset rides
-		// along between glyphs and is not undone.
-		if dyPts != 0 {
-			stream.MoveText(0, -dyPts)
+		if dyPts == 0 {
+			// No vertical join: the natural hmtx advance already
+			// places this glyph correctly.
+			stream.ShowTextHex(ef.EncodeGIDs(gids[i:i+1], ""))
+			continue
 		}
+		// Open: shift up/down to the cursive baseline join.
+		stream.MoveText(0, dyPts)
+		stream.ShowTextHex(ef.EncodeGIDs(gids[i:i+1], ""))
+		// Close: restore Y so subsequent glyphs sit on the run's
+		// baseline. The cursive Y join is local to this pair.
+		stream.MoveText(0, -dyPts)
 	}
 }
 
@@ -567,24 +563,35 @@ func drawWordEmbeddedWithMarks(stream *content.Stream, word Word) {
 		// when it is, marks resolve against the ligature's per-component
 		// anchor grid instead of the Type 4 mark-to-base grid.
 		//
-		// Component attribution heuristic: the first Extend/ZWJ mark in
-		// the cluster attaches to component 0 (leftmost in glyph order).
-		// Subsequent marks attach to the LAST component
-		// (len(components)-1). This is a documented stop-gap until the
-		// shaper plumbs cluster→component IDs through the layout
-		// pipeline; see TODO(#218).
-		// TODO(#218): replace the first/last component heuristic with
-		// real cluster→component attribution from the shaper. The HTML
-		// path currently has no source for component IDs at draw time.
+		// Component attribution heuristic: the first mark that resolves
+		// through the Type 5 branch attaches to component 0 (leftmost
+		// in glyph order); subsequent Type 5 placements attach to the
+		// LAST component (len(components)-1). The counter tracks Type 5
+		// placements only — marks intercepted by the Type 6 (mark-mark)
+		// branch do not advance it, so the "first vs rest" rule is
+		// stable regardless of how many marks stack on top of a prior
+		// mark before any reach the Type 5 path.
+		//
+		// The heuristic is only meaningful for 2-component ligatures.
+		// 3+ component ligatures (ffl, ffi+modifier, etc.) have at
+		// least one middle component that the heuristic cannot reach;
+		// silently misplacing those marks is worse than falling back
+		// to Type 4 mark-to-base on the ligature glyph itself, so this
+		// path is gated on componentCount <= 2.
+		// TODO: replace the heuristic with real cluster→component
+		// attribution from the shaper. The HTML path currently has no
+		// source for component IDs at draw time, so a wider ligature
+		// would need shaper plumbing to position marks correctly.
 		var ligComponents int
 		isLigatureBase := false
 		if gpos != nil {
 			if rec, ok := gpos.LigatureBases[font.GPOSMark][baseGID]; ok {
 				ligComponents = len(rec.Components)
-				isLigatureBase = ligComponents > 0
+				isLigatureBase = ligComponents > 0 && ligComponents <= 2
 			}
 		}
-		for mi, m := range extendMarks {
+		type5Placements := 0
+		for _, m := range extendMarks {
 			markGID := face.GlyphIndex(m.r)
 			var dxPts, dyPts float64
 			placed := false
@@ -597,13 +604,14 @@ func drawWordEmbeddedWithMarks(stream *content.Stream, word Word) {
 			}
 			if !placed && isLigatureBase {
 				comp := 0
-				if mi > 0 {
+				if type5Placements > 0 {
 					comp = ligComponents - 1
 				}
 				if dx, dy, ok := gpos.MarkLigatureOffset(baseGID, comp, markGID, font.GPOSMark); ok {
 					dxPts = float64(dx) * scale
 					dyPts = float64(dy) * scale
 					placed = true
+					type5Placements++
 				}
 			}
 			if !placed {

--- a/layout/gpos_mark_draw_test.go
+++ b/layout/gpos_mark_draw_test.go
@@ -672,14 +672,10 @@ func newCursiveFace() *mockGPOSFace {
 	return face
 }
 
-// TestGPOSCursiveJoinTwoGlyphs renders a two-glyph cursive run and
-// asserts the draw stream contains the expected per-glyph Td shift.
-// At fontSize=10 with upem=1000, FUnit→pt scale is 1/100.
-//
-//	dx = (700 - 50) / 1000 * 10 = 6.5 pt
-//	dy = (0   - 0)  / 1000 * 10 = 0
-//
-// The first glyph emits without a Td; the second emits with "6.5 0 Td".
+// TestGPOSCursiveJoinTwoGlyphs renders a two-glyph cursive run whose
+// link carries dy=0. Per OpenType spec §6.3 the X delta is already
+// encoded by hmtx, so a Y-zero join emits no Td between glyphs: the
+// only Td in the stream is the initial MoveText.
 func TestGPOSCursiveJoinTwoGlyphs(t *testing.T) {
 	face := newCursiveFace()
 	ef := font.NewEmbeddedFont(face)
@@ -690,22 +686,27 @@ func TestGPOSCursiveJoinTwoGlyphs(t *testing.T) {
 	}
 	b := capturedWordStream(word)
 
-	// One initial Td (MoveText), one cursive Td between glyphs.
-	if countTdOps(b) != 2 {
-		t.Fatalf("expected 2 Td ops (initial + cursive), got %d:\n%s", countTdOps(b), b)
+	// Only the initial MoveText Td: the join is dy=0 so no extra Td.
+	if countTdOps(b) != 1 {
+		t.Fatalf("expected 1 Td op (initial only) for dy=0 join, got %d:\n%s", countTdOps(b), b)
 	}
-	if !bytes.Contains(b, []byte("6.5 0 Td")) {
-		t.Errorf("missing cursive Td '6.5 0 Td' in stream:\n%s", b)
+	// And the run still emits one Tj per glyph.
+	tjCount := 0
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.HasSuffix(strings.TrimSpace(line), " Tj") {
+			tjCount++
+		}
+	}
+	if tjCount != 2 {
+		t.Errorf("expected 2 Tj operators (one per glyph), got %d:\n%s", tjCount, b)
 	}
 }
 
-// TestGPOSCursiveJoinThreeGlyphs verifies cumulative cursive offset
-// across a three-glyph chain. Each link contributes its own Td bracket;
-// the second Td (5.9, +0.1) carries the dy non-zero so the close-Td of
-// 0,-0.1 appears in the stream as well.
-//
-//	link 1 dx = 6.5, dy = 0    → "6.5 0 Td"
-//	link 2 dx = 5.9, dy = 0.1  → "5.9 0.1 Td"  + close "0 -0.1 Td"
+// TestGPOSCursiveJoinThreeGlyphs verifies that a three-glyph chain
+// applies the Y component of the cursive join only — the X component
+// is already in hmtx. Link 1 has dy=0 (no Td emitted); link 2 has
+// dy=0.1 pt, which produces an open "0 0.1 Td" before the third glyph
+// and a matching close "0 -0.1 Td" after it.
 func TestGPOSCursiveJoinThreeGlyphs(t *testing.T) {
 	face := newCursiveFace()
 	ef := font.NewEmbeddedFont(face)
@@ -716,14 +717,69 @@ func TestGPOSCursiveJoinThreeGlyphs(t *testing.T) {
 	}
 	b := capturedWordStream(word)
 
-	if !bytes.Contains(b, []byte("6.5 0 Td")) {
-		t.Errorf("missing link-1 cursive Td '6.5 0 Td':\n%s", b)
-	}
-	if !bytes.Contains(b, []byte("5.9 0.1 Td")) {
-		t.Errorf("missing link-2 cursive Td '5.9 0.1 Td':\n%s", b)
+	if !bytes.Contains(b, []byte("0 0.1 Td")) {
+		t.Errorf("missing link-2 open cursive Td '0 0.1 Td':\n%s", b)
 	}
 	if !bytes.Contains(b, []byte("0 -0.1 Td")) {
 		t.Errorf("missing link-2 close Td '0 -0.1 Td':\n%s", b)
+	}
+	// No bare X-only Td should appear: the buggy double-counted form.
+	if bytes.Contains(b, []byte("6.5 0 Td")) {
+		t.Errorf("unexpected X-component Td '6.5 0 Td' (cursive must not double-count hmtx):\n%s", b)
+	}
+	if bytes.Contains(b, []byte("5.9 0.1 Td")) {
+		t.Errorf("unexpected XY Td '5.9 0.1 Td' (cursive must not double-count hmtx):\n%s", b)
+	}
+}
+
+// TestGPOSCursiveAbsoluteAdvanceMatchesNaturalSum is the regression
+// guard against double-counting the cursive horizontal delta. Per the
+// OpenType spec §6.3 LookupType 3, in horizontal text the entry/exit
+// X delta is already encoded by hmtx — the cursive feature only aligns
+// the join in Y. A draw path that shifts by dxPts in addition to the
+// natural advance lands the next glyph roughly one extra advance past
+// its predecessor; this test pins the absolute X cursor position after
+// the run to the sum of natural advances.
+func TestGPOSCursiveAbsoluteAdvanceMatchesNaturalSum(t *testing.T) {
+	face := newCursiveFace()
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Embedded: ef,
+		FontSize: 10,
+		GIDs:     []uint16{1, 2, 3},
+	}
+	b := capturedWordStream(word)
+
+	// Sum the X deltas from every Td after the initial MoveText. Each
+	// glyph's own Tj advances by its hmtx, so the post-run cursor X is
+	// the initial X (0) + sum(Td.x) + sum(advance_i).
+	netTdX := 0.0
+	seenInitial := false
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasSuffix(line, " Td") {
+			continue
+		}
+		if !seenInitial {
+			seenInitial = true // initial MoveText(0, 0)
+			continue
+		}
+		var tx, ty float64
+		n, err := fmt.Sscanf(line, "%f %f Td", &tx, &ty)
+		if err != nil || n != 2 {
+			t.Fatalf("unparseable Td line %q: %v", line, err)
+		}
+		netTdX += tx
+	}
+	scale := word.FontSize / float64(face.upem)
+	naturalAdv := 0.0
+	for _, gid := range word.GIDs {
+		naturalAdv += float64(face.advance[gid]) * scale
+	}
+	cursorX := netTdX + naturalAdv
+	if !almostEqual(cursorX, naturalAdv, 1e-9) {
+		t.Errorf("cursor X after cursive run = %v, want %v (sum of natural advances); netTdX = %v\n%s",
+			cursorX, naturalAdv, netTdX, b)
 	}
 }
 
@@ -742,6 +798,12 @@ func TestGPOSCursiveFallbackWithoutCursData(t *testing.T) {
 	b := capturedWordStream(word)
 	if countTdOps(b) != 1 {
 		t.Errorf("without curs data expect only initial Td, got %d:\n%s", countTdOps(b), b)
+	}
+	// The non-cursive path emits exactly one Tj carrying every GID in
+	// big-endian uint16 pairs (Identity-H). For GIDs 1, 2, 3 that is
+	// the hex literal <000100020003>.
+	if !bytes.Contains(b, []byte("<000100020003> Tj")) {
+		t.Errorf("expected single Tj '<000100020003> Tj' for GIDs [1,2,3]:\n%s", b)
 	}
 	tjCount := 0
 	for _, line := range strings.Split(string(b), "\n") {
@@ -853,12 +915,114 @@ func TestGPOSMarkLigatureTwoComponentMarks(t *testing.T) {
 	}
 }
 
+// TestGPOSMarkLigatureThreeComponentFallsBackToType4 covers the safety
+// gate on the Type 5 path: a 3+ component ligature cannot be served by
+// the "first→0, rest→last" component heuristic without silently
+// misplacing middle-component marks. The draw path must therefore
+// bypass Type 5 and apply Type 4 mark-to-base on the ligature glyph.
+//
+// Fixture: a 3-component ligature where component 0 declares one
+// anchor (only reachable to the heuristic's "first" mark) and a Type 4
+// mark-to-base anchor is also declared on the ligature glyph. Both
+// marks must land at the Type 4 offset; neither at the Type 5 anchor.
+func TestGPOSMarkLigatureThreeComponentFallsBackToType4(t *testing.T) {
+	const (
+		ligGID   uint16 = 80
+		markAGID uint16 = 90
+		markBGID uint16 = 91
+		ligRune         = rune(0xE000)
+		markA           = rune(0x0300)
+		markB           = rune(0x0301)
+	)
+	face := &mockGPOSFace{
+		upem: 1000,
+		advance: map[uint16]int{
+			ligGID:   1500,
+			markAGID: 0,
+			markBGID: 0,
+		},
+		cmap: map[rune]uint16{
+			ligRune: ligGID,
+			markA:   markAGID,
+			markB:   markBGID,
+		},
+		gpos: &font.GPOSAdjustments{
+			// Type 5 data: 3 components, anchor only on component 0.
+			LigatureMarks: map[font.GPOSFeature]map[uint16]font.MarkRecord{
+				font.GPOSMark: {
+					markAGID: {Class: 0, Anchor: font.Anchor{X: 50, Y: 100}},
+					markBGID: {Class: 0, Anchor: font.Anchor{X: 50, Y: 100}},
+				},
+			},
+			LigatureBases: map[font.GPOSFeature]map[uint16]font.LigatureRecord{
+				font.GPOSMark: {
+					ligGID: {
+						Components: [][]font.Anchor{
+							{{X: 300, Y: 700}},
+							{{}},
+							{{X: 1100, Y: 700}},
+						},
+						Present: [][]bool{
+							{true},
+							{false},
+							{true},
+						},
+					},
+				},
+			},
+			// Type 4 data on the ligature glyph itself: anchor (200, 400).
+			Marks: map[font.GPOSFeature]map[uint16]font.MarkRecord{
+				font.GPOSMark: {
+					markAGID: {Class: 0, Anchor: font.Anchor{X: 50, Y: 100}},
+					markBGID: {Class: 0, Anchor: font.Anchor{X: 50, Y: 100}},
+				},
+			},
+			Bases: map[font.GPOSFeature]map[uint16]font.BaseRecord{
+				font.GPOSMark: {
+					ligGID: {Anchors: []font.Anchor{{X: 200, Y: 400}}},
+				},
+			},
+		},
+	}
+	ef := font.NewEmbeddedFont(face)
+	word := Word{
+		Text:     string([]rune{ligRune, markA, markB}),
+		Embedded: ef,
+		FontSize: 12,
+	}
+	b := capturedWordStream(word)
+
+	// Type 4 fallback for both marks: target offset = (200-50, 400-100)
+	// = (150, 300) FUnits = (1.8, 3.6) pt at fontSize=12, upem=1000.
+	// clusterAdvance = 1500 / 1000 * 12 = 18 pt.
+	// open Td: (1.8 - 18, 3.6) = (-16.2, 3.6); close: (16.2, -3.6).
+	if !bytes.Contains(b, []byte("-16.2 3.6 Td")) {
+		t.Errorf("expected Type 4 open '-16.2 3.6 Td' (Type 5 must be bypassed for 3-component ligs):\n%s", b)
+	}
+	if !bytes.Contains(b, []byte("16.2 -3.6 Td")) {
+		t.Errorf("expected Type 4 close '16.2 -3.6 Td':\n%s", b)
+	}
+	// Sanity: the Type 5 component-0 offset (300-50, 700-100) =
+	// (250, 600) FUnits = (3, 7.2) pt would emit (-15, 7.2). It must
+	// not appear anywhere in the stream — the gate must hold.
+	if bytes.Contains(b, []byte("-15 7.2 Td")) {
+		t.Errorf("Type 5 component-0 Td '-15 7.2 Td' leaked through 3-component gate:\n%s", b)
+	}
+}
+
 // TestGPOSMarkLigatureFallsBackToType4 verifies that when a cluster
 // base has no Type 5 ligature record, mark resolution falls through to
 // Type 4 mark-to-base unchanged. This is the regression guard against
 // any accidental Type 5 hijacking of plain marks.
 func TestGPOSMarkLigatureFallsBackToType4(t *testing.T) {
 	face := newLamFathaFace()
+	// Pin the precondition: lam (GID 50) must be ABSENT from the
+	// LigatureBases map before render. Otherwise the test would not
+	// be exercising the fallback path.
+	const lamGID uint16 = 50
+	if _, ok := face.gpos.LigatureBases[font.GPOSMark][lamGID]; ok {
+		t.Fatalf("test fixture invariant: lam (GID %d) must not have a LigatureBases entry", lamGID)
+	}
 	ef := font.NewEmbeddedFont(face)
 	word := Word{
 		Text:     "\u0644\u064E",


### PR DESCRIPTION
## Summary

Follow-up to #218 covering the post-merge audit. The headline fix is a correctness bug in cursive (GPOS LookupType 3) horizontal placement; the rest are smaller corrections and additional test coverage.

### Critical

- **C1 — Cursive double-counted hmtx.** `drawShapedGIDsCursive` applied the entry/exit X delta as a `Td` shift on top of the glyph's natural advance, landing each joined glyph one extra advance past its predecessor. Per the OpenType spec section 6.3, in horizontal text the X component of the cursive join is already encoded by hmtx; the feature only aligns the join in Y. Draw path now applies only the Y component.
- **C2 — RTL contract.** Cursive draw is LTR-only today. `CursiveOffset` and `drawShapedGIDsCursive` now document the gap and reference the lookup-flag bit.

### Notable

- **N1** — `MarkLigatureOffset`: removed redundant bounds (`componentIdx >= len(lig.Present)`, `int(mark.Class) >= len(lig.Present[componentIdx])`); the parallel-length invariant of `Components` and `Present` is now asserted by construction.
- **N2** — Comment cleanup around the "first mark to component 0, remaining marks to last component" heuristic.
- **N3** — `cursivePositioningEligible` collapsed to a single map-presence check (`len(gpos.Cursives[GPOSCurs]) > 0`) instead of probing every GID in the run.
- **N4** — `parseCursivePos` now reads the lookup flag and stores it on the `CursiveRecord` so the `RIGHT_TO_LEFT` bit is available to the future RTL pass.
- **N5** — Type 5 path now bails out for ligatures with three or more components and falls back to Type 4 mark-to-base. Without per-cluster component attribution the middle-component anchors would silently misplace marks.

### Tests

- T1 — cursive absolute-advance regression guard (would fail against the C1 bug).
- T2, T3 — cursive anchor formats 2 and 3; entry-or-exit-omitted record.
- T4, T5, T6 — mark-to-lig anchor formats 2 and 3; Type 4 vs Type 5 isolation; Type 4 and Type 5 coexisting on the same lookup.
- T7 — cursive Y-only LTR contract.
- T8 — Type 4 fallback for 3-component ligatures (N5 gate).
- T9, T10 — strengthened existing fallback assertions, including a hex-byte check on the non-cursive Tj.

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -s -l .` clean
- [x] `golangci-lint run` clean
- [x] T1 confirmed as a regression guard against the original C1 patch