### PR TITLE
font: address review feedback on language-aware TTC PR (#277 follow-up)

### DIFF
--- a/examples/cjk/main.go
+++ b/examples/cjk/main.go
@@ -414,14 +414,15 @@ func findCJKFont() string {
 			// SC-specific variants first; design glyphs match the example's
 			// Chinese text content. Fall back to the pan-CJK TTC (face 0
 			// is JP per the upstream ordering) when only the bundle is
-			// installed.
+			// installed. wqy-zenhei is the last-resort SC font on older
+			// Debian/Ubuntu installs.
 			"/usr/share/fonts/opentype/noto/NotoSansSC-Regular.otf",
 			"/usr/share/fonts/noto-cjk/NotoSansSC-Regular.otf",
-			"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
 			"/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
 			"/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
 			"/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
 			"/usr/share/fonts/google-noto-cjk/NotoSansCJK-Regular.ttc",
+			"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
 			"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
 		}
 	case "windows":

--- a/font/ttc_lang.go
+++ b/font/ttc_lang.go
@@ -5,6 +5,7 @@ package font
 
 import (
 	"encoding/binary"
+	"slices"
 	"strings"
 )
 
@@ -48,13 +49,34 @@ func pickFaceForLanguage(data []byte, lang string) int {
 		if family == "" {
 			continue
 		}
-		for _, tok := range tokens {
-			if strings.Contains(family, tok) {
-				return int(i)
-			}
+		if familyContainsAnyToken(family, tokens) {
+			return int(i)
 		}
 	}
 	return -1
+}
+
+// familyContainsAnyToken returns true when family — split into
+// space-separated words — contains at least one of tokens as a
+// whole word. Whole-word matching avoids the false positives
+// [strings.Contains] would produce against family names like
+// "Noto Sans Special Compressed" (contains the substring "SC" in
+// "Special" / "Compressed") or "JapanesEsque Title" — neither of
+// which represents a Japanese-targeting face. Pan-CJK collections
+// embed tokens as whole words ("Noto Sans CJK JP"), so the tighter
+// match still hits everything we need to.
+//
+// Comparison is case-sensitive because the regional tokens we
+// match against are stable upper-case ("JP", "SC") and the family
+// names that carry them are also case-stable. A future need for
+// case-insensitive matching would lower-case both sides.
+func familyContainsAnyToken(family string, tokens []string) bool {
+	for _, word := range strings.Fields(family) {
+		if slices.Contains(tokens, word) {
+			return true
+		}
+	}
+	return false
 }
 
 // readFontFamily extracts the FontFamily (NameID 1) string for a
@@ -162,8 +184,13 @@ func languageTokens(lang string) []string {
 		strings.HasPrefix(l, "zh-hk"), strings.HasPrefix(l, "zh-mo"):
 		return []string{"TC", "Hant", "Traditional"}
 	case strings.HasPrefix(l, "zh"):
-		// Bare "zh" without region defaults to Simplified, matching
-		// the IETF/CLDR default-script convention.
+		// Bare "zh" without region defaults to Simplified. RFC 5646
+		// itself takes no position on default scripts; this matches
+		// CLDR's likelySubtags entry mapping `zh` → `zh_Hans_CN`,
+		// which is what browsers (Chrome, Safari) and Wikipedia use
+		// when only `zh` is supplied. Callers who need the legacy
+		// `zh` → Traditional default should pass `zh-TW` or
+		// `zh-Hant` explicitly.
 		return []string{"SC", "Hans", "Simplified"}
 	case strings.HasPrefix(l, "ja"):
 		return []string{"JP", "Japanese", "Jpan"}

--- a/font/ttc_lang_test.go
+++ b/font/ttc_lang_test.go
@@ -51,6 +51,95 @@ func TestPickFaceForLanguageMatchesRegionalFamily(t *testing.T) {
 	}
 }
 
+// TestPickFaceForLanguageDeterministicTiebreak pins the contract
+// when multiple faces match the same language. The picker walks
+// faces in TTC-declared order and returns the first match — this
+// is observable and deterministic, but the matrix test in
+// TestPickFaceForLanguageMatchesRegionalFamily can't catch a
+// regression that flips the iteration order, because each face
+// in that fixture matches exactly one language.
+//
+// Fixture: two faces both carrying the SC token. Expected: face 0
+// wins. A reverse-iteration regression would return face 1.
+func TestPickFaceForLanguageDeterministicTiebreak(t *testing.T) {
+	ttc := buildSyntheticCJKTTC(t,
+		"Noto Sans CJK SC",      // face 0 — first match wins
+		"Noto Sans CJK SC Bold", // face 1 — also matches
+	)
+	if got := pickFaceForLanguage(ttc, "zh-CN"); got != 0 {
+		t.Errorf("two-face tiebreak: got %d, want 0 (TTC-declared order regression)", got)
+	}
+}
+
+// TestPickFaceForLanguageSkipsMalformedFaceNameTable verifies the
+// safety contract for partially-malformed TTCs: when one face's
+// `name` table is unreadable (truncated, bad offsets), the picker
+// silently skips that face and continues to the next rather than
+// aborting the whole match. Real-world TTCs occasionally ship with
+// one corrupt face among several valid ones (font-tooling bugs,
+// truncated downloads); we don't want a single bad face to deny
+// all language selection from the collection.
+//
+// Fixture: face 0 has a `name` table whose stringOffset points
+// past the table's end (corrupt). Face 1 has a valid SC name.
+// Expected: picker returns 1.
+func TestPickFaceForLanguageSkipsMalformedFaceNameTable(t *testing.T) {
+	ttc := buildSyntheticCJKTTCWithCorruptFace(t,
+		"Noto Sans CJK JP", // face 0 — name table will be corrupted
+		"Noto Sans CJK SC", // face 1 — valid
+	)
+	if got := pickFaceForLanguage(ttc, "zh-CN"); got != 1 {
+		t.Errorf("malformed face skip: got %d, want 1 (picker should pass over face 0 and pick face 1)", got)
+	}
+}
+
+// TestParseFontForLanguageDifferentHintsReturnDifferentFaces is the
+// end-to-end pin for face-selection dispatch through the public API.
+// TestParseFontForLanguageRoundTripsThroughTTC only checks that some
+// face loads; this asserts that ja and zh-CN return BYTE-DIFFERENT
+// faces, proving the language hint actually drives selection rather
+// than both calls silently falling back to face 0.
+func TestParseFontForLanguageDifferentHintsReturnDifferentFaces(t *testing.T) {
+	ttfBytes := loadAnySystemTTF(t)
+	ttc := buildSyntheticCJKTTCFromTTF(t, ttfBytes,
+		"Noto Sans CJK JP",
+		"Noto Sans CJK SC",
+	)
+	jaFace, err := ParseFontForLanguage(ttc, "ja")
+	if err != nil {
+		t.Fatalf("ParseFontForLanguage(ja): %v", err)
+	}
+	zhFace, err := ParseFontForLanguage(ttc, "zh-CN")
+	if err != nil {
+		t.Fatalf("ParseFontForLanguage(zh-CN): %v", err)
+	}
+	if bytesEqual(jaFace.RawData(), zhFace.RawData()) {
+		t.Error("ja and zh-CN returned byte-identical faces; language hint did not drive selection")
+	}
+}
+
+// TestPickFaceForLanguageWordBoundaryMatch pins the false-positive
+// guard from the code review: a Latin face name where a regional
+// token appears as part of a longer word ("JPEG" contains "JP",
+// "HansLite" contains "Hans") must NOT match. The picker uses
+// strings.Fields + whole-word equality precisely to avoid this.
+func TestPickFaceForLanguageWordBoundaryMatch(t *testing.T) {
+	// "JPEG Designer" contains "JP" as a substring of "JPEG"; with
+	// pre-fix substring matching it would match "ja". Word-boundary
+	// matching splits into ["JPEG", "Designer"] — "JPEG" != "JP", so
+	// no match. Same shape for "HansLite" containing "Hans" → "zh".
+	ttc := buildSyntheticCJKTTC(t,
+		"JPEG Designer",
+		"HansLite Sans",
+	)
+	if got := pickFaceForLanguage(ttc, "ja"); got != -1 {
+		t.Errorf("'JPEG Designer' + ja: got %d, want -1 (substring 'JP' inside 'JPEG' regressed to a match)", got)
+	}
+	if got := pickFaceForLanguage(ttc, "zh-CN"); got != -1 {
+		t.Errorf("'HansLite Sans' + zh-CN: got %d, want -1 (substring 'Hans' inside 'HansLite' regressed to a match)", got)
+	}
+}
+
 // TestPickFaceForLanguageReturnsNegativeOnNoMatch verifies the
 // fallback signal: when no face matches the requested language (or
 // the language isn't a known CJK convention), the picker returns -1
@@ -219,6 +308,38 @@ func buildSyntheticCJKTTC(t *testing.T, families ...string) []byte {
 		binary.BigEndian.PutUint32(out[dirOff+12:dirOff+16], uint32(len(nt)))
 		// name table data
 		copy(out[nameTableOff:nameTableOff+len(nt)], nt)
+	}
+	return out
+}
+
+// buildSyntheticCJKTTCWithCorruptFace is buildSyntheticCJKTTC with a
+// single face's `name` table corrupted: the stringOffset header
+// field is set to a value past the table's end, so [readNameID1]
+// returns "" and the picker must silently move on. Used by
+// TestPickFaceForLanguageSkipsMalformedFaceNameTable to verify
+// per-face fault tolerance. Only face 0 is corrupted (in a TTC
+// where face 0 is JP and face 1 is SC); a regression that aborts
+// the picker on the first malformed face would return -1 instead
+// of 1 when asked for zh-CN.
+func buildSyntheticCJKTTCWithCorruptFace(t *testing.T, families ...string) []byte {
+	t.Helper()
+	out := buildSyntheticCJKTTC(t, families...)
+	// Find face 0's `name` table directory entry, follow it to the
+	// table data, and corrupt the stringOffset header field
+	// (uint16 at offset 4).
+	face0Off := int(binary.BigEndian.Uint32(out[12:16]))
+	numTables0 := int(binary.BigEndian.Uint16(out[face0Off+4 : face0Off+6]))
+	for i := range numTables0 {
+		entry := face0Off + 12 + i*16
+		if string(out[entry:entry+4]) != "name" {
+			continue
+		}
+		nameTableOff := int(binary.BigEndian.Uint32(out[entry+8 : entry+12]))
+		nameTableLen := int(binary.BigEndian.Uint32(out[entry+12 : entry+16]))
+		// Set stringOffset to a value past the table's end so
+		// readNameID1's `stringOff > dataLen` guard rejects.
+		binary.BigEndian.PutUint16(out[nameTableOff+4:nameTableOff+6], uint16(nameTableLen+1))
+		break
 	}
 	return out
 }


