### PR TITLE
export: add C ABI wrappers for paragraph measure/split + language-aware font parse

### DIFF
--- a/export/cabi_font.go
+++ b/export/cabi_font.go
@@ -176,6 +176,34 @@ func folio_font_parse_ttf(data unsafe.Pointer, length C.int32_t) C.uint64_t {
 	return C.uint64_t(ht.store(ef))
 }
 
+// folio_font_parse_for_language parses a font (TTF or TTC) from
+// in-memory bytes and selects a face by BCP-47 language tag. For TTC
+// inputs, picks the face whose family name best matches the requested
+// language: "zh-CN"/"zh-Hans" → SC, "zh-TW"/"zh-Hant" → TC, "ja" → JP,
+// "ko" → KR. Empty or unrecognised lang falls back to face 0
+// (matching folio_font_parse_ttf). For non-TTC fonts the lang argument
+// is ignored.
+//
+//export folio_font_parse_for_language
+func folio_font_parse_for_language(data unsafe.Pointer, length C.int32_t, lang *C.char) C.uint64_t {
+	if data == nil || length <= 0 {
+		setLastError("invalid font data")
+		return 0
+	}
+	goData := C.GoBytes(data, C.int(length))
+	goLang := ""
+	if lang != nil {
+		goLang = C.GoString(lang)
+	}
+	face, err := font.ParseFontForLanguage(goData, goLang)
+	if err != nil {
+		setLastError(err.Error())
+		return 0
+	}
+	ef := font.NewEmbeddedFont(face)
+	return C.uint64_t(ht.store(ef))
+}
+
 // folio_font_free releases an embedded font handle. Standard fonts are singletons and are not freed.
 //
 //export folio_font_free

--- a/export/cabi_paragraph.go
+++ b/export/cabi_paragraph.go
@@ -159,6 +159,66 @@ func folio_paragraph_set_direction(pH C.uint64_t, dir C.int32_t) C.int32_t {
 	return errOK
 }
 
+// folio_paragraph_measure_lines reports how many wrapped lines the
+// paragraph produces at the given maxWidth (in points). Returns -1 on
+// invalid handle. Use this to make clamp/truncate decisions before
+// calling folio_paragraph_split_after_line.
+//
+//export folio_paragraph_measure_lines
+func folio_paragraph_measure_lines(pH C.uint64_t, maxWidth C.double) C.int32_t {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	return C.int32_t(p.MeasureLines(float64(maxWidth)))
+}
+
+// folio_paragraph_measure_height reports the rendered height (in
+// points) of the paragraph wrapped at maxWidth. Excludes
+// SpaceBefore/SpaceAfter so callers compose with their own pagination
+// math. Returns a negative sentinel (NaN-like) on invalid handle:
+// callers should check the error via folio_last_error.
+//
+//export folio_paragraph_measure_height
+func folio_paragraph_measure_height(pH C.uint64_t, maxWidth C.double) C.double {
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return -1
+	}
+	return C.double(p.MeasureHeight(float64(maxWidth)))
+}
+
+// folio_paragraph_split_after_line splits the paragraph after the
+// first n rendered lines at maxWidth. On success, *outHead and *outTail
+// receive paragraph handles (either may be 0 for the no-op halves):
+// n <= 0 returns (0, full clone); n >= total lines returns (full clone, 0).
+// The receiver is unchanged. Returned handles must be freed via
+// folio_paragraph_free. outHead and outTail may not be NULL.
+//
+//export folio_paragraph_split_after_line
+func folio_paragraph_split_after_line(pH C.uint64_t, n C.int32_t, maxWidth C.double, outHead, outTail *C.uint64_t) C.int32_t {
+	if outHead == nil || outTail == nil {
+		setLastError("outHead and outTail must be non-NULL")
+		return errInvalidHandle
+	}
+	p, errCode := loadParagraph(pH)
+	if errCode != errOK {
+		return errCode
+	}
+	head, tail := p.SplitAfterLine(int(n), float64(maxWidth))
+	if head != nil {
+		*outHead = C.uint64_t(ht.store(head))
+	} else {
+		*outHead = 0
+	}
+	if tail != nil {
+		*outTail = C.uint64_t(ht.store(tail))
+	} else {
+		*outTail = 0
+	}
+	return errOK
+}
+
 // folio_paragraph_free removes a paragraph handle from the handle table.
 //
 //export folio_paragraph_free

--- a/export/folio.h
+++ b/export/folio.h
@@ -321,6 +321,7 @@ uint64_t folio_font_zapf_dingbats(void);
 
 uint64_t folio_font_load_ttf(const char *path);
 uint64_t folio_font_parse_ttf(const void *data, int32_t length);
