### PR TITLE
html: fix @page size with calc/min/max values

### DIFF
--- a/html/page.go
+++ b/html/page.go
@@ -53,7 +53,7 @@ func parsePageConfig(rules []pageRule, defaultFontSize float64) *PageConfig {
 
 			switch prop {
 			case "size":
-				parsePageSize(val, pc)
+				parsePageSize(val, pc, defaultFontSize)
 				hasAny = true
 			case "margin":
 				t, r, b, l := parseMarginShorthand(val, defaultFontSize)
@@ -219,10 +219,16 @@ func parseContentValue(val string) string {
 }
 
 // parsePageSize parses the CSS @page size property.
-// Supports: "a4", "letter", "a4 landscape", "8.5in 11in", "210mm 297mm"
-func parsePageSize(val string, pc *PageConfig) {
+// Supports: "a4", "letter", "a4 landscape", "8.5in 11in", "210mm 297mm",
+// and functional values like "calc(8in + 0.5in) 11in".
+//
+// fontSize is used to resolve em/rem inside calc() and is passed through
+// to parseLengthPt (which routes through the main parseLength).
+func parsePageSize(val string, pc *PageConfig, fontSize float64) {
 	val = strings.ToLower(strings.TrimSpace(val))
-	parts := strings.Fields(val)
+	// splitTopLevelFields keeps calc()/min()/max()/clamp() values as a
+	// single token even when they contain internal whitespace.
+	parts := splitTopLevelFields(val)
 
 	if len(parts) == 0 {
 		return
@@ -250,11 +256,15 @@ func parsePageSize(val string, pc *PageConfig) {
 		return // no dimensions, just orientation
 	}
 
-	// Explicit dimensions: "8.5in 11in" or "210mm 297mm"
+	// Explicit dimensions: "8.5in 11in" or "210mm 297mm" or
+	// "calc(8in + 0.5in) 11in". parseLengthPt routes through the
+	// calc-aware parseLength in properties.go (NOT the page-local
+	// parseSingleLength/parseCSSLengthWithUnit, which only strip unit
+	// suffixes and don't understand functional values).
 	// Special case: height of "0" means auto-height (size page to content).
 	if len(parts) >= 2 {
-		w := parseCSSLength(parts[0])
-		h := parseCSSLength(parts[1])
+		w := parseLengthPt(parts[0], fontSize)
+		h := parseLengthPt(parts[1], fontSize)
 		explicitZeroH := parts[1] == "0"
 		if w > 0 && (h > 0 || explicitZeroH) {
 			pc.Width = w
@@ -268,7 +278,7 @@ func parsePageSize(val string, pc *PageConfig) {
 		}
 	} else if len(parts) == 1 {
 		// Single dimension → square page
-		s := parseCSSLength(parts[0])
+		s := parseLengthPt(parts[0], fontSize)
 		if s > 0 {
 			pc.Width = s
 			pc.Height = s
@@ -283,30 +293,6 @@ func parseSingleLength(val string, fontSize float64) float64 {
 		return 0
 	}
 	return l.toPoints(0, fontSize)
-}
-
-// parseCSSLength parses a CSS length string (e.g. "8.5in", "210mm") to points.
-func parseCSSLength(val string) float64 {
-	val = strings.TrimSpace(strings.ToLower(val))
-
-	if strings.HasSuffix(val, "in") {
-		return parseFloat(strings.TrimSuffix(val, "in")) * 72
-	}
-	if strings.HasSuffix(val, "mm") {
-		return parseFloat(strings.TrimSuffix(val, "mm")) * 72 / 25.4
-	}
-	if strings.HasSuffix(val, "cm") {
-		return parseFloat(strings.TrimSuffix(val, "cm")) * 72 / 2.54
-	}
-	if strings.HasSuffix(val, "pt") {
-		return parseFloat(strings.TrimSuffix(val, "pt"))
-	}
-	if strings.HasSuffix(val, "px") {
-		return parseFloat(strings.TrimSuffix(val, "px")) * 0.75
-	}
-
-	// Bare number → assume px
-	return parseFloat(val) * 0.75
 }
 
 // parseCSSLengthWithUnit parses a CSS length into a cssLength struct.

--- a/html/page_test.go
+++ b/html/page_test.go
@@ -196,3 +196,158 @@ func TestBreakInsideAvoid(t *testing.T) {
 		t.Error("expected elements")
 	}
 }
+
+// TestPageSizeWithCalc is a regression test for two connected bugs in
+// the @page size parser:
+//
+//  1. Tokenization: `parsePageSize` used strings.Fields, which split
+//     functional values like calc(8in + 0.5in) on internal whitespace.
+//     Pre-fix `@page { size: calc(8in + 0.5in) 11in }` became 4 tokens
+//     ["calc(8in", "+", "0.5in)", "11in"], parts[0] = "calc(8in"
+//     failed parseCSSLength → w stayed 0, so the `w > 0` guard
+//     suppressed any size assignment and the page silently kept the
+//     default. Same root cause as #236, #237, #240, #242, #244.
+//  2. The page-local `parseCSSLength` only stripped known unit suffixes
+//     (in/mm/cm/pt/px) and did not recognize calc()/min()/max()/clamp()
+//     at all. So even after fixing tokenization, the bare calc token
+//     would still parse to 0. Switched to `parseLengthPt`, which
+//     routes through the main `parseLength` (calc-aware) and avoids
+//     the page-local `parseSingleLength`/`parseCSSLengthWithUnit`.
+//
+// fontSize is now plumbed through parsePageSize so em/rem inside calc
+// resolve correctly. parsePageConfig already had defaultFontSize.
+func TestPageSizeWithCalc(t *testing.T) {
+	tests := []struct {
+		name           string
+		size           string
+		wantWidth      float64
+		wantHeight     float64
+		wantLandscape  bool
+		wantAutoHeight bool
+	}{
+		{
+			name: "calc width, plain in height",
+			size: "calc(8in + 0.5in) 11in",
+			// 8in + 0.5in = 8.5in = 612pt; 11in = 792pt.
+			wantWidth: 612, wantHeight: 792,
+		},
+		{
+			name:      "calc on both axes",
+			size:      "calc(8in + 0.5in) calc(10in + 1in)",
+			wantWidth: 612, wantHeight: 792,
+		},
+		{
+			name: "calc with subtraction",
+			size: "calc(9in - 0.5in) 11in",
+			// 8.5in = 612pt; 11in = 792pt.
+			wantWidth: 612, wantHeight: 792,
+		},
+		{
+			name: "calc with multiplication",
+			size: "calc(2in * 4) 11in",
+			// 8in = 576pt; 11in = 792pt.
+			wantWidth: 576, wantHeight: 792,
+		},
+		{
+			name: "calc with division",
+			size: "calc(17in / 2) 11in",
+			// 8.5in = 612pt; 11in = 792pt.
+			wantWidth: 612, wantHeight: 792,
+		},
+		{
+			name: "calc with mm units",
+			size: "calc(105mm + 105mm) 297mm",
+			// 210mm = 595.28pt; 297mm = 841.89pt (A4).
+			wantWidth: 595.28, wantHeight: 841.89,
+		},
+		{
+			name: "calc with cm units",
+			size: "calc(10cm + 11cm) 29.7cm",
+			// 21cm = 595.28pt; 29.7cm = 841.89pt.
+			wantWidth: 595.28, wantHeight: 841.89,
+		},
+		{
+			name: "mixed units: calc(in) and mm",
+			size: "calc(8in + 0.5in) 297mm",
+			// 8.5in = 612pt; 297mm = 841.89pt.
+			wantWidth: 612, wantHeight: 841.89,
+		},
+		{
+			name: "min() width, max() height",
+			size: "min(8.5in, 9in) max(10in, 11in)",
+			// min picks 8.5in = 612pt; max picks 11in = 792pt.
+			wantWidth: 612, wantHeight: 792,
+		},
+		{
+			name: "clamp() width",
+			size: "clamp(7in, 8.5in, 10in) 11in",
+			// clamp middle = 8.5in = 612pt.
+			wantWidth: 612, wantHeight: 792,
+		},
+		{
+			name: "calc with landscape orientation",
+			size: "calc(8in + 0.5in) 11in landscape",
+			// landscape swaps: width becomes 792pt, height 612pt.
+			wantWidth: 792, wantHeight: 612, wantLandscape: true,
+		},
+		{
+			name: "single calc value → square page",
+			size: "calc(5in + 1in)",
+			// 6in = 432pt, applied to both axes.
+			wantWidth: 432, wantHeight: 432,
+		},
+		{
+			name:      "tab and newline as separators",
+			size:      "calc(8in + 0.5in)\t11in",
+			wantWidth: 612, wantHeight: 792,
+		},
+		{
+			name: "calc width + zero height (auto-height special case)",
+			size: "calc(8in + 0.5in) 0",
+			// 8.5in = 612pt; literal "0" triggers AutoHeight.
+			wantWidth: 612, wantHeight: 0, wantAutoHeight: true,
+		},
+		{
+			name: "unbalanced calc paren: parser silently drops the size",
+			// splitTopLevelFields keeps the unbalanced calc + trailing
+			// characters as one token (depth never returns to 0). The
+			// `w > 0` guard then suppresses any size assignment, so width
+			// and height stay at zero. Documents the no-crash invariant.
+			size:      "calc(8in + 0.5in 11in",
+			wantWidth: 0, wantHeight: 0,
+		},
+		{
+			name: "3+ tokens: extras silently ignored",
+			// CSS @page size accepts 1 or 2 dimensions plus an
+			// optional orientation. Anything beyond is ignored; the
+			// first two tokens become width/height.
+			size:      "8.5in 11in foo bar",
+			wantWidth: 612, wantHeight: 792,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			htmlStr := `<html><head><style>@page { size: ` + tt.size + `; }</style></head><body><p>X</p></body></html>`
+			result, err := ConvertFull(htmlStr, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.PageConfig == nil {
+				t.Fatal("expected PageConfig from @page rule")
+			}
+			if math.Abs(result.PageConfig.Width-tt.wantWidth) > 1 {
+				t.Errorf("width = %.2f, want ~%.2f", result.PageConfig.Width, tt.wantWidth)
+			}
+			if math.Abs(result.PageConfig.Height-tt.wantHeight) > 1 {
+				t.Errorf("height = %.2f, want ~%.2f", result.PageConfig.Height, tt.wantHeight)
+			}
+			if result.PageConfig.Landscape != tt.wantLandscape {
+				t.Errorf("landscape = %v, want %v", result.PageConfig.Landscape, tt.wantLandscape)
+			}
+			if result.PageConfig.AutoHeight != tt.wantAutoHeight {
+				t.Errorf("AutoHeight = %v, want %v",
+					result.PageConfig.AutoHeight, tt.wantAutoHeight)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two connected bugs in the `@page size` parser:

1. **Tokenization** — same root cause as #236/#237/#240/#242/#244. `parsePageSize` used `strings.Fields`, which split functional values on internal whitespace. `@page { size: calc(8in + 0.5in) 11in }` became 4 tokens `[\"calc(8in\", \"+\", \"0.5in)\", \"11in\"]`; `parts[0]` failed length parsing → `w` stayed 0 → the `w > 0` guard suppressed any size assignment and the page silently kept the default.
2. **Calc-blind length parser** — the page-local `parseCSSLength`/`parseCSSLengthWithUnit` only stripped known unit suffixes (in/mm/cm/pt/px). They didn't recognize `calc()/min()/max()/clamp()` at all. So even after fixing tokenization, a calc token would still resolve to 0.

This PR is wider scope than the previous five in the series — both fixes are needed for `@page` calc to work.

## Fix

- `parsePageSize`: `strings.Fields` → `splitTopLevelFields` (added in #236).
- `parsePageSize`: switch from `parseCSSLength` to `parseLengthPt` (`html/properties.go`), which routes through the main calc-aware `parseLength`. The page-local `parseSingleLength`/`parseCSSLengthWithUnit` are also calc-blind and intentionally not used here.
- `parsePageSize` now takes a `fontSize float64` parameter (used by calc for em/rem). `parsePageConfig` already had `defaultFontSize` and threads it through; only one call site to update.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `gofmt -s -l .` clean
- [x] `TestPageSizeWithCalc` (16 subtests via `t.Run`):
  - calc with `+`, `-`, `*`, `/` operators
  - `min()`, `max()`, `clamp()`
  - calc on both axes (single + dual)
  - calc with `in`, `mm`, `cm` units; mixed-unit dual
  - calc + landscape orientation (verifies w/h swap still applied)
  - Single-value calc → square page
  - Tab/newline separators
  - calc + literal `0` height → `AutoHeight=true` (`wantAutoHeight` folded into the table)
  - Unbalanced calc paren → no crash, defaults preserved
  - 3+ tokens → extras silently ignored
- [x] All pre-existing `TestPageSize*` (named sizes, landscape, mm, auto-height) unchanged and still pass