### PR DESCRIPTION
Follow-up to the merged PR #277. The two parallel reviews (code + tests) landed after the original PR was merged; their findings are real and worth applying as a small dedicated PR rather than left as residual debt.

## Code review (2 must-fix)

**Tighten substring matcher to whole-word equality.** Pre-fix `strings.Contains` would false-positive on Latin family names where a regional token appears inside a longer word: `"JPEG Designer"` contains the substring `"JP"` inside `"JPEG"`; `"HansLite Sans"` contains `"Hans"` inside `"HansLite"`. Word-boundary matching via `strings.Fields` + `slices.Contains` avoids the class. Pinned by `TestPickFaceForLanguageWordBoundaryMatch` — verified the test fails when the matcher is reverted to substring-based.

**Soften the bare-`zh` → Simplified rationale.** RFC 5646 takes no position on default scripts; the prior "IETF/CLDR default-script convention" comment was overstated. Replaced with a citation of CLDR's `likelySubtags` entry mapping `zh` → `zh_Hans_CN`, which is what browsers (Chrome, Safari) and Wikipedia actually do. Comment also notes the escape hatch for callers who want the legacy `zh` → Traditional convention (pass `zh-TW` or `zh-Hant` explicitly).

## Test review (2 must-haves)

**`TestPickFaceForLanguageDeterministicTiebreak`** — locks the iteration-order contract when multiple faces match the same language. Fixture: two faces both carrying SC (`"Noto Sans CJK SC"` at index 0, `"Noto Sans CJK SC Bold"` at index 1). Picker must return 0; a reverse-iteration regression returns 1. Verified by reverting the loop direction — test fails with `got 1, want 0`.

