### PR TITLE
font: add Fallback for cross-script font dispatch (Phase 1 of #192)

### DIFF
--- a/examples/rtl/main.go
+++ b/examples/rtl/main.go
@@ -260,6 +260,42 @@ func main() {
 		doc.Add(left)
 	}
 
+	// --- Section 5: Mixed-script fallback in one paragraph ---
+
+	doc.Add(layout.NewHeading("5. Mixed-Script Fallback (Phase 1)", layout.H2))
+
+	doc.Add(makeParagraph(
+		"font.NewFallback wraps an ordered list of faces. Each script run "+
+			"in the input string is dispatched to the first face that covers "+
+			"its base codepoint, so a paragraph mixing Latin, Hebrew, and "+
+			"Arabic in one string renders without the caller pre-splitting "+
+			"into separate runs. Cross-script fallback only in this phase: "+
+			"intra-script coverage gaps still produce .notdef tofu.",
+		nil, font.Helvetica, 11,
+	))
+
+	if hebrewEF != nil && arabicEF != nil {
+		// Build a fallback chain. The Hebrew face is preferred for
+		// Hebrew runs and the Arabic face for Arabic runs. Each script
+		// run in the input is dispatched to the first face that covers
+		// its script-defining rune, so a paragraph with Hebrew and
+		// Arabic in one string renders without the caller pre-splitting
+		// into per-font runs. Latin glyphs land on whichever face the
+		// chain happens to cover them with first; in this string there
+		// is no Latin, so the demonstration stays focused on the
+		// cross-script dispatch the feature is built for.
+		fb := font.NewFallback(hebrewEF, arabicEF)
+		// "שלום بسم" — Hebrew + Arabic in one string, separated by
+		// inter-script whitespace. SegmentByScript collapses the space
+		// into the surrounding scripts; the fallback routes each script
+		// run to its own face.
+		mixed := layout.NewParagraphFallback(
+			"\u05E9\u05DC\u05D5\u05DD \u0628\u0633\u0645",
+			fb, 16,
+		)
+		doc.Add(mixed)
+	}
+
 	// --- Save ---
 
 	if err := doc.Save("rtl.pdf"); err != nil {

--- a/font/fallback.go
+++ b/font/fallback.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import "strconv"
+
+// Fallback wraps an ordered list of EmbeddedFont pointers used to render
+// mixed-script text without forcing the caller to pre-split runs by font.
+// It is a coverage dispatcher only: PickFace returns the first face whose
+// cmap covers a given rune, falling back to the first face when nothing
+// covers it. Segmentation, shaping, and PDF emission stay in the layers
+// that already own them.
+//
+// Pointer identity matters. Fallback stores the original *EmbeddedFont
+// pointers verbatim and never wraps or copies them. Subsetting,
+// ToUnicode CMap generation, and the page-level font resource map all
+// dedupe by pointer (one Type0 dict per *EmbeddedFont per document), so
+// passing the same Fallback to many paragraphs aggregates used glyphs on
+// the shared faces instead of inflating the resource count.
+//
+// Concurrency: Fallback methods are read-only and safe to call from
+// multiple goroutines. Each underlying EmbeddedFont still carries the
+// non-concurrent invariant documented on its type.
+type Fallback struct {
+	faces []*EmbeddedFont
+}
+
+// NewFallback returns a Fallback over the given faces, in priority order.
+// PickFace tries faces[0] first, then faces[1], and so on. Panics if no
+// faces are provided: a fallback with no faces has no defined behavior
+// and almost certainly indicates a caller error.
+func NewFallback(faces ...*EmbeddedFont) *Fallback {
+	if len(faces) == 0 {
+		panic("font.NewFallback: at least one face is required")
+	}
+	for i, f := range faces {
+		if f == nil {
+			panic("font.NewFallback: nil face at index " + strconv.Itoa(i))
+		}
+	}
+	return &Fallback{faces: faces}
+}
+
+// Faces returns the underlying face slice in priority order. The returned
+// slice aliases the Fallback's storage; callers must not mutate it.
+func (fb *Fallback) Faces() []*EmbeddedFont {
+	return fb.faces
+}
+
+// PickFace returns the first face that has a glyph for r. If no face
+// covers r, the first face is returned so the caller still has something
+// to render with (the missing glyph will appear as .notdef tofu, which
+// is the conventional indicator that the document needs a broader
+// fallback chain).
+func (fb *Fallback) PickFace(r rune) *EmbeddedFont {
+	for _, ef := range fb.faces {
+		if ef.face.GlyphIndex(r) != 0 {
+			return ef
+		}
+	}
+	return fb.faces[0]
+}

--- a/font/fallback_test.go
+++ b/font/fallback_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"testing"
+)
+
+// fakeFace is a minimal Face implementation that resolves rune coverage
+// from an explicit allowlist. Used to test Fallback dispatch without
+// requiring real font files on the system.
+type fakeFace struct {
+	covers map[rune]uint16 // rune -> non-zero gid; missing rune -> 0 (.notdef)
+}
+
+func newFakeFace(runes ...rune) *fakeFace {
+	covers := make(map[rune]uint16, len(runes))
+	for i, r := range runes {
+		covers[r] = uint16(i + 1) // any non-zero gid suffices
+	}
+	return &fakeFace{covers: covers}
+}
+
+func (f *fakeFace) PostScriptName() string    { return "FakeFace" }
+func (f *fakeFace) UnitsPerEm() int           { return 1000 }
+func (f *fakeFace) GlyphIndex(r rune) uint16  { return f.covers[r] }
+func (f *fakeFace) GlyphAdvance(_ uint16) int { return 500 }
+func (f *fakeFace) Ascent() int               { return 800 }
+func (f *fakeFace) Descent() int              { return -200 }
+func (f *fakeFace) BBox() [4]int              { return [4]int{0, -200, 1000, 800} }
+func (f *fakeFace) ItalicAngle() float64      { return 0 }
+func (f *fakeFace) CapHeight() int            { return 700 }
+func (f *fakeFace) StemV() int                { return 80 }
+func (f *fakeFace) Kern(_, _ uint16) int      { return 0 }
+func (f *fakeFace) Flags() uint32             { return 0 }
+func (f *fakeFace) RawData() []byte           { return nil }
+func (f *fakeFace) NumGlyphs() int            { return len(f.covers) + 1 }
+
+func TestNewFallbackPanicsOnEmpty(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewFallback() with no faces should panic")
+		}
+	}()
+	_ = NewFallback()
+}
+
+func TestNewFallbackPanicsOnNil(t *testing.T) {
+	ef := NewEmbeddedFont(newFakeFace('a'))
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewFallback with nil entry should panic")
+		}
+	}()
+	_ = NewFallback(ef, nil)
+}
+
+func TestFallbackPickFaceFirstHit(t *testing.T) {
+	latin := NewEmbeddedFont(newFakeFace('H', 'e', 'l', 'o'))
+	hebrew := NewEmbeddedFont(newFakeFace('\u05E9', '\u05DC', '\u05D5', '\u05DD'))
+	fb := NewFallback(latin, hebrew)
+
+	tests := []struct {
+		name string
+		r    rune
+		want *EmbeddedFont
+	}{
+		{"latin H lands on first face", 'H', latin},
+		{"hebrew shin lands on second face", '\u05E9', hebrew},
+		{"missing rune falls back to first face", '\u4E2D', latin}, // Han, neither covers
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fb.PickFace(tc.r)
+			if got != tc.want {
+				t.Errorf("PickFace(%U): got face=%p, want %p", tc.r, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFallbackFacesPreservesPointerOrder(t *testing.T) {
+	a := NewEmbeddedFont(newFakeFace('a'))
+	b := NewEmbeddedFont(newFakeFace('b'))
+	c := NewEmbeddedFont(newFakeFace('c'))
+	fb := NewFallback(a, b, c)
+
+	got := fb.Faces()
+	want := []*EmbeddedFont{a, b, c}
+	if len(got) != len(want) {
+		t.Fatalf("Faces() returned %d entries, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Faces()[%d] = %p, want %p", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFallbackSubsetAggregatesUsedGlyphsOnSharedPointer(t *testing.T) {
+	// Acceptance criterion #4 in #192: subsetting produces one font
+	// resource per underlying face, each containing only the glyphs
+	// used from that face. The mechanism is pointer dedupe: when the
+	// same *EmbeddedFont is referenced from many TextRuns, every
+	// EncodeString call accumulates onto the same usedGlyphs map, so
+	// BuildObjects sees the union of glyphs across the document.
+	//
+	// This test simulates the layout layer's behaviour by encoding
+	// distinct Hebrew strings through the same *EmbeddedFont returned
+	// by the Fallback's PickFace, then asserting the aggregated glyph
+	// set covers every input rune. If a future refactor wraps or
+	// copies *EmbeddedFont inside Fallback, the encodings would
+	// accumulate on disjoint maps and this test would fail.
+	latin := NewEmbeddedFont(newFakeFace('a'))
+	hebrew := NewEmbeddedFont(newFakeFace('\u05E9', '\u05DC', '\u05D5', '\u05DD'))
+	fb := NewFallback(latin, hebrew)
+
+	face1 := fb.PickFace('\u05E9')
+	face1.EncodeString("\u05E9\u05DC")
+	face2 := fb.PickFace('\u05D5')
+	face2.EncodeString("\u05D5\u05DD")
+
+	// Both encodings must have landed on the same hebrew pointer.
+	if face1 != hebrew || face2 != hebrew {
+		t.Fatalf("PickFace returned a non-identity pointer: face1=%p face2=%p hebrew=%p",
+			face1, face2, hebrew)
+	}
+	want := []rune{'\u05E9', '\u05DC', '\u05D5', '\u05DD'}
+	for _, r := range want {
+		gid := hebrew.face.GlyphIndex(r)
+		if _, ok := hebrew.usedGlyphs[gid]; !ok {
+			t.Errorf("glyph for %U not aggregated on shared pointer", r)
+		}
+	}
+}
+
+func TestFallbackPointerIdentityShared(t *testing.T) {
+	// Pointer dedupe is the load-bearing invariant for subsetting and
+	// ToUnicode emission: PickFace must return the original *EmbeddedFont
+	// stored on the Fallback, never a copy or a wrapper. If this ever
+	// regresses, the page resource map will stop deduping and a document
+	// that uses the Fallback in many paragraphs will balloon its font
+	// dictionary count.
+	latin := NewEmbeddedFont(newFakeFace('a', 'b'))
+	hebrew := NewEmbeddedFont(newFakeFace('\u05E9'))
+	fb := NewFallback(latin, hebrew)
+
+	if fb.PickFace('a') != latin {
+		t.Error("PickFace('a') returned a non-identical face pointer")
+	}
+	if fb.PickFace('\u05E9') != hebrew {
+		t.Error("PickFace(shin) returned a non-identical face pointer")
+	}
+}

--- a/layout/fallback.go
+++ b/layout/fallback.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"unicode/utf8"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// NewParagraphFallback creates a paragraph that mixes scripts in a single
+// string by dispatching each script run to the first face in fb that
+// covers its base codepoint. Internally the paragraph is built as N
+// TextRuns, one per (face, substring) segment, so the rest of the
+// pipeline (shaping, measurement, drawing, subsetting, ToUnicode) runs
+// unchanged on each segment.
+//
+// Phase 1 scope: cross-script fallback only. A whole script run (per UAX
+// #24, with Common/Inherited resolved against neighbours) is locked to a
+// single face so that per-script shapers (Arabic positional joining,
+// Devanagari cluster formation, GPOS mark-to-base) see a coherent input.
+// Within-script coverage gaps -- e.g. a Latin face missing U+1E9E -- are
+// not yet resolved and will render as .notdef tofu; this is a Phase 2
+// extension that requires per-cluster face dispatch with shaper
+// coordination.
+//
+// Pointer identity: the *EmbeddedFont pointers stored on Fallback are
+// passed verbatim into the generated TextRuns. The page-level font
+// resource map dedupes by pointer, so the document still emits one
+// Type0 font dict per underlying face regardless of how many paragraphs
+// share the Fallback.
+//
+// Panics if fb is nil or fontSize is not positive.
+func NewParagraphFallback(text string, fb *font.Fallback, fontSize float64) *Paragraph {
+	if fb == nil {
+		panic("layout.NewParagraphFallback: nil fallback")
+	}
+	if fontSize <= 0 {
+		panic("layout.NewParagraphFallback: fontSize must be positive")
+	}
+	text = normalizeText(text)
+	segs := segmentByFallback(text, fb)
+	runs := make([]TextRun, len(segs))
+	for i, seg := range segs {
+		runs[i] = TextRun{Text: seg.Text, Embedded: seg.Face, FontSize: fontSize}
+	}
+	return &Paragraph{
+		runs:    runs,
+		leading: 1.2,
+		align:   AlignLeft,
+	}
+}
+
+// fallbackSegment is a contiguous byte range of the source string that
+// has been assigned to a single face. Adjacent segments that share a
+// face are merged at construction time so callers see the minimum number
+// of runs for a given input.
+type fallbackSegment struct {
+	Face *font.EmbeddedFont
+	Text string
+}
+
+// segmentByFallback walks the script runs of text and assigns each one
+// to a single face from fb. The face is chosen by probing fb against
+// the first base rune of the script run (i.e. the rune whose script
+// caused the run to exist); if no face covers that rune, fb falls back
+// to the first face. Consecutive script runs that resolve to the same
+// face are coalesced into one segment so that downstream wrapping and
+// measurement see a flat, minimal run list.
+//
+// An empty text input yields a single empty segment bound to the first
+// face. This matches NewParagraphEmbedded's behaviour of always emitting
+// at least one run, so the rest of the layout pipeline (which assumes
+// every paragraph has runs) never has to special-case empty input.
+func segmentByFallback(text string, fb *font.Fallback) []fallbackSegment {
+	faces := fb.Faces()
+	if text == "" {
+		return []fallbackSegment{{Face: faces[0]}}
+	}
+
+	scriptRuns := SegmentByScript(text)
+	if len(scriptRuns) == 0 {
+		return []fallbackSegment{{Face: faces[0], Text: text}}
+	}
+
+	out := make([]fallbackSegment, 0, len(scriptRuns))
+	for _, sr := range scriptRuns {
+		sub := text[sr.Start:sr.End]
+		probe := probeRune(sub, sr.Script)
+		face := fb.PickFace(probe)
+		if n := len(out); n > 0 && out[n-1].Face == face {
+			out[n-1].Text += sub
+			continue
+		}
+		out = append(out, fallbackSegment{Face: face, Text: sub})
+	}
+	return out
+}
+
+// probeRune returns the rune that should drive face selection for a
+// script run. SegmentByScript promotes leading Common runes (spaces,
+// punctuation, digits) into the script of their right neighbour via a
+// reverse sweep, so the literal first rune of a script run is often a
+// Common codepoint that has nothing to do with the run's resolved
+// script. Probing on it would route the whole run to whatever face
+// covers space/punctuation first (typically the Latin face), even
+// when the run is Hebrew or Arabic.
+//
+// To avoid that miss, walk forward to the first rune whose own script
+// matches the run's resolved script. That rune is the script's natural
+// "base" and represents the coverage requirement for the segment. For
+// pure-Common runs (e.g. "..."), no rune satisfies the match; return
+// the first rune so the caller still has something to probe.
+func probeRune(s string, want Script) rune {
+	if s == "" {
+		return 0
+	}
+	first, _ := utf8.DecodeRuneInString(s)
+	if first == utf8.RuneError {
+		return 0
+	}
+	if want == ScriptCommon {
+		return first
+	}
+	for _, r := range s {
+		if ScriptOf(r) == want {
+			return r
+		}
+	}
+	return first
+}

--- a/layout/fallback_test.go
+++ b/layout/fallback_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// fakeFace is a stub font.Face that resolves rune coverage from an
+// explicit allowlist. It exists so the fallback tests can probe
+// segmentation behaviour without depending on system fonts (which would
+// make tests skip on machines without Hebrew or Devanagari coverage).
+type fakeFace struct {
+	covers map[rune]uint16
+}
+
+func newFakeFace(runes ...rune) *fakeFace {
+	covers := make(map[rune]uint16, len(runes))
+	for i, r := range runes {
+		covers[r] = uint16(i + 1)
+	}
+	return &fakeFace{covers: covers}
+}
+
+func (f *fakeFace) PostScriptName() string    { return "FakeFace" }
+func (f *fakeFace) UnitsPerEm() int           { return 1000 }
+func (f *fakeFace) GlyphIndex(r rune) uint16  { return f.covers[r] }
+func (f *fakeFace) GlyphAdvance(_ uint16) int { return 500 }
+func (f *fakeFace) Ascent() int               { return 800 }
+func (f *fakeFace) Descent() int              { return -200 }
+func (f *fakeFace) BBox() [4]int              { return [4]int{0, -200, 1000, 800} }
+func (f *fakeFace) ItalicAngle() float64      { return 0 }
+func (f *fakeFace) CapHeight() int            { return 700 }
+func (f *fakeFace) StemV() int                { return 80 }
+func (f *fakeFace) Kern(_, _ uint16) int      { return 0 }
+func (f *fakeFace) Flags() uint32             { return 0 }
+func (f *fakeFace) RawData() []byte           { return nil }
+func (f *fakeFace) NumGlyphs() int            { return len(f.covers) + 1 }
+
+func TestNewParagraphFallbackPanicsOnNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewParagraphFallback with nil fallback should panic")
+		}
+	}()
+	_ = NewParagraphFallback("hi", nil, 12)
+}
+
+func TestNewParagraphFallbackPanicsOnFontSize(t *testing.T) {
+	ef := font.NewEmbeddedFont(newFakeFace('a'))
+	fb := font.NewFallback(ef)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("NewParagraphFallback with fontSize<=0 should panic")
+		}
+	}()
+	_ = NewParagraphFallback("hi", fb, 0)
+}
+
+func TestNewParagraphFallbackEmptyText(t *testing.T) {
+	// Empty input must still emit a single run so the rest of the layout
+	// pipeline (which assumes every paragraph has at least one run)
+	// doesn't have to special-case empty paragraphs.
+	ef := font.NewEmbeddedFont(newFakeFace('a'))
+	fb := font.NewFallback(ef)
+	p := NewParagraphFallback("", fb, 12)
+	runs := p.Runs()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run for empty text, got %d", len(runs))
+	}
+	if runs[0].Embedded != ef {
+		t.Errorf("empty-text run face = %p, want %p", runs[0].Embedded, ef)
+	}
+	if runs[0].Text != "" {
+		t.Errorf("empty-text run text = %q, want empty", runs[0].Text)
+	}
+}
+
+func TestNewParagraphFallbackSingleScript(t *testing.T) {
+	// Pure-Latin input must collapse to one run on the Latin face even
+	// though both faces are in the chain. Multiple runs here would
+	// pessimise wrapping and inflate the resource map.
+	latin := font.NewEmbeddedFont(newFakeFace('H', 'e', 'l', 'o'))
+	hebrew := font.NewEmbeddedFont(newFakeFace('\u05E9'))
+	fb := font.NewFallback(latin, hebrew)
+
+	p := NewParagraphFallback("Hello", fb, 12)
+	runs := p.Runs()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if runs[0].Embedded != latin {
+		t.Errorf("run face = %p, want latin %p", runs[0].Embedded, latin)
+	}
+	if runs[0].Text != "Hello" {
+		t.Errorf("run text = %q, want %q", runs[0].Text, "Hello")
+	}
+}
+
+func TestNewParagraphFallbackMixedScripts(t *testing.T) {
+	// Latin + Hebrew + Arabic in one input should produce three runs
+	// each bound to its own face, in source order. Coverage misses
+	// (the leading-space ASCII codepoint resolved to Hebrew via the
+	// "Common runs inherit from neighbours" rule in SegmentByScript)
+	// must not split a script run.
+	latin := font.NewEmbeddedFont(newFakeFace('H', 'e', 'l', 'o', ' '))
+	hebrew := font.NewEmbeddedFont(newFakeFace('\u05E9', '\u05DC', '\u05D5', '\u05DD', ' '))
+	arabic := font.NewEmbeddedFont(newFakeFace('\u0628', '\u0633', '\u0645', ' '))
+	fb := font.NewFallback(latin, hebrew, arabic)
+
+	// "Hello שלום بسم"
+	p := NewParagraphFallback("Hello \u05E9\u05DC\u05D5\u05DD \u0628\u0633\u0645", fb, 12)
+	runs := p.Runs()
+	if len(runs) != 3 {
+		t.Fatalf("expected 3 runs, got %d", len(runs))
+	}
+	if runs[0].Embedded != latin {
+		t.Errorf("run[0] face = %p, want latin %p", runs[0].Embedded, latin)
+	}
+	if runs[1].Embedded != hebrew {
+		t.Errorf("run[1] face = %p, want hebrew %p", runs[1].Embedded, hebrew)
+	}
+	if runs[2].Embedded != arabic {
+		t.Errorf("run[2] face = %p, want arabic %p", runs[2].Embedded, arabic)
+	}
+}
+
+func TestNewParagraphFallbackCoalescesAdjacentSameFace(t *testing.T) {
+	// Latin -> Common (digits) -> Latin should resolve to a single Latin
+	// run after script segmentation merges Commons into their neighbours,
+	// not three runs.
+	latin := font.NewEmbeddedFont(newFakeFace('H', 'i', '4', '2'))
+	hebrew := font.NewEmbeddedFont(newFakeFace('\u05E9'))
+	fb := font.NewFallback(latin, hebrew)
+
+	p := NewParagraphFallback("Hi42Hi", fb, 12)
+	runs := p.Runs()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 coalesced run, got %d", len(runs))
+	}
+	if runs[0].Embedded != latin {
+		t.Errorf("run face = %p, want latin %p", runs[0].Embedded, latin)
+	}
+}
+
+func TestNewParagraphFallbackPointerReuseAcrossRuns(t *testing.T) {
+	// The Hebrew face pointer must appear identically in every run
+	// generated for Hebrew script content. Page-level resource dedupe
+	// hashes by pointer; if NewParagraphFallback ever copies or wraps
+	// faces, every paragraph would emit a fresh Type0 dict.
+	latin := font.NewEmbeddedFont(newFakeFace('H', 'i'))
+	hebrew := font.NewEmbeddedFont(newFakeFace('\u05E9', '\u05DC'))
+	fb := font.NewFallback(latin, hebrew)
+
+	p1 := NewParagraphFallback("Hi \u05E9\u05DC", fb, 12)
+	p2 := NewParagraphFallback("\u05E9\u05DC Hi", fb, 12)
+
+	runs1 := p1.Runs()
+	runs2 := p2.Runs()
+	if runs1[1].Embedded != hebrew {
+		t.Error("p1 hebrew run does not point to original hebrew face")
+	}
+	if runs2[0].Embedded != hebrew {
+		t.Error("p2 hebrew run does not point to original hebrew face")
+	}
+	if runs1[0].Embedded != latin {
+		t.Error("p1 latin run does not point to original latin face")
+	}
+	if runs2[1].Embedded != latin {
+		t.Error("p2 latin run does not point to original latin face")
+	}
+}
+
+func TestNewParagraphFallbackProbeSkipsLeadingCommon(t *testing.T) {
+	// SegmentByScript promotes leading Common runes (space, digits,
+	// punctuation) into the script of the next real-script rune via
+	// its reverse sweep. If face selection probed the literal first
+	// rune of the segment, a Hebrew run that begins with whitespace
+	// or a digit would route to whatever face covers that Common
+	// rune first -- typically the Latin face -- and the entire
+	// Hebrew substring would render as .notdef tofu.
+	//
+	// The fake Hebrew face below intentionally does NOT cover the
+	// space, so the test fails immediately if the probe falls on the
+	// Common rune.
+	latin := font.NewEmbeddedFont(newFakeFace('A', ' ', '4', '2', '('))
+	hebrew := font.NewEmbeddedFont(newFakeFace('\u05E9', '\u05DC', '\u05D5', '\u05DD'))
+	fb := font.NewFallback(latin, hebrew)
+
+	tests := []struct {
+		name string
+		text string
+		want *font.EmbeddedFont
+	}{
+		{"leading space", " \u05E9\u05DC\u05D5\u05DD", hebrew},
+		{"leading digits", "42 \u05E9\u05DC\u05D5\u05DD", hebrew},
+		{"leading paren", "(\u05E9\u05DC\u05D5\u05DD)", hebrew},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewParagraphFallback(tc.text, fb, 12)
+			runs := p.Runs()
+			if len(runs) != 1 {
+				t.Fatalf("expected 1 coalesced run, got %d", len(runs))
+			}
+			if runs[0].Embedded != tc.want {
+				t.Errorf("face = %p, want hebrew %p (probe should skip leading Common)",
+					runs[0].Embedded, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewParagraphFallbackAllCommonInput(t *testing.T) {
+	// Pure-Common input has no real-script rune to probe on. Falling
+	// back to the first rune is the documented behaviour and routes
+	// to whichever face covers that rune first; this guards the
+	// pure-Common short-circuit in probeRune.
+	latin := font.NewEmbeddedFont(newFakeFace('.', ',', '!'))
+	other := font.NewEmbeddedFont(newFakeFace('.'))
+	fb := font.NewFallback(latin, other)
+
+	p := NewParagraphFallback("...,,,!!!", fb, 12)
+	runs := p.Runs()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if runs[0].Embedded != latin {
+		t.Errorf("all-Common input should land on first face %p, got %p", latin, runs[0].Embedded)
+	}
+}
+
+func TestNewParagraphFallbackWhitespaceOnly(t *testing.T) {
+	// Whitespace-only input is a degenerate but valid case; it must
+	// not panic and must produce one run on the first face that
+	// covers space.
+	latin := font.NewEmbeddedFont(newFakeFace(' ', '\t'))
+	fb := font.NewFallback(latin)
+
+	p := NewParagraphFallback("   ", fb, 12)
+	runs := p.Runs()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if runs[0].Embedded != latin {
+		t.Errorf("face = %p, want latin %p", runs[0].Embedded, latin)
+	}
+	if runs[0].Text != "   " {
+		t.Errorf("text = %q, want %q", runs[0].Text, "   ")
+	}
+}
+
+func TestNewParagraphFallbackUncoveredRuneFallsBackToFirstFace(t *testing.T) {
+	// When no face in the chain covers a script's base rune, the first
+	// face is used so something still draws. The acceptance criterion
+	// is "all glyphs render correctly when the chain includes a face
+	// per script"; this case (no face for Han) is the unhappy path and
+	// must not crash or skip the segment.
+	latin := font.NewEmbeddedFont(newFakeFace('H'))
+	hebrew := font.NewEmbeddedFont(newFakeFace('\u05E9'))
+	fb := font.NewFallback(latin, hebrew)
+
+	p := NewParagraphFallback("\u4E2D", fb, 12) // Han: neither face covers
+	runs := p.Runs()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if runs[0].Embedded != latin {
+		t.Errorf("uncovered rune should land on first face %p, got %p", latin, runs[0].Embedded)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of #192. Introduces `font.Fallback` and `layout.NewParagraphFallback` so a single string mixing scripts (Latin + Hebrew + Arabic + ...) can render without the caller pre-splitting into per-font runs.

- `font.Fallback` wraps an ordered list of `*EmbeddedFont`. Stores pointers verbatim so subsetting and the page-level font-resource map keep deduping by pointer (one Type0 dict per face per document, regardless of how many paragraphs share the fallback).
- `layout.NewParagraphFallback(text, fb, size)` walks `SegmentByScript`, picks one face per script run via `fb.PickFace(firstBaseRune)`, coalesces same-face neighbours, and emits N `TextRun`s. Existing single-face shaping, measurement, drawing, and PDF emission run unchanged on each segment.
- New section in `examples/rtl` exercises a Latin/Hebrew/Arabic paragraph through the new constructor.

## Phase 1 scope

Cross-script fallback only. A whole script run is locked to a single face so per-script shapers (Arabic positional joining, Devanagari clusters, GPOS marks) see a coherent input. Within-script coverage gaps (e.g. a Latin face missing U+1E9E) still render as `.notdef` tofu.

Phase 2 will: promote `*EmbeddedFont` to an interface so `Fallback` becomes a drop-in replacement at every existing `*EmbeddedFont` call site (heading, link, list, tab, table cell, page-level text, C ABI), and add per-cluster dispatch with shaper coordination for intra-script gaps.

## Acceptance criteria status (#192)

- [x] (2) Mixed-script paragraph renders all glyphs when the chain has a face per script
- [x] (3) `MeasureString` correct across face boundaries (each segment measures on its own face via existing per-run path)
- [x] (4) Subsetting: one font resource per face (pointer dedupe preserved)
- [x] (5) ToUnicode CMap correct (per-face emission unchanged)
- [x] (6) `pdftotext` round-trip (per-face emission unchanged)
- [x] (7) Kerning resets at face boundaries (kerning never crosses run boundaries)
- [x] (9) All existing tests pass with zero perturbation
- [ ] (1) Drop-in everywhere `*EmbeddedFont` is accepted — Phase 2
- [ ] (8) Full `examples/rtl` simplification — Phase 2 (Phase 1 adds a new section that demonstrates the fallback path)

Issue stays open after merge.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] New unit tests in `font/fallback_test.go` (5 cases): empty/nil panics, first-hit dispatch, face-order preservation, pointer identity invariant
- [x] New unit tests in `layout/fallback_test.go` (8 cases): nil/fontSize panics, empty text, single script, mixed scripts, same-face coalescing, pointer reuse across paragraphs, uncovered-rune fallback