### PR TITLE
layout: honor SpaceAfter=0 when reconstructing paragraph runs across page splits

### DIFF
--- a/layout/clone_test.go
+++ b/layout/clone_test.go
@@ -285,3 +285,120 @@ func TestDevanagariGIDsRegenerateAfterPageSplit(t *testing.T) {
 		t.Error("Devanagari GIDs not regenerated after page split — Identity-H text emission will fail")
 	}
 }
+
+// TestCJKNoSpuriousSpacesAfterPageSplit verifies that when a CJK
+// paragraph crosses a page break, the reconstructed overflow text
+// does not contain spurious ASCII spaces between ideographs.
+//
+// Before this fix, cloneWithWords joined same-style words with a
+// literal " " regardless of the word's SpaceAfter. CJK ideographs
+// have SpaceAfter=0 (no inter-word spacing); the join rule corrupted
+// the output by inserting visible spaces, e.g. "中文" became "中 文"
+// in any second-page continuation.
+func TestCJKNoSpuriousSpacesAfterPageSplit(t *testing.T) {
+	text := strings.Repeat("中文文本", 30)
+	p := NewParagraph(text, font.Helvetica, 12)
+
+	plan := p.PlanLayout(LayoutArea{Width: 60, Height: 30})
+	if plan.Status != LayoutPartial {
+		t.Fatalf("expected LayoutPartial, got %v", plan.Status)
+	}
+	overflow := plan.Overflow.(*Paragraph)
+
+	// The reconstructed runs hold the joined text; no run should
+	// contain an ASCII space between ideographs.
+	for i, run := range overflow.Runs() {
+		if strings.ContainsRune(run.Text, ' ') {
+			t.Errorf("run %d text contains spurious space: %q", i, run.Text)
+		}
+	}
+}
+
+// TestCJKLineCountReconcilesAfterPageSplit verifies that the line
+// count of head + tail matches the original. With the spurious-space
+// bug, re-laying the overflow produced MORE lines than the original
+// at the same width, because every inserted space became a real
+// spaceW-wide gap during re-measurement.
+func TestCJKLineCountReconcilesAfterPageSplit(t *testing.T) {
+	text := strings.Repeat("中文文本", 30)
+	p := NewParagraph(text, font.Helvetica, 12)
+	totalLines := p.MeasureLines(60)
+	if totalLines < 5 {
+		t.Fatalf("test setup needs ≥5 wrapped lines; got %d (Helvetica CJK measurement may have changed)", totalLines)
+	}
+
+	plan := p.PlanLayout(LayoutArea{Width: 60, Height: 30})
+	if plan.Status != LayoutPartial {
+		t.Fatalf("expected LayoutPartial, got %v", plan.Status)
+	}
+	overflow := plan.Overflow.(*Paragraph)
+	overflowLines := overflow.MeasureLines(60)
+
+	consumedLines := totalLines - overflowLines
+	if consumedLines < 1 {
+		t.Errorf("overflow line count exceeds original (corruption likely): total=%d overflow=%d", totalLines, overflowLines)
+	}
+	if overflowLines == 0 {
+		t.Errorf("overflow has zero lines despite LayoutPartial status")
+	}
+}
+
+// TestMixedCJKLatinNoSpuriousSpacesAfterPageSplit verifies that when
+// CJK and Latin text mix in the same paragraph, page-split joins:
+//   - preserve glued boundaries (CJK adjacent to Latin without source space)
+//   - preserve real source spaces (one and only one between Latin words)
+//   - never insert spaces between adjacent CJK characters
+func TestMixedCJKLatinNoSpuriousSpacesAfterPageSplit(t *testing.T) {
+	// Source has explicit spaces only between "word" and the next CJK chunk.
+	text := strings.Repeat("中文word ", 30)
+	p := NewParagraph(text, font.Helvetica, 12)
+
+	plan := p.PlanLayout(LayoutArea{Width: 80, Height: 30})
+	if plan.Status != LayoutPartial {
+		t.Fatalf("expected LayoutPartial, got %v", plan.Status)
+	}
+	overflow := plan.Overflow.(*Paragraph)
+
+	for i, run := range overflow.Runs() {
+		// "中 文" or "文 word" or "word中" would all indicate corruption.
+		// The intended forms are "中文word" (glued) and "word 中" (source space).
+		if strings.Contains(run.Text, "中 ") || strings.Contains(run.Text, "文 中") || strings.Contains(run.Text, "文 文") {
+			t.Errorf("run %d: spurious space between CJK chars: %q", i, run.Text)
+		}
+		// "word中" without an intervening space would indicate the source
+		// space was dropped. The source had "word " before each "中".
+		if strings.Contains(run.Text, "word中") {
+			t.Errorf("run %d: source space dropped between Latin and CJK: %q", i, run.Text)
+		}
+	}
+}
+
+// TestLineBreakResetsJoinStateAcrossPageSplit verifies that a forced
+// linebreak (\n) in the middle of a CJK paragraph splits cleanly
+// across a page boundary — the LineBreak branch must update
+// prevSpaceAfter so the post-break word joins correctly.
+func TestLineBreakResetsJoinStateAcrossPageSplit(t *testing.T) {
+	// Several lines of CJK with explicit \n breaks; long enough to
+	// force a page split somewhere mid-paragraph.
+	chunk := "中文文本"
+	text := ""
+	for i := 0; i < 20; i++ {
+		if i > 0 {
+			text += "\n"
+		}
+		text += chunk
+	}
+	p := NewParagraph(text, font.Helvetica, 12)
+
+	plan := p.PlanLayout(LayoutArea{Width: 60, Height: 30})
+	if plan.Status != LayoutPartial {
+		t.Fatalf("expected LayoutPartial, got %v", plan.Status)
+	}
+	overflow := plan.Overflow.(*Paragraph)
+
+	for i, run := range overflow.Runs() {
+		if strings.Contains(run.Text, " ") {
+			t.Errorf("run %d contains spurious space after linebreak split: %q", i, run.Text)
+		}
+	}
+}

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -1611,12 +1611,26 @@ func (p *Paragraph) cloneWithWords(words []Word) *Paragraph {
 		if words[0].Text == "" && words[0].LineBreak {
 			cur.Text = "\n"
 		}
+		// Track the SpaceAfter of the most recently appended word so we
+		// can decide whether to insert a separator before the next word
+		// in the same run. The discriminator is SpaceAfter==0 vs >0,
+		// not script — glueAdjacentRuns zeros SpaceAfter on Latin words
+		// at run boundaries, breakCJKWords zeros it between CJK chars,
+		// and breakLongWords does the same for character-broken words.
+		// Re-measurement on the cloned paragraph regenerates the actual
+		// space width for the destination font/size, so we only need
+		// to faithfully encode "was there a space here" as a bool.
+		prevSpaceAfter := words[0].SpaceAfter
 		for _, w := range words[1:] {
 			// Blank words (from consecutive \n\n) represent empty lines.
 			// Serialize as "\n" so splitWords regenerates lineBreakMarkers.
 			// Blank words have no visible text so style doesn't matter.
 			if w.Text == "" && w.LineBreak {
 				cur.Text += "\n"
+				// A blank line resets the join state — whatever
+				// follows starts a fresh visual line and should not
+				// inherit the pre-blank-line word's SpaceAfter.
+				prevSpaceAfter = 0
 				continue
 			}
 			// Inline elements never merge with text or with another inline
@@ -1641,14 +1655,20 @@ func (p *Paragraph) cloneWithWords(words []Word) *Paragraph {
 					runs = append(runs, cur)
 					cur = wordToRun(w)
 				}
+				prevSpaceAfter = w.SpaceAfter
 				continue
 			}
 			if sameRun {
-				cur.Text += " " + w.Text
+				if prevSpaceAfter == 0 {
+					cur.Text += w.Text
+				} else {
+					cur.Text += " " + w.Text
+				}
 			} else {
 				runs = append(runs, cur)
 				cur = wordToRun(w)
 			}
+			prevSpaceAfter = w.SpaceAfter
 		}
 		runs = append(runs, cur)
 	}


