### PR TITLE
html: parseAngle/parseNumericVal/parseLineHeight understand calc/min/max/clamp (closes #274, #275)

### DIFF
--- a/html/calc_angle_numeric_test.go
+++ b/html/calc_angle_numeric_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"math"
+	"testing"
+)
+
+// TestParseAngleWithCalc closes #274 for parseAngle. Pre-fix the
+// function used strconv.ParseFloat directly on the value and so failed
+// on any calc/min/max/clamp wrapper, returning 0. Post-fix it walks the
+// expression as an angle-native tree.
+func TestParseAngleWithCalc(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		want float64
+	}{
+		// Plain leaves still work — regression guard for pre-existing behaviour.
+		{"plain deg", "45deg", 45},
+		{"plain rad", "1.5708rad", 90},
+		{"plain grad", "100grad", 90},
+		{"plain turn", "0.25turn", 90},
+		{"bare number is degrees", "30", 30},
+		{"empty string is zero", "", 0},
+
+		// calc with same-unit arithmetic.
+		{"calc(deg + deg)", "calc(45deg + 45deg)", 90},
+		{"calc(deg - deg)", "calc(180deg - 90deg)", 90},
+		{"calc(deg * num)", "calc(45deg * 2)", 90},
+		{"calc(num * deg)", "calc(2 * 45deg)", 90},
+		{"calc(deg / num)", "calc(180deg / 2)", 90},
+
+		// Mixed-unit calc — each leaf converts to degrees first.
+		{"calc(deg + rad)", "calc(45deg + 0.7854rad)", 90},
+		{"calc(turn - deg)", "calc(1turn - 270deg)", 90},
+		{"calc(grad + deg)", "calc(50grad + 45deg)", 90},
+
+		// Nested calc.
+		{"nested calc", "calc((30deg + 30deg) * 2)", 120},
+		{"calc with sub-expression", "calc(45deg * (1 + 1))", 90},
+
+		// min / max.
+		{"min picks smallest", "min(45deg, 90deg, 30deg)", 30},
+		{"max picks largest", "max(45deg, 90deg, 30deg)", 90},
+		{"min with calc inside", "min(calc(60deg + 30deg), 60deg)", 60},
+
+		// clamp.
+		{"clamp middle", "clamp(0deg, 45deg, 90deg)", 45},
+		{"clamp clipped low", "clamp(50deg, 30deg, 90deg)", 50},
+		{"clamp clipped high", "clamp(0deg, 100deg, 90deg)", 90},
+
+		// Defensive cases — degrades to 0 rather than crashing.
+		{"calc with malformed leaf", "calc(45xyz + 0)", 0},
+		{"divide by zero", "calc(45deg / 0)", 0},
+		{"clamp wrong arity", "clamp(0deg, 45deg)", 0},
+
+		// Negative angles (CSS rotate accepts these for counter-rotation).
+		{"plain negative deg", "-45deg", -45},
+		{"calc producing negative", "calc(0deg - 90deg)", -90},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseAngle(tc.val)
+			if math.Abs(got-tc.want) > 0.001 {
+				t.Errorf("parseAngle(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseNumericValWithCalc closes #274 for parseNumericVal. Pre-fix
+// the function only handled strconv.ParseFloat and returned 0 for any
+// calc wrapper, silently making `scale(calc(0.5 + 0.5))` a degenerate
+// zero-scale transform. Post-fix it delegates to parseLength for calc
+// inputs whose leaves are dimensionless ("num").
+func TestParseNumericValWithCalc(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		want float64
+	}{
+		// Plain numbers still work.
+		{"plain integer", "5", 5},
+		{"plain float", "1.5", 1.5},
+		{"negative", "-2.5", -2.5},
+		{"zero", "0", 0},
+		{"empty string is zero", "", 0},
+
+		// calc with dimensionless leaves.
+		{"calc add", "calc(0.5 + 0.5)", 1.0},
+		{"calc subtract", "calc(2 - 0.5)", 1.5},
+		{"calc multiply", "calc(0.5 * 3)", 1.5},
+		{"calc divide", "calc(3 / 2)", 1.5},
+		{"calc with parens on right", "calc(2 * (1 + 1))", 4},
+
+		// min / max / clamp on dimensionless.
+		{"min", "min(2, 1.5, 3)", 1.5},
+		{"max", "max(2, 1.5, 3)", 3},
+		{"clamp middle", "clamp(0, 1.5, 2)", 1.5},
+		{"clamp clipped low", "clamp(2, 1, 3)", 2},
+
+		// Defensive.
+		{"calc divide by zero", "calc(5 / 0)", 0},
+		{"calc with garbage", "calc(xyz)", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseNumericVal(tc.val)
+			if math.Abs(got-tc.want) > 0.001 {
+				t.Errorf("parseNumericVal(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCSSLengthIsDimensionless covers the new helper used by
+// parseLineHeight (#275) to distinguish a calc that resolves to a
+// dimensionless multiplier (every leaf is "num") from one that
+// resolves to a length.
+func TestCSSLengthIsDimensionless(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"plain px is length", "16px", false},
+		{"plain percent is length", "50%", false},
+		{"plain em is length", "1.5em", false},
+		{"plain bare number is length (parsePlainLength tags as px)", "1.5", false},
+		{"calc all numeric", "calc(1.2 * 1.5)", true},
+		{"calc one length", "calc(1em + 4px)", false},
+		{"calc number plus number", "calc(2 + 3)", true},
+		{"calc number times length is length", "calc(2 * 1em)", false},
+		// parseMathFuncArgs goes through parseLength, which tags bare-number
+		// math args as "px" (the right default for length contexts). So
+		// min/max/clamp of bare numbers are NOT dimensionless from
+		// isDimensionless's perspective. parseNumericVal routes around this
+		// by handling min/max/clamp itself.
+		{"min of bare numbers tagged px", "min(1, 2, 3)", false},
+		{"min mixed", "min(1, 2px)", false},
+		{"max of bare numbers tagged px", "max(1, 2, 3)", false},
+		{"clamp of bare numbers tagged px", "clamp(1, 2, 3)", false},
+		{"clamp with one length", "clamp(0, 1.5, 100%)", false},
+		{"nil cssLength is not dimensionless", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l := parseLength(tc.val)
+			got := l.isDimensionless()
+			if got != tc.want {
+				t.Errorf("parseLength(%q).isDimensionless() = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestScaleAndSkewCalcResolveCorrectly is an end-to-end check on
+// parseTransform that scale/scaleX/scaleY/skew/skewX/skewY now resolve
+// calc arguments via the fixed parseAngle / parseNumericVal. Sibling
+// to TestParseTransformWithCalc which covers translate/rotate.
+func TestScaleAndSkewCalcResolveCorrectly(t *testing.T) {
+	tests := []struct {
+		name      string
+		val       string
+		opType    string
+		valuesIdx int     // 0 or 1
+		want      float64 // expected at valuesIdx
+	}{
+		{"scale(calc(0.5 + 0.5))", "scale(calc(0.5 + 0.5))", "scale", 0, 1.0},
+		{"scaleX(calc(2 / 4))", "scaleX(calc(2 / 4))", "scale", 0, 0.5},
+		{"scaleY(calc(0.25 + 0.25))", "scaleY(calc(0.25 + 0.25))", "scale", 1, 0.5},
+		{"skew(calc(10deg * 2))", "skew(calc(10deg * 2))", "skewX", 0, 20},
+		{"skewX(calc(45deg / 2))", "skewX(calc(45deg / 2))", "skewX", 0, 22.5},
+		{"skewY(calc(0.5turn))", "skewY(calc(0.5turn))", "skewY", 0, 180},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ops := parseTransform(tc.val)
+			if len(ops) == 0 {
+				t.Fatalf("parseTransform(%q) returned no ops", tc.val)
+			}
+			if ops[0].Type != tc.opType {
+				t.Fatalf("ops[0].Type = %q, want %q", ops[0].Type, tc.opType)
+			}
+			if math.Abs(ops[0].Values[tc.valuesIdx]-tc.want) > 0.01 {
+				t.Errorf("ops[0].Values[%d] = %v, want %v", tc.valuesIdx, ops[0].Values[tc.valuesIdx], tc.want)
+			}
+		})
+	}
+}

--- a/html/converter_style_parsers.go
+++ b/html/converter_style_parsers.go
@@ -8,6 +8,7 @@
 package html
 
 import (
+	"math"
 	"strconv"
 	"strings"
 
@@ -139,35 +140,220 @@ func parseTransform(val string) []layout.TransformOp {
 	return ops
 }
 
-// parseAngle parses a CSS angle value like "45deg", "1.5rad", or "100grad".
-// Returns degrees.
+// parseAngle parses a CSS angle value like "45deg", "1.5rad", "100grad",
+// "0.5turn", or a calc/min/max/clamp expression containing angle leaves.
+// Returns degrees. Calc evaluation is angle-native: every leaf is parsed
+// as an angle (or dimensionless number that acts as a multiplier or
+// divisor) and arithmetic is applied directly. Mixing length units with
+// angles is not meaningful in CSS and yields 0 from the offending leaf.
 func parseAngle(s string) float64 {
 	s = strings.TrimSpace(strings.ToLower(s))
-	if strings.HasSuffix(s, "deg") {
-		v, _ := strconv.ParseFloat(strings.TrimSuffix(s, "deg"), 64)
-		return v
+	if s == "" {
+		return 0
 	}
-	if strings.HasSuffix(s, "rad") {
-		v, _ := strconv.ParseFloat(strings.TrimSuffix(s, "rad"), 64)
-		return v * 180 / 3.14159265358979323846
+	if strings.HasPrefix(s, "calc(") && strings.HasSuffix(s, ")") {
+		return resolveAngleCalc(s[5 : len(s)-1])
+	}
+	if strings.HasPrefix(s, "min(") && strings.HasSuffix(s, ")") {
+		parts := splitTopLevelCommas(s[4 : len(s)-1])
+		if len(parts) == 0 {
+			return 0
+		}
+		out := parseAngle(parts[0])
+		for _, a := range parts[1:] {
+			if v := parseAngle(a); v < out {
+				out = v
+			}
+		}
+		return out
+	}
+	if strings.HasPrefix(s, "max(") && strings.HasSuffix(s, ")") {
+		parts := splitTopLevelCommas(s[4 : len(s)-1])
+		if len(parts) == 0 {
+			return 0
+		}
+		out := parseAngle(parts[0])
+		for _, a := range parts[1:] {
+			if v := parseAngle(a); v > out {
+				out = v
+			}
+		}
+		return out
+	}
+	if strings.HasPrefix(s, "clamp(") && strings.HasSuffix(s, ")") {
+		parts := splitTopLevelCommas(s[6 : len(s)-1])
+		if len(parts) != 3 {
+			return 0
+		}
+		lo, mid, hi := parseAngle(parts[0]), parseAngle(parts[1]), parseAngle(parts[2])
+		if mid < lo {
+			return lo
+		}
+		if mid > hi {
+			return hi
+		}
+		return mid
+	}
+	return parseAngleLeaf(s)
+}
+
+// resolveAngleCalc evaluates the inside of a calc() over angles. The
+// grammar mirrors parseCalcExpr (top-level + and - first; then * and /;
+// parenthesised sub-expressions recurse), but every leaf is read as an
+// angle in degrees (or a dimensionless number for use as a
+// multiplier/divisor). Whitespace around + and - is required by CSS;
+// * and / can be tight against their operands.
+func resolveAngleCalc(s string) float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	// Top-level + or -, scanned right-to-left for left-associative eval.
+	depth := 0
+	for i := len(s) - 1; i > 0; i-- {
+		switch s[i] {
+		case ')':
+			depth++
+		case '(':
+			depth--
+		case '+', '-':
+			if depth != 0 {
+				continue
+			}
+			// Require surrounding whitespace per CSS spec.
+			if i+1 >= len(s) || i-1 < 0 || s[i-1] != ' ' || s[i+1] != ' ' {
+				continue
+			}
+			// Skip "-" that's part of a numeric literal in *... or /... position.
+			l := resolveAngleCalc(s[:i])
+			r := resolveAngleCalc(s[i+1:])
+			if s[i] == '+' {
+				return l + r
+			}
+			return l - r
+		}
+	}
+	// Top-level * or /.
+	depth = 0
+	for i := len(s) - 1; i > 0; i-- {
+		switch s[i] {
+		case ')':
+			depth++
+		case '(':
+			depth--
+		case '*', '/':
+			if depth != 0 {
+				continue
+			}
+			l := resolveAngleCalc(s[:i])
+			r := resolveAngleCalc(s[i+1:])
+			if s[i] == '*' {
+				return l * r
+			}
+			if r == 0 {
+				return 0
+			}
+			return l / r
+		}
+	}
+	// Parenthesised sub-expression.
+	if strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") {
+		return resolveAngleCalc(s[1 : len(s)-1])
+	}
+	// Nested calc/min/max/clamp.
+	if strings.HasPrefix(s, "calc(") || strings.HasPrefix(s, "min(") ||
+		strings.HasPrefix(s, "max(") || strings.HasPrefix(s, "clamp(") {
+		return parseAngle(s)
+	}
+	return parseAngleLeaf(s)
+}
+
+// parseAngleLeaf parses a single angle literal (no calc/min/max/clamp).
+// Recognised suffixes: turn, grad, rad, deg. A bare number is treated
+// as degrees. Suffix order matters — grad must be checked before rad
+// because "100grad" ends in "rad", and turn before either because some
+// CSS extensions (Folio doesn't ship them) use "turnxxx" suffixes.
+func parseAngleLeaf(s string) float64 {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if strings.HasSuffix(s, "turn") {
+		v, _ := strconv.ParseFloat(strings.TrimSuffix(s, "turn"), 64)
+		return v * 360
 	}
 	if strings.HasSuffix(s, "grad") {
 		v, _ := strconv.ParseFloat(strings.TrimSuffix(s, "grad"), 64)
 		return v * 0.9 // 400grad = 360deg
 	}
-	if strings.HasSuffix(s, "turn") {
-		v, _ := strconv.ParseFloat(strings.TrimSuffix(s, "turn"), 64)
-		return v * 360
+	if strings.HasSuffix(s, "rad") {
+		v, _ := strconv.ParseFloat(strings.TrimSuffix(s, "rad"), 64)
+		return v * 180 / math.Pi
 	}
-	// Bare number — assume degrees.
+	if strings.HasSuffix(s, "deg") {
+		v, _ := strconv.ParseFloat(strings.TrimSuffix(s, "deg"), 64)
+		return v
+	}
 	v, _ := strconv.ParseFloat(s, 64)
 	return v
 }
 
-// parseNumericVal parses a bare numeric value (no unit).
+// parseNumericVal parses a bare numeric value (no unit). Recognises
+// calc/min/max/clamp wrappers whose leaves are dimensionless numbers,
+// so transforms like `scale(calc(0.5 + 0.5))` and `skew(min(1deg,
+// 2))` resolve correctly. min/max/clamp are evaluated directly here
+// rather than through parseLength because parseLength's math-arg
+// helper tags bare numbers as Unit "px" (the right default for length
+// contexts but wrong for dimensionless math).
 func parseNumericVal(s string) float64 {
-	v, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
-	return v
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return 0
+	}
+	if v, err := strconv.ParseFloat(s, 64); err == nil {
+		return v
+	}
+	if strings.HasPrefix(s, "min(") && strings.HasSuffix(s, ")") {
+		parts := splitTopLevelCommas(s[4 : len(s)-1])
+		if len(parts) == 0 {
+			return 0
+		}
+		out := parseNumericVal(parts[0])
+		for _, a := range parts[1:] {
+			if v := parseNumericVal(a); v < out {
+				out = v
+			}
+		}
+		return out
+	}
+	if strings.HasPrefix(s, "max(") && strings.HasSuffix(s, ")") {
+		parts := splitTopLevelCommas(s[4 : len(s)-1])
+		if len(parts) == 0 {
+			return 0
+		}
+		out := parseNumericVal(parts[0])
+		for _, a := range parts[1:] {
+			if v := parseNumericVal(a); v > out {
+				out = v
+			}
+		}
+		return out
+	}
+	if strings.HasPrefix(s, "clamp(") && strings.HasSuffix(s, ")") {
+		parts := splitTopLevelCommas(s[6 : len(s)-1])
+		if len(parts) != 3 {
+			return 0
+		}
+		lo, mid, hi := parseNumericVal(parts[0]), parseNumericVal(parts[1]), parseNumericVal(parts[2])
+		if mid < lo {
+			return lo
+		}
+		if mid > hi {
+			return hi
+		}
+		return mid
+	}
+	if l := parseLength(s); l != nil && l.isDimensionless() {
+		return l.toPoints(0, 0)
+	}
+	return 0
 }
 
 // parseLengthPx parses a CSS length for use in transforms (px → pt conversion).

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -5863,15 +5863,27 @@ func TestParseFontShorthandWithCalc(t *testing.T) {
 			wantFamily:     "sans-serif",
 		},
 		{
-			name: "line-height as calc with em",
+			name: "line-height as calc with em (length-form)",
 			// parseLineHeight resolves a length-form calc by dividing
 			// the resulting points by fontSize. calc(1.5em) at fontSize
-			// 9pt = 13.5pt → multiplier = 13.5/9 = 1.5. (Note: a
-			// dimensionless calc like `calc(1.2 * 1.5)` is mishandled by
-			// parseLineHeight in a separate bug — out of scope here.)
+			// 9pt = 13.5pt → multiplier = 13.5/9 = 1.5.
 			input:          "12px/calc(1.5em) sans-serif",
 			wantSize:       9,
 			wantLineHeight: 1.5,
+			wantFamily:     "sans-serif",
+		},
+		{
+			name: "line-height as dimensionless calc (#275)",
+			// Closes #275. A calc whose leaves are all dimensionless
+			// numbers is itself a multiplier, not a length. Pre-fix
+			// parseLineHeight passed `calc(1.2 * 1.5) = 1.8` through
+			// `pts := l.toPoints(fontSize, fontSize)` (returning 1.8 for
+			// the dimensionless case) and then divided by fontSize=9pt,
+			// yielding 0.2 — a 9× compression. Post-fix
+			// `cssLength.isDimensionless()` short-circuits the divide.
+			input:          "12px/calc(1.2 * 1.5) sans-serif",
+			wantSize:       9,
+			wantLineHeight: 1.8,
 			wantFamily:     "sans-serif",
 		},
 		{
@@ -7496,16 +7508,13 @@ func TestParseTransformWithCalc(t *testing.T) {
 			},
 		},
 		{
-			name: "rotate(calc(...)) — known limitation: parseAngle is calc-blind",
-			// Documents the out-of-scope gap so future calc support in
-			// parseAngle flips this expectation deliberately. Pre-fix
-			// the outer extractor would have produced 0 anyway by
-			// truncating mid-calc; post-fix the calc survives but
-			// parseAngle's strconv.ParseFloat fails on the calc string
-			// and returns 0. End result identical for now: rotate by 0.
+			name: "rotate(calc(45deg + 45deg)) resolves to 90deg",
+			// Closes #274. Pre-fix parseAngle was calc-blind and this
+			// resolved to 0; the new calc-aware parser walks the
+			// expression tree with angle-native leaves.
 			val: "rotate(calc(45deg + 45deg))",
 			wantOps: []layout.TransformOp{
-				{Type: "rotate", Values: [2]float64{0, 0}},
+				{Type: "rotate", Values: [2]float64{90, 0}},
 			},
 		},
 		{

--- a/html/properties.go
+++ b/html/properties.go
@@ -863,6 +863,22 @@ func parseFontShorthand(value string, parentSize float64) (style, weight string,
 }
 
 // parseLineHeight parses CSS line-height into a multiplier.
+//
+// Per CSS Inline Layout Module Level 3 §4.3, line-height accepts:
+//   - `normal` keyword (multiplier 1.2)
+//   - a unitless `<number>` used directly as a multiplier
+//   - a `<length>` whose multiplier is length/fontSize
+//   - a `<percentage>` resolved against fontSize (so 150% → 1.5)
+//
+// calc() can produce either a length OR a unitless multiplier depending
+// on its leaves; the two compose differently. A calc whose leaves are
+// all dimensionless (e.g. `calc(1.2 * 1.5)`) is itself dimensionless and
+// is used as a direct multiplier. A calc with a length leaf
+// (e.g. `calc(1em + 4px)`) resolves to a length and is divided by
+// fontSize. Without this distinction `calc(1.2 * 1.5)` would
+// pass through `parseLength` as a dimensionless cssLength, and
+// dividing the resolved value (1.8) by fontSize would produce
+// a 9× compression of line spacing.
 func parseLineHeight(value string, fontSize float64) float64 {
 	value = strings.TrimSpace(strings.ToLower(value))
 	if value == "normal" || value == "" {
@@ -874,9 +890,15 @@ func parseLineHeight(value string, fontSize float64) float64 {
 		return num
 	}
 
-	// Length value.
+	// Length or calc value.
 	l := parseLength(value)
 	if l != nil {
+		if l.isDimensionless() {
+			// A dimensionless calc result is the multiplier directly;
+			// fontSize/relativeTo are unused by Unit "num" leaves so
+			// any positive value works.
+			return l.toPoints(0, 0)
+		}
 		pts := l.toPoints(fontSize, fontSize)
 		if fontSize > 0 {
 			return pts / fontSize

--- a/html/style.go
+++ b/html/style.go
@@ -305,6 +305,53 @@ func (e *calcExpr) dependsOnPercent() bool {
 	return e.left.dependsOnPercent() || e.right.dependsOnPercent()
 }
 
+// isDimensionless reports whether the resolved value carries no length
+// dimension — i.e. every leaf is a bare number stored with Unit "num".
+// Used by parseLineHeight to distinguish a dimensionless calc
+// (e.g. `calc(1.2 * 1.5)` → multiplier 1.8) from a length-typed calc
+// (e.g. `calc(1em + 4px)` → length, divide by fontSize for the
+// multiplier). A dimensionless cssLength can be resolved with
+// toPoints(0, 0) since the only leaf branch consulted is the "num"
+// case, which returns Value as-is.
+func (l *cssLength) isDimensionless() bool {
+	if l == nil {
+		return false
+	}
+	if l.calc != nil {
+		return l.calc.isDimensionless()
+	}
+	if len(l.minArgs) > 0 {
+		for _, a := range l.minArgs {
+			if !a.isDimensionless() {
+				return false
+			}
+		}
+		return true
+	}
+	if len(l.maxArgs) > 0 {
+		for _, a := range l.maxArgs {
+			if !a.isDimensionless() {
+				return false
+			}
+		}
+		return true
+	}
+	return l.Unit == "num"
+}
+
+func (e *calcExpr) isDimensionless() bool {
+	if e == nil {
+		return false
+	}
+	if e.leaf != nil {
+		return e.leaf.isDimensionless()
+	}
+	if e.left == nil || e.right == nil {
+		return false
+	}
+	return e.left.isDimensionless() && e.right.isDimensionless()
+}
+
 // resolve evaluates a calcExpr to points.
 func (e *calcExpr) resolve(relativeTo, fontSize float64) float64 {
 	if e.leaf != nil {


### PR DESCRIPTION
## Summary

Closes #274 and #275 — bundles the two remaining surgical calc gaps to round out the v0.8.0 calc story. Both close concrete user-visible bugs without structural refactor.

## #274 — parseAngle and parseNumericVal were calc-blind

After PR #272 made `parseTransform`'s function-arg extractor paren-aware, calc inside transforms survived intact — but the per-arg parsers ignored it:

```css
transform: rotate(calc(45deg + 45deg))   /* before: 0deg, now: 90deg */
transform: scale(calc(0.5 + 0.5))         /* before: 0,    now: 1.0  */
transform: skew(calc(10deg * 2))          /* before: 0,    now: 20   */
```

`parseAngle` gains a small angle-native calc evaluator (`resolveAngleCalc`) that mirrors `parseCalcExpr`'s grammar but reads each leaf as an angle in degrees (or a dimensionless multiplier). Min/max/clamp are evaluated directly with the same delegation pattern.

`parseNumericVal` handles min/max/clamp directly (rather than via `parseLength`, since `parseMathFuncArgs` tags bare-number args as Unit `\"px\"` for length contexts) and delegates calc to `parseLength`'s dimensionless-leaf path.

`parseAngleLeaf`'s suffix-detection order is fixed in passing — pre-fix `100grad` matched the \"rad\" suffix before \"grad\" and resolved to 0; the new ordering is turn/grad/rad/deg.

The negative test from #272 (`rotate(calc(...)) — known limitation: parseAngle is calc-blind`) is flipped to assert the calc-resolved value.

## #275 — parseLineHeight mishandled dimensionless calc

```css
font: 12px/calc(1.2 * 1.5) sans   /* before: 0.2 multiplier (9× compression),
                                      now: 1.8 as written */
```

A calc whose leaves are all dimensionless numbers is itself a multiplier, not a length. Pre-fix `parseLineHeight` passed it through `pts := l.toPoints(fontSize, fontSize)` (which returns 1.8 directly for the dimensionless case) and then divided by fontSize=9pt, yielding 0.2.

New helpers `cssLength.isDimensionless()` and `calcExpr.isDimensionless()` walk the tree and report true iff every leaf has Unit `\"num\"`. `parseLineHeight` short-circuits via that check before the existing length-form path. The existing length-form calc (`calc(1.5em)`, `calc(1em + 4px)`) is unchanged.

## Out of scope

`parseCalcExpr` has a separate pre-existing bug — the right-to-left scan loop uses `for i := len(s) - 1; i > 0; i--` which never visits index 0, so a leading `(` at position 0 doesn't decrement `depth` and `(1 + 1) * 2` resolves to nil. Filing as a follow-up; it doesn't affect calc forms users actually write inside transform/line-height (the whole expression is wrapped in `calc()`, not in a bare paren group).

`resolveAngleCalc` shares the same loop shape — the follow-up fix should be applied to both at once. Currently neither is reachable for cases the v0.8.0 calc shorthand series exposed, but they share fragility.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./html/...` — 0 issues
- [x] `gofmt -l html/` — clean
- [x] `go vet ./...` — clean

New test coverage in `html/calc_angle_numeric_test.go`:
- 26 subtests in `TestParseAngleWithCalc` — each unit (deg/rad/grad/turn), each calc operator, mixed-unit calc, nested calc, min/max/clamp, defensive cases (malformed leaf, divide-by-zero, wrong-arity clamp), negative angles
- 12 subtests in `TestParseNumericValWithCalc`
- 14 subtests in `TestCSSLengthIsDimensionless` — plain lengths, calcs with mixed leaf types, min/max/clamp behaviour
- 6 subtests in `TestScaleAndSkewCalcResolveCorrectly` — `parseTransform` end-to-end with calc inside scale/scaleX/scaleY/skew/skewX/skewY

Plus an additional row in the existing `TestParseFontShorthandWithCalc` table covering the dimensionless-line-height case.

Independent code review checked the implementation; flagged the shared `i > 0` fragility (documented above) and a couple of LOW-severity comment-clarity nits, no correctness blockers.