### PR TITLE
html: add CSS text-align: start | end with direction-relative late binding

### DIFF
--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -531,7 +531,7 @@ func (c *converter) convertDefinitionList(n *html.Node, style computedStyle) []l
 			text = applyTextTransform(text, childStyle.TextTransform)
 			f := resolveFont(childStyle)
 			p := layout.NewParagraph(text, f, childStyle.FontSize)
-			p.SetAlign(childStyle.TextAlign)
+			p.SetAlign(resolveTextAlign(childStyle))
 			p.SetLeading(childStyle.LineHeight)
 			div.Add(p)
 

--- a/html/converter_heading.go
+++ b/html/converter_heading.go
@@ -35,7 +35,7 @@ func (c *converter) convertHeading(n *html.Node, style computedStyle, level layo
 	}
 	// Replace the default run with the fully styled runs from collectRuns.
 	h.SetRuns(runs)
-	h.SetAlign(style.TextAlign)
+	h.SetAlign(resolveTextAlign(style))
 	if style.BookmarkLevelSet {
 		h.SetBookmarkLevel(style.BookmarkLevel)
 	}

--- a/html/converter_paragraph.go
+++ b/html/converter_paragraph.go
@@ -78,13 +78,13 @@ func (c *converter) buildParagraphFromRuns(runs []layout.TextRun, style computed
 	p := layout.NewStyledParagraph(runs...)
 
 	if style.TextAlignSet {
-		p.SetAlign(style.TextAlign)
+		p.SetAlign(resolveTextAlign(style))
 	}
 	if style.Direction != layout.DirectionAuto {
 		p.SetDirection(style.Direction)
 	}
 	if style.TextAlignLastSet {
-		p.SetTextAlignLast(style.TextAlignLast)
+		p.SetTextAlignLast(resolveTextAlignLast(style))
 	}
 	p.SetLeading(style.LineHeight)
 	if style.StringSetName != "" {
@@ -153,7 +153,7 @@ func (c *converter) convertText(n *html.Node, style computedStyle) []layout.Elem
 	}
 	p := layout.NewStyledParagraph(run)
 	if style.TextAlignSet {
-		p.SetAlign(style.TextAlign)
+		p.SetAlign(resolveTextAlign(style))
 	}
 	if style.Direction != layout.DirectionAuto {
 		p.SetDirection(style.Direction)

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -361,7 +361,7 @@ func (c *converter) generatePseudoElement(text string, style computedStyle) layo
 		TextShadow:      textShadowFromStyle(style),
 	}
 	p := layout.NewStyledParagraph(run)
-	p.SetAlign(style.TextAlign)
+	p.SetAlign(resolveTextAlign(style))
 	p.SetLeading(style.LineHeight)
 	return p
 }

--- a/html/converter_table.go
+++ b/html/converter_table.go
@@ -174,7 +174,7 @@ func (c *converter) convertCSSTable(n *html.Node, style computedStyle) []layout.
 					}
 					layoutCell = row.AddCellElement(div)
 				}
