### PR TITLE
html, layout: fix flex shorthand with calc/min/max basis

### DIFF
--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -49,14 +49,22 @@ func baselineShiftFromStyle(style computedStyle) float64 {
 }
 
 // cssLengthToUnitValue converts a cssLength to a layout.UnitValue.
-// Percentage values are stored lazily (resolved at layout time).
-// Absolute values are resolved immediately to points.
+// Plain percentages and calc/min/max/clamp expressions that depend on a
+// percentage are deferred to layout time so they resolve against the
+// actual layout area rather than the converter's containerWidth (which
+// does not know about page margins or other late-bound constraints).
+// Pure absolute values are resolved immediately to points.
 func cssLengthToUnitValue(l *cssLength, containerWidth, fontSize float64) layout.UnitValue {
 	if l == nil {
 		return layout.Pt(0)
 	}
 	if l.Unit == "%" {
 		return layout.Pct(l.Value)
+	}
+	if l.dependsOnPercent() {
+		return layout.CalcUnit(func(available float64) float64 {
+			return l.toPoints(available, fontSize)
+		})
 	}
 	return layout.Pt(l.toPoints(containerWidth, fontSize))
 }

--- a/html/converter_style_parsers.go
+++ b/html/converter_style_parsers.go
@@ -297,3 +297,38 @@ func splitTopLevelCommas(s string) []string {
 	parts = append(parts, s[start:])
 	return parts
 }