+uint64_t folio_font_parse_for_language(const void *data, int32_t length, const char *lang);
 void     folio_font_free(uint64_t font);
 
 /* ── Paragraph ─────────────────────────────────────────────────────── */
@@ -344,6 +345,10 @@ int32_t  folio_paragraph_set_hyphens(uint64_t para, const char *mode);
 int32_t  folio_paragraph_set_text_align_last(uint64_t para, int32_t align);
 
 int32_t  folio_paragraph_add_run(uint64_t para, const char *text, uint64_t font, double font_size, double r, double g, double b);
+
+int32_t  folio_paragraph_measure_lines(uint64_t para, double max_width);
+double   folio_paragraph_measure_height(uint64_t para, double max_width);
+int32_t  folio_paragraph_split_after_line(uint64_t para, int32_t n, double max_width, uint64_t *out_head, uint64_t *out_tail);
 
 /* ── Heading ───────────────────────────────────────────────────────── */
 

--- a/export/testdata/test_cabi.c
+++ b/export/testdata/test_cabi.c
@@ -1733,6 +1733,78 @@ int main(void) {
     ASSERT(rc != 0, "columns_set_balanced rejects bad handle");
     folio_columns_free(cBal);
 
+    /* Paragraph measurement and split (v0.8.0) */
+    uint64_t pMeasure = folio_paragraph_new(
+        "The quick brown fox jumps over the lazy dog. "
+        "The quick brown fox jumps over the lazy dog. "
+        "The quick brown fox jumps over the lazy dog. "
+        "The quick brown fox jumps over the lazy dog.",
+        helvDir, 12.0);
+    ASSERT(pMeasure != 0, "paragraph_new for measure/split tests");
+
+    int32_t lines = folio_paragraph_measure_lines(pMeasure, 200.0);
+    ASSERT(lines > 1, "paragraph_measure_lines returns >1 for narrow width");
+    int32_t linesWide = folio_paragraph_measure_lines(pMeasure, 800.0);
+    ASSERT(linesWide >= 1 && linesWide <= lines,
+           "paragraph_measure_lines returns fewer lines at wider width");
+    int32_t linesBad = folio_paragraph_measure_lines(99999, 200.0);
+    ASSERT(linesBad < 0, "paragraph_measure_lines rejects bad handle");
+
+    double height = folio_paragraph_measure_height(pMeasure, 200.0);
+    ASSERT(height > 0.0, "paragraph_measure_height returns positive height");
+    double heightBad = folio_paragraph_measure_height(99999, 200.0);
+    ASSERT(heightBad < 0.0, "paragraph_measure_height rejects bad handle");
+
+    /* Split after line 2: head should have 2 lines, tail should have rest */
+    uint64_t splitHead = 0, splitTail = 0;
+    rc = folio_paragraph_split_after_line(pMeasure, 2, 200.0, &splitHead, &splitTail);
+    ASSERT(rc == 0, "paragraph_split_after_line(n=2) succeeds");
+    ASSERT(splitHead != 0, "paragraph_split_after_line head handle is non-zero");
+    ASSERT(splitTail != 0, "paragraph_split_after_line tail handle is non-zero (paragraph wraps to >2 lines)");
+    int32_t headLines = folio_paragraph_measure_lines(splitHead, 200.0);
+    ASSERT(headLines == 2, "split head measures to exactly n lines");
+    int32_t tailLines = folio_paragraph_measure_lines(splitTail, 200.0);
+    ASSERT(tailLines > 0, "split tail measures to >0 lines");
+    folio_paragraph_free(splitHead);
+    folio_paragraph_free(splitTail);
+
+    /* n <= 0: head=0, tail=full clone */
+    splitHead = 999; splitTail = 999;
+    rc = folio_paragraph_split_after_line(pMeasure, 0, 200.0, &splitHead, &splitTail);
+    ASSERT(rc == 0, "paragraph_split_after_line(n=0) succeeds");
+    ASSERT(splitHead == 0, "paragraph_split_after_line(n=0) head is 0");
+    ASSERT(splitTail != 0, "paragraph_split_after_line(n=0) tail is full clone");
+    folio_paragraph_free(splitTail);
+
+    /* n >= total: head=full clone, tail=0 */
+    splitHead = 999; splitTail = 999;
+    rc = folio_paragraph_split_after_line(pMeasure, 1000, 200.0, &splitHead, &splitTail);
+    ASSERT(rc == 0, "paragraph_split_after_line(n=large) succeeds");
+    ASSERT(splitHead != 0, "paragraph_split_after_line(n=large) head is full clone");
+    ASSERT(splitTail == 0, "paragraph_split_after_line(n=large) tail is 0");
+    folio_paragraph_free(splitHead);
+
+    /* Bad handle */
+    splitHead = 999; splitTail = 999;
+    rc = folio_paragraph_split_after_line(99999, 1, 200.0, &splitHead, &splitTail);
+    ASSERT(rc != 0, "paragraph_split_after_line rejects bad handle");
+
+    /* NULL out pointer rejection */
+    rc = folio_paragraph_split_after_line(pMeasure, 1, 200.0, NULL, &splitTail);
+    ASSERT(rc != 0, "paragraph_split_after_line rejects NULL out_head");
+    rc = folio_paragraph_split_after_line(pMeasure, 1, 200.0, &splitHead, NULL);
+    ASSERT(rc != 0, "paragraph_split_after_line rejects NULL out_tail");
+
+    folio_paragraph_free(pMeasure);
+
+    /* font_parse_for_language: empty data rejected, empty lang accepted (face 0) */
+    uint64_t fontBad = folio_font_parse_for_language(NULL, 0, "ja");
+    ASSERT(fontBad == 0, "font_parse_for_language rejects NULL data");
+    /* Round-trip with a real TTF would require shipping a fixture; the
+     * Go-side tests in font/load_test.go already exercise the face-pick
+     * matrix against synthetic TTCs. Here we cover only the C-boundary
+     * argument handling. */
+
     /* Summary */
     printf("\n%d passed, %d failed\n", passes, failures);
     return failures > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

Surfaces four v0.8.0 Go-side additions to the C ABI so non-Go callers (Python, Node, Rust, etc.) get the same surface area without each having to write their own CGO bridge.

| New C export | Wraps | Source PR |
|---|---|---|
| `folio_paragraph_measure_lines(p, max_width)` | `layout.Paragraph.MeasureLines` | #238 |
| `folio_paragraph_measure_height(p, max_width)` | `layout.Paragraph.MeasureHeight` | #238 |
| `folio_paragraph_split_after_line(p, n, max_width, *head, *tail)` | `layout.Paragraph.SplitAfterLine` | #253 |
| `folio_font_parse_for_language(data, length, lang)` | `font.ParseFontForLanguage` | #277 |

## Out of scope

`font.Fallback` / `layout.NewParagraphFallback` (#225) is intentionally NOT wrapped here. Per its PR description, C ABI exposure is Phase 2 work tied to promoting `*EmbeddedFont` to an interface so `Fallback` becomes a drop-in replacement at every existing call site (heading, link, list, tab, table cell, page-level text, **C ABI**). Wiring the C ABI to the Phase-1 `*EmbeddedFont`-only constructor and then refactoring it again in Phase 2 would create churn for downstream consumers.

`html.Options.Logger` (`*slog.Logger`), `Options.Client` (`*http.Client`), and `Options.StrictAssets` are Go-specific by nature — `slog` and `*http.Client` don't have portable C equivalents. Adding a C-flavoured logging callback / HTTP transport surface is its own design pass, deferred.

## API design notes

- **Split semantics for `split_after_line`**: returns two handles via out-pointers. Either may be 0 for the no-op halves: `n <= 0` returns `(0, full clone)`; `n >= total lines` returns `(full clone, 0)`. The receiver is unchanged. Caller frees non-zero handles via `folio_paragraph_free`. `out_head` and `out_tail` themselves must be non-NULL — the wrapper returns `errInvalidHandle` if either is missing rather than crashing.
- **`measure_lines` returns `int32_t`**: `-1` on bad handle. Callers should check `folio_last_error` for the message.
- **`measure_height` returns `double`**: `-1.0` on bad handle (negative height is impossible for a real paragraph).
- **`font_parse_for_language` accepts NULL `lang`**: treated as empty string, which `font.ParseFontForLanguage` handles by falling back to face 0 (matching `folio_font_parse_ttf` semantics for non-TTC inputs).

## Tests

`test_cabi.c` grows from 397 to 411 assertions (+14 new), covering:

- `measure_lines` happy path (narrow vs wide width invariant), bad handle
- `measure_height` happy path, bad handle
- `split_after_line` n=2 success path with head/tail line-count assertions
- `split_after_line` edge cases: n=0 (head=0, tail=full), n=large (head=full, tail=0)
- `split_after_line` bad handle, NULL `out_head`, NULL `out_tail`
- `font_parse_for_language` NULL data rejection (round-trip with real TTC is covered by Go-side tests in `font/load_test.go`)

## Audit

`scripts/audit-cabi.sh --build` reports:
- Go `//export` directives: 393
- Header declarations: 393
- Built dylib symbols: 393

All three in sync.

## Test plan

- [x] `go vet ./export/...` — clean
- [x] `make test-cabi` — 411 passed, 0 failed
- [x] `scripts/audit-cabi.sh --build` — clean