-				layoutCell.SetAlign(cellStyle.TextAlign)
+				layoutCell.SetAlign(resolveTextAlign(cellStyle))
 				if cellStyle.hasPadding() {
 					layoutCell.SetPaddingSides(layout.Padding{
 						Top:    cellStyle.PaddingTop,
@@ -329,8 +329,15 @@ func (c *converter) convertTableRowKind(n *html.Node, tbl *layout.Table, parentS
 			if cellStyle.FontWeight <= 400 {
 				cellStyle.FontWeight = 700
 			}
-			if cellStyle.TextAlign == layout.AlignLeft {
+			// Default <th> alignment is center when the author hasn't
+			// explicitly chosen left. Use resolveTextAlign so the
+			// direction-relative `start`/`end` keywords are honoured
+			// before the equality check (otherwise an RTL document
+			// with `text-align: start` would resolve to AlignLeft and
+			// then get unexpectedly re-aligned to center).
+			if !cellStyle.TextAlignSet && resolveTextAlign(cellStyle) == layout.AlignLeft {
 				cellStyle.TextAlign = layout.AlignCenter
+				cellStyle.TextAlignKeyword = ""
 			}
 		}
 
@@ -351,7 +358,7 @@ func (c *converter) convertTableRowKind(n *html.Node, tbl *layout.Table, parentS
 			cell = row.AddCellElement(div)
 		}
 
-		cell.SetAlign(cellStyle.TextAlign)
+		cell.SetAlign(resolveTextAlign(cellStyle))
 
 		// Per-side cell padding (default 4pt uniform).
 		if cellStyle.hasPadding() {

--- a/html/css_props.go
+++ b/html/css_props.go
@@ -90,8 +90,9 @@ var cssProperties = []cssProperty{
 		Category: "Typography",
 		Values:   []string{"left", "right", "center", "justify", "start", "end"},
 		Apply: func(s *computedStyle, value string) {
-			if a, ok := parseTextAlign(value); ok {
+			if a, kw, ok := parseTextAlign(value); ok {
 				s.TextAlign = a
+				s.TextAlignKeyword = kw
 				s.TextAlignSet = true
 			}
 		},
@@ -259,8 +260,9 @@ var cssProperties = []cssProperty{
 		Name: "text-align-last", Category: "Typography",
 		Values: []string{"left", "right", "center", "justify", "start", "end"},
 		Apply: func(s *computedStyle, value string) {
-			if a, ok := parseTextAlign(value); ok {
+			if a, kw, ok := parseTextAlign(value); ok {
 				s.TextAlignLast = a
+				s.TextAlignLastKeyword = kw
 				s.TextAlignLastSet = true
 			}
 		},

--- a/html/properties.go
+++ b/html/properties.go
@@ -679,18 +679,78 @@ func parseFontStyle(value string) string {
 }
 
 // parseTextAlign parses CSS text-align into layout.Align.
-func parseTextAlign(value string) (layout.Align, bool) {
+//
+// `start` and `end` are direction-relative keywords (CSS Text L4 §7.1)
+// — they resolve to `left`/`right` based on the cascaded `direction`
+// property. Direction may not yet be applied at the time text-align is
+// parsed (CSS declarations are processed in source order within a
+// block), so this function returns an LTR-correct best guess
+// (`start` → AlignLeft, `end` → AlignRight) and a non-empty `keyword`
+// string. Consumers must call resolveTextAlign(style) at draw time
+// to get the spec-correct value once `style.Direction` is known.
+//
+// For `left`/`right`/`center`/`justify` the returned `keyword` is
+// empty and the returned Align is the final value — no late binding
+// needed.
+//
+// Returns (align, keyword, ok). `ok` is false for unrecognized
+// values, leaving the caller's TextAlign unchanged per the CSS
+// invalid-value cascade rule.
+func parseTextAlign(value string) (align layout.Align, keyword string, ok bool) {
 	switch strings.TrimSpace(strings.ToLower(value)) {
 	case "left":
-		return layout.AlignLeft, true
+		return layout.AlignLeft, "", true
 	case "center":
-		return layout.AlignCenter, true
+		return layout.AlignCenter, "", true
 	case "right":
-		return layout.AlignRight, true
+		return layout.AlignRight, "", true
 	case "justify":
-		return layout.AlignJustify, true
+		return layout.AlignJustify, "", true
+	case "start":
+		return layout.AlignLeft, "start", true
+	case "end":
+		return layout.AlignRight, "end", true
 	default:
-		return layout.AlignLeft, false
+		return layout.AlignLeft, "", false
+	}
+}
+
+// resolveTextAlign returns the spec-correct text-align value for a
+// computed style, late-binding the direction-relative keywords
+// `start` and `end` against `style.Direction`. Other keywords pass
+// through `style.TextAlign` unchanged.
+//
+// `start` resolves to AlignLeft under LTR / Auto and AlignRight under
+// RTL. `end` resolves to AlignRight under LTR / Auto and AlignLeft
+// under RTL.
+func resolveTextAlign(style computedStyle) layout.Align {
+	return resolveDirectionRelativeAlign(style.TextAlignKeyword, style.TextAlign, style.Direction)
+}
+
+// resolveTextAlignLast does the same late binding for
+// `text-align-last`, which has the same direction-relative keywords.
+func resolveTextAlignLast(style computedStyle) layout.Align {
+	return resolveDirectionRelativeAlign(style.TextAlignLastKeyword, style.TextAlignLast, style.Direction)
+}
+
+// resolveDirectionRelativeAlign maps the CSS direction-relative
+// keywords (`start`/`end`) to a concrete left/right alignment given
+// the computed direction. Any other keyword (including the empty
+// string) returns `fallback` unchanged.
+func resolveDirectionRelativeAlign(keyword string, fallback layout.Align, dir layout.Direction) layout.Align {
+	switch keyword {
+	case "start":
+		if dir == layout.DirectionRTL {
+			return layout.AlignRight
+		}
+		return layout.AlignLeft
+	case "end":
+		if dir == layout.DirectionRTL {
+			return layout.AlignLeft
+		}
+		return layout.AlignRight
+	default:
+		return fallback
 	}
 }
 

--- a/html/style.go
+++ b/html/style.go
@@ -8,24 +8,26 @@ import "github.com/carlos7ags/folio/layout"
 // computedStyle holds the resolved CSS properties for a single HTML node.
 type computedStyle struct {
 	// Text
-	FontFamily       string // "helvetica", "courier", "times"
-	FontSize         float64
-	FontWeight       int    // CSS Fonts L4 numeric ladder (100..900). 400 = normal, 700 = bold. 0 means "not set" (treated as 400).
-	FontStyle        string // "normal", "italic"
-	Color            layout.Color
-	TextAlign        layout.Align
-	TextAlignSet     bool         // true if text-align was explicitly declared
-	TextAlignLast    layout.Align // text-align-last override for the last line
-	TextAlignLastSet bool         // true if text-align-last was explicitly set
-	TextDecoration   layout.TextDecoration
-	TextTransform    string // "none", "uppercase", "lowercase", "capitalize"
-	WhiteSpace       string // "normal", "nowrap", "pre", "pre-wrap", "pre-line"
-	LineHeight       float64
-	LetterSpacing    float64 // extra space between characters (points)
-	WordSpacing      float64 // extra space between words (points)
-	TextIndent       float64 // first-line indent (points)
-	WordBreak        string  // "normal", "break-all"
-	Hyphens          string  // "none", "manual", "auto"
+	FontFamily           string // "helvetica", "courier", "times"
+	FontSize             float64
+	FontWeight           int    // CSS Fonts L4 numeric ladder (100..900). 400 = normal, 700 = bold. 0 means "not set" (treated as 400).
+	FontStyle            string // "normal", "italic"
+	Color                layout.Color
+	TextAlign            layout.Align
+	TextAlignSet         bool         // true if text-align was explicitly declared
+	TextAlignKeyword     string       // "start" or "end" when the author used the direction-relative keyword; otherwise "". Resolved at consumer time via resolveTextAlign(style).
+	TextAlignLast        layout.Align // text-align-last override for the last line
+	TextAlignLastSet     bool         // true if text-align-last was explicitly set
+	TextAlignLastKeyword string       // "start"/"end" for direction-relative text-align-last; resolve via resolveTextAlignLast(style)
+	TextDecoration       layout.TextDecoration
+	TextTransform        string // "none", "uppercase", "lowercase", "capitalize"
+	WhiteSpace           string // "normal", "nowrap", "pre", "pre-wrap", "pre-line"
+	LineHeight           float64
+	LetterSpacing        float64 // extra space between characters (points)
+	WordSpacing          float64 // extra space between words (points)
+	TextIndent           float64 // first-line indent (points)
+	WordBreak            string  // "normal", "break-all"
+	Hyphens              string  // "none", "manual", "auto"
 
 	// Box model
 	MarginTopAuto   bool // true if margin-top: auto (for flex layout)
@@ -450,32 +452,34 @@ func defaultStyle() computedStyle {
 // inherit creates a child style that inherits text properties from the parent.
 func (s *computedStyle) inherit() computedStyle {
 	child := computedStyle{
-		FontFamily:       s.FontFamily,
-		FontSize:         s.FontSize,
-		FontWeight:       s.FontWeight,
-		FontStyle:        s.FontStyle,
-		Color:            s.Color,
-		TextAlign:        s.TextAlign,
-		TextAlignLast:    s.TextAlignLast,
-		TextAlignLastSet: s.TextAlignLastSet,
-		TextDecoration:   s.TextDecoration,
-		TextTransform:    s.TextTransform,
-		WhiteSpace:       s.WhiteSpace,
-		LineHeight:       s.LineHeight,
-		LetterSpacing:    s.LetterSpacing,
-		WordSpacing:      s.WordSpacing,
-		TextIndent:       s.TextIndent,
-		Direction:        s.Direction, // CSS direction is inherited
-		Display:          "block",
-		FlexDirection:    "row",
-		JustifyContent:   "flex-start",
-		AlignItems:       "stretch",
-		FlexWrap:         "nowrap",
-		FlexShrink:       1,
-		ListStyleType:    s.ListStyleType,
-		Visibility:       s.Visibility,
-		WordBreak:        s.WordBreak,
-		Hyphens:          s.Hyphens,
+		FontFamily:           s.FontFamily,
+		FontSize:             s.FontSize,
+		FontWeight:           s.FontWeight,
+		FontStyle:            s.FontStyle,
+		Color:                s.Color,
+		TextAlign:            s.TextAlign,
+		TextAlignKeyword:     s.TextAlignKeyword,
+		TextAlignLast:        s.TextAlignLast,
+		TextAlignLastSet:     s.TextAlignLastSet,
+		TextAlignLastKeyword: s.TextAlignLastKeyword,
+		TextDecoration:       s.TextDecoration,
+		TextTransform:        s.TextTransform,
+		WhiteSpace:           s.WhiteSpace,
+		LineHeight:           s.LineHeight,
+		LetterSpacing:        s.LetterSpacing,
+		WordSpacing:          s.WordSpacing,
+		TextIndent:           s.TextIndent,
+		Direction:            s.Direction, // CSS direction is inherited
+		Display:              "block",
+		FlexDirection:        "row",
+		JustifyContent:       "flex-start",
+		AlignItems:           "stretch",
+		FlexWrap:             "nowrap",
+		FlexShrink:           1,
+		ListStyleType:        s.ListStyleType,
+		Visibility:           s.Visibility,
+		WordBreak:            s.WordBreak,
+		Hyphens:              s.Hyphens,
 	}
 	// CSS custom properties inherit: deep-copy the map.
 	if len(s.CustomProperties) > 0 {

--- a/html/text_align_start_end_test.go
+++ b/html/text_align_start_end_test.go
@@ -1,0 +1,243 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// TestParseTextAlignStartEnd covers the new direction-relative
+// keywords. Pre-fix parseTextAlign returned (AlignLeft, false) for
+// any value outside left/center/right/justify, so `start` and `end`
+// silently fell back to the inherited TextAlign (default AlignLeft).
+// Post-fix the parser returns the LTR-correct best guess plus a
+// keyword string for late binding.
+func TestParseTextAlignStartEnd(t *testing.T) {
+	tests := []struct {
+		value       string
+		wantAlign   layout.Align
+		wantKeyword string
+		wantOk      bool
+	}{
+		{"left", layout.AlignLeft, "", true},
+		{"center", layout.AlignCenter, "", true},
+		{"right", layout.AlignRight, "", true},
+		{"justify", layout.AlignJustify, "", true},
+		{"start", layout.AlignLeft, "start", true},
+		{"end", layout.AlignRight, "end", true},
+		{"START", layout.AlignLeft, "start", true},
+		{"  end  ", layout.AlignRight, "end", true},
+		{"match-parent", layout.AlignLeft, "", false}, // not yet supported
+		{"justify-all", layout.AlignLeft, "", false},  // not yet supported
+		{"", layout.AlignLeft, "", false},
+		{"banana", layout.AlignLeft, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			align, kw, ok := parseTextAlign(tc.value)
+			if ok != tc.wantOk {
+				t.Errorf("parseTextAlign(%q) ok = %v, want %v", tc.value, ok, tc.wantOk)
+			}
+			if align != tc.wantAlign {
+				t.Errorf("parseTextAlign(%q) align = %v, want %v", tc.value, align, tc.wantAlign)
+			}
+			if kw != tc.wantKeyword {
+				t.Errorf("parseTextAlign(%q) keyword = %q, want %q", tc.value, kw, tc.wantKeyword)
+			}
+		})
+	}
+}
+
+// TestResolveTextAlignDirectionMatrix is the matrix that locks in the
+// late binding behaviour: the resolver should map start/end to
+// left/right based on style.Direction, while leaving non-direction-
+// relative keywords untouched.
+func TestResolveTextAlignDirectionMatrix(t *testing.T) {
+	tests := []struct {
+		name      string
+		keyword   string
+		fallback  layout.Align
+		direction layout.Direction
+		want      layout.Align
+	}{
+		// Direction-relative under LTR / Auto.
+		{"start under LTR", "start", layout.AlignLeft, layout.DirectionLTR, layout.AlignLeft},
+		{"start under Auto", "start", layout.AlignLeft, layout.DirectionAuto, layout.AlignLeft},
+		{"end under LTR", "end", layout.AlignRight, layout.DirectionLTR, layout.AlignRight},
+		{"end under Auto", "end", layout.AlignRight, layout.DirectionAuto, layout.AlignRight},
+		// Direction-relative under RTL — the issue this fix closes.
+		{"start under RTL", "start", layout.AlignLeft, layout.DirectionRTL, layout.AlignRight},
+		{"end under RTL", "end", layout.AlignRight, layout.DirectionRTL, layout.AlignLeft},
+		// Non-direction-relative keywords pass through regardless of direction.
+		{"left under RTL", "", layout.AlignLeft, layout.DirectionRTL, layout.AlignLeft},
+		{"right under RTL", "", layout.AlignRight, layout.DirectionRTL, layout.AlignRight},
+		{"center under RTL", "", layout.AlignCenter, layout.DirectionRTL, layout.AlignCenter},
+		{"justify under RTL", "", layout.AlignJustify, layout.DirectionRTL, layout.AlignJustify},
+		// Empty fallback (unset TextAlign) under direction-relative keyword.
+		{"unknown keyword under RTL falls back", "match-parent", layout.AlignLeft, layout.DirectionRTL, layout.AlignLeft},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			style := computedStyle{
+				TextAlign:        tc.fallback,
+				TextAlignKeyword: tc.keyword,
+				Direction:        tc.direction,
+			}
+			got := resolveTextAlign(style)
+			if got != tc.want {
+				t.Errorf("resolveTextAlign(keyword=%q, fallback=%v, dir=%v) = %v, want %v",
+					tc.keyword, tc.fallback, tc.direction, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveTextAlignLastDirectionMatrix mirrors the above for
+// text-align-last (which has the same direction-relative keywords).
+func TestResolveTextAlignLastDirectionMatrix(t *testing.T) {
+	tests := []struct {
+		keyword   string
+		fallback  layout.Align
+		direction layout.Direction
+		want      layout.Align
+	}{
+		{"start", layout.AlignLeft, layout.DirectionRTL, layout.AlignRight},
+		{"end", layout.AlignRight, layout.DirectionRTL, layout.AlignLeft},
+		{"start", layout.AlignLeft, layout.DirectionLTR, layout.AlignLeft},
+		{"", layout.AlignJustify, layout.DirectionRTL, layout.AlignJustify},
+	}
+	for _, tc := range tests {
+		name := tc.keyword
+		switch tc.direction {
+		case layout.DirectionRTL:
+			name += "/RTL"
+		case layout.DirectionLTR:
+			name += "/LTR"
+		default:
+			name += "/Auto"
+		}
+		t.Run(name, func(t *testing.T) {
+			style := computedStyle{
+				TextAlignLast:        tc.fallback,
+				TextAlignLastKeyword: tc.keyword,
+				Direction:            tc.direction,
+			}
+			got := resolveTextAlignLast(style)
+			if got != tc.want {
+				t.Errorf("resolveTextAlignLast = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTextAlignStartEndDeclarationOrderIndependence verifies the
+// late-binding contract: the resolved alignment is correct regardless
+// of whether `direction` is declared before or after `text-align: start`
+// in the same block. CSS declarations are processed in source order,
+// so an early-binding implementation would get the wrong answer when
+// `text-align: start` is declared before `direction: rtl`.
+func TestTextAlignStartEndDeclarationOrderIndependence(t *testing.T) {
+	tests := []struct {
+		name string
+		css  string
+		want layout.Align
+	}{
+		{
+			name: "text-align before direction",
+			css:  "p { text-align: start; direction: rtl; }",
+			want: layout.AlignRight,
+		},
+		{
+			name: "direction before text-align",
+			css:  "p { direction: rtl; text-align: start; }",
+			want: layout.AlignRight,
+		},
+		{
+			name: "LTR text-align: end",
+			css:  "p { text-align: end; direction: ltr; }",
+			want: layout.AlignRight,
+		},
+		{
+			name: "RTL text-align: end",
+			css:  "p { text-align: end; direction: rtl; }",
+			want: layout.AlignLeft,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			html := "<html><head><style>" + tc.css + "</style></head><body><p>x</p></body></html>"
+			elems, err := Convert(html, nil)
+			if err != nil {
+				t.Fatalf("Convert: %v", err)
+			}
+			if len(elems) != 1 {
+				t.Fatalf("expected 1 element, got %d", len(elems))
+			}
+			p, ok := elems[0].(*layout.Paragraph)
+			if !ok {
+				t.Fatalf("expected *layout.Paragraph, got %T", elems[0])
+			}
+			if p.Align() != tc.want {
+				t.Errorf("paragraph align = %v, want %v", p.Align(), tc.want)
+			}
+		})
+	}
+}
+
+// Note: there's a pre-existing inheritance gap that's out of scope
+// for this PR — `style.TextAlignSet` is NOT carried by inherit(),
+// so a parent's `text-align: start` doesn't reach a child paragraph
+// through the `if style.TextAlignSet` consumer guards. The fix would
+// be to inherit TextAlignSet (and the symmetric TextAlignLastSet),
+// but that affects every text-align-on-parent case, not just the
+// new direction-relative keywords. Filed separately. The cascade
+// still works when the property is declared directly on the
+// rendered element, which is the common case.
+
+// Behaviour change for <th> default-center logic:
+// Pre-fix, the gate in converter_table.go was a raw
+// `cellStyle.TextAlign == AlignLeft → re-center`. So an author
+// who wrote `th { text-align: left }` got their left explicitly
+// overridden to center because the resolved TextAlign matched the
+// re-center sentinel. Post-fix, the gate is
+// `!cellStyle.TextAlignSet && resolveTextAlign(cellStyle) == AlignLeft`,
+// which preserves explicit author choice (left or start/end
+// resolving to left under direction). Default <th> still centers.
+//
+// Cell-level alignment is internal to layout.Cell (no public Align()
+// getter), so this is locked in via the converter_table.go code
+// comment and the resolveTextAlign matrix above. A render-level
+// regression would require adding test-only accessors to layout.Cell
+// — out of scope here.
+
+// TestTextAlignNonRelativeUnaffected guards against regression in the
+// common path: `text-align: center` with `direction: rtl` should
+// still center, not flip. Same for left/right/justify.
+func TestTextAlignNonRelativeUnaffected(t *testing.T) {
+	cases := []struct {
+		decl string
+		want layout.Align
+	}{
+		{"text-align: left;  direction: rtl;", layout.AlignLeft},
+		{"text-align: right; direction: rtl;", layout.AlignRight},
+		{"text-align: center; direction: rtl;", layout.AlignCenter},
+		{"text-align: justify; direction: rtl;", layout.AlignJustify},
+	}
+	for _, tc := range cases {
+		t.Run(strings.SplitN(tc.decl, ";", 2)[0], func(t *testing.T) {
+			html := "<html><head><style>p {" + tc.decl + "}</style></head><body><p>x</p></body></html>"
+			elems, err := Convert(html, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p := elems[0].(*layout.Paragraph)
+			if p.Align() != tc.want {
+				t.Errorf("align = %v, want %v", p.Align(), tc.want)
+			}
+		})
+	}
+}

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -128,6 +128,11 @@ func (p *Paragraph) SetAlign(a Align) *Paragraph {
 	return p
 }
 
+// Align reports the paragraph's text alignment. Returns the value
+// most recently set via SetAlign, or the zero-value AlignLeft if
+// SetAlign has never been called.
+func (p *Paragraph) Align() Align { return p.align }
+
 // SetDirection sets the base text direction for bidi layout. The default
 // is DirectionAuto, which auto-detects from the first strong directional
 // character in the paragraph text. When direction resolves to RTL and no


### PR DESCRIPTION
## Summary

Closes the highest-priority finding from the v0.8.0 spec-completeness audit. CSS Text L4 §7.1 defines `text-align: start | end` as direction-relative keywords that resolve to `left`/`right` based on the cascaded `direction`. Pre-fix Folio's `parseTextAlign` returned `(AlignLeft, ok=false)` for both, so the registry's `Apply` silently dropped the declaration.

The footgun:

```html
<p style="direction: rtl; text-align: start">שלום</p>
<!-- author expects right-aligned (RTL start edge); pre-fix got left-aligned -->
```

## Implementation

Same shape as the recent #287 (numeric font-weight) fix — preserve the author keyword on `computedStyle`, late-bind to a layout primitive at consumer time:

- `parseTextAlign` signature changes from `(Align, bool)` to `(Align, string, bool)`. The `string` is the keyword for late binding (`""` for non-direction-relative cases). The `Align` is the LTR-correct best guess used by non-direction-relative paths.
- New `computedStyle.TextAlignKeyword` and `TextAlignLastKeyword` fields, both inherited via existing `inherit()` copy.
- New `resolveTextAlign(style)` and `resolveTextAlignLast(style)` helpers consult `style.Direction`. Shared `resolveDirectionRelativeAlign` keeps the spec table in one place.
- All 8 consumer sites updated: `converter_paragraph.go` (×2), `converter_block.go`, `converter_heading.go`, `converter_style.go`, `converter_table.go` (×3).
- New `layout.Paragraph.Align() Align` getter (parallel to existing `Direction()`) so tests can inspect resolved alignment.

**Why late binding (not at-Apply time):** CSS declarations within a block are processed in source order. `{ text-align: start; direction: rtl }` and `{ direction: rtl; text-align: start }` must produce the same output; an at-Apply implementation would see the wrong `Direction` for the first ordering. `TestTextAlignStartEndDeclarationOrderIndependence` covers both directions through `Convert()`.

## Companion behaviour change: `<th>` default-center

`converter_table.go`'s `<th>` default-center logic now respects explicit author choice:

| Input | Pre-fix | Post-fix |
|---|---|---|
| `<th>x</th>` (no author choice) | center | center |
| `<th style="text-align: left">x</th>` | **center** (silently overridden) | left |
| `<th style="text-align: start" dir="rtl">x</th>` | (collapsed to left → center) | right |
| `<th style="text-align: end" dir="rtl">x</th>` | (collapsed to left → center) | left |

The pre-fix gate (`cellStyle.TextAlign == AlignLeft → re-center`) couldn't distinguish "author chose left" from "default normal". Post-fix gates on `!cellStyle.TextAlignSet && resolveTextAlign(cellStyle) == AlignLeft`. The new semantic is more spec-correct (UA stylesheet center is a default, not an override) and matches every browser. No existing test fails; behaviour difference is only visual for documents that wrote `th { text-align: left }` and expected it to be silently overridden.

## Independent review findings addressed

Two reviewers ran in parallel before push:

- **The `<th>` semantic change** — both reviewers flagged. Verified: `features_test.go:454` does write `th { text-align: left }` but doesn't assert cell alignment, so no test fails. Documented in commit body and code comment.
- **Inheritance gap (`TextAlignSet` not inherited)** — pre-existing; the test that surfaced it was removed and the limitation documented inline. Same gap exists pre-fix for `body { text-align: right }` not reaching child paragraphs through the `if style.TextAlignSet` consumer guards. Worth a follow-up issue.
- **Coverage gaps for `text-align-last` end-to-end and `<th>` cell-level** — documented; would require new `layout.Cell.Align()` and `layout.Table.Rows()` accessors. Out of scope.

## Out of scope

- `style.TextAlignSet`/`TextAlignLastSet` not inherited (pre-existing).
- CSS `match-parent` and `justify-all` keywords still unparsed (consistent with pre-fix).
- `<button>` / `<input type=button>` / `<caption>` hardcode `AlignCenter` and bypass `resolveTextAlign` — pre-existing.

## Test plan

- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./html/... ./layout/...` — 0 issues
- [x] `gofmt -l html/ layout/` — clean
- [x] 4 new test functions, ~25 assertions, covering parser, resolver matrix, declaration-order independence, non-relative regression