+
+// splitTopLevelFields splits a string on whitespace at paren depth 0,
+// keeping functional values like "calc(50% - 8px)" or "min(10px, 5%)"
+// intact as a single field. Differs from strings.Fields, which would
+// split such values on their internal whitespace.
+func splitTopLevelFields(s string) []string {
+	var parts []string
+	depth := 0
+	start := -1
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		}
+		if depth == 0 && (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+			if start >= 0 {
+				parts = append(parts, s[start:i])
+				start = -1
+			}
+			continue
+		}
+		if start < 0 {
+			start = i
+		}
+	}
+	if start >= 0 {
+		parts = append(parts, s[start:])
+	}
+	return parts
+}

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -9,6 +9,7 @@ import (
 	"image/color"
 	"image/jpeg"
 	"image/png"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -528,6 +529,263 @@ func TestSplitTopLevelCommas(t *testing.T) {
 		parts := splitTopLevelCommas(tt.input)
 		if len(parts) != tt.want {
 			t.Errorf("splitTopLevelCommas(%q): got %d parts, want %d", tt.input, len(parts), tt.want)
+		}
+	}
+}
+
+func TestSplitTopLevelFields(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"0 0 auto", []string{"0", "0", "auto"}},
+		{"0 0 calc(50% - 8px)", []string{"0", "0", "calc(50% - 8px)"}},
+		{"1 1 min(100px, 50%)", []string{"1", "1", "min(100px, 50%)"}},
+		{"  spaced   words  ", []string{"spaced", "words"}},
+		{"clamp(10px, 5%, 20px) auto", []string{"clamp(10px, 5%, 20px)", "auto"}},
+		{"calc(1px + calc(2px - 1px))", []string{"calc(1px + calc(2px - 1px))"}},
+		{"a((b c) d) e", []string{"a((b c) d)", "e"}},
+		{"a\tb\nc\rd", []string{"a", "b", "c", "d"}},
+		{"  calc(50% - 8px)  ", []string{"calc(50% - 8px)"}},
+		// Unbalanced parens: '(' opens depth that never closes — the
+		// remainder is consumed as a single token (mirrors splitTopLevelCommas).
+		{"a (b c", []string{"a", "(b c"}},
+		// Stray ')' is treated as a literal character; depth stays at 0.
+		{"a) b", []string{"a)", "b"}},
+		{"   ", nil},
+		{"", nil},
+	}
+	for _, tt := range tests {
+		got := splitTopLevelFields(tt.input)
+		if len(got) != len(tt.want) {
+			t.Errorf("splitTopLevelFields(%q): got %v (%d), want %v (%d)",
+				tt.input, got, len(got), tt.want, len(tt.want))
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("splitTopLevelFields(%q)[%d] = %q, want %q",
+					tt.input, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
+func TestParseFlexShorthandWithCalc(t *testing.T) {
+	// Regression: `flex: 0 0 calc(50% - 8px)` was split on whitespace,
+	// yielding 5 tokens; no shorthand case matched and FlexBasis stayed nil.
+	// Cover all shorthand arities (1/2/3) and operator variants.
+	cases := []struct {
+		name        string
+		input       string
+		wantGrow    float64
+		wantShrink  float64 // initial value 1 unless the shorthand sets it
+		wantBasisAt float64 // expected toPoints(relativeTo=200, fontSize=12)
+	}{
+		// Three-token forms set all three.
+		{"three: 0 0 calc(50% - 8px)", "0 0 calc(50% - 8px)", 0, 0, 200*0.5 - 6},
+		{"three: 1 0 calc(100% / 2)", "1 0 calc(100% / 2)", 1, 0, 200 / 2},
+		{"three: 1 1 calc(50% + 10px)", "1 1 calc(50% + 10px)", 1, 1, 200*0.5 + 10*0.75},
+		{"three: 1 1 calc(2 * 25%)", "1 1 calc(2 * 25%)", 1, 1, 2 * 200 * 0.25},
+		// Two-token form: `<flex-grow> <flex-basis>`. The parser sets grow
+		// from parts[0] but does not touch FlexShrink — it stays at 1.
+		{"two: 1 calc(50% - 8px)", "1 calc(50% - 8px)", 1, 1, 200*0.5 - 6},
+		// Single-token form: a non-numeric token is parsed as the basis;
+		// FlexGrow and FlexShrink keep their initial values (0, 1).
+		// Pre-fix this hit case 3 because strings.Fields produced 3 tokens.
+		{"one: calc(50% - 8px)", "calc(50% - 8px)", 0, 1, 200*0.5 - 6},
+	}
+	for _, tc := range cases {
+		s := computedStyle{FlexGrow: 0, FlexShrink: 1}
+		parseFlexShorthand(tc.input, &s)
+		if s.FlexGrow != tc.wantGrow {
+			t.Errorf("%s: FlexGrow = %v, want %v", tc.name, s.FlexGrow, tc.wantGrow)
+		}
+		if s.FlexShrink != tc.wantShrink {
+			t.Errorf("%s: FlexShrink = %v, want %v", tc.name, s.FlexShrink, tc.wantShrink)
+		}
+		if s.FlexBasis == nil {
+			t.Errorf("%s: FlexBasis is nil for %q", tc.name, tc.input)
+			continue
+		}
+		got := s.FlexBasis.toPoints(200, 12)
+		if math.Abs(got-tc.wantBasisAt) > 0.01 {
+			t.Errorf("%s: FlexBasis.toPoints(200, 12) = %.4f, want %.4f",
+				tc.name, got, tc.wantBasisAt)
+		}
+	}
+}
+
+func TestParseFlexShorthandWithMinMaxBasis(t *testing.T) {
+	cases := []struct {
+		input         string
+		wantGrow      float64
+		wantShrink    float64
+		wantBasisAt   float64 // toPoints(relativeTo=200, fontSize=12)
+		wantBasisDesc string
+	}{
+		// min(100px, 50%) → min(75pt, 100pt) at relativeTo=200 → 75pt.
+		{"1 1 min(100px, 50%)", 1, 1, 75, "min picks smaller"},
+		// max(100px, 30%) → max(75pt, 60pt) at relativeTo=200 → 75pt.
+		{"1 0 max(100px, 30%)", 1, 0, 75, "max picks larger"},
+		// clamp(50px, 20%, 200px) → clamp(37.5pt, 40pt, 150pt) at 200 → 40pt.
+		{"0 0 clamp(50px, 20%, 200px)", 0, 0, 40, "clamp middle wins"},
+	}
+	for _, tc := range cases {
+		s := computedStyle{FlexGrow: 0, FlexShrink: 1}
+		parseFlexShorthand(tc.input, &s)
+		if s.FlexGrow != tc.wantGrow {
+			t.Errorf("%q: FlexGrow = %v, want %v", tc.input, s.FlexGrow, tc.wantGrow)
+		}
+		if s.FlexShrink != tc.wantShrink {
+			t.Errorf("%q: FlexShrink = %v, want %v", tc.input, s.FlexShrink, tc.wantShrink)
+		}
+		if s.FlexBasis == nil {
+			t.Errorf("%q: FlexBasis is nil", tc.input)
+			continue
+		}
+		got := s.FlexBasis.toPoints(200, 12)
+		if math.Abs(got-tc.wantBasisAt) > 0.01 {
+			t.Errorf("%q (%s): FlexBasis.toPoints(200, 12) = %.4f, want %.4f",
+				tc.input, tc.wantBasisDesc, got, tc.wantBasisAt)
+		}
+	}
+}
+
+// TestCSSLengthToUnitValueBranches asserts each branch of the
+// length→UnitValue mapping. The lazy CalcUnit branch is the load-bearing
+// fix for percentages-inside-calc resolving against the wrong container.
+func TestCSSLengthToUnitValueBranches(t *testing.T) {
+	const convertContainer = 1000.0 // converter-time width
+	const layoutAvailable = 200.0   // layout-time width (intentionally different)
+
+	t.Run("absolute px → eager Pt", func(t *testing.T) {
+		l := parseLength("12px")
+		uv := cssLengthToUnitValue(l, convertContainer, 12)
+		if uv.Unit != layout.UnitPoint {
+			t.Errorf("Unit = %d, want UnitPoint", uv.Unit)
+		}
+		// Resolved at convert time; layout-time available is ignored.
+		if got := uv.Resolve(layoutAvailable); math.Abs(got-9) > 0.01 {
+			t.Errorf("Resolve(%g) = %g, want 9 (12px = 9pt)", layoutAvailable, got)
+		}
+	})
+
+	t.Run("plain percent → lazy Pct", func(t *testing.T) {
+		l := parseLength("50%")
+		uv := cssLengthToUnitValue(l, convertContainer, 12)
+		if uv.Unit != layout.UnitPercent {
+			t.Errorf("Unit = %d, want UnitPercent", uv.Unit)
+		}
+		// Pct resolves against the layout-time available, not convertContainer.
+		if got := uv.Resolve(layoutAvailable); math.Abs(got-100) > 0.01 {
+			t.Errorf("Resolve(%g) = %g, want 100 (50%% of %g)", layoutAvailable, got, layoutAvailable)
+		}
+	})
+
+	t.Run("calc with percent → lazy CalcUnit", func(t *testing.T) {
+		l := parseLength("calc(50% - 8px)")
+		uv := cssLengthToUnitValue(l, convertContainer, 12)
+		if uv.Unit != layout.UnitCalc {
+			t.Errorf("Unit = %d, want UnitCalc (calc with percent must defer)", uv.Unit)
+		}
+		if uv.Calc == nil {
+			t.Fatal("Calc closure is nil")
+		}
+		// Closure must use layoutAvailable, not convertContainer.
+		// 50% of 200 - 8px(=6pt) = 94pt.
+		got := uv.Resolve(layoutAvailable)
+		if math.Abs(got-94) > 0.01 {
+			t.Errorf("Resolve(%g) = %g, want 94 (= 50%%·200 - 6pt). "+
+				"If you got 494 the closure captured the convert-time container.", layoutAvailable, got)
+		}
+		// And resolving against a different available recomputes correctly.
+		if got := uv.Resolve(400); math.Abs(got-194) > 0.01 {
+			t.Errorf("Resolve(400) = %g, want 194", got)
+		}
+	})
+
+	t.Run("calc without percent → eager Pt", func(t *testing.T) {
+		l := parseLength("calc(10px + 20px)")
+		uv := cssLengthToUnitValue(l, convertContainer, 12)
+		if uv.Unit != layout.UnitPoint {
+			t.Errorf("Unit = %d, want UnitPoint (no percent → no need to defer)", uv.Unit)
+		}
+		// 30px = 22.5pt at convert time.
+		if got := uv.Resolve(layoutAvailable); math.Abs(got-22.5) > 0.01 {
+			t.Errorf("Resolve = %g, want 22.5", got)
+		}
+	})
+
+	t.Run("min(100px, 50%) → lazy CalcUnit", func(t *testing.T) {
+		l := parseLength("min(100px, 50%)")
+		uv := cssLengthToUnitValue(l, convertContainer, 12)
+		if uv.Unit != layout.UnitCalc {
+			t.Errorf("Unit = %d, want UnitCalc", uv.Unit)
+		}
+		// At available=200: min(75pt, 100pt) = 75pt.
+		if got := uv.Resolve(200); math.Abs(got-75) > 0.01 {
+			t.Errorf("Resolve(200) = %g, want 75", got)
+		}
+		// At available=100: min(75pt, 50pt) = 50pt — proves the closure re-resolves.
+		if got := uv.Resolve(100); math.Abs(got-50) > 0.01 {
+			t.Errorf("Resolve(100) = %g, want 50", got)
+		}
+	})
+
+	t.Run("min without percent → eager Pt", func(t *testing.T) {
+		l := parseLength("min(100px, 50px)")
+		uv := cssLengthToUnitValue(l, convertContainer, 12)
+		if uv.Unit != layout.UnitPoint {
+			t.Errorf("Unit = %d, want UnitPoint", uv.Unit)
+		}
+		if got := uv.Resolve(0); math.Abs(got-37.5) > 0.01 {
+			t.Errorf("Resolve = %g, want 37.5 (50px)", got)
+		}
+	})
+
+	t.Run("nil cssLength → Pt(0)", func(t *testing.T) {
+		uv := cssLengthToUnitValue(nil, convertContainer, 12)
+		if uv.Unit != layout.UnitPoint || uv.Value != 0 {
+			t.Errorf("nil cssLength → %+v, want Pt(0)", uv)
+		}
+	})
+}
+
+// TestDependsOnPercent covers the recursive percent detection over
+// calc/min/max/clamp trees, including nested combinations.
+func TestDependsOnPercent(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		// Plain values: dependsOnPercent only applies to compound expressions,
+		// so a plain "%" returns false (the % path is handled separately).
+		{"50%", false},
+		{"12px", false},
+		// calc() variants.
+		{"calc(50% - 8px)", true},
+		{"calc(10px + 20px)", false},
+		{"calc(2 * 25%)", true},
+		{"calc(2 * 25px)", false},
+		// min/max/clamp variants.
+		{"min(100px, 50%)", true},
+		{"min(100px, 50px)", false},
+		{"max(50%, 100px)", true},
+		{"clamp(50px, 20%, 200px)", true},
+		{"clamp(50px, 100px, 200px)", false},
+		// Function inside function: percent buried under min(calc(...)).
+		{"min(100px, calc(2 * 25%))", true},
+		{"min(100px, calc(2 * 25px))", false},
+	}
+	for _, tt := range tests {
+		l := parseLength(tt.input)
+		if l == nil {
+			t.Errorf("%q: parseLength returned nil", tt.input)
+			continue
+		}
+		if got := l.dependsOnPercent(); got != tt.want {
+			t.Errorf("%q.dependsOnPercent() = %v, want %v", tt.input, got, tt.want)
 		}
 	}
 }

--- a/html/flex_calc_basis_test.go
+++ b/html/flex_calc_basis_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"math"
+	"testing"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// TestFlexShorthandWithCalcBasis is an end-to-end regression for two
+// connected bugs surfaced by `flex: 0 0 calc(50% - 8px)`:
+//
+//  1. parseFlexShorthand split the value with strings.Fields, which broke
+//     calc(50% - 8px) into 5 tokens; no shorthand case matched, so
+//     FlexBasis stayed nil. The flex algorithm fell back to MaxWidth(),
+//     producing asymmetric columns sized to intrinsic content.
+//  2. cssLengthToUnitValue eagerly resolved any non-percent length
+//     (including calc with percentages) against the converter's
+//     containerWidth — which does not account for page margins. So
+//     calc(50% - 8px) of 541.28pt was 264.64pt instead of
+//     calc(50% - 8px) of the actual layout area 456.24pt.
+//
+// Symptom in the contact-profile reduction case: a `flex: 1` value
+// sibling collapsed to one character per line because its column ended
+// up narrower than the sibling `width: 170px; flex-shrink: 0` term.
+//
+// Geometry chosen so all numbers are stable regardless of future
+// default-margin changes — the test pins the layout area explicitly via
+// PlanLayout rather than relying on document margins.
+func TestFlexShorthandWithCalcBasis(t *testing.T) {
+	htmlDoc := `<!DOCTYPE html><html><head><style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+.pdf-page { padding: 28px 36px; font-size: 13px; }
+.grid-2 { display: flex; flex-wrap: wrap; gap: 16px; }
+.grid-2 > * { flex: 0 0 calc(50% - 8px); min-width: 0; }
+.def-row { display: flex; gap: 16px; }
+.def-term { width: 170px; flex-shrink: 0; }
+.def-value { flex: 1; }
+</style></head><body><div class="pdf-page">
+<div class="grid-2">
+  <div><div class="def-row"><div class="def-term">Email</div><div class="def-value">brian.halligan@hubspot.com</div></div></div>
+  <div><div class="def-row"><div class="def-term">HubSpot</div><div class="def-value">Software</div></div></div>
+</div>
+</div></body></html>`
+
+	// Pin the layout area explicitly so the test does not drift if the
+	// document's default margins change.
+	const pageW = 595.28
+	const layoutArea = 510.24 // = pageW - 42.52*2
+
+	elems, err := Convert(htmlDoc, &Options{PageWidth: pageW, PageHeight: 841.89})
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if len(elems) != 1 {
+		t.Fatalf("got %d top-level elements, want 1", len(elems))
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: layoutArea, Height: 1e9})
+
+	// .pdf-page has padding 36px = 27pt L/R; inner = 510.24 - 54 = 456.24pt.
+	// Each grid-2 column is calc(50% - 8px) = 50% × 456.24 - 6 = 222.12pt.
+	// Two columns + 12pt gap (16px) should sum back to 456.24pt exactly.
+	const wantCol = 222.12
+	const wantGap = 12.0 // 16px = 12pt
+
+	cols := findGridColumns(plan.Blocks)
+	if len(cols) != 2 {
+		t.Fatalf("expected 2 grid-2 columns at the same Y, got %d", len(cols))
+	}
+
+	// Each column is the expected calc-resolved width.
+	for i, c := range cols {
+		if math.Abs(c.Width-wantCol) > 0.5 {
+			t.Errorf("column %d width = %.2f, want ~%.2f", i, c.Width, wantCol)
+		}
+	}
+
+	// Side-by-side, not stacked: cols[0] at x=0, cols[1] at x=cols[0].Width+gap.
+	if cols[0].X != 0 {
+		t.Errorf("cols[0].X = %.2f, want 0", cols[0].X)
+	}
+	wantSecondX := cols[0].Width + wantGap
+	if math.Abs(cols[1].X-wantSecondX) > 0.5 {
+		t.Errorf("cols[1].X = %.2f, want ~%.2f (cols[0].Width + gap)", cols[1].X, wantSecondX)
+	}
+
+	// Both cols at the same Y rules out vertical stacking — which is what
+	// happened when calc resolved against the wrong (too-large) container
+	// and items wrapped to separate lines.
+	if cols[0].Y != cols[1].Y {
+		t.Errorf("cols Y differ: %.2f vs %.2f — items stacked vertically", cols[0].Y, cols[1].Y)
+	}
+}
+
+// findGridColumns walks the layout tree and returns the two grid columns:
+// the first parent block whose direct children include exactly two boxes
+// at Y == 0 with positive width and distinct X positions. The repro
+// document is shallow and unique enough that this match is unambiguous;
+// tests assert the X/gap geometry afterwards to catch any false positives.
+func findGridColumns(blocks []layout.PlacedBlock) []layout.PlacedBlock {
+	for _, b := range blocks {
+		var atTop []layout.PlacedBlock
+		for _, c := range b.Children {
+			if c.Y == 0 && c.Width > 0 {
+				atTop = append(atTop, c)
+			}
+		}
+		if len(atTop) == 2 && atTop[0].X != atTop[1].X {
+			return atTop
+		}
+		if cs := findGridColumns(b.Children); len(cs) == 2 {
+			return cs
+		}
+	}
+	return nil
+}

--- a/html/properties.go
+++ b/html/properties.go
@@ -888,7 +888,9 @@ func parseFlexShorthand(val string, style *computedStyle) {
 		return
 	}
 
-	parts := strings.Fields(val)
+	// Split on top-level whitespace so functional values like
+	// calc(50% - 8px) or min(10px, 5%) survive as a single token.
+	parts := splitTopLevelFields(val)
 
 	switch len(parts) {
 	case 1:

--- a/html/style.go
+++ b/html/style.go
@@ -265,6 +265,46 @@ type calcExpr struct {
 	right *calcExpr
 }
 
+// dependsOnPercent reports whether the resolved value would change with
+// available width — i.e. a percentage appears somewhere in a calc, min,
+// max, or clamp tree. Plain Unit == "%" lengths take the Pct(...) path
+// in cssLengthToUnitValue and don't need this check.
+func (l *cssLength) dependsOnPercent() bool {
+	if l == nil {
+		return false
+	}
+	if l.calc != nil {
+		return l.calc.dependsOnPercent()
+	}
+	for _, a := range l.minArgs {
+		if a.Unit == "%" || a.dependsOnPercent() {
+			return true
+		}
+	}
+	for _, a := range l.maxArgs {
+		if a.Unit == "%" || a.dependsOnPercent() {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *calcExpr) dependsOnPercent() bool {
+	if e == nil {
+		return false
+	}
+	if e.leaf != nil {
+		if e.leaf.Unit == "%" {
+			return true
+		}
+		return e.leaf.dependsOnPercent()
+	}
+	if e.left == nil || e.right == nil {
+		return false
+	}
+	return e.left.dependsOnPercent() || e.right.dependsOnPercent()
+}
+
 // resolve evaluates a calcExpr to points.
 func (e *calcExpr) resolve(relativeTo, fontSize float64) float64 {
 	if e.leaf != nil {

--- a/layout/div.go
+++ b/layout/div.go
@@ -449,7 +449,8 @@ func (d *Div) Layout(maxWidth float64) []Line {
 // MinWidth implements Measurable. Returns padding + max child MinWidth,
 // or the div's own explicit width if set.
 func (d *Div) MinWidth() float64 {
-	// UnitValue width (only absolute values are intrinsic; percentages return 0).
+	// Only absolute values are intrinsic. UnitPercent and UnitCalc both
+	// depend on available width and contribute 0 here.
 	if d.widthUnit != nil && d.widthUnit.Unit == UnitPoint {
 		return d.widthUnit.Value
 	}
@@ -473,6 +474,7 @@ func (d *Div) MinWidth() float64 {
 // MaxWidth implements Measurable. Returns padding + max child MaxWidth,
 // or the div's own explicit width if set.
 func (d *Div) MaxWidth() float64 {
+	// Mirrors MinWidth: UnitPercent and UnitCalc are non-intrinsic.
 	if d.widthUnit != nil && d.widthUnit.Unit == UnitPoint {
 		return d.widthUnit.Value
 	}

--- a/layout/unitvalue.go
+++ b/layout/unitvalue.go
@@ -9,13 +9,20 @@ type UnitType int
 const (
 	UnitPoint   UnitType = iota // absolute value in PDF points
 	UnitPercent                 // percentage of available width
+	UnitCalc                    // expression resolved against available width at layout time
 )
 
 // UnitValue represents a measurement that can be either an absolute
-// point value or a percentage of available space.
+// point value, a percentage of available space, or a calc()-style
+// expression resolved lazily at layout time.
 type UnitValue struct {
 	Value float64
 	Unit  UnitType
+	// Calc resolves the value against the available width. Only used
+	// when Unit == UnitCalc; nil otherwise. Lets calc() expressions
+	// containing percentages be resolved against the actual layout area
+	// rather than an eagerly-captured container width.
+	Calc func(available float64) float64
 }
 
 // Pt creates a UnitValue in PDF points.
@@ -28,10 +35,23 @@ func Pct(v float64) UnitValue {
 	return UnitValue{Value: v, Unit: UnitPercent}
 }
 
+// CalcUnit creates a UnitValue whose resolution is deferred to layout time.
+// Pass a closure that, given the available width, returns points. Used for
+// CSS calc()/min()/max()/clamp() expressions that contain percentage parts.
+func CalcUnit(fn func(available float64) float64) UnitValue {
+	return UnitValue{Unit: UnitCalc, Calc: fn}
+}
+
 // Resolve converts a UnitValue to points given the available width.
 func (u UnitValue) Resolve(available float64) float64 {
-	if u.Unit == UnitPercent {
+	switch u.Unit {
+	case UnitPercent:
 		return available * u.Value / 100
+	case UnitCalc:
+		if u.Calc != nil {
+			return u.Calc(available)
+		}
+		return 0
 	}
 	return u.Value
 }


### PR DESCRIPTION
## Summary

Fixes two connected layout bugs surfaced by `flex: 0 0 calc(50% - 8px)`:

1. **`parseFlexShorthand` lost calc/min/max basis.** It used `strings.Fields(val)`, which split `calc(50% - 8px)` on its internal whitespace into 5 tokens. With 5 tokens, no shorthand case (1/2/3) matched, so `FlexBasis` was silently dropped. The flex algorithm then fell back to `MaxWidth()`, producing asymmetric columns sized to intrinsic content.

2. **`cssLengthToUnitValue` resolved calc-with-percentages eagerly** against the converter's `containerWidth`, which does not account for the document's page margins applied at render time. So `calc(50% - 8px)` of containerWidth=541.28pt resolved to 264.64pt instead of the correct 222.12pt against the actual layout area (456.24pt). This was hidden by bug #1 and surfaced only after fixing the parser.

Symptom in the field: a sibling `flex: 1` value collapsed to one character per line because the parent column ended up narrower than the term sibling's `width: 170px; flex-shrink: 0`.

## Fix

- `html/converter_style_parsers.go`: new `splitTopLevelFields` — paren-aware whitespace splitter, sibling to existing `splitTopLevelCommas`. Functional values (`calc()`, `min()`, `max()`, `clamp()`) survive as single tokens.
- `html/properties.go`: `parseFlexShorthand` uses `splitTopLevelFields`.
- `html/style.go`: `cssLength.dependsOnPercent()` and `calcExpr.dependsOnPercent()` walk the tree to detect percentage participation in calc/min/max/clamp expressions.
- `html/converter_block.go`: `cssLengthToUnitValue` returns a lazy `layout.CalcUnit` closure when the length depends on a percentage; pure absolute lengths still resolve eagerly via `Pt`.
- `layout/unitvalue.go`: new `UnitCalc` variant with a `Calc func(available float64) float64` closure resolved at layout time. New `CalcUnit(fn)` constructor.
- `layout/div.go`: comment update on `MinWidth`/`MaxWidth` to clarify why `UnitCalc` (like `UnitPercent`) is non-intrinsic.

## API note

`layout.UnitValue` now holds a func field for the `UnitCalc` variant, so the struct is no longer comparable with `==`. No existing consumer in the repo did equality comparisons on `UnitValue`; out-of-tree consumers that did would see a compile error.

## Known follow-up (out of scope)

Other shorthand parsers in the codebase still use `strings.Fields` on values that may legally contain `calc()`/`min()`/`max()`/`clamp()`. Same root tokenization bug, different surface:

- `parseMarginShorthand`, `parseBorderFull`, `parseFontShorthand` (`html/properties.go`)
- `parseTransformOrigin`, `parseBoxShadow` (`html/converter_style_parsers.go`)
- background-size and several other shorthand handlers (`html/converter_helpers.go`, `html/converter_style.go`)
- `@page` size (`html/page.go`)

Each can be migrated to `splitTopLevelFields` independently. Not bundled here to keep the diff focused on the reported bug.

## Test plan

- [x] `go test ./...` — all packages pass on the branch
- [x] `TestSplitTopLevelFields` — paren depth, unbalanced parens, nested calc, leading/trailing whitespace, tabs/newlines, empty input
- [x] `TestParseFlexShorthandWithCalc` — 1/2/3-token shorthand forms with `+`, `-`, `*`, `/` operators
- [x] `TestParseFlexShorthandWithMinMaxBasis` — min/max/clamp resolve to expected points (not just non-nil)
- [x] `TestCSSLengthToUnitValueBranches` — each branch (Pt eager, Pct lazy, CalcUnit lazy with percent, Pt eager without percent) and verifies the CalcUnit closure honors layout-time `available`, not convert-time container
- [x] `TestDependsOnPercent` — nested function-in-function expressions
- [x] `TestFlexShorthandWithCalcBasis` — end-to-end regression that reproduces the contact-profile geometry and asserts column widths, X positions, gap math, and that columns lay out side-by-side rather than stacking