**`TestPickFaceForLanguageSkipsMalformedFaceNameTable`** — pins per-face fault tolerance: when one face's `name` table is unreadable (corrupted `stringOffset`), the picker must skip it silently and continue rather than abort the whole match. New `buildSyntheticCJKTTCWithCorruptFace` fixture corrupts face 0's `stringOffset` and expects face 1 to win.

## Optional applied

- **`TestParseFontForLanguageDifferentHintsReturnDifferentFaces`** — end-to-end pin through the public API. The original round-trip test only asserted `UnitsPerEm > 0`, which would still pass if both `ja` and `zh-CN` silently fell back to face 0. The new test asserts byte-different faces.
- **`examples/cjk` Linux candidate list reordered** — NotoSansCJK pan-CJK bundle ahead of `wqy-zenhei` (older / less common). NotoSansSC remains first.

## Test plan

- [x] All four new tests verified to catch their corresponding regressions when the relevant code is reverted (substring matcher, reverse iteration, malformed-name-table abort, hint-ignored fallback).
- [x] Full `go test ./...` green.
- [x] `gofmt -s -l .` clean.

## Out of scope

- Promoting `buildSyntheticCJKTTC*` to a shared `font/testfontfixtures` package (test-private OK for now).
- Opportunistic real-system NotoSansCJK test on Linux (nice-to-have).