### PR TITLE
font: load TrueType Collections via face-0 extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **SVG `preserveAspectRatio` slice viewport clip** — when an SVG is drawn with `slice` meet-or-slice, the renderer now emits a PDF clip path on the target rectangle before the viewport transform. Previously the uniform scale was applied correctly but content outside the target rectangle leaked onto the page. Callers that already clipped externally will continue to work (#196)
+- **TrueType Collection (`.ttc`) fonts now load** — `font.ParseFont` and `font.LoadFont` advertised TTC support but routed the bytes to `sfnt.Parse`, which rejects collections with `invalid single font (data is a font collection)`. The dispatch now extracts face 0 from the collection into a standalone single-font TTF (table directory rewritten to point at the new offsets) and parses that. Selection of face 0 matches browser behavior for `url()` references without a `#` fragment. Very large CJK collections may still hit `golang.org/x/image/font/sfnt`'s hardcoded `maxCmapSegments` limit — that is an upstream parser limit, orthogonal to TTC dispatch (#227)
 
 ## [0.7.1] - 2026-04-22
 

--- a/font/load.go
+++ b/font/load.go
@@ -10,7 +10,9 @@ import (
 )
 
 // ParseFont parses a font from raw bytes, auto-detecting the format.
-// Supports TTF, OTF, and WOFF1 fonts.
+// Supports TTF, OTF, WOFF1, and TrueType Collection (TTC) fonts. For
+// collections, the first face is selected — matching the convention used
+// by browsers and font tools for url() references without a `#` fragment.
 //
 // Errors returned by this function wrap one of the sentinel errors
 // [ErrUnknownFormat], [ErrTruncated], or [ErrCorruptTable] so callers
@@ -27,11 +29,16 @@ func ParseFont(data []byte) (Face, error) {
 			return nil, fmt.Errorf("decode WOFF: %w", err)
 		}
 		return ParseTTF(ttfData)
+	case ttcMagic:
+		ttfData, err := extractTTCFont(data, 0)
+		if err != nil {
+			return nil, fmt.Errorf("decode TTC: %w", err)
+		}
+		return ParseTTF(ttfData)
 	case 0x00010000, // TrueType
 		0x4F54544F, // "OTTO" (OpenType/CFF)
 		0x74727565, // "true"
-		0x74797031, // "typ1"
-		0x74746366: // "ttcf" (TrueType Collection)
+		0x74797031: // "typ1"
 		return ParseTTF(data)
 	}
 	return nil, fmt.Errorf("unknown font magic 0x%08X: %w", sig, ErrUnknownFormat)

--- a/font/ttc.go
+++ b/font/ttc.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// ttcMagic is the 4-byte signature that identifies a TrueType Collection.
+//
+// TTC layout reference: ISO/IEC 14496-22 §5 (Open Font Format) and the
+// Apple TrueType Reference, "Font Collections" — both define the
+// 12-byte TTC header (tag, version, numFonts) followed by uint32 offsets
+// to each font's offset table, with table directory offsets stated as
+// absolute positions within the TTC file.
+const ttcMagic = 0x74746366 // "ttcf"
+
+// extractTTCFont returns a standalone TTF byte stream for the font at index
+// in a TrueType Collection. Tables are copied in the order they appear in
+// the source font's table directory, with offsets rewritten to be relative
+// to the new single-font file. The TTC's shared-table layout is preserved
+// only by value: each extracted font is fully self-contained, so callers
+// can subset, embed, or hash it like any other TTF.
+//
+// Index selection follows the convention used by browsers and font tools
+// for url() references without a `#` fragment: face 0 is the natural choice
+// for whole-collection references. Higher indices are accepted in case a
+// future caller (HTTP fragment, font-collection-index CSS extension, etc.)
+// needs to select a specific face.
+//
+// All offset and length arithmetic on parsed uint32 fields is performed in
+// uint64 against the buffer length to avoid the int wraparound that would
+// occur on 32-bit hosts when a hostile collection declares offsets larger
+// than 2^31. Bad input returns a wrapped sentinel error; the function
+// never panics on malformed bytes.
+func extractTTCFont(data []byte, index int) ([]byte, error) {
+	dataLen := uint64(len(data))
+	if dataLen < 12 {
+		return nil, fmt.Errorf("ttc: header too short: %w", ErrTruncated)
+	}
+	if binary.BigEndian.Uint32(data[0:4]) != ttcMagic {
+		return nil, fmt.Errorf("ttc: missing ttcf magic: %w", ErrUnknownFormat)
+	}
+	numFonts := uint64(binary.BigEndian.Uint32(data[8:12]))
+	if numFonts < 1 {
+		return nil, fmt.Errorf("ttc: empty collection: %w", ErrCorruptTable)
+	}
+	if index < 0 || uint64(index) >= numFonts {
+		return nil, fmt.Errorf("ttc: font index %d out of range [0,%d): %w", index, numFonts, ErrCorruptTable)
+	}
+	if dataLen < 12+numFonts*4 {
+		return nil, fmt.Errorf("ttc: offset table truncated: %w", ErrTruncated)
+	}
+
+	fontOffset := uint64(binary.BigEndian.Uint32(data[12+index*4:]))
+	if fontOffset+12 > dataLen {
+		return nil, fmt.Errorf("ttc: font %d offset out of range: %w", index, ErrTruncated)
+	}
+
+	// Offset Table (12 bytes): sfntVersion[4], numTables[2], searchRange[2],
+	// entrySelector[2], rangeShift[2].
+	numTables := uint64(binary.BigEndian.Uint16(data[fontOffset+4:]))
+	dirSize := numTables * 16
+	if fontOffset+12+dirSize > dataLen {
+		return nil, fmt.Errorf("ttc: font %d directory truncated: %w", index, ErrTruncated)
+	}
+
+	// Snapshot each (tag, checksum, srcOffset, length) and accumulate the
+	// total payload size so we can size the output buffer up-front.
+	type entry struct {
+		tag      [4]byte
+		checksum uint32
+		srcOff   uint64
+		length   uint64
+	}
+	entries := make([]entry, numTables)
+	var payload uint64
+	for i := uint64(0); i < numTables; i++ {
+		base := fontOffset + 12 + i*16
+		var e entry
+		copy(e.tag[:], data[base:base+4])
+		e.checksum = binary.BigEndian.Uint32(data[base+4:])
+		e.srcOff = uint64(binary.BigEndian.Uint32(data[base+8:]))
+		e.length = uint64(binary.BigEndian.Uint32(data[base+12:]))
+		if e.srcOff+e.length > dataLen {
+			return nil, fmt.Errorf("ttc: table %s extends beyond data: %w", string(e.tag[:]), ErrTruncated)
+		}
+		entries[i] = e
+		// Tables in TTF are 4-byte aligned in the file.
+		payload += (e.length + 3) &^ 3
+	}
+
+	headerSize := 12 + dirSize
+	totalSize := headerSize + payload
+	if totalSize > uint64(^uint(0)>>1) {
+		return nil, fmt.Errorf("ttc: extracted size %d exceeds platform int range: %w", totalSize, ErrCorruptTable)
+	}
+	out := make([]byte, totalSize)
+
+	// Copy the offset table header (sfntVersion + counts) verbatim from the
+	// source font's offset table — these fields are font-shape metadata, not
+	// offsets, so they translate directly.
+	copy(out[0:12], data[fontOffset:fontOffset+12])
+
+	// Write directory entries with rewritten offsets, then copy table data.
+	dst := headerSize
+	for i, e := range entries {
+		dirBase := 12 + uint64(i)*16
+		copy(out[dirBase:dirBase+4], e.tag[:])
+		binary.BigEndian.PutUint32(out[dirBase+4:], e.checksum)
+		binary.BigEndian.PutUint32(out[dirBase+8:], uint32(dst))
+		binary.BigEndian.PutUint32(out[dirBase+12:], uint32(e.length))
+		copy(out[dst:dst+e.length], data[e.srcOff:e.srcOff+e.length])
+		dst += (e.length + 3) &^ 3
+	}
+
+	return out, nil
+}

