### PR TITLE
layout: resolve CSS counter(page)/counter(pages) in body flow

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -581,14 +581,6 @@ func (d *Document) WriteTo(w io.Writer) (int64, error) {
 func (d *Document) WriteToWithOptions(w io.Writer, opts WriteOptions) (int64, error) {
 	allPages, structTags := d.buildAllPages()
 
-	// Second pass: replace ##TOTAL_PAGES## placeholder with actual count.
-	totalStr := strconv.Itoa(len(allPages))
-	for _, p := range allPages {
-		if p.stream != nil {
-			p.stream.ReplaceInBytes("##TOTAL_PAGES##", totalStr)
-		}
-	}
-
 	version := "1.7"
 	if d.pdfA != nil {
 		version = pdfVersionForPdfA(d.pdfA.Level)

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -1092,7 +1092,18 @@ func (c *converter) resolveContentValue(val string) string {
 			closeIdx := strings.IndexByte(remaining, ')')
 			if closeIdx >= 0 {
 				name := strings.TrimSpace(remaining[len("counter("):closeIdx])
-				result.WriteString(strconv.Itoa(c.getCounter(name)))
+				// `page` and `pages` are reserved counters whose value is
+				// only known once pagination runs. Emit the same deferred
+				// placeholder used by @page margin boxes; `layout` resolves
+				// it during content-stream emission.
+				switch name {
+				case "page":
+					result.WriteString(layout.CounterPagePlaceholder)
+				case "pages":
+					result.WriteString(layout.CounterPagesPlaceholder)
+				default:
+					result.WriteString(strconv.Itoa(c.getCounter(name)))
+				}
 				remaining = remaining[closeIdx+1:]
 				continue
 			}

--- a/integration/body_counter_test.go
+++ b/integration/body_counter_test.go
@@ -1,0 +1,409 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// TestBodyCounterInline verifies that CSS counter(page) and counter(pages)
+// inside body-flow content (via ::before pseudo-element) resolve to the
+// correct values per page. This is the primary acceptance test for the
+// body-flow counter feature.
+func TestBodyCounterInline(t *testing.T) {
+	htmlSrc := `
+<html>
+<head><style>
+p.page-of::before { content: "Page " counter(page) " of " counter(pages); }
+</style></head>
+<body>
+<p class="page-of"></p>
+<p>` + strings.Repeat("Lorem ipsum dolor sit amet. ", 200) + `</p>
+<p class="page-of"></p>
+<p>` + strings.Repeat("Consectetur adipiscing elit. ", 200) + `</p>
+<p class="page-of"></p>
+</body>
+</html>`
+
+	doc := document.NewDocument(document.PageSizeLetter)
+	if err := doc.AddHTML(htmlSrc, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := reader.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	total := r.PageCount()
+	if total < 2 {
+		t.Fatalf("expected multi-page document, got %d page(s)", total)
+	}
+
+	// First body-flow counter sits on page 1 → "Page 1 of N".
+	p1, _ := r.Page(0)
+	t1, _ := p1.ExtractText()
+	want1 := fmt.Sprintf("Page 1 of %d", total)
+	if !strings.Contains(t1, want1) {
+		t.Errorf("page 1 should contain %q, got: %s", want1, truncate(t1, 300))
+	}
+
+	// Last body-flow counter sits on the last page → "Page N of N".
+	last := total - 1
+	pN, _ := r.Page(last)
+	tN, _ := pN.ExtractText()
+	wantN := fmt.Sprintf("Page %d of %d", last+1, total)
+	if !strings.Contains(tN, wantN) {
+		t.Errorf("page %d should contain %q, got: %s", last+1, wantN, truncate(tN, 300))
+	}
+}
+
+// TestBodyCounterAgreesWithMarginBox verifies that body-flow counter(page)
+// resolves to the same value as the @page margin-box counter(page) on the
+// same page — the two render sites share one counter machinery per the
+// design.
+func TestBodyCounterAgreesWithMarginBox(t *testing.T) {
+	htmlSrc := `
+<html>
+<head><style>
+@page { @bottom-center { content: "footer page " counter(page); } }
+p.body-page::before { content: "body page " counter(page); }
+</style></head>
+<body>
+<p class="body-page"></p>
+<p>` + strings.Repeat("Filler content. ", 300) + `</p>
+<p class="body-page"></p>
+</body>
+</html>`
+
+	doc := document.NewDocument(document.PageSizeLetter)
+	if err := doc.AddHTML(htmlSrc, nil); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	r, err := reader.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.PageCount() < 2 {
+		t.Fatalf("expected at least 2 pages, got %d", r.PageCount())
+	}
+
+	for i := 0; i < r.PageCount(); i++ {
+		p, _ := r.Page(i)
+		text, _ := p.ExtractText()
+		// Footer is always present on each page.
+		wantFooter := fmt.Sprintf("footer page %d", i+1)
+		if !strings.Contains(text, wantFooter) {
+			t.Errorf("page %d footer should contain %q, got: %s", i+1, wantFooter, truncate(text, 300))
+			continue
+		}
+		// Body counter only appears on pages that contain a .body-page span;
+		// when present it must match the footer value (same machinery).
+		wantBody := fmt.Sprintf("body page %d", i+1)
+		if strings.Contains(text, "body page") && !strings.Contains(text, wantBody) {
+			t.Errorf("page %d body counter mismatch: want %q, got: %s", i+1, wantBody, truncate(text, 300))
+		}
+	}
+}
+
+// TestBodyCounterPagesPlaceholderNotLeaked guards against the legacy
+// ##TOTAL_PAGES## placeholder leaking into rendered output. The two-pass
+// emission resolves counter(pages) directly during draw — the placeholder
+// must never reach the content stream.
+func TestBodyCounterPagesPlaceholderNotLeaked(t *testing.T) {
+	htmlSrc := `
+<html>
+<head><style>
+@page { @bottom-center { content: counter(pages); } }
+p.tot::before { content: counter(pages); }
+</style></head>
+<body>
+<p class="tot"></p>
+<p>` + strings.Repeat("Body. ", 200) + `</p>
+</body>
+</html>`
+
+	doc := document.NewDocument(document.PageSizeLetter)
+	if err := doc.AddHTML(htmlSrc, nil); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(buf.Bytes(), []byte("##TOTAL_PAGES##")) {
+		t.Error("##TOTAL_PAGES## placeholder leaked into PDF output")
+	}
+}
+
+// TestBodyCounterStableAcrossDigitTransition documents that line layout
+// is decided once at measurement time, with width reserved for a fixed
+// digit budget. The number of counter-bearing blocks that fit on page 1
+// must not shift as digit count grows from 1 to 2 (page 9 → 10) — width
+// is reserved at measurement time for a max-digit string, so pagination
+// is independent of the resolved digit count.
+func TestBodyCounterStableAcrossDigitTransition(t *testing.T) {
+	mkDoc := func(forcedPages int) *bytes.Buffer {
+		var body strings.Builder
+		// Many counter-bearing paragraphs at the top — each renders
+		// a single counter via ::before. Their height (and therefore
+		// pagination) must depend only on reserved width, not on the
+		// digit count of the resolved value.
+		for i := 0; i < 40; i++ {
+			body.WriteString(`<p class="cnt"></p>`)
+		}
+		// Force the chosen page count via page-break-after blocks.
+		for i := 0; i < forcedPages-1; i++ {
+			body.WriteString(`<p style="page-break-after:always">x</p>`)
+		}
+		htmlSrc := `<html><head><style>
+p.cnt::before { content: counter(page) "/" counter(pages); }
+</style></head><body>` + body.String() + `</body></html>`
+
+		doc := document.NewDocument(document.PageSizeLetter)
+		if err := doc.AddHTML(htmlSrc, nil); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		if _, err := doc.WriteTo(&buf); err != nil {
+			t.Fatal(err)
+		}
+		return &buf
+	}
+
+	count := func(s, sub string) int {
+		n := 0
+		for i := 0; ; {
+			j := strings.Index(s[i:], sub)
+			if j < 0 {
+				return n
+			}
+			n++
+			i += j + len(sub)
+		}
+	}
+
+	// 9 pages → counter is "1/9" (3 chars). 12 pages → "1/12" (4 chars).
+	out9 := mkDoc(9)
+	r9, err := reader.Parse(out9.Bytes())
+	if err != nil {
+		t.Fatalf("n=9: parse failed: %v", err)
+	}
+	p9, _ := r9.Page(0)
+	t9, _ := p9.ExtractText()
+
+	out12 := mkDoc(12)
+	r12, err := reader.Parse(out12.Bytes())
+	if err != nil {
+		t.Fatalf("n=12: parse failed: %v", err)
+	}
+	p12, _ := r12.Page(0)
+	t12, _ := p12.ExtractText()
+
+	// Both totals must resolve correctly.
+	if !strings.Contains(t9, fmt.Sprintf("1/%d", r9.PageCount())) {
+		t.Errorf("9-page doc: expected counter %q in page 1, got: %s",
+			fmt.Sprintf("1/%d", r9.PageCount()), truncate(t9, 300))
+	}
+	if !strings.Contains(t12, fmt.Sprintf("1/%d", r12.PageCount())) {
+		t.Errorf("12-page doc: expected counter %q in page 1, got: %s",
+			fmt.Sprintf("1/%d", r12.PageCount()), truncate(t12, 300))
+	}
+
+	// Geometry stability: the number of counter-bearing paragraphs that
+	// land on page 1 must be the same in both documents. If width
+	// reservation drifted with digit count, fewer would fit when the
+	// resolved counter is 4 chars vs 3 chars.
+	c9 := count(t9, fmt.Sprintf("1/%d", r9.PageCount()))
+	c12 := count(t12, fmt.Sprintf("1/%d", r12.PageCount()))
+	if c9 != c12 {
+		t.Errorf("digit-transition layout instability: page 1 has %d counter instances at 9 pages but %d at 12 pages", c9, c12)
+	}
+	if c9 == 0 {
+		t.Errorf("expected counter instances on page 1, got none")
+	}
+}
+
+// TestBodyCounterUnusedZeroOverhead is a smoke test for the
+// no-regression promise: documents that don't use counter() in body
+// flow must produce byte-identical output across runs and contain no
+// leftover placeholder syntax.
+func TestBodyCounterUnusedZeroOverhead(t *testing.T) {
+	htmlSrc := `
+<html><body>
+<p>Plain content with no counter references.</p>
+<p>` + strings.Repeat("Word. ", 50) + `</p>
+</body></html>`
+
+	render := func() []byte {
+		doc := document.NewDocument(document.PageSizeLetter)
+		if err := doc.AddHTML(htmlSrc, nil); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		if _, err := doc.WriteTo(&buf); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+
+	out1 := render()
+	out2 := render()
+
+	leftover := regexp.MustCompile(`\{counter\((page|pages)\)\}`)
+	if leftover.Find(out1) != nil {
+		t.Error("unexpected counter placeholder in output for document that uses no counters")
+	}
+	if !bytes.Equal(out1, out2) {
+		t.Errorf("non-counter document not deterministic: %d vs %d bytes", len(out1), len(out2))
+	}
+}
+
+// TestBodyCounterInTableCell verifies that counter(page) resolves
+// inside a table cell — the body-flow counter mechanism must work for
+// content nested in <td> just as it does for free-flow blocks.
+func TestBodyCounterInTableCell(t *testing.T) {
+	htmlSrc := `
+<html>
+<head><style>
+p.pg::before { content: "p" counter(page); }
+</style></head>
+<body>
+<table><tr><td><p class="pg"></p></td><td>data</td></tr></table>
+<p>` + strings.Repeat("Filler. ", 200) + `</p>
+<table><tr><td><p class="pg"></p></td><td>more</td></tr></table>
+<p>` + strings.Repeat("More filler. ", 200) + `</p>
+<table><tr><td><p class="pg"></p></td><td>last</td></tr></table>
+</body>
+</html>`
+
+	doc := document.NewDocument(document.PageSizeLetter)
+	if err := doc.AddHTML(htmlSrc, nil); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	r, err := reader.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First table cell counter sits on page 1 — must resolve to "p1".
+	p1, _ := r.Page(0)
+	t1, _ := p1.ExtractText()
+	if !strings.Contains(t1, "p1") {
+		t.Errorf("page 1 table cell should contain 'p1', got: %s", truncate(t1, 300))
+	}
+
+	// Last table cell counter must equal its page number.
+	last := r.PageCount() - 1
+	pN, _ := r.Page(last)
+	tN, _ := pN.ExtractText()
+	wantN := fmt.Sprintf("p%d", last+1)
+	if !strings.Contains(tN, wantN) {
+		t.Errorf("last page table cell should contain %q, got: %s", wantN, truncate(tN, 300))
+	}
+
+	// Placeholder must never leak.
+	if bytes.Contains(buf.Bytes(), []byte("{counter(page)}")) {
+		t.Error("counter placeholder leaked through table-cell rendering")
+	}
+}
+
+// TestBodyCounterSinglePage verifies the degenerate case where the
+// document fits on one page — counter(pages) must resolve to 1.
+func TestBodyCounterSinglePage(t *testing.T) {
+	htmlSrc := `
+<html>
+<head><style>
+p.tot::before { content: "Page " counter(page) " of " counter(pages); }
+</style></head>
+<body>
+<p class="tot"></p>
+<p>Short content.</p>
+</body>
+</html>`
+
+	doc := document.NewDocument(document.PageSizeLetter)
+	if err := doc.AddHTML(htmlSrc, nil); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	r, err := reader.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.PageCount() != 1 {
+		t.Fatalf("expected single-page document, got %d pages", r.PageCount())
+	}
+	p1, _ := r.Page(0)
+	t1, _ := p1.ExtractText()
+	if !strings.Contains(t1, "Page 1 of 1") {
+		t.Errorf("single-page doc should resolve to 'Page 1 of 1', got: %s", truncate(t1, 300))
+	}
+}
+
+// TestBodyCounterFirstPageMargin verifies that counter() inside a
+// @page :first margin box resolves to 1 (a common cover-page pattern).
+func TestBodyCounterFirstPageMargin(t *testing.T) {
+	htmlSrc := `
+<html>
+<head><style>
+@page :first { @top-center { content: "cover " counter(page) "/" counter(pages); } }
+@page { @bottom-center { content: "p" counter(page) "/" counter(pages); } }
+</style></head>
+<body>
+<p>Cover.</p>
+<p style="page-break-before:always">` + strings.Repeat("Body. ", 200) + `</p>
+<p style="page-break-before:always">` + strings.Repeat("More. ", 200) + `</p>
+</body>
+</html>`
+
+	doc := document.NewDocument(document.PageSizeLetter)
+	if err := doc.AddHTML(htmlSrc, nil); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	r, err := reader.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	total := r.PageCount()
+	if total < 2 {
+		t.Fatalf("expected multi-page doc, got %d", total)
+	}
+	p1, _ := r.Page(0)
+	t1, _ := p1.ExtractText()
+	wantCover := fmt.Sprintf("cover 1/%d", total)
+	if !strings.Contains(t1, wantCover) {
+		t.Errorf("first page :first margin should contain %q, got: %s", wantCover, truncate(t1, 300))
+	}
+	wantFooter := fmt.Sprintf("p1/%d", total)
+	if !strings.Contains(t1, wantFooter) {
+		t.Errorf("first page footer should contain %q, got: %s", wantFooter, truncate(t1, 300))
+	}
+}

--- a/integration/running_headers_test.go
+++ b/integration/running_headers_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -55,6 +56,8 @@ h1 { string-set: chapter content(); }
 		t.Skipf("expected at least 3 pages, got %d", r.PageCount())
 	}
 
+	total := r.PageCount()
+
 	// Page 1 should have "Chapter 1" in its text (from the margin box).
 	p1, _ := r.Page(0)
 	t1, _ := p1.ExtractText()
@@ -63,10 +66,22 @@ h1 { string-set: chapter content(); }
 	}
 
 	// A later page should have a different chapter title.
-	lastPage, _ := r.Page(r.PageCount() - 1)
+	lastPage, _ := r.Page(total - 1)
 	lastText, _ := lastPage.ExtractText()
 	if !strings.Contains(lastText, "Chapter") {
 		t.Logf("last page text (may or may not have chapter header): %s", truncate(lastText, 200))
+	}
+
+	// Margin box footer must resolve counter(page) / counter(pages) on
+	// every page — these are emitted at the same time as body counters
+	// and share the two-pass machinery.
+	for i := 0; i < total; i++ {
+		p, _ := r.Page(i)
+		text, _ := p.ExtractText()
+		want := fmt.Sprintf("Page %d of %d", i+1, total)
+		if !strings.Contains(text, want) {
+			t.Errorf("page %d footer should contain %q, got: %s", i+1, want, truncate(text, 300))
+		}
 	}
 
 	// Basic validity.

--- a/layout/counter.go
+++ b/layout/counter.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"strconv"
+	"strings"
+)
+
+// CounterPagePlaceholder is the deferred sentinel produced by CSS
+// `counter(page)` evaluations whose value is not yet known when the
+// containing TextRun is built (HTML→Element conversion runs before
+// pagination). The placeholder travels through paragraph layout and is
+// substituted at content-stream emission with the resolved 1-based page
+// index. The same string is emitted by `html/page.go` for `@page`
+// margin-box content.
+const CounterPagePlaceholder = "{counter(page)}"
+
+// CounterPagesPlaceholder is the deferred sentinel for CSS
+// `counter(pages)`. It is substituted with the document's final page
+// total once pagination is complete and emission begins.
+const CounterPagesPlaceholder = "{counter(pages)}"
+
+// counterMeasureDigits is the digit string used to reserve width for a
+// counter placeholder during paragraph measurement. The reserved width
+// must be at least as wide as the worst-case substituted value so that
+// line breaks decided at layout time remain valid after substitution.
+// Four "8" digits cover documents up to 9,999 pages; "8" is chosen as a
+// conservative wide-glyph approximation. Documents exceeding this bound
+// still render correctly (substitution writes the real digits) but may
+// see counter values overflow their reserved trailing whitespace.
+const counterMeasureDigits = "8888"
+
+// substituteCounters replaces page-counter placeholders in s with their
+// resolved 1-based page index and total page count. Returns s unchanged
+// when no placeholder is present.
+func substituteCounters(s string, pageIdx, totalPages int) string {
+	if !strings.Contains(s, "{counter(") {
+		return s
+	}
+	if strings.Contains(s, CounterPagePlaceholder) {
+		s = strings.ReplaceAll(s, CounterPagePlaceholder, strconv.Itoa(pageIdx+1))
+	}
+	if strings.Contains(s, CounterPagesPlaceholder) {
+		s = strings.ReplaceAll(s, CounterPagesPlaceholder, strconv.Itoa(totalPages))
+	}
+	return s
+}
+
+// expandCountersForMeasure replaces page-counter placeholders with a
+// fixed-width digit reservation string used only for measurement. The
+// returned text is used to compute Word.Width so that line breaks are
+// stable across digit-count transitions (page 9 → 10, 99 → 100). The
+// real placeholder remains on Word.Text and is substituted at emit
+// time.
+func expandCountersForMeasure(s string) string {
+	if !strings.Contains(s, "{counter(") {
+		return s
+	}
+	s = strings.ReplaceAll(s, CounterPagePlaceholder, counterMeasureDigits)
+	s = strings.ReplaceAll(s, CounterPagesPlaceholder, counterMeasureDigits)
+	return s
+}
+
+// hasCounterPlaceholder reports whether s contains a page-counter
+// placeholder needing emit-time substitution.
+func hasCounterPlaceholder(s string) bool {
+	return strings.Contains(s, CounterPagePlaceholder) || strings.Contains(s, CounterPagesPlaceholder)
+}

--- a/layout/counter_test.go
+++ b/layout/counter_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import "testing"
+
+func TestSubstituteCountersResolvesPageAndPages(t *testing.T) {
+	got := substituteCounters("Page "+CounterPagePlaceholder+" of "+CounterPagesPlaceholder, 2, 7)
+	want := "Page 3 of 7"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSubstituteCountersIsNoopWhenAbsent(t *testing.T) {
+	in := "no placeholders here"
+	if got := substituteCounters(in, 0, 5); got != in {
+		t.Errorf("expected unchanged %q, got %q", in, got)
+	}
+}
+
+func TestExpandCountersForMeasureUsesDigitReservation(t *testing.T) {
+	got := expandCountersForMeasure(CounterPagePlaceholder)
+	if got != counterMeasureDigits {
+		t.Errorf("page reservation: got %q, want %q", got, counterMeasureDigits)
+	}
+	got = expandCountersForMeasure(CounterPagesPlaceholder)
+	if got != counterMeasureDigits {
+		t.Errorf("pages reservation: got %q, want %q", got, counterMeasureDigits)
+	}
+}
+
+func TestHasCounterPlaceholderDetectsBoth(t *testing.T) {
+	if !hasCounterPlaceholder("Page " + CounterPagePlaceholder) {
+		t.Error("page placeholder should be detected")
+	}
+	if !hasCounterPlaceholder(CounterPagesPlaceholder + " total") {
+		t.Error("pages placeholder should be detected")
+	}
+	if hasCounterPlaceholder("plain text") {
+		t.Error("plain text should not be flagged")
+	}
+}
+
+func TestSubstituteCountersIgnoresUnknownCounterTokens(t *testing.T) {
+	// A future or user-defined counter name (e.g. {counter(chapter)}) that
+	// looks like a placeholder but isn't one of the two known names must
+	// pass through unchanged — substitution only resolves page/pages.
+	in := "see {counter(chapter)} for details"
+	if got := substituteCounters(in, 0, 5); got != in {
+		t.Errorf("unknown counter token should pass through: got %q, want %q", got, in)
+	}
+	if got := expandCountersForMeasure(in); got != in {
+		t.Errorf("unknown counter token should not be expanded: got %q, want %q", got, in)
+	}
+	if hasCounterPlaceholder(in) {
+		t.Error("unknown counter token should not register as a placeholder")
+	}
+}

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -132,6 +132,15 @@ func drawTextLine(ctx DrawContext, words []Word, x, baselineY, maxWidth float64,
 	curColor := Color{R: -1, G: -1, B: -1}
 	curX := x
 	for i, word := range words {
+		// Resolve CSS counter(page)/counter(pages) placeholders carried
+		// in body-flow text. The reserved width was computed at layout
+		// time; substituted digits fit within it for typical document
+		// lengths. Width is intentionally not recomputed: keeping the
+		// reservation preserves stable line breaks across digit-count
+		// transitions (page 9→10, 99→100).
+		if hasCounterPlaceholder(word.Text) {
+			word.Text = substituteCounters(word.Text, ctx.PageIdx, ctx.TotalPages)
+		}
 		// Inline-block words: skip text rendering (rendered as child PlacedBlocks).
 		if word.InlineBlock != nil {
 			if i < len(words)-1 {

--- a/layout/layouter.go
+++ b/layout/layouter.go
@@ -102,6 +102,16 @@ type DrawContext struct {
 	// its actualText field; tests that build a DrawContext directly may
 	// leave it false to suppress emission.
 	ActualText bool
+	// PageIdx is the 0-based index of the page this draw call targets.
+	// Used to substitute CSS counter(page) placeholders in body-flow
+	// text. Tests building a DrawContext for non-paged rendering may
+	// leave this zero.
+	PageIdx int
+	// TotalPages is the final page count of the document, set during the
+	// emission pass after pagination completes. Used to substitute
+	// counter(pages) placeholders. Zero indicates the count is not yet
+	// known; placeholders remain in the emitted text in that case.
+	TotalPages int
 }
 
 // measureConsumed returns the height an element consumes at the given width.

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -544,9 +544,18 @@ func shapeAndMeasureWord(w *Word, run TextRun, measurer font.TextMeasurer) {
 
 	// Arabic / general rune path.
 	w.Text = ShapeArabic(w.Text)
-	w.Width = measurer.MeasureString(w.Text, run.FontSize)
-	if run.LetterSpacing != 0 && len([]rune(w.Text)) > 1 {
-		w.Width += run.LetterSpacing * float64(len([]rune(w.Text))-1)
+	// CSS counter(page) / counter(pages) placeholders are resolved at
+	// content-stream emission once pagination is final. Measure them
+	// here using a fixed-digit reservation so line breaks stay valid
+	// after substitution. Width of the actual digits is bounded by the
+	// reserved width for typical document lengths.
+	measureText := w.Text
+	if hasCounterPlaceholder(measureText) {
+		measureText = expandCountersForMeasure(measureText)
+	}
+	w.Width = measurer.MeasureString(measureText, run.FontSize)
+	if run.LetterSpacing != 0 && len([]rune(measureText)) > 1 {
+		w.Width += run.LetterSpacing * float64(len([]rune(measureText))-1)
 	}
 	if w.Text != origText {
 		w.OriginalText = origText
@@ -1244,9 +1253,13 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 				if punct != "" {
 					prev.Text += punct
 					prevMeasurer := wordMeasurer(*prev)
-					prev.Width = prevMeasurer.MeasureString(prev.Text, prev.FontSize)
+					prevMeasureText := prev.Text
+					if hasCounterPlaceholder(prevMeasureText) {
+						prevMeasureText = expandCountersForMeasure(prevMeasureText)
+					}
+					prev.Width = prevMeasurer.MeasureString(prevMeasureText, prev.FontSize)
 					if prev.LetterSpacing != 0 {
-						prev.Width += prev.LetterSpacing * float64(len([]rune(prev.Text))-1)
+						prev.Width += prev.LetterSpacing * float64(len([]rune(prevMeasureText))-1)
 					}
 					text = rest
 				}

--- a/layout/render_plans.go
+++ b/layout/render_plans.go
@@ -39,11 +39,19 @@ func (r *Renderer) renderWithPlans() []PageResult {
 	queue := make([]Element, len(r.elements))
 	copy(queue, r.elements)
 
+	// Per-page record captured during pagination. Drawing is deferred to
+	// a second pass so DrawContext.TotalPages can carry the final page
+	// count when CSS counter(pages) placeholders are substituted in body
+	// flow text. This also lets margin boxes resolve counter(pages)
+	// directly without relying on a post-stream byte replacement.
+	type pageRecord struct {
+		blocks  []PlacedBlock
+		margins Margins
+		idx     int
+	}
+	var records []pageRecord
+
 	var curBlocks []PlacedBlock
-	curPageStream := content.NewStream()
-	curFonts := []FontEntry{}
-	curImages := []ImageEntry{}
-	curLinks := []LinkArea{}
 	remainingHeight := usableHeight
 	curY := 0.0
 	pageIdx := 0
@@ -55,45 +63,18 @@ func (r *Renderer) renderWithPlans() []PageResult {
 		r.captureStringSets(curBlocks)
 		r.snapshotStrings()
 
-		// Draw all placed blocks into the content stream.
-		ctx := DrawContext{
-			Stream: curPageStream,
-			Page: &PageResult{
-				Stream: curPageStream,
-				Fonts:  curFonts,
-				Images: curImages,
-				Links:  curLinks,
-			},
-			ActualText: r.actualText,
-		}
-		for _, block := range curBlocks {
-			drawBlock(block, curMargins.Left, r.pageHeight-curMargins.Top, &ctx, r.tagged, &r.structTags, pageIdx)
-		}
-
-		// Draw margin boxes (headers/footers from @page CSS).
-		totalPages := len(queue) // approximate; will be corrected in second pass
-		_ = totalPages
-		r.drawMarginBoxes(&ctx, pageIdx, curMargins)
-
-		pages = append(pages, PageResult{
-			Stream:     curPageStream,
-			Fonts:      ctx.Page.Fonts,
-			Images:     ctx.Page.Images,
-			Links:      ctx.Page.Links,
-			ExtGStates: ctx.Page.ExtGStates,
-			Headings:   ctx.Page.Headings,
+		records = append(records, pageRecord{
+			blocks:  curBlocks,
+			margins: curMargins,
+			idx:     pageIdx,
 		})
 	}
 
 	startNewPage := func() {
-		if len(curBlocks) > 0 || curPageStream.Bytes() != nil {
+		if len(curBlocks) > 0 {
 			flushPage()
 		}
 		curBlocks = nil
-		curPageStream = content.NewStream()
-		curFonts = nil
-		curImages = nil
-		curLinks = nil
 		pageIdx++
 		// Recalculate margins for the new page.
 		maxWidth, usableHeight, curMargins = pageMarginsFor(pageIdx)
@@ -149,10 +130,6 @@ func (r *Renderer) renderWithPlans() []PageResult {
 		if _, ok := elem.(*AreaBreak); ok {
 			flushPage()
 			curBlocks = nil
-			curPageStream = content.NewStream()
-			curFonts = nil
-			curImages = nil
-			curLinks = nil
 			remainingHeight = usableHeight
 			curY = 0
 			floats = nil
@@ -279,12 +256,40 @@ func (r *Renderer) renderWithPlans() []PageResult {
 	// Flush the last page.
 	if len(curBlocks) > 0 {
 		flushPage()
-	} else if len(pages) == 0 {
+	} else if len(records) == 0 {
 		// Ensure at least one page.
 		if autoHeight {
 			r.pageHeight = r.margins.Top + r.margins.Bottom
 		}
-		pages = append(pages, PageResult{Stream: content.NewStream()})
+		records = append(records, pageRecord{idx: 0, margins: r.marginsForPage(0)})
+	}
+
+	// Emission pass: now that pagination is final, draw each page with
+	// the resolved total page count available for counter(pages)
+	// substitution.
+	totalPages := len(records)
+	for _, rec := range records {
+		stream := content.NewStream()
+		page := &PageResult{Stream: stream}
+		ctx := DrawContext{
+			Stream:     stream,
+			Page:       page,
+			ActualText: r.actualText,
+			PageIdx:    rec.idx,
+			TotalPages: totalPages,
+		}
+		for _, block := range rec.blocks {
+			drawBlock(block, rec.margins.Left, r.pageHeight-rec.margins.Top, &ctx, r.tagged, &r.structTags, rec.idx)
+		}
+		r.drawMarginBoxes(&ctx, rec.idx, rec.margins)
+		pages = append(pages, PageResult{
+			Stream:     stream,
+			Fonts:      page.Fonts,
+			Images:     page.Images,
+			Links:      page.Links,
+			ExtGStates: page.ExtGStates,
+			Headings:   page.Headings,
+		})
 	}
 
 	// Tag auto-height pages with their computed height.
@@ -295,7 +300,7 @@ func (r *Renderer) renderWithPlans() []PageResult {
 	}
 
 	// Render absolutely positioned elements.
-	r.renderAbsolutes(pages, maxWidth)
+	r.renderAbsolutes(pages, maxWidth, totalPages)
 
 	return pages
 }
@@ -410,7 +415,10 @@ func headingLevel(tag string) int {
 // renderAbsolutes lays out and draws absolutely positioned elements
 // onto the appropriate pages. Elements with negative z-index are
 // prepended (rendered behind normal flow); others are appended (on top).
-func (r *Renderer) renderAbsolutes(pages []PageResult, defaultWidth float64) {
+// totalPages carries the document's final page count so that any CSS
+// counter(pages) placeholders inside absolute-positioned text resolve
+// to the same value used by body and margin-box content.
+func (r *Renderer) renderAbsolutes(pages []PageResult, defaultWidth float64, totalPages int) {
 	lastPage := len(pages) - 1
 
 	for _, item := range r.absolutes {
@@ -445,13 +453,25 @@ func (r *Renderer) renderAbsolutes(pages []PageResult, defaultWidth float64) {
 		if item.zIndex < 0 {
 			// Render into a temporary stream and prepend to draw behind flow content.
 			bgStream := content.NewStream()
-			bgCtx := DrawContext{Stream: bgStream, Page: page, ActualText: r.actualText}
+			bgCtx := DrawContext{
+				Stream:     bgStream,
+				Page:       page,
+				ActualText: r.actualText,
+				PageIdx:    pageIdx,
+				TotalPages: totalPages,
+			}
 			for _, block := range plan.Blocks {
 				drawBlock(block, x, item.y, &bgCtx, r.tagged, &r.structTags, pageIdx)
 			}
 			page.Stream.PrependBytes(bgStream.Bytes())
 		} else {
-			ctx := DrawContext{Stream: page.Stream, Page: page, ActualText: r.actualText}
+			ctx := DrawContext{
+				Stream:     page.Stream,
+				Page:       page,
+				ActualText: r.actualText,
+				PageIdx:    pageIdx,
+				TotalPages: totalPages,
+			}
 			for _, block := range plan.Blocks {
 				drawBlock(block, x, item.y, &ctx, r.tagged, &r.structTags, pageIdx)
 			}

--- a/layout/renderer.go
+++ b/layout/renderer.go
@@ -204,8 +204,11 @@ func (r *Renderer) drawMarginBoxes(ctx *DrawContext, pageIdx int, margins Margin
 			continue
 		}
 		// Resolve {counter(page)} and {counter(pages)} placeholders.
-		text = strings.ReplaceAll(text, "{counter(page)}", fmt.Sprintf("%d", pageIdx+1))
-		text = strings.ReplaceAll(text, "{counter(pages)}", "##TOTAL_PAGES##")
+		// pageIdx is 0-based; counter(page) is 1-based per CSS GCPM.
+		// counter(pages) uses ctx.TotalPages, set during the emission
+		// pass once pagination is final.
+		text = strings.ReplaceAll(text, CounterPagePlaceholder, fmt.Sprintf("%d", pageIdx+1))
+		text = strings.ReplaceAll(text, CounterPagesPlaceholder, fmt.Sprintf("%d", ctx.TotalPages))
 
 		// Resolve {string(name)} placeholders from CSS string-set.
 		text = r.resolveStringRefs(text, pageIdx)


### PR DESCRIPTION
## Summary
- Extends CSS GCPM page counters so `counter(page)` and `counter(pages)` resolve when used in `content:` on body-flow elements (`::before` / `::after`), not only inside `@page` margin boxes.
- Two-pass emission: pagination is decided once, then a second pass draws each page with the final page total available — so `counter(pages)` is substituted directly during draw rather than via a post-stream byte replace.
- Layout-time width reservation for counter placeholders keeps line breaks stable across digit-count transitions (page 9 → 10, 99 → 100).
- Retires the `##TOTAL_PAGES##` post-stream replacement; margin boxes now resolve `counter(pages)` directly through `DrawContext.TotalPages`.

## Design
Mirrors the existing `@page` margin-box machinery (parser → placeholder → emit-time substitution), now reachable from body flow. The HTML converter emits `{counter(page)}` / `{counter(pages)}` placeholders for the `page` and `pages` CSS counters (other counters keep their existing HTML-conversion-time resolution). Paragraph measurement expands placeholders to a fixed-digit reservation string before measuring, so `Word.Width` is computed against the reserved width while `Word.Text` keeps the placeholder. `drawTextLine` substitutes placeholders at emit time using `DrawContext.PageIdx` / `DrawContext.TotalPages`.

To make `TotalPages` available to body-text emission, `renderWithPlans` records per-page state (blocks + margins + index) during pagination and runs a single emission pass once pagination is final. This preserves the immutable `LayoutPlan` invariant from `ARCHITECTURE.md` §6.

## Out of scope (filed as follow-up)
- `target-counter(url(#anchor), page)` for body-flow cross-references — separate issue.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (full suite)
- [x] New layout unit tests for placeholder helpers (`layout/counter_test.go`)
- [x] New integration tests for body-flow counters (`integration/body_counter_test.go`):
  - `counter(page)` / `counter(pages)` resolve correctly per page
  - Body counter agrees with `@page` margin box counter
  - `##TOTAL_PAGES##` placeholder never leaks into PDF output
  - Layout stable across 1→2 digit transition (9 vs 12 pages)
  - No regression for documents that don't use the helpers