### PR TITLE
html: fix background-size with calc/min/max values

### DIFF
--- a/html/converter_helpers.go
+++ b/html/converter_helpers.go
@@ -619,7 +619,9 @@ func (c *converter) resolveBackgroundImage(style computedStyle) *layout.Backgrou
 
 	// Parse explicit size values.
 	if style.BackgroundSize != "" && style.BackgroundSize != "cover" && style.BackgroundSize != "contain" && style.BackgroundSize != "auto" {
-		parts := strings.Fields(style.BackgroundSize)
+		// splitTopLevelFields keeps calc()/min()/max()/clamp() values as
+		// a single token even when they contain internal whitespace.
+		parts := splitTopLevelFields(style.BackgroundSize)
 		if len(parts) >= 1 {
 			if l := parseLength(parts[0]); l != nil {
 				bgImg.SizeW = l.toPoints(0, style.FontSize)

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -6695,6 +6695,141 @@ func TestBackgroundSize(t *testing.T) {
 	}
 }
 
+// TestBackgroundSizeWithCalc is a regression test for the same
+// strings.Fields tokenization bug fixed for `flex:` (#236),
+// `margin:`/`padding:` (#237), `font:` (#240), and `border:` (#242),
+// applied here to `background-size:`. Pre-fix, a value like
+// `background-size: calc(50px + 50px) 100px` was split into 5 tokens
+// ["calc(50px", "+", "50px)", "100px", ...]; parts[0] = "calc(50px"
+// (unbalanced) parsed nil → SizeW stayed 0; parts[1] = "+" parsed nil
+// → SizeH stayed 0; the explicit size was silently lost.
+//
+// Pre-existing limitation NOT addressed here: SizeW/SizeH are stored
+// as float64 and the parser passes relativeTo=0 to toPoints, so plain
+// percent values (`background-size: 50%`) resolve to 0pt. Mirrors the
+// margin/padding limitation called out in #237. Out of scope.
+func TestBackgroundSizeWithCalc(t *testing.T) {
+	tests := []struct {
+		name      string
+		size      string
+		wantSizeW float64 // in pt
+		wantSizeH float64 // 0 means unset
+	}{
+		{
+			name: "calc width, plain px height",
+			size: "calc(50px + 50px) 100px",
+			// 100px = 75pt, 100px = 75pt.
+			wantSizeW: 75, wantSizeH: 75,
+		},
+		{
+			name: "calc width only",
+			size: "calc(50px + 50px)",
+			// Single value → only SizeW set.
+			wantSizeW: 75, wantSizeH: 0,
+		},
+		{
+			name: "calc on both axes",
+			size: "calc(50px + 50px) calc(20px * 2)",
+			// 100px = 75pt; 40px = 30pt.
+			wantSizeW: 75, wantSizeH: 30,
+		},
+		{
+			name: "min() width, max() height",
+			size: "min(80px, 100px) max(40px, 60px)",
+			// min picks 80px = 60pt; max picks 60px = 45pt.
+			wantSizeW: 60, wantSizeH: 45,
+		},
+		{
+			name: "clamp() width",
+			size: "clamp(50px, 100px, 200px) 80px",
+			// clamp middle = 100px = 75pt; 80px = 60pt.
+			wantSizeW: 75, wantSizeH: 60,
+		},
+		{
+			name: "calc with subtraction",
+			size: "calc(200px - 100px) 50px",
+			// 100px = 75pt, 50px = 37.5pt.
+			wantSizeW: 75, wantSizeH: 37.5,
+		},
+		{
+			name: "calc with multiplication",
+			size: "calc(50px * 2) 50px",
+			// 100px = 75pt, 50px = 37.5pt.
+			wantSizeW: 75, wantSizeH: 37.5,
+		},
+		{
+			name: "calc with division",
+			size: "calc(200px / 2) 50px",
+			// 100px = 75pt.
+			wantSizeW: 75, wantSizeH: 37.5,
+		},
+		{
+			name:      "tab as separator",
+			size:      "calc(50px + 50px)\t100px",
+			wantSizeW: 75, wantSizeH: 75,
+		},
+		{
+			name:      "newline as separator",
+			size:      "calc(50px + 50px)\n100px",
+			wantSizeW: 75, wantSizeH: 75,
+		},
+		{
+			name:      "plain two-value (no calc) still works post-swap",
+			size:      "100px 50px",
+			wantSizeW: 75, wantSizeH: 37.5,
+		},
+		{
+			name: "3+ tokens: extras silently dropped",
+			// CSS background-size accepts 1 or 2 values. The parser only
+			// reads parts[0] and parts[1]; any extras are ignored. Locks
+			// that contract.
+			size:      "100px 50px 25px",
+			wantSizeW: 75, wantSizeH: 37.5,
+		},
+		{
+			name: "auto keyword short-circuits before token parsing",
+			// "auto" hits the early-exit guard before splitTopLevelFields
+			// is reached; SizeW/SizeH stay at 0. Sanity check that the
+			// guard wasn't accidentally dropped by this PR.
+			size:      "auto",
+			wantSizeW: 0, wantSizeH: 0,
+		},
+		{
+			name: "unbalanced calc paren: SizeW and SizeH stay 0",
+			// splitTopLevelFields keeps the unbalanced calc + trailing
+			// characters as one single token (depth never returns to 0).
+			// So len(parts) == 1: parseLength rejects the lone token →
+			// SizeW stays 0; SizeH stays 0 because there's no parts[1] —
+			// not because parseLength rejected anything. Documents the
+			// no-crash invariant on malformed input.
+			size:      "calc(50px + 50px 100px",
+			wantSizeW: 0, wantSizeH: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &converter{
+				embeddedFonts: make(map[string]*font.EmbeddedFont),
+			}
+			style := computedStyle{
+				BackgroundImage: "linear-gradient(red, blue)",
+				BackgroundSize:  tt.size,
+				FontSize:        12,
+			}
+			bgImg := c.resolveBackgroundImage(style)
+			if bgImg == nil {
+				t.Fatal("resolveBackgroundImage returned nil")
+			}
+			if math.Abs(bgImg.SizeW-tt.wantSizeW) > 0.01 {
+				t.Errorf("SizeW = %.4f, want %.4f", bgImg.SizeW, tt.wantSizeW)
+			}
+			if math.Abs(bgImg.SizeH-tt.wantSizeH) > 0.01 {
+				t.Errorf("SizeH = %.4f, want %.4f", bgImg.SizeH, tt.wantSizeH)
+			}
+		})
+	}
+}
+
 func TestBackgroundPosition(t *testing.T) {
 	htmlStr := `<div style="background-image: linear-gradient(to right, red, blue); background-position: center; padding: 10px;"><p>Center</p></div>`
 	elems, err := Convert(htmlStr, nil)


### PR DESCRIPTION
## Summary

Same tokenization bug as #236 (flex), #237 (margin/padding), #240 (font), #242 (border), applied to `background-size:`. The parser inside `resolveBackgroundImage` used `strings.Fields`, which split functional values on internal whitespace.

Pre-fix: `background-size: calc(50px + 50px) 100px` became 4 tokens `[\"calc(50px\", \"+\", \"50px)\", \"100px\"]`. `parts[0] = \"calc(50px\"` (unbalanced) failed `parseLength` → `SizeW` stayed 0; `parts[1] = \"+\"` failed too → `SizeH` stayed 0; the explicit size was silently lost.

Fix: swap `strings.Fields` for `splitTopLevelFields` (added in #236) so functional values survive as single tokens.

## Out of scope (pre-existing)

`SizeW`/`SizeH` are stored as `float64` and the parser calls `toPoints(0, fontSize)`, so plain percent values like `background-size: 50%` resolve to `0pt`. Same data-model limitation as `margin`/`padding` called out in #237 — would require widening to `*cssLength` resolved at draw time against the element's box.

## Known follow-ups (other parsers in the same series)

Reviewer flagged additional `strings.Fields` callsites worth follow-up PRs in the same shape: `gap`/`grid-gap`, `border-spacing`, `border-radius`, `columns`, `@page size`, `transform-origin`, `box-shadow` lengths, gradient-stop position, `background-position`, plus the margin auto-flag detector. Each is its own focused PR.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `gofmt -s -l .` clean
- [x] `TestBackgroundSizeWithCalc` (14 subtests via `t.Run`):
  - calc with `+`, `-`, `*`, `/` operators
  - `min()`, `max()`, `clamp()`
  - calc width only / calc on both axes / mixed calc + plain
  - tab and newline separators
  - plain two-value parsing
  - 3+ tokens (extras silently dropped)
  - `auto` keyword short-circuits before the swap site
  - unbalanced-paren no-crash
- [x] Existing `TestBackgroundSize` / `TestBackgroundPosition` / `TestBackgroundRepeatNoRepeat` unchanged