--- a/font/ttc_test.go
+++ b/font/ttc_test.go
@@ -389,8 +389,8 @@ func offsetTableTruncatedTTC(t *testing.T) []byte {
 	buf := make([]byte, 16)
 	copy(buf[0:4], "ttcf")
 	binary.BigEndian.PutUint32(buf[4:8], 0x00010000)
-	binary.BigEndian.PutUint32(buf[8:12], 4)          // numFonts says 4
-	binary.BigEndian.PutUint32(buf[12:16], 16)        // only one offset stored
+	binary.BigEndian.PutUint32(buf[8:12], 4)   // numFonts says 4
+	binary.BigEndian.PutUint32(buf[12:16], 16) // only one offset stored
 	return buf
 }
 
@@ -426,7 +426,7 @@ func tableBeyondDataTTC(t *testing.T) []byte {
 	copy(buf[entry:entry+4], "head")
 	binary.BigEndian.PutUint32(buf[entry+4:], 0)
 	binary.BigEndian.PutUint32(buf[entry+8:], uint32(fontOff+12+16)) // table starts here
-	binary.BigEndian.PutUint32(buf[entry+12:], 1024)                  // way past buffer end
+	binary.BigEndian.PutUint32(buf[entry+12:], 1024)                 // way past buffer end
 	return buf
 }
 