### PR DESCRIPTION
## Summary
`cloneWithWords` reconstructs the overflow paragraph during page-break splitting. When grouping words back into runs, it joined same-style words with a literal `" "` regardless of whether the words actually had any inter-word gap.

This is wrong for any word with `SpaceAfter=0`:
- CJK ideographs (per `breakCJKWords`) — every interior char gap
- Latin words across run boundaries (per `glueAdjacentRuns`)
- Character-broken words (per `breakLongWords`)

## User-visible regression
A Japanese / Chinese / Korean paragraph that crosses a page break corrupts every ideograph in the continuation with a spurious ASCII space — `"中文文本"` became `"中 文 文 本"`. The corrupted text re-wraps to MORE lines than the original because the inserted spaces become real `spaceW`-wide gaps at re-measure time, breaking pagination math.

## Fix
Track the previous word's `SpaceAfter` through the reconstruction loop. When `SpaceAfter == 0`, join with no separator; otherwise insert a single ASCII space (the actual width regenerates from `spaceW` when the overflow is re-measured). Also reset `prevSpaceAfter` through the blank-line-mid-paragraph branch so a `\n` inside the run doesn't leak the pre-blank-line word's gap state forward.

The discriminator is `SpaceAfter == 0` vs `> 0`, not script. The `SpaceAfter` field is a measured width in points, not a count — re-measurement on the cloned paragraph regenerates the correct space width for the destination font/size, so we only need to faithfully encode "was there a space here" as a bool.

## Test plan
- [x] 4 regression tests in `layout/clone_test.go`:
  - `TestCJKNoSpuriousSpacesAfterPageSplit` — pure CJK
  - `TestCJKLineCountReconcilesAfterPageSplit` — catches the corrupted-wrap symptom (overflow > total lines at the same width)
  - `TestMixedCJKLatinNoSpuriousSpacesAfterPageSplit` — glued boundaries stay glued, source spaces survive
  - `TestLineBreakResetsJoinStateAcrossPageSplit` — `\n` inside a CJK run
- [x] All four verified to FAIL on revert and PASS with the fix.
- [x] `go test ./...` — full Folio suite green across all 11 packages.

## Why now
Surfaced during reviewer audit of a future `SplitAtLine` API (third in a series of `cloneWithWords` audit fixes). The same path that `SplitAtLine` would use is already broken for the existing page-break path — fixing it on its own merit.

Earlier in series: PR #241 (wordToRun field copy: inline elements + Arabic OriginalText).

Still pending follow-ups: hyphenated word reconstruction (in PlanLayout path it's a non-issue; tracked as task), and `breakLongWords` field loss for shaped scripts.