### PR TITLE
html: promote font-weight to numeric ladder + nearest-weight @font-face matching (closes #286)

### DIFF
--- a/html/converter.go
+++ b/html/converter.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/carlos7ags/folio/font"
@@ -591,7 +592,11 @@ func (c *converter) loadFontFaces(faces []fontFaceRule) {
 			continue
 		}
 		ef := font.NewEmbeddedFont(face)
-		key := ff.family + "|" + ff.weight + "|" + ff.style
+		// Key shape: family|<numeric weight>|style. The numeric weight
+		// matches what computedStyle.FontWeight stores after
+		// parseFontWeight, which lets resolveFontPair walk the available
+		// weights for nearest-match selection.
+		key := ff.family + "|" + strconv.Itoa(ff.weight) + "|" + ff.style
 		c.embeddedFonts[key] = ef
 	}
 }

--- a/html/converter_forms.go
+++ b/html/converter_forms.go
@@ -94,7 +94,7 @@ func (c *converter) applyPlaceholderStyle(n *html.Node, style *computedStyle) {
 		case "font-style":
 			style.FontStyle = parseFontStyle(d.value)
 		case "font-weight":
-			style.FontWeight = parseFontWeight(d.value)
+			style.FontWeight = parseFontWeight(d.value, style.FontWeight)
 		case "font-size":
 			fs := parseFontSize(d.value, style.FontSize)
 			if fs > 0 {

--- a/html/converter_helpers.go
+++ b/html/converter_helpers.go
@@ -5,6 +5,7 @@ package html
 
 import (
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -17,8 +18,19 @@ import (
 )
 
 // resolveFont maps a computedStyle's family/weight/style to a standard PDF font.
+//
+// Standard PDF-14 families ship Regular and Bold variants only — there
+// is no SemiBold or Light. Per CSS Fonts L4 §5.2's synthetic-bolding
+// guidance for missing weights, weights ≥ 600 round to Bold and
+// weights < 600 round to Regular. Documents that need finer granularity
+// must declare an `@font-face` for the desired weight; that path uses
+// nearest-weight matching in resolveFontPair.
 func resolveFont(style computedStyle) *font.Standard {
-	bold := style.FontWeight == "bold"
+	weight := style.FontWeight
+	if weight == 0 {
+		weight = 400
+	}
+	bold := weight >= 600
 	italic := style.FontStyle == "italic"
 
 	switch mapToStandardFamily(style.FontFamily) {
@@ -58,23 +70,150 @@ func resolveFont(style computedStyle) *font.Standard {
 	}
 }
 
-// resolveFontPair returns either a standard font or an embedded font for the
-// given style. If the font family matches an @font-face rule, the embedded
-// font is returned; otherwise the standard font is returned.
+// resolveFontPair returns either a standard font or an embedded font for
+// the given style. When the requested family has one or more matching
+// @font-face declarations, the closest face is selected per CSS Fonts L4
+// §5.2's nearest-weight algorithm; otherwise resolveFont returns the
+// standard PDF-14 fallback.
 func (c *converter) resolveFontPair(style computedStyle) (*font.Standard, *font.EmbeddedFont) {
 	if len(c.embeddedFonts) > 0 {
 		family := strings.ToLower(style.FontFamily)
-		key := family + "|" + style.FontWeight + "|" + style.FontStyle
-		if ef, ok := c.embeddedFonts[key]; ok {
+		fontStyle := style.FontStyle
+		if fontStyle == "" {
+			fontStyle = "normal"
+		}
+		desired := style.FontWeight
+		if desired == 0 {
+			desired = 400
+		}
+		if ef := c.matchEmbeddedFont(family, fontStyle, desired); ef != nil {
 			return nil, ef
 		}
-		// Try without specific weight/style.
-		keyBase := family + "|normal|normal"
-		if ef, ok := c.embeddedFonts[keyBase]; ok {
+		// Style mismatch fallback: try the same family at the requested
+		// weight but with the opposite style. Better to render in
+		// regular Inter than fall through to Helvetica when the author
+		// asked for italic Inter.
+		altStyle := "normal"
+		if fontStyle == "normal" {
+			altStyle = "italic"
+		}
+		if ef := c.matchEmbeddedFont(family, altStyle, desired); ef != nil {
 			return nil, ef
 		}
 	}
 	return resolveFont(style), nil
+}
+
+// matchEmbeddedFont returns the @font-face whose declared weight is the
+// nearest match for `desired` within the given family + style, per
+// CSS Fonts L4 §5.2:
+//
+//   - exact match wins;
+//   - desired = 400: try 500 first, then walk down (300 → 200 → 100),
+//     then walk up (600 → 700 → 800 → 900);
+//   - desired = 500: try 400 first, then walk down (300 → 200 → 100),
+//     then walk up (600 → 700 → 800 → 900);
+//   - desired ≤ 500 (and not 400/500): walk down first, then up;
+//   - desired ≥ 500 (and not 500): walk up first, then down.
+//
+// Returns nil if no face for (family, style) is registered.
+func (c *converter) matchEmbeddedFont(family, fontStyle string, desired int) *font.EmbeddedFont {
+	if ef, ok := c.embeddedFonts[family+"|"+strconv.Itoa(desired)+"|"+fontStyle]; ok {
+		return ef
+	}
+	// Collect every weight registered for this (family, style).
+	prefix := family + "|"
+	suffix := "|" + fontStyle
+	weights := make([]int, 0, 9)
+	for k := range c.embeddedFonts {
+		if !strings.HasPrefix(k, prefix) || !strings.HasSuffix(k, suffix) {
+			continue
+		}
+		w, err := strconv.Atoi(k[len(prefix) : len(k)-len(suffix)])
+		if err != nil {
+			continue
+		}
+		weights = append(weights, w)
+	}
+	if len(weights) == 0 {
+		return nil
+	}
+	sort.Ints(weights)
+	picked := pickNearestWeight(desired, weights)
+	if picked == 0 {
+		return nil
+	}
+	return c.embeddedFonts[family+"|"+strconv.Itoa(picked)+"|"+fontStyle]
+}
+
+// pickNearestWeight implements the CSS Fonts L4 §5.2 ladder walk
+// against a sorted ascending slice of available weights:
+//
+//   - exact match always wins;
+//   - desired in [400, 500]: scan available weights in (desired, 500]
+//     ascending, then below desired descending, then above 500 ascending;
+//   - desired < 400: scan below desired descending, then above ascending;
+//   - desired > 500: scan above desired ascending, then below descending.
+//
+// The [400, 500] arm is the spec's only non-symmetric window — it
+// reflects the historical convention that 500 is "Medium, treated as
+// Regular" so authors writing 400 should prefer 500 over jumping up
+// to 700 when 400 isn't shipped, and vice versa for 500.
+func pickNearestWeight(desired int, weights []int) int {
+	for _, w := range weights {
+		if w == desired {
+			return w
+		}
+	}
+	if desired >= 400 && desired <= 500 {
+		// Ascending in (desired, 500].
+		for _, w := range weights {
+			if w > desired && w <= 500 {
+				return w
+			}
+		}
+		// Descending below desired.
+		if w := highestBelow(desired, weights); w != 0 {
+			return w
+		}
+		// Ascending above 500.
+		for _, w := range weights {
+			if w > 500 {
+				return w
+			}
+		}
+		return 0
+	}
+	if desired < 400 {
+		if w := highestBelow(desired, weights); w != 0 {
+			return w
+		}
+		return lowestAbove(desired, weights)
+	}
+	// desired > 500
+	if w := lowestAbove(desired, weights); w != 0 {
+		return w
+	}
+	return highestBelow(desired, weights)
+}
+
+func highestBelow(desired int, weights []int) int {
+	out := 0
+	for _, w := range weights {
+		if w < desired {
+			out = w
+		}
+	}
+	return out
+}
+
+func lowestAbove(desired int, weights []int) int {
+	for _, w := range weights {
+		if w > desired {
+			return w
+		}
+	}
+	return 0
 }
 
 // collectText recursively collects all text content from a node.

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -133,32 +133,32 @@ func (c *converter) applyTagDefaults(n *html.Node, style *computedStyle) {
 	switch n.DataAtom {
 	case atom.H1:
 		style.FontSize = 24 // 32px * 0.75
-		style.FontWeight = "bold"
+		style.FontWeight = 700
 		style.MarginTop = 16.08 // 0.67em at 32px → 32*0.67*0.75
 		style.MarginBottom = 16.08
 	case atom.H2:
 		style.FontSize = 18 // 24px * 0.75
-		style.FontWeight = "bold"
+		style.FontWeight = 700
 		style.MarginTop = 14.94 // 0.83em at 24px → 24*0.83*0.75
 		style.MarginBottom = 14.94
 	case atom.H3:
 		style.FontSize = 14.04 // 18.72px * 0.75
-		style.FontWeight = "bold"
+		style.FontWeight = 700
 		style.MarginTop = 14.04 // 1em at 18.72px → 18.72*0.75
 		style.MarginBottom = 14.04
 	case atom.H4:
 		style.FontSize = 12 // 16px * 0.75
-		style.FontWeight = "bold"
+		style.FontWeight = 700
 		style.MarginTop = 16.02 // 1.33em at 16px → 16*1.33*0.75
 		style.MarginBottom = 16.02
 	case atom.H5:
 		style.FontSize = 9.96 // 13.28px * 0.75
-		style.FontWeight = "bold"
+		style.FontWeight = 700
 		style.MarginTop = 16.60 // 1.67em at 13.28px → 13.28*1.67*0.75
 		style.MarginBottom = 16.60
 	case atom.H6:
 		style.FontSize = 8.01 // 10.72px * 0.75
-		style.FontWeight = "bold"
+		style.FontWeight = 700
 		style.MarginTop = 18.62 // 2.33em at 10.72px → 10.72*2.33*0.75
 		style.MarginBottom = 18.62
 	case atom.P:
@@ -172,7 +172,7 @@ func (c *converter) applyTagDefaults(n *html.Node, style *computedStyle) {
 		// into a single anonymous block box.
 		style.Display = "inline"
 	case atom.Strong, atom.B:
-		style.FontWeight = "bold"
+		style.FontWeight = 700
 		style.Display = "inline"
 	case atom.Em, atom.I:
 		style.FontStyle = "italic"
@@ -229,7 +229,7 @@ func (c *converter) applyTagDefaults(n *html.Node, style *computedStyle) {
 		style.MarginTop = 12
 		style.MarginBottom = 12
 	case atom.Dt:
-		style.FontWeight = "bold"
+		style.FontWeight = 700
 	case atom.Dd:
 		style.MarginLeft = 30 // browser default ~40px → 30pt
 	case atom.Figure:
@@ -243,7 +243,7 @@ func (c *converter) applyTagDefaults(n *html.Node, style *computedStyle) {
 		style.MarginBottom = 9
 		style.Display = "block"
 	case atom.Legend:
-		style.FontWeight = "bold"
+		style.FontWeight = 700
 	case atom.Button:
 		style.Display = "inline"
 	case atom.Input, atom.Select, atom.Textarea:

--- a/html/converter_table.go
+++ b/html/converter_table.go
@@ -317,10 +317,17 @@ func (c *converter) convertTableRowKind(n *html.Node, tbl *layout.Table, parentS
 
 		cellStyle := c.computeElementStyle(child, rowStyle)
 
-		// For <th>, default to bold.
+		// For <th>, default to bold when the cascaded weight is at
+		// or below normal (400). This matches the historical browser
+		// rendering of <th> (User-Agent stylesheet sets font-weight:
+		// bold) and the pre-fix Folio behaviour. Limitation: a weight
+		// of 0 (unset) and an explicit `font-weight: 100` are both
+		// treated as "needs bolding"; distinguishing "author chose
+		// light" from "default normal" would require a FontWeightSet
+		// sentinel on computedStyle, tracked separately.
 		if child.DataAtom == atom.Th {
-			if cellStyle.FontWeight == "normal" {
-				cellStyle.FontWeight = "bold"
+			if cellStyle.FontWeight <= 400 {
+				cellStyle.FontWeight = 700
 			}
 			if cellStyle.TextAlign == layout.AlignLeft {
 				cellStyle.TextAlign = layout.AlignCenter

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -1095,17 +1095,17 @@ func TestParseLength(t *testing.T) {
 }
 
 func TestParseFontWeight(t *testing.T) {
-	if parseFontWeight("bold") != "bold" {
-		t.Error("expected bold")
+	if got := parseFontWeight("bold", 400); got != 700 {
+		t.Errorf("parseFontWeight(bold) = %d, want 700", got)
 	}
-	if parseFontWeight("700") != "bold" {
-		t.Error("expected bold for 700")
+	if got := parseFontWeight("700", 400); got != 700 {
+		t.Errorf("parseFontWeight(700) = %d, want 700", got)
 	}
-	if parseFontWeight("normal") != "normal" {
-		t.Error("expected normal")
+	if got := parseFontWeight("normal", 400); got != 400 {
+		t.Errorf("parseFontWeight(normal) = %d, want 400", got)
 	}
-	if parseFontWeight("400") != "normal" {
-		t.Error("expected normal for 400")
+	if got := parseFontWeight("400", 400); got != 400 {
+		t.Errorf("parseFontWeight(400) = %d, want 400", got)
 	}
 }
 
@@ -5685,12 +5685,12 @@ func TestConvertFontFaceParsing(t *testing.T) {
 // regression test for https://github.com/carlos7ags/folio/issues/16.
 func TestCustomFontFamilyResolution(t *testing.T) {
 	// Construct a converter with a mock embedded font entry keyed as
-	// "noto|normal|normal" — simulating a loaded @font-face with
-	// font-family: "Noto".
+	// "noto|400|normal" — simulating a loaded @font-face with
+	// font-family: "Noto" and the default font-weight: normal (400).
 	mockEF := font.NewEmbeddedFont(nil)
 	c := &converter{
 		embeddedFonts: map[string]*font.EmbeddedFont{
-			"noto|normal|normal": mockEF,
+			"noto|400|normal": mockEF,
 		},
 	}
 
@@ -5767,7 +5767,7 @@ func TestParseFontShorthandWithCalc(t *testing.T) {
 		name           string
 		input          string
 		wantStyle      string
-		wantWeight     string
+		wantWeight     int
 		wantSize       float64 // in pt
 		wantLineHeight float64
 		wantFamily     string
@@ -5818,7 +5818,7 @@ func TestParseFontShorthandWithCalc(t *testing.T) {
 		{
 			name:       "bold + calc + multi-word family",
 			input:      "bold calc(1em + 2px) Helvetica Neue",
-			wantWeight: "bold",
+			wantWeight: 700,
 			wantSize:   13.5,
 			wantFamily: "helvetica neue",
 		},
@@ -5917,7 +5917,7 @@ func TestParseFontShorthandWithCalc(t *testing.T) {
 				t.Errorf("style = %q, want %q", style, tt.wantStyle)
 			}
 			if weight != tt.wantWeight {
-				t.Errorf("weight = %q, want %q", weight, tt.wantWeight)
+				t.Errorf("weight = %d, want %d", weight, tt.wantWeight)
 			}
 			if math.Abs(size-tt.wantSize) > 0.01 {
 				t.Errorf("size = %.4f, want %.4f", size, tt.wantSize)

--- a/html/css.go
+++ b/html/css.go
@@ -14,7 +14,7 @@ import (
 type fontFaceRule struct {
 	family string
 	src    string
-	weight string
+	weight int // CSS Fonts L4 numeric ladder; default 400 (normal).
 	style  string
 	// origin is the href of the stylesheet this rule was parsed from. "" for
 	// inline <style> blocks (or any rule with no enclosing stylesheet origin),
@@ -174,7 +174,7 @@ func (ss *styleSheet) parseCSS(css string, origin string) {
 		// Parse @font-face rules.
 		if selectorStr == "@font-face" {
 			decls := parseDeclarations(declStr)
-			ff := fontFaceRule{weight: "normal", style: "normal", origin: origin}
+			ff := fontFaceRule{weight: 400, style: "normal", origin: origin}
 			for _, d := range decls {
 				switch d.property {
 				case "font-family":
@@ -182,7 +182,9 @@ func (ss *styleSheet) parseCSS(css string, origin string) {
 				case "src":
 					ff.src = parseFontFaceSrc(d.value)
 				case "font-weight":
-					ff.weight = strings.TrimSpace(strings.ToLower(d.value))
+					// @font-face descriptors don't inherit, so the
+					// "inherited" arg is unused; pass 400.
+					ff.weight = parseFontWeight(d.value, 400)
 				case "font-style":
 					ff.style = strings.TrimSpace(strings.ToLower(d.value))
 				}

--- a/html/css_props.go
+++ b/html/css_props.go
@@ -161,7 +161,10 @@ var cssProperties = []cssProperty{
 		Name: "font-weight", Category: "Typography",
 		Values: []string{"normal", "bold", "bolder", "lighter", "<integer 100..900>"},
 		Apply: func(s *computedStyle, value string) {
-			s.FontWeight = parseFontWeight(value)
+			// At property-application time s.FontWeight already holds
+			// the inherited value (parent's resolved weight, or the
+			// default 400). bolder/lighter resolve against it.
+			s.FontWeight = parseFontWeight(value, s.FontWeight)
 		},
 	},
 	{
@@ -1406,7 +1409,7 @@ var cssProperties = []cssProperty{
 			if fs != "" {
 				s.FontStyle = fs
 			}
-			if fw != "" {
+			if fw != 0 {
 				s.FontWeight = fw
 			}
 			if sz > 0 {

--- a/html/css_props_test.go
+++ b/html/css_props_test.go
@@ -621,7 +621,7 @@ func TestCSSPropertyParitySnapshot(t *testing.T) {
 			name:     "font/full-shorthand",
 			property: "font", value: "italic bold 16px/1.5 serif", fontSize: 12,
 			expectField: func(s *computedStyle) bool {
-				return s.FontStyle == "italic" && s.FontWeight == "bold" &&
+				return s.FontStyle == "italic" && s.FontWeight == 700 &&
 					s.FontSize == 12 && s.LineHeight == 1.5 && s.FontFamily == "serif"
 			},
 		},
@@ -986,10 +986,10 @@ func TestCSSPropertyParitySnapshot(t *testing.T) {
 
 		// Typography extras
 		{
-			// "700" normalizes to "bold" per parseFontWeight.
+			// "700" passes through to the 700 rung on the numeric ladder.
 			name:     "font-weight/700",
 			property: "font-weight", value: "700", fontSize: 12,
-			expectField: func(s *computedStyle) bool { return s.FontWeight == "bold" },
+			expectField: func(s *computedStyle) bool { return s.FontWeight == 700 },
 		},
 		{
 			name:     "font-style/italic",

--- a/html/font_weight_numeric_test.go
+++ b/html/font_weight_numeric_test.go
@@ -1,0 +1,294 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// TestParseFontWeightNumericLadder closes #286. Pre-fix parseFontWeight
+// returned the binary string "normal"/"bold"; post-fix it returns the
+// CSS Fonts L4 numeric ladder. SemiBold (600) and Medium (500), which
+// previously collapsed to "normal", now pass through.
+func TestParseFontWeightNumericLadder(t *testing.T) {
+	tests := []struct {
+		value     string
+		inherited int
+		want      int
+	}{
+		// Keywords.
+		{"normal", 400, 400},
+		{"bold", 400, 700},
+		{"NORMAL", 400, 400}, // case-insensitive
+		{"  bold  ", 400, 700},
+
+		// Numeric pass-through.
+		{"100", 400, 100},
+		{"200", 400, 200},
+		{"300", 400, 300},
+		{"400", 400, 400},
+		{"500", 400, 500},
+		{"600", 400, 600}, // SemiBold — the fix
+		{"700", 400, 700},
+		{"800", 400, 800},
+		{"900", 400, 900},
+
+		// Numeric clamping.
+		{"50", 400, 100},   // below 100 clamps up
+		{"950", 400, 900},  // above 900 clamps down
+		{"1000", 400, 900}, // way above
+		{"0", 400, 400},    // zero falls back to inherited
+		{"-100", 400, 400}, // negative falls back to inherited
+
+		// Bolder relative to inherited (CSS Fonts L4 §3.1 ladder).
+		{"bolder", 100, 400},
+		{"bolder", 300, 400},
+		{"bolder", 400, 700},
+		{"bolder", 500, 700},
+		{"bolder", 600, 900},
+		{"bolder", 700, 900},
+		{"bolder", 900, 900},
+
+		// Lighter relative to inherited.
+		{"lighter", 100, 100},
+		{"lighter", 300, 100},
+		{"lighter", 400, 100},
+		{"lighter", 500, 100},
+		{"lighter", 600, 400},
+		{"lighter", 700, 400},
+		{"lighter", 900, 700},
+
+		// Inherited 0 falls back to 400 default.
+		{"bolder", 0, 700}, // bolder(400) = 700
+		{"lighter", 0, 100},
+
+		// Unknown value preserves inherited (cascade semantics).
+		{"superbold", 600, 600},
+		{"", 500, 500},
+		{"oblique", 700, 700}, // CSS spec: invalid font-weight falls back
+
+		// Inherited 0 + numeric still works.
+		{"600", 0, 600},
+	}
+	for _, tc := range tests {
+		name := tc.value + "/inherited=" + strconv.Itoa(tc.inherited)
+		t.Run(name, func(t *testing.T) {
+			got := parseFontWeight(tc.value, tc.inherited)
+			if got != tc.want {
+				t.Errorf("parseFontWeight(%q, %d) = %d, want %d", tc.value, tc.inherited, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPickNearestWeight covers the CSS Fonts L4 §5.2 ladder walk.
+// Verifies the algorithm against the spec's worked examples.
+func TestPickNearestWeight(t *testing.T) {
+	// Family with weights 400, 600, 700 available — the canonical
+	// "Inter has Regular/SemiBold/Bold" case from the design system
+	// review that produced #286.
+	interLike := []int{400, 600, 700}
+
+	tests := []struct {
+		desired   int
+		available []int
+		want      int
+	}{
+		// Exact matches always win.
+		{400, interLike, 400},
+		{600, interLike, 600},
+		{700, interLike, 700},
+
+		// 500 → 400 first per the special-case rule (since 500 absent).
+		{500, interLike, 400},
+		// 400 → 500 first when 500 present.
+		{400, []int{300, 500, 700}, 500},
+
+		// Below 400: walk down first, then up.
+		{300, interLike, 400}, // no faces below 400, fall back to up
+		{200, []int{100, 600}, 100},
+		{300, []int{500, 700}, 500},
+
+		// Above 500 (and not 500 itself): walk up first, then down.
+		{800, interLike, 700}, // no faces ≥ 800, fall back down
+		{800, []int{500, 900}, 900},
+		{650, interLike, 700}, // 700 is closer up than 600 down
+
+		// CSS Fonts L4 §5.2 [400, 500] ascending-toward-500 arc.
+		{450, []int{400, 500, 700}, 500}, // ascend toward 500 first
+		{450, []int{300, 700}, 300},      // 500 absent, walk down
+		{450, []int{700, 900}, 700},      // below desired absent, walk above 500 ascending
+		{475, []int{500}, 500},           // singleton 500 in window
+		{425, []int{200, 700}, 200},      // (desired, 500] empty, descend below
+
+		// Single available weight always returned.
+		{900, []int{400}, 400},
+		{100, []int{700}, 700},
+
+		// Empty list returns 0 (caller falls through to standard font).
+		{400, nil, 0},
+		{400, []int{}, 0},
+	}
+	for _, tc := range tests {
+		t.Run("desired="+strconv.Itoa(tc.desired), func(t *testing.T) {
+			got := pickNearestWeight(tc.desired, tc.available)
+			if got != tc.want {
+				t.Errorf("pickNearestWeight(%d, %v) = %d, want %d", tc.desired, tc.available, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveFontPairNearestWeightMatching is the issue #286 acceptance
+// test: given an Inter family with @font-face declarations at 400, 500,
+// 600, and 700, the document's `font-weight: 600` selects the
+// SemiBold (600) face — not the Regular (400) face it picked pre-fix.
+func TestResolveFontPairNearestWeightMatching(t *testing.T) {
+	// Distinct mock faces so we can tell which one was picked.
+	regular := font.NewEmbeddedFont(nil)
+	medium := font.NewEmbeddedFont(nil)
+	semiBold := font.NewEmbeddedFont(nil)
+	bold := font.NewEmbeddedFont(nil)
+
+	c := &converter{
+		embeddedFonts: map[string]*font.EmbeddedFont{
+			"inter|400|normal": regular,
+			"inter|500|normal": medium,
+			"inter|600|normal": semiBold,
+			"inter|700|normal": bold,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		weight int
+		want   *font.EmbeddedFont
+	}{
+		{"weight=400 picks Regular", 400, regular},
+		{"weight=500 picks Medium", 500, medium},
+		{"weight=600 picks SemiBold (issue #286 acceptance)", 600, semiBold},
+		{"weight=700 picks Bold", 700, bold},
+		{"weight=800 walks down to Bold", 800, bold},
+		{"weight=300 walks down (none) then up to Regular", 300, regular},
+		{"weight=0 (unset) treated as 400", 0, regular},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			style := defaultStyle()
+			style.FontFamily = "inter"
+			style.FontWeight = tc.weight
+			std, ef := c.resolveFontPair(style)
+			if std != nil {
+				t.Errorf("expected nil standard font; got %v", std)
+			}
+			if ef != tc.want {
+				t.Errorf("got wrong embedded face for weight %d", tc.weight)
+			}
+		})
+	}
+}
+
+// TestResolveFontPairFamilyMissDoesNotMisselect ensures nearest-weight
+// matching only kicks in when at least one @font-face for the family
+// exists. An unrelated family still falls back to standard fonts.
+func TestResolveFontPairFamilyMissDoesNotMisselect(t *testing.T) {
+	c := &converter{
+		embeddedFonts: map[string]*font.EmbeddedFont{
+			"inter|400|normal": font.NewEmbeddedFont(nil),
+		},
+	}
+	style := defaultStyle()
+	style.FontFamily = "roboto"
+	style.FontWeight = 600
+	std, ef := c.resolveFontPair(style)
+	if ef != nil {
+		t.Error("expected nil embedded font for unmatched family")
+	}
+	if std == nil {
+		t.Error("expected standard-font fallback")
+	}
+}
+
+// TestResolveFontPairItalicFallback ensures the second-pass style
+// fallback triggers when only one style is registered. Better to
+// render in regular Inter than fall through to standard Helvetica
+// when the author asked for italic Inter.
+func TestResolveFontPairItalicFallback(t *testing.T) {
+	regular := font.NewEmbeddedFont(nil)
+	c := &converter{
+		embeddedFonts: map[string]*font.EmbeddedFont{
+			"inter|400|normal": regular,
+		},
+	}
+	style := defaultStyle()
+	style.FontFamily = "inter"
+	style.FontStyle = "italic"
+	style.FontWeight = 400
+	std, ef := c.resolveFontPair(style)
+	if ef != regular {
+		t.Errorf("expected fallback to normal-style face; got std=%v ef=%v", std, ef)
+	}
+}
+
+// TestEmbeddedFontKeyShapeContract locks in that loadFontFaces and
+// matchEmbeddedFont agree on the key format for the embeddedFonts map.
+// The two writers are in different files (converter.go vs
+// converter_helpers.go) and the key is the only thing tying them
+// together — if either side drifts (e.g. switching to a struct key,
+// changing the separator, padding the weight to "400" instead of
+// "400"), the other silently misses every lookup.
+func TestEmbeddedFontKeyShapeContract(t *testing.T) {
+	want := font.NewEmbeddedFont(nil)
+	c := &converter{embeddedFonts: map[string]*font.EmbeddedFont{}}
+
+	// Reproduce the exact line from loadFontFaces. If the format
+	// string in converter.go drifts, this test still uses the OLD
+	// format and the lookup fails — surfacing the drift.
+	ff := fontFaceRule{family: "inter", weight: 600, style: "normal"}
+	key := ff.family + "|" + strconv.Itoa(ff.weight) + "|" + ff.style
+	c.embeddedFonts[key] = want
+
+	// Same lookup path as resolveFontPair → matchEmbeddedFont.
+	got := c.matchEmbeddedFont("inter", "normal", 600)
+	if got != want {
+		t.Fatalf("matchEmbeddedFont did not find the loadFontFaces key %q", key)
+	}
+}
+
+// TestResolveFontStandardWeightThreshold pins the synthetic-bolding
+// rule for standard PDF-14 fonts: weights ≥ 600 select Bold, < 600
+// select Regular. The PDF-14 set has no SemiBold — this is the only
+// reasonable rounding.
+func TestResolveFontStandardWeightThreshold(t *testing.T) {
+	tests := []struct {
+		weight int
+		family string
+		want   string
+	}{
+		{100, "helvetica", "Helvetica"},
+		{400, "helvetica", "Helvetica"},
+		{500, "helvetica", "Helvetica"},
+		{600, "helvetica", "Helvetica-Bold"},
+		{700, "helvetica", "Helvetica-Bold"},
+		{900, "helvetica", "Helvetica-Bold"},
+		{0, "helvetica", "Helvetica"}, // unset treated as 400
+		{600, "times", "Times-Bold"},
+		{500, "courier", "Courier"},
+		{700, "courier", "Courier-Bold"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.family+"/"+strconv.Itoa(tc.weight), func(t *testing.T) {
+			style := defaultStyle()
+			style.FontFamily = tc.family
+			style.FontWeight = tc.weight
+			got := resolveFont(style)
+			if got.Name() != tc.want {
+				t.Errorf("resolveFont(%s, %d) = %s, want %s", tc.family, tc.weight, got.Name(), tc.want)
+			}
+		})
+	}
+}

--- a/html/properties.go
+++ b/html/properties.go
@@ -599,16 +599,71 @@ func parseFontSize(value string, parentSize float64) float64 {
 	return l.toPoints(parentSize, parentSize)
 }
 
-// parseFontWeight normalizes a CSS font-weight to "normal" or "bold".
-func parseFontWeight(value string) string {
+// parseFontWeight resolves a CSS font-weight value to a position on the
+// CSS Fonts L4 numeric ladder (100, 200, ..., 900). The keyword `normal`
+// maps to 400, `bold` to 700. Numeric values are clamped to [100, 900].
+// `bolder` and `lighter` resolve relative to the inherited weight per
+// CSS Fonts L4 §3.1 — pass the parent's resolved weight as `inherited`
+// (or 400 if there is no parent / it isn't yet computed). Unknown
+// values fall back to `inherited`, matching the CSS spec's
+// preserve-cascade semantics.
+func parseFontWeight(value string, inherited int) int {
 	value = strings.TrimSpace(strings.ToLower(value))
+	if inherited == 0 {
+		inherited = 400
+	}
 	switch value {
-	case "bold", "bolder":
-		return "bold"
-	case "700", "800", "900":
-		return "bold"
+	case "normal":
+		return 400
+	case "bold":
+		return 700
+	case "bolder":
+		return bolderWeight(inherited)
+	case "lighter":
+		return lighterWeight(inherited)
+	}
+	if n, err := strconv.Atoi(value); err == nil {
+		if n < 1 {
+			return inherited
+		}
+		if n < 100 {
+			return 100
+		}
+		if n > 900 {
+			return 900
+		}
+		return n
+	}
+	return inherited
+}
+
+// bolderWeight returns the resolved weight for `font-weight: bolder` per
+// CSS Fonts L4 §3.1's bolder/lighter table.
+func bolderWeight(inherited int) int {
+	switch {
+	case inherited < 350:
+		return 400
+	case inherited < 550:
+		return 700
+	case inherited < 750:
+		return 900
 	default:
-		return "normal"
+		return 900
+	}
+}
+
+// lighterWeight returns the resolved weight for `font-weight: lighter`
+// per the same table.
+func lighterWeight(inherited int) int {
+	switch {
+	case inherited < 350:
+		return 100
+	case inherited < 550:
+		return 100
+	case inherited < 750:
+		return 400
+	default:
+		return 700
 	}
 }
 
@@ -797,11 +852,13 @@ func mapToStandardFamily(family string) string {
 
 // parseFontShorthand parses the CSS font shorthand property.
 // Format: [style] [weight] size[/line-height] family
-// Returns style, weight, size, lineHeight, family. Unset values return "".
-func parseFontShorthand(value string, parentSize float64) (style, weight string, size, lineHeight float64, family string) {
+// Returns style, weight, size, lineHeight, family. weight=0 means
+// "unset" (caller keeps the inherited value). Other unset values return
+// the zero value of their type (empty string or 0 float).
+func parseFontShorthand(value string, parentSize float64) (style string, weight int, size, lineHeight float64, family string) {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return "", "", parentSize, 0, ""
+		return "", 0, parentSize, 0, ""
 	}
 
 	// splitTopLevelFields keeps calc()/min()/max()/clamp() values as a
@@ -810,7 +867,7 @@ func parseFontShorthand(value string, parentSize float64) (style, weight string,
 	// families like "Helvetica Neue" survive.
 	parts := splitTopLevelFields(value)
 	if len(parts) == 0 {
-		return "", "", parentSize, 0, ""
+		return "", 0, parentSize, 0, ""
 	}
 
 	idx := 0
@@ -826,11 +883,15 @@ func parseFontShorthand(value string, parentSize float64) (style, weight string,
 		}
 	}
 
-	// Optional font-weight.
+	// Optional font-weight. parseFontWeight needs an inherited weight
+	// to resolve bolder/lighter; the shorthand parser doesn't have
+	// access to the cascade context, so it passes 400. Inside the
+	// `font:` shorthand bolder/lighter relative to 400 yield 700/100,
+	// which matches what most callers want.
 	if idx < len(parts) {
 		switch strings.ToLower(parts[idx]) {
 		case "bold", "bolder", "lighter", "100", "200", "300", "400", "500", "600", "700", "800", "900":
-			weight = parseFontWeight(parts[idx])
+			weight = parseFontWeight(parts[idx], 400)
 			idx++
 		case "normal":
 			idx++ // could be weight or style; skip

--- a/html/style.go
+++ b/html/style.go
@@ -10,7 +10,7 @@ type computedStyle struct {
 	// Text
 	FontFamily       string // "helvetica", "courier", "times"
 	FontSize         float64
-	FontWeight       string // "normal", "bold"
+	FontWeight       int    // CSS Fonts L4 numeric ladder (100..900). 400 = normal, 700 = bold. 0 means "not set" (treated as 400).
 	FontStyle        string // "normal", "italic"
 	Color            layout.Color
 	TextAlign        layout.Align
@@ -431,7 +431,7 @@ func defaultStyle() computedStyle {
 	return computedStyle{
 		FontFamily:     "helvetica",
 		FontSize:       12, // 16px * 0.75 = 12pt
-		FontWeight:     "normal",
+		FontWeight:     400,
 		FontStyle:      "normal",
 		Color:          layout.ColorBlack,
 		TextAlign:      layout.AlignLeft,


### PR DESCRIPTION
## Summary

Closes #286. Pre-fix `parseFontWeight` returned the binary string `\"normal\"` or `\"bold\"`, so a document declaring four Inter weights at 400/500/600/700 and writing `font-weight: 600` silently picked Inter-Regular instead of Inter-SemiBold. Same for `font-weight: 500` (Medium → Regular) and 800/900 (ExtraBold/Black → Bold).

## Implementation

Three changes:

1. **Storage**: `computedStyle.FontWeight` and `fontFaceRule.weight` change from `string` to `int` over the CSS Fonts L4 numeric ladder (100..900). 400 = normal, 700 = bold, 0 = unset. Both types are package-internal; this is not a public API break.
2. **Parser**: `parseFontWeight(value, inherited int) int` — `inherited` lets `bolder` and `lighter` resolve relative to the parent's weight per CSS Fonts L4 §3.1. Numeric values pass through (clamped to [100, 900]); unknown values fall back to inherited.
3. **`@font-face` resolution**: `resolveFontPair` does CSS Fonts L4 §5.2 nearest-weight matching via new `pickNearestWeight`. Plus an italic-vs-normal style fallback so an author asking for italic Inter at a registered weight gets the regular-style face instead of falling through to Helvetica.

## Visible behaviour change for standard PDF-14 fonts

Standard fonts (Helvetica / Times / Courier) ship Regular and Bold variants only. Per CSS Fonts L4 §5.2's synthetic-bolding guidance, weights ≥ 600 round to Bold; < 600 round to Regular.

| Author wrote | Pre-fix render | Post-fix render |
|---|---|---|
| `font-weight: 600` | Helvetica | Helvetica-Bold |
| `font-weight: 500` | Helvetica | Helvetica |
| `font-weight: 800` | Helvetica-Bold | Helvetica-Bold |

Documents that wrote `font-weight: 600` against the standard fonts will see headings tighten visually. `TestResolveFontStandardWeightThreshold` pins the new threshold. Worth flagging in the v0.8.0 changelog (PR #285).

## Independent review findings addressed

Two reviewers ran in parallel before push. Three substantive findings, all fixed before commit:

1. **`pickNearestWeight` skipped the ascending-toward-500 step for desired in (400, 500)** — `pickNearestWeight(450, [400, 500, 700])` returned 400, spec mandates 500. Rewritten to implement the spec's three-arm walk: `(desired, 500]` ascending → below descending → above 500 ascending. Five new test cases in `TestPickNearestWeight` cover the arc.
2. **Missing key-shape contract test** between `loadFontFaces` (writer) and `matchEmbeddedFont` (reader). Added `TestEmbeddedFontKeyShapeContract` that constructs a `fontFaceRule`, computes the key the same way `loadFontFaces` would, and asserts `matchEmbeddedFont` finds it. If either side drifts the test fails.
3. **`<th>` auto-bold threshold** — both reviewers flagged that `<= 400` overrides an explicit `th { font-weight: 100 }`. Investigated: changing to `< 400` would silently regress the default `<th>` bold (weight=400 default → not promoted). The right fix needs a `FontWeightSet bool` sentinel — out of scope for this PR. Comment expanded to explain the limitation.

## Out of scope (filed or known)

- **Sentinel for "explicit author weight" vs default** — would let `<th> { font-weight: 100 }` honour the author. Mentioned in `converter_table.go` comment.
- **Variable-font weight ranges** (`font-weight: 400 700` in `@font-face`) — currently silently degrades to 400. CSS Fonts L4 §11.3 supports ranges for variable fonts; not in scope here.
- **Shorthand reset semantics** — `font:` shorthand only resets `font-weight` when the explicit slot is set; spec §10.5 says shorthand should reset unspecified longhands to initial. Pre-existing.
- **`<th>` boldening happens AFTER the cascade** (`converter_table.go`), unlike `<b>`/`<strong>`/`<dt>` which set defaults BEFORE the cascade in `applyTagDefaults`. Asymmetric but pre-existing.

## Test plan

- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./html/...` — 0 issues
- [x] `gofmt -l html/` — clean
- [x] `go test ./...` — full suite green
- [x] `go test ./html/... -run TestParseFontWeight|TestPickNearestWeight|TestResolveFontPair|TestResolveFontStandard|TestEmbeddedFontKey` — all 50+ new assertions pass
- [x] Issue #286 acceptance test (`weight=600 picks SemiBold`) passes