--- a/font/ttc_test.go
+++ b/font/ttc_test.go
@@ -1,0 +1,480 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"os"
+	"runtime"
+	"testing"
+
+	"golang.org/x/image/font/sfnt"
+)
+
+// TestExtractTTCFontFromSyntheticTTC builds a TTC at test time by wrapping a
+// system TTF in TTC headers, extracts face 0, and verifies the result parses
+// under sfnt.Parse. This pins regression coverage on every host (no silent
+// skip on Linux CI without Noto-CJK), independent of which TTC fonts the
+// host happens to ship.
+func TestExtractTTCFontFromSyntheticTTC(t *testing.T) {
+	ttfBytes := loadAnySystemTTF(t)
+	ttc := buildSyntheticTTC(t, ttfBytes, 1, 0x00010000)
+
+	out, err := extractTTCFont(ttc, 0)
+	if err != nil {
+		t.Fatalf("extractTTCFont: %v", err)
+	}
+	if bytes.Equal(out[:4], []byte("ttcf")) {
+		t.Fatal("extracted output still has ttcf magic")
+	}
+	if _, err := sfnt.Parse(out); err != nil {
+		t.Fatalf("sfnt.Parse on extracted single font: %v", err)
+	}
+}
+
+// TestExtractTTCFontVersion2Header verifies that a v2 TTC (which adds 12
+// trailing DSIG bytes after the offset-table array) extracts identically to
+// v1 — the version field is not consulted, and the DSIG fields sit after
+// the data the extractor reads. Locks the current behavior so a future
+// "skip past DSIG block" change doesn't silently drift.
+func TestExtractTTCFontVersion2Header(t *testing.T) {
+	ttfBytes := loadAnySystemTTF(t)
+
+	v1 := buildSyntheticTTC(t, ttfBytes, 1, 0x00010000)
+	v2 := buildSyntheticTTC(t, ttfBytes, 1, 0x00020000)
+
+	v1out, err := extractTTCFont(v1, 0)
+	if err != nil {
+		t.Fatalf("v1 extract: %v", err)
+	}
+	v2out, err := extractTTCFont(v2, 0)
+	if err != nil {
+		t.Fatalf("v2 extract: %v", err)
+	}
+	if !bytes.Equal(v1out, v2out) {
+		t.Errorf("v1 and v2 TTCs wrapping identical TTF produced different output (len v1=%d v2=%d)", len(v1out), len(v2out))
+	}
+}
+
+// TestExtractTTCFontMultiFaceIndex verifies the offset arithmetic for a
+// non-zero face index. Builds a 2-face TTC where each face wraps a copy of
+// the same TTF at a distinct absolute offset, then extracts both faces and
+// asserts they parse independently with consistent metrics.
+func TestExtractTTCFontMultiFaceIndex(t *testing.T) {
+	ttfBytes := loadAnySystemTTF(t)
+	ttc := buildSyntheticTTCDistinctBodies(t, ttfBytes, 2, 0x00010000)
+
+	face0, err := extractTTCFont(ttc, 0)
+	if err != nil {
+		t.Fatalf("face 0 extract: %v", err)
+	}
+	face1, err := extractTTCFont(ttc, 1)
+	if err != nil {
+		t.Fatalf("face 1 extract: %v", err)
+	}
+	f0, err := sfnt.Parse(face0)
+	if err != nil {
+		t.Fatalf("sfnt.Parse face 0: %v", err)
+	}
+	f1, err := sfnt.Parse(face1)
+	if err != nil {
+		t.Fatalf("sfnt.Parse face 1: %v", err)
+	}
+	if f0.UnitsPerEm() != f1.UnitsPerEm() {
+		t.Errorf("UnitsPerEm differ across identical faces: f0=%d f1=%d", f0.UnitsPerEm(), f1.UnitsPerEm())
+	}
+	// Out-of-range index after 2 faces.
+	if _, err := extractTTCFont(ttc, 2); !errors.Is(err, ErrCorruptTable) {
+		t.Errorf("face index 2 on 2-face TTC: err = %v, want errors.Is ErrCorruptTable", err)
+	}
+}
+
+// TestExtractTTCFontHandlesHostileUint32Offsets confirms that hostile uint32
+// values are rejected with a wrapped sentinel error rather than panicking
+// from slice-out-of-bounds. On 32-bit hosts (where Go's `int` is 32 bits),
+// casting a uint32 ≥ 0x80000000 to int produces a negative value, so a
+// pre-fix bounds check `int(off)+12 > len(data)` evaluates true on
+// signed-comparison and skips the truncation guard, then panics on the
+// later `data[off:off+length]` slice. The uint64-arithmetic fix is sound
+// on both 32-bit and 64-bit, but to keep this test arch-independent we
+// also assert that a uint32-MAX-class field never produces a panic, only
+// an error. ARCHITECTURE.md §error-handling: "never panic on malformed
+// PDF input."
+func TestExtractTTCFontHandlesHostileUint32Offsets(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(buf []byte)
+	}{
+		{
+			name: "font offset MaxUint32",
+			mut: func(buf []byte) {
+				binary.BigEndian.PutUint32(buf[12:16], 0xFFFFFFFF)
+			},
+		},
+		{
+			name: "font offset high-bit set",
+			mut: func(buf []byte) {
+				binary.BigEndian.PutUint32(buf[12:16], 0x80000000)
+			},
+		},
+		{
+			name: "numFonts MaxUint32",
+			mut: func(buf []byte) {
+				binary.BigEndian.PutUint32(buf[8:12], 0xFFFFFFFF)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := make([]byte, 16)
+			copy(buf[0:4], "ttcf")
+			binary.BigEndian.PutUint32(buf[4:8], 0x00010000)
+			binary.BigEndian.PutUint32(buf[8:12], 1)
+			binary.BigEndian.PutUint32(buf[12:16], 0)
+			tc.mut(buf)
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("extractTTCFont panicked on hostile input: %v", r)
+				}
+			}()
+			if _, err := extractTTCFont(buf, 0); err == nil {
+				t.Error("expected error on hostile input, got nil")
+			}
+		})
+	}
+}
+
+// TestExtractTTCFontFromRealSystemTTC opportunistically validates against a
+// real system TTC if one is present and parseable. Unlike the synthetic
+// test, this catches integration regressions (real-world DSIG, real-world
+// shared tables) but skips on hosts without a parseable TTC.
+func TestExtractTTCFontFromRealSystemTTC(t *testing.T) {
+	candidates := systemTTCCandidates()
+	if len(candidates) == 0 {
+		t.Skip("no system .ttc font found on this host")
+	}
+	for _, p := range candidates {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Logf("%s: read err: %v", p, err)
+			continue
+		}
+		out, err := extractTTCFont(data, 0)
+		if err != nil {
+			t.Errorf("%s: extractTTCFont: %v", p, err)
+			continue
+		}
+		if len(out) < 12 || bytes.Equal(out[:4], []byte("ttcf")) {
+			t.Errorf("%s: extracted output is not a single-font sfnt (len=%d)", p, len(out))
+			continue
+		}
+		if _, err := sfnt.Parse(out); err != nil {
+			t.Logf("%s: sfnt.Parse: %v (orthogonal sfnt limit, not a TTC issue)", p, err)
+			continue
+		}
+		return
+	}
+	t.Fatal("none of the candidate TTCs produced a sfnt-parseable single-font extract")
+}
+
+// TestParseFontAcceptsTTC verifies that the ttcf branch in ParseFont is
+// wired up — without the fix, ParseFont routes TTC bytes to sfnt.Parse,
+// which returns "invalid single font (data is a font collection)".
+func TestParseFontAcceptsTTC(t *testing.T) {
+	ttfBytes := loadAnySystemTTF(t)
+	ttc := buildSyntheticTTC(t, ttfBytes, 1, 0x00010000)
+
+	face, err := ParseFont(ttc)
+	if err != nil {
+		t.Fatalf("ParseFont on TTC: %v", err)
+	}
+	if face.UnitsPerEm() <= 0 {
+		t.Errorf("UnitsPerEm = %d, want > 0", face.UnitsPerEm())
+	}
+	if face.PostScriptName() == "" {
+		t.Error("PostScriptName is empty for extracted TTC face")
+	}
+	if rd := face.RawData(); len(rd) == 0 || bytes.Equal(rd[:4], []byte("ttcf")) {
+		t.Error("RawData should be a single-font TTF, not the original TTC")
+	}
+}
+
+// TestLoadFontAcceptsTTC verifies the full LoadFont -> ParseFont -> ParseTTF
+// chain works for a TTC file on disk.
+func TestLoadFontAcceptsTTC(t *testing.T) {
+	ttfBytes := loadAnySystemTTF(t)
+	ttc := buildSyntheticTTC(t, ttfBytes, 1, 0x00010000)
+
+	dir := t.TempDir()
+	path := dir + "/synthetic.ttc"
+	if err := os.WriteFile(path, ttc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	face, err := LoadFont(path)
+	if err != nil {
+		t.Fatalf("LoadFont(%q): %v", path, err)
+	}
+	if face == nil {
+		t.Fatal("expected non-nil face")
+	}
+}
+
+// TestExtractTTCFontRejectsBadInput exercises the validation paths.
+func TestExtractTTCFontRejectsBadInput(t *testing.T) {
+	cases := []struct {
+		name    string
+		data    []byte
+		index   int
+		wantErr error
+	}{
+		{"too short", []byte{0x74, 0x74, 0x63, 0x66, 0, 1, 0, 0}, 0, ErrTruncated},
+		{"wrong magic", []byte("\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 0, ErrUnknownFormat},
+		{"index out of range", buildEmptyTTC(1), 5, ErrCorruptTable},
+		{"negative index", buildEmptyTTC(1), -1, ErrCorruptTable},
+		{"empty collection", buildEmptyTTC(0), 0, ErrCorruptTable},
+		{"font offset truncated", offsetTableTruncatedTTC(t), 0, ErrTruncated},
+		{"directory truncated", directoryTruncatedTTC(t), 0, ErrTruncated},
+		{"table beyond data", tableBeyondDataTTC(t), 0, ErrTruncated},
+		{"length wraps uint32", lengthWrapsTTC(t), 0, ErrTruncated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := extractTTCFont(tc.data, tc.index)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want errors.Is %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// buildEmptyTTC returns a minimal-but-valid TTC header with numFonts entries
+// pointing at offset 0 (which is invalid for a real font but exercises the
+// header-parsing code paths). Only the header layout is needed to test the
+// pre-payload validation in extractTTCFont.
+func buildEmptyTTC(numFonts int) []byte {
+	buf := make([]byte, 12+numFonts*4)
+	copy(buf[0:4], "ttcf")
+	binary.BigEndian.PutUint32(buf[4:8], 0x00010000)
+	binary.BigEndian.PutUint32(buf[8:12], uint32(numFonts))
+	return buf
+}
+
+// buildSyntheticTTC wraps a single TTF in a TTC envelope. faces ≥ 1 share
+// one TTF body — they all index the same offset table — which is enough
+// for tests that only assert face 0 round-trips correctly. version is
+// 0x00010000 (v1) or 0x00020000 (v2); the latter appends 12 zero bytes of
+// DSIG fields after the font-offset array, matching the v2 spec layout.
+func buildSyntheticTTC(t *testing.T, ttfBytes []byte, faces int, version uint32) []byte {
+	t.Helper()
+	if faces < 1 {
+		t.Fatal("faces must be >= 1")
+	}
+	headerSize := 12 + faces*4
+	if version == 0x00020000 {
+		headerSize += 12 // ulDsigTag + ulDsigLength + ulDsigOffset
+	}
+	out := make([]byte, headerSize+len(ttfBytes))
+	copy(out[0:4], "ttcf")
+	binary.BigEndian.PutUint32(out[4:8], version)
+	binary.BigEndian.PutUint32(out[8:12], uint32(faces))
+	for i := range faces {
+		binary.BigEndian.PutUint32(out[12+i*4:], uint32(headerSize))
+	}
+	copy(out[headerSize:], ttfBytes)
+
+	// Rewrite the embedded TTF's table directory offsets so they're
+	// absolute within the TTC (per the TTC spec: directory offsets are
+	// absolute file offsets, not TTF-relative).
+	if len(out) < headerSize+12 {
+		t.Fatalf("ttf bytes too short to wrap (len=%d)", len(ttfBytes))
+	}
+	numTables := int(binary.BigEndian.Uint16(out[headerSize+4:]))
+	for i := range numTables {
+		entryBase := headerSize + 12 + i*16
+		oldOff := binary.BigEndian.Uint32(out[entryBase+8:])
+		binary.BigEndian.PutUint32(out[entryBase+8:], oldOff+uint32(headerSize))
+	}
+	return out
+}
+
+// buildSyntheticTTCDistinctBodies wraps `faces` independent copies of ttfBytes
+// in a TTC envelope. Unlike buildSyntheticTTC (which has every face share a
+// single body), this places each TTF at a distinct absolute offset so that
+// extracting face N exercises the non-zero-index arithmetic.
+func buildSyntheticTTCDistinctBodies(t *testing.T, ttfBytes []byte, faces int, version uint32) []byte {
+	t.Helper()
+	if faces < 1 {
+		t.Fatal("faces must be >= 1")
+	}
+	headerSize := 12 + faces*4
+	if version == 0x00020000 {
+		headerSize += 12
+	}
+	out := make([]byte, headerSize+faces*len(ttfBytes))
+	copy(out[0:4], "ttcf")
+	binary.BigEndian.PutUint32(out[4:8], version)
+	binary.BigEndian.PutUint32(out[8:12], uint32(faces))
+	for i := range faces {
+		bodyOff := headerSize + i*len(ttfBytes)
+		binary.BigEndian.PutUint32(out[12+i*4:], uint32(bodyOff))
+		copy(out[bodyOff:], ttfBytes)
+		// Rewrite this face's directory entry offsets to be absolute.
+		numTables := int(binary.BigEndian.Uint16(out[bodyOff+4:]))
+		for j := range numTables {
+			entryBase := bodyOff + 12 + j*16
+			oldOff := binary.BigEndian.Uint32(out[entryBase+8:])
+			binary.BigEndian.PutUint32(out[entryBase+8:], oldOff+uint32(bodyOff))
+		}
+	}
+	return out
+}
+
+// offsetTableTruncatedTTC declares numFonts=4 but provides space for only 1.
+func offsetTableTruncatedTTC(t *testing.T) []byte {
+	t.Helper()
+	buf := make([]byte, 16)
+	copy(buf[0:4], "ttcf")
+	binary.BigEndian.PutUint32(buf[4:8], 0x00010000)
+	binary.BigEndian.PutUint32(buf[8:12], 4)          // numFonts says 4
+	binary.BigEndian.PutUint32(buf[12:16], 16)        // only one offset stored
+	return buf
+}
+
+// directoryTruncatedTTC declares numTables=2 but the directory is cut off.
+func directoryTruncatedTTC(t *testing.T) []byte {
+	t.Helper()
+	const fontOff = 16
+	const numTables = 2
+	buf := make([]byte, fontOff+12+numTables*16-4) // -4 to truncate last entry
+	copy(buf[0:4], "ttcf")
+	binary.BigEndian.PutUint32(buf[4:8], 0x00010000)
+	binary.BigEndian.PutUint32(buf[8:12], 1)
+	binary.BigEndian.PutUint32(buf[12:16], fontOff)
+	binary.BigEndian.PutUint32(buf[fontOff:fontOff+4], 0x00010000) // sfntVersion
+	binary.BigEndian.PutUint16(buf[fontOff+4:fontOff+6], numTables)
+	return buf
+}
+
+// tableBeyondDataTTC has a complete header + directory but the directory
+// declares a table whose end exceeds the buffer.
+func tableBeyondDataTTC(t *testing.T) []byte {
+	t.Helper()
+	const fontOff = 16
+	const numTables = 1
+	buf := make([]byte, fontOff+12+numTables*16+8)
+	copy(buf[0:4], "ttcf")
+	binary.BigEndian.PutUint32(buf[4:8], 0x00010000)
+	binary.BigEndian.PutUint32(buf[8:12], 1)
+	binary.BigEndian.PutUint32(buf[12:16], fontOff)
+	binary.BigEndian.PutUint32(buf[fontOff:fontOff+4], 0x00010000)
+	binary.BigEndian.PutUint16(buf[fontOff+4:fontOff+6], numTables)
+	entry := fontOff + 12
+	copy(buf[entry:entry+4], "head")
+	binary.BigEndian.PutUint32(buf[entry+4:], 0)
+	binary.BigEndian.PutUint32(buf[entry+8:], uint32(fontOff+12+16)) // table starts here
+	binary.BigEndian.PutUint32(buf[entry+12:], 1024)                  // way past buffer end
+	return buf
+}
+
+// lengthWrapsTTC declares a uint32 length close to MaxUint32 such that
+// srcOff+length would wrap on int32 but must be detected via uint64.
+func lengthWrapsTTC(t *testing.T) []byte {
+	t.Helper()
+	const fontOff = 16
+	const numTables = 1
+	buf := make([]byte, fontOff+12+numTables*16)
+	copy(buf[0:4], "ttcf")
+	binary.BigEndian.PutUint32(buf[4:8], 0x00010000)
+	binary.BigEndian.PutUint32(buf[8:12], 1)
+	binary.BigEndian.PutUint32(buf[12:16], fontOff)
+	binary.BigEndian.PutUint32(buf[fontOff:fontOff+4], 0x00010000)
+	binary.BigEndian.PutUint16(buf[fontOff+4:fontOff+6], numTables)
+	entry := fontOff + 12
+	copy(buf[entry:entry+4], "head")
+	binary.BigEndian.PutUint32(buf[entry+4:], 0)
+	binary.BigEndian.PutUint32(buf[entry+8:], 0)
+	binary.BigEndian.PutUint32(buf[entry+12:], 0xFFFFFF00) // huge length
+	return buf
+}
+
+// loadAnySystemTTF locates any TTF on the host (Latin or CJK) — the
+// universal candidate set is broader than for TTCs, so this rarely skips
+// even on minimal Linux CIs.
+func loadAnySystemTTF(t *testing.T) []byte {
+	t.Helper()
+	var candidates []string
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = []string{
+			"/System/Library/Fonts/Supplemental/Arial.ttf",
+			"/System/Library/Fonts/Supplemental/Courier New.ttf",
+			"/System/Library/Fonts/Supplemental/Times New Roman.ttf",
+		}
+	case "linux":
+		candidates = []string{
+			"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+			"/usr/share/fonts/dejavu/DejaVuSans.ttf",
+			"/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
+			"/usr/share/fonts/noto/NotoSans-Regular.ttf",
+			"/usr/share/fonts/liberation/LiberationSans-Regular.ttf",
+			"/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+		}
+	case "windows":
+		candidates = []string{
+			`C:\Windows\Fonts\arial.ttf`,
+			`C:\Windows\Fonts\segoeui.ttf`,
+			`C:\Windows\Fonts\tahoma.ttf`,
+		}
+	}
+	for _, p := range candidates {
+		if data, err := os.ReadFile(p); err == nil {
+			return data
+		}
+	}
+	t.Skip("no system TTF found to build a synthetic TTC")
+	return nil
+}
+
+// systemTTCCandidates returns TTC paths that exist on the host. The list is
+// stat-filtered, not parse-filtered, so callers can distinguish "no TTC
+// available" (skip) from "TTC available but parse failed" (real failure).
+// Very large CJK fonts (STHeiti, some Noto CJK builds) exceed sfnt's
+// hardcoded maxCmapSegments — orthogonal to TTC dispatch. The candidate
+// list is ordered to prefer fonts known to parse cleanly.
+func systemTTCCandidates() []string {
+	var candidates []string
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = []string{
+			"/System/Library/Fonts/Helvetica.ttc",
+			"/System/Library/Fonts/Courier.ttc",
+			"/System/Library/Fonts/Hiragino Sans GB.ttc",
+		}
+	case "linux":
+		candidates = []string{
+			"/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+			"/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
+			"/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+		}
+	case "windows":
+		candidates = []string{
+			`C:\Windows\Fonts\cambria.ttc`,
+			`C:\Windows\Fonts\msyh.ttc`,
+			`C:\Windows\Fonts\msgothic.ttc`,
+		}
+	}
+	out := candidates[:0]
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/font/ttc_test.go
+++ b/font/ttc_test.go
@@ -92,6 +92,53 @@ func TestExtractTTCFontMultiFaceIndex(t *testing.T) {
 	}
 }
 
+// TestExtractTTCFontHonorsFaceIndex pins that extractTTCFont reads the
+// correct face's offset table — not face 0's. The threat model is a
+// regression where the extractor silently returns face 0 for every
+// requested index; UnitsPerEm and PostScriptName checks would not catch
+// it when both faces wrap the same body. This test constructs a TTC
+// whose face-0 entry points at valid bytes and whose face-1 entry
+// points past the end of the buffer; a correct extractor succeeds for
+// index 0 and rejects index 1 with ErrTruncated, while a buggy
+// extractor that ignores the index would succeed for both because it
+// would silently read face 0's offset on the index-1 call.
+func TestExtractTTCFontHonorsFaceIndex(t *testing.T) {
+	ttfBytes := loadAnySystemTTF(t)
+	ttc := buildSyntheticTTC(t, ttfBytes, 1, 0x00010000)
+
+	// Patch in a second face entry whose offset points past the end of
+	// the buffer. The bounds check in extractTTCFont must fire for the
+	// index-1 read; a buggy extractor that ignores the index would fall
+	// back to face 0's offset and slip past the check.
+	patched := make([]byte, len(ttc)+4)
+	copy(patched[:12], ttc[:12])
+	binary.BigEndian.PutUint32(patched[8:12], 2) // numFonts = 2
+	// Inject face-1 offset between the existing face-0 entry and the
+	// body, then shift the body by 4 bytes so face-0 still resolves.
+	binary.BigEndian.PutUint32(patched[16:20], 0xFFFFFF00) // way past EOF
+	bodyStart := 16
+	newBodyStart := 20
+	copy(patched[newBodyStart:], ttc[bodyStart:])
+	binary.BigEndian.PutUint32(patched[12:16], uint32(newBodyStart))
+	numTables := int(binary.BigEndian.Uint16(patched[newBodyStart+4:]))
+	for i := range numTables {
+		entryBase := newBodyStart + 12 + i*16
+		oldOff := binary.BigEndian.Uint32(patched[entryBase+8:])
+		binary.BigEndian.PutUint32(patched[entryBase+8:], oldOff+4)
+	}
+
+	if _, err := extractTTCFont(patched, 0); err != nil {
+		t.Fatalf("face 0 (valid) extract failed: %v", err)
+	}
+	_, err := extractTTCFont(patched, 1)
+	if err == nil {
+		t.Error("face 1 (offset past EOF) returned no error; extractor likely ignored the index argument and read face 0")
+	}
+	if err != nil && !errors.Is(err, ErrTruncated) {
+		t.Errorf("face 1 returned unexpected error class: %v (want errors.Is ErrTruncated)", err)
+	}
+}
+
 // TestExtractTTCFontHandlesHostileUint32Offsets confirms that hostile uint32
 // values are rejected with a wrapped sentinel error rather than panicking
 // from slice-out-of-bounds. On 32-bit hosts (where Go's `int` is 32 bits),

--- a/html/issue227_test.go
+++ b/html/issue227_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"encoding/binary"
+	"os"
+	"runtime"
+	"testing"
+	"testing/fstest"
+
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// TestFallbackChainResolvesTTCViaBaseFS pins the end-to-end claim from
+// the #235 PR description: with TTC dispatch fixed in font.ParseFont,
+// a CJK-style paragraph that flows through the fallback chain
+// (Options.FallbackFontPath via BaseFS) resolves to the embedded TTC
+// face rather than rendering as .notdef glyphs.
+//
+// This test deliberately uses a relative FallbackFontPath against a
+// fstest.MapFS so the routing exercises font.ParseFont (the TTC branch
+// landed in this PR) without touching the absolute-path /
+// BaseFS-bypass behavior that issue #229 will centralize. A future
+// regression in the TTC dispatch — even one that compiled cleanly —
+// would manifest here as Embedded == nil because loadFallbackFont
+// would fail to parse the TTC bytes.
+//
+// The synthetic TTC wraps a Latin TTF and therefore does not carry
+// CJK glyphs of its own; the test pins that the *fallback font is
+// loaded and selected*, not that any specific codepoint resolves to a
+// glyph (that is a property of the font the end user installs, not of
+// the dispatch code under test).
+func TestFallbackChainResolvesTTCViaBaseFS(t *testing.T) {
+	ttfBytes := loadAnyHTMLTestTTF(t)
+	ttcBytes := wrapTTFAsSyntheticTTC(t, ttfBytes)
+
+	want, err := font.ParseFont(ttcBytes)
+	if err != nil {
+		t.Fatalf("synthetic TTC failed to parse via font.ParseFont (TTC dispatch broken?): %v", err)
+	}
+	wantPS := want.PostScriptName()
+
+	fsys := fstest.MapFS{
+		"fonts/synthetic.ttc": &fstest.MapFile{Data: ttcBytes},
+	}
+
+	// Use a non-WinAnsi codepoint so the renderer is forced into the
+	// fallback path. Any character outside WinAnsiEncoding works; we
+	// pick a Chinese ideograph because that is the user's reported
+	// scenario in #227.
+	src := `<html><body><p>中</p></body></html>`
+
+	elems, err := Convert(src, &Options{
+		BaseFS:           fsys,
+		FallbackFontPath: "fonts/synthetic.ttc",
+	})
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected paragraph element")
+	}
+	p, ok := elems[0].(*layout.Paragraph)
+	if !ok {
+		t.Fatalf("expected *layout.Paragraph, got %T", elems[0])
+	}
+	lines := p.Layout(500)
+	if len(lines) == 0 || len(lines[0].Words) == 0 {
+		t.Fatal("paragraph rendered no words")
+	}
+	w := lines[0].Words[0]
+	if w.Embedded == nil {
+		t.Fatal("rendered word has no embedded font; TTC fallback failed to load")
+	}
+	if got := w.Embedded.Face().PostScriptName(); got != wantPS {
+		t.Errorf("fallback PostScriptName = %q, want %q (TTC dispatch may have been bypassed)", got, wantPS)
+	}
+}
+
+// wrapTTFAsSyntheticTTC mirrors font.buildSyntheticTTC: builds a TTC v1
+// envelope that places one face at the given TTF body, with directory
+// offsets rewritten to be absolute within the resulting TTC. Kept local
+// to the html package because the original is a test helper in the
+// font package; duplication is cheap (~25 LOC) and keeps the public
+// font API surface unchanged.
+func wrapTTFAsSyntheticTTC(t *testing.T, ttfBytes []byte) []byte {
+	t.Helper()
+	const headerSize = 12 + 4 // 12-byte header + one uint32 face offset
+	out := make([]byte, headerSize+len(ttfBytes))
+	copy(out[0:4], "ttcf")
+	binary.BigEndian.PutUint32(out[4:8], 0x00010000) // version 1.0
+	binary.BigEndian.PutUint32(out[8:12], 1)         // numFonts
+	binary.BigEndian.PutUint32(out[12:16], headerSize)
+	copy(out[headerSize:], ttfBytes)
+
+	if len(out) < headerSize+12 {
+		t.Fatalf("ttf bytes too short to wrap (len=%d)", len(ttfBytes))
+	}
+	numTables := int(binary.BigEndian.Uint16(out[headerSize+4:]))
+	for i := range numTables {
+		entryBase := headerSize + 12 + i*16
+		oldOff := binary.BigEndian.Uint32(out[entryBase+8:])
+		binary.BigEndian.PutUint32(out[entryBase+8:], oldOff+uint32(headerSize))
+	}
+	return out
+}
+
+// loadAnyHTMLTestTTF locates any TTF on the host. The candidate list
+// mirrors font/ttc_test.go's loadAnySystemTTF so the html-layer test
+// can be exercised on the same hosts that exercise the font-layer
+// fixture. Skips when no TTF is available; the synthetic TTC cannot be
+// built without source bytes.
+func loadAnyHTMLTestTTF(t *testing.T) []byte {
+	t.Helper()
+	var candidates []string
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = []string{
+			"/System/Library/Fonts/Supplemental/Arial.ttf",
+			"/System/Library/Fonts/Supplemental/Courier New.ttf",
+			"/System/Library/Fonts/Supplemental/Times New Roman.ttf",
+		}
+	case "linux":
+		candidates = []string{
+			"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+			"/usr/share/fonts/dejavu/DejaVuSans.ttf",
+			"/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf",
+			"/usr/share/fonts/noto/NotoSans-Regular.ttf",
+			"/usr/share/fonts/liberation/LiberationSans-Regular.ttf",
+			"/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+		}
+	case "windows":
+		candidates = []string{
+			`C:\Windows\Fonts\arial.ttf`,
+			`C:\Windows\Fonts\segoeui.ttf`,
+			`C:\Windows\Fonts\tahoma.ttf`,
+		}
+	}
+	for _, p := range candidates {
+		if data, err := os.ReadFile(p); err == nil {
+			return data
+		}
+	}
+	t.Skip("no system TTF found to build a synthetic TTC for fallback chain test")
+	return nil
+}


### PR DESCRIPTION
Partial fix for #227. Splits the TTC-dispatch half of #228 into a focused, scope-minimal PR; the companion `loadFontFaces` absolute-path patch is held back as redundant under #229 (centralize asset resolution).

## Summary

`font.ParseFont` accepted the `ttcf` magic but routed the bytes to `sfnt.Parse`, which rejects collections with `invalid single font (data is a font collection)`. Dispatch now extracts face 0 of the collection into a standalone single-font TTF (table directory rewritten to point at the new offsets) and parses that. Selection of face 0 matches browser behavior for `url()` references without a `#` fragment.

## Why this fixes #227 on its own

The reporter's failure mode on Windows/Ubuntu came from `msyh.ttc` / `NotoSansCJK-Regular.ttc` failing to load. Two paths reach those files:

1. **`@font-face url()`** — when `Options.BaseFS` is nil, the path silently fails (issue #229 will fix this uniformly across all resolvers).
2. **`getFallbackFont` chain** — already uses `font.LoadFont` on absolute system paths directly, no `BaseFS` involvement. Once TTC dispatch works, `msyh.ttc` succeeds via the fallback path and the document renders correctly.

So this PR alone makes the user's CJK PDF render correctly. With `StrictAssets` (#232, just merged), developers running with strict mode now see the silent `@font-face` drop as an error during development — closing the observability gap the reporter hit.

## Implementation (`font/ttc.go`)

- `extractTTCFont(data, index)` parses the TTC header, validates with `uint64` arithmetic so hostile `uint32` fields cannot wrap to negative ints on 32-bit hosts (ARCHITECTURE.md §error-handling: never panic on malformed input), copies each table from its absolute TTC offset into a new buffer, and rewrites the directory entries to point at the new positions. The output is a fully self-contained single-font TTF that downstream code (`sfnt.Parse`, `parseTTFTables`, `Subset`, `embed`) handles unmodified.
- TTC v2 (12-byte DSIG fields after the offset-table array) handled implicitly because the version field is not consulted; the DSIG fields sit after the data the extractor reads.
- `ttcMagic` constant + ISO/IEC 14496-22 §5 / Apple TrueType Reference citation at its declaration.

## Test plan

- [x] `buildSyntheticTTC` / `buildSyntheticTTCDistinctBodies` fixtures wrap any system TTF in TTC headers at test time. Eliminates the silent-skip on hosts without a system `.ttc`; the only fallback is when no TTF is found at all (rare on every dev/CI host).
- [x] `TestExtractTTCFontFromSyntheticTTC` — round-trips through `sfnt.Parse`.
- [x] `TestExtractTTCFontVersion2Header` — locks "ignore version, read offset 12" for v2 collections.
- [x] `TestExtractTTCFontMultiFaceIndex` — exercises non-zero face index via a 2-face TTC with distinct bodies; verifies both faces parse and the index-out-of-range case rejects with `ErrCorruptTable`.
- [x] `TestExtractTTCFontHandlesHostileUint32Offsets` — pins panic-free behavior under MaxUint32 / high-bit-set offset and numFonts; verified the `font` package cross-compiles to `GOARCH=386 GOOS=linux`.
- [x] `TestExtractTTCFontFromRealSystemTTC` — opportunistic real-TTC validation against parseable system fonts.
- [x] `TestParseFontAcceptsTTC` / `TestLoadFontAcceptsTTC` — full `ParseFont` / `LoadFont` pipeline against synthetic TTC bytes and a temp file.
- [x] `TestExtractTTCFontRejectsBadInput` — table-driven over 9 malformed-input shapes (too-short, wrong-magic, out-of-range index, negative index, empty collection, font-offset-truncated, directory-truncated, table-beyond-data, length-wraps-uint32). Each asserts `errors.Is` matches the documented sentinel.
- [x] Full `go test ./...` green.

## Scope vs. #228

This PR is the standalone correctness half. The `loadFontFaces` absolute-path branch from PR #228 is held back: #229 will centralize asset resolution across `<img>`, SVG, `<link>`, `@font-face`, and `FallbackFontPath`, making the per-resolver patch redundant. Closing #228 once this lands.

## Known follow-up

Very large CJK collections (STHeiti, some Noto CJK builds) may still hit `golang.org/x/image/font/sfnt`'s hardcoded `maxCmapSegments = 20000` limit. That is an upstream parser limit, orthogonal to TTC dispatch — the same font would fail in non-TTC form too. Worth a separate issue if it surfaces in the wild.