### PR TITLE
html: render CSS border styles groove / ridge / inset / outset

### DIFF
--- a/docs/CSS_SUPPORT.md
+++ b/docs/CSS_SUPPORT.md
@@ -161,7 +161,7 @@ also takes effect on flex containers as the gap between items.
 | `border-radius` | — | `<length>`, `<percentage>`, `<1-4 of these>` | splitTopLevelFields preserves calc()/min()/max()/clamp() as single tokens. |
 | `border-right` | — | `<line-width> <line-style> <color>` | — |
 | `border-right-width` | — | `<length>`, `thin`, `medium`, `thick` | — |
-| `border-style` | — | `solid`, `dashed`, `dotted`, `double`, `none` | — |
+| `border-style` | — | `solid`, `dashed`, `dotted`, `double`, `none`, `hidden`, `groove`, `ridge`, `inset`, `outset` | groove/ridge/inset/outset are rendered as a single solid stroke per side with the spec's per-side dark/light color modulation, rather than the strict two-half-width split bevel. |
 | `border-top` | — | `<line-width> <line-style> <color>` | — |
 | `border-top-left-radius` | — | `<length>`, `<percentage>` | — |
 | `border-top-right-radius` | — | `<length>`, `<percentage>` | — |

--- a/html/border_3d_styles_test.go
+++ b/html/border_3d_styles_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"math"
+	"testing"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// TestParseBorderFullStyleKeywords pins that the shorthand parser
+// accepts the full CSS Backgrounds L3 §4.1 set of border-style
+// keywords. Pre-fix `groove`, `ridge`, `inset`, `outset` were
+// rejected (kept the default "solid" string).
+func TestParseBorderFullStyleKeywords(t *testing.T) {
+	keywords := []string{"solid", "dashed", "dotted", "double", "none", "hidden",
+		"groove", "ridge", "inset", "outset"}
+	for _, kw := range keywords {
+		t.Run(kw, func(t *testing.T) {
+			_, st, _ := parseBorderFull("2px "+kw+" red", 12)
+			if st != kw {
+				t.Errorf("parseBorderFull style = %q, want %q", st, kw)
+			}
+		})
+	}
+}
+
+// TestBeveledColorMatrix locks in the per-side, per-style color
+// modulation table for the 3D border styles. groove/inset behave
+// identically here (top/left dark, bottom/right light); same for
+// ridge/outset (the inverse).
+func TestBeveledColorMatrix(t *testing.T) {
+	base := layout.RGB(0.5, 0.5, 0.5) // mid-gray so light/dark are obviously different
+
+	tests := []struct {
+		name      string
+		side      borderSide
+		sunken    bool // true for groove/inset, false for ridge/outset
+		wantDark  bool // expected to be darker than base
+		wantLight bool // expected to be lighter than base
+	}{
+		{"groove top → dark", borderTop, true, true, false},
+		{"groove left → dark", borderLeft, true, true, false},
+		{"groove bottom → light", borderBottom, true, false, true},
+		{"groove right → light", borderRight, true, false, true},
+		{"ridge top → light", borderTop, false, false, true},
+		{"ridge left → light", borderLeft, false, false, true},
+		{"ridge bottom → dark", borderBottom, false, true, false},
+		{"ridge right → dark", borderRight, false, true, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := beveledColor(tc.side, base, tc.sunken)
+			if tc.wantDark && got.R >= base.R {
+				t.Errorf("expected darker than base, got R=%v vs base R=%v", got.R, base.R)
+			}
+			if tc.wantLight && got.R <= base.R {
+				t.Errorf("expected lighter than base, got R=%v vs base R=%v", got.R, base.R)
+			}
+		})
+	}
+}
+
+// TestBuildBorderForSide3DStyles verifies the per-side dispatch
+// produces a SolidBorder with a modulated color (rather than the
+// pre-fix "fall through to solid" behaviour that lost the modulation
+// entirely).
+func TestBuildBorderForSide3DStyles(t *testing.T) {
+	base := layout.RGB(0.5, 0.5, 0.5)
+	width := 4.0
+
+	for _, st := range []string{"groove", "ridge", "inset", "outset"} {
+		t.Run(st, func(t *testing.T) {
+			top := buildBorderForSide(borderTop, width, st, base)
+			bottom := buildBorderForSide(borderBottom, width, st, base)
+			if top.Style != layout.BorderSolid {
+				t.Errorf("3D border %s top.Style = %v, want BorderSolid", st, top.Style)
+			}
+			if top.Width != width || bottom.Width != width {
+				t.Errorf("3D border %s widths = (%v, %v), want both %v", st, top.Width, bottom.Width, width)
+			}
+			// Top and bottom must differ — that's the whole point of
+			// the bevel. Pre-fix both got the same source color.
+			if math.Abs(top.Color.R-bottom.Color.R) < 0.01 {
+				t.Errorf("3D border %s top.R (%v) and bottom.R (%v) should differ — modulation not applied",
+					st, top.Color.R, bottom.Color.R)
+			}
+		})
+	}
+}
+
+// TestBuildBorderForSidePassthroughStyles guards against regression
+// in the existing styles: solid / dashed / dotted / double / hidden
+// / unknown should produce identical output to pre-fix. The Color is
+// untouched (no light/dark modulation) and the Style enum maps to the
+// existing layout primitives.
+func TestBuildBorderForSidePassthroughStyles(t *testing.T) {
+	base := layout.RGB(0.2, 0.4, 0.6)
+	w := 2.0
+
+	tests := []struct {
+		input string
+		want  layout.BorderStyle
+	}{
+		{"solid", layout.BorderSolid},
+		{"dashed", layout.BorderDashed},
+		{"dotted", layout.BorderDotted},
+		{"double", layout.BorderDouble},
+		{"hidden", layout.BorderSolid}, // unknown to layout, falls back
+		{"banana", layout.BorderSolid},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			b := buildBorderForSide(borderTop, w, tc.input, base)
+			if b.Style != tc.want {
+				t.Errorf("style %q produced layout.Style %v, want %v", tc.input, b.Style, tc.want)
+			}
+			if b.Color != base {
+				t.Errorf("style %q modulated the color (%v vs base %v); should pass through", tc.input, b.Color, base)
+			}
+		})
+	}
+}
+
+// TestBorderStyleEndToEndThroughConvert verifies the new keywords
+// survive the full HTML → buildCellBorders → render pipeline. The
+// assertion is bounded: we can confirm CellBorders exists and each
+// side has a Border with the expected Width and Style — but the
+// post-modulation Color is internal to the resolver. The unit tests
+// above cover the modulation table.
+func TestBorderStyleEndToEndThroughConvert(t *testing.T) {
+	html := `<div style="border: 4px ridge silver; padding: 8px">x</div>`
+	elems, err := Convert(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("no elements")
+	}
+	// A bordered div emits a layout.Div with non-empty CellBorders.
+	// We can't easily inspect Div.borders without an accessor, but
+	// the test exists to lock in the contract that Convert() does
+	// not error and that the new keyword survives the parser.
+	// If a future change drops "ridge" from the parser whitelist,
+	// this test would still pass — it's the unit tests that lock in
+	// the visual semantic. This integration test is a smoke check
+	// that the pipeline accepts the input without error.
+	_ = elems
+}

--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -429,18 +429,39 @@ func (c *converter) buildColumnsSegment(children []layout.Element, style compute
 	return cols
 }
 
+// borderSide identifies which side of a four-sided border is being
+// rendered. Used by buildBorderForSide to pick the light vs dark
+// color modulation for the 3D bevel styles (groove/ridge/inset/outset).
+type borderSide int
+
+const (
+	borderTop borderSide = iota
+	borderRight
+	borderBottom
+	borderLeft
+)
+
 // buildCellBorders creates layout.CellBorders from a computed style.
 func buildCellBorders(style computedStyle) layout.CellBorders {
 	return layout.CellBorders{
-		Top:    buildBorder(style.BorderTopWidth, style.BorderTopStyle, style.BorderTopColor),
-		Right:  buildBorder(style.BorderRightWidth, style.BorderRightStyle, style.BorderRightColor),
-		Bottom: buildBorder(style.BorderBottomWidth, style.BorderBottomStyle, style.BorderBottomColor),
-		Left:   buildBorder(style.BorderLeftWidth, style.BorderLeftStyle, style.BorderLeftColor),
+		Top:    buildBorderForSide(borderTop, style.BorderTopWidth, style.BorderTopStyle, style.BorderTopColor),
+		Right:  buildBorderForSide(borderRight, style.BorderRightWidth, style.BorderRightStyle, style.BorderRightColor),
+		Bottom: buildBorderForSide(borderBottom, style.BorderBottomWidth, style.BorderBottomStyle, style.BorderBottomColor),
+		Left:   buildBorderForSide(borderLeft, style.BorderLeftWidth, style.BorderLeftStyle, style.BorderLeftColor),
 	}
 }
 
-// buildBorder creates a single layout.Border from width, style, and color.
-func buildBorder(width float64, style string, color layout.Color) layout.Border {
+// buildBorderForSide creates a single layout.Border from width, style,
+// and color, with side awareness for the CSS Backgrounds L3 §4.1 3D
+// border styles (groove / ridge / inset / outset). Those styles
+// modulate the border color per-side to simulate a beveled or carved
+// edge — top/left vs bottom/right get opposite modulation. Folio
+// approximates each as a single solid stroke in the modulated color
+// (rather than the spec's strict two-half-width split-line bevel) —
+// this matches what most PDF and browser-print pipelines do, and is
+// visually indistinguishable for thin borders. For wider borders the
+// bevel is less pronounced than a real browser would draw.
+func buildBorderForSide(side borderSide, width float64, style string, color layout.Color) layout.Border {
 	if width <= 0 {
 		return layout.Border{}
 	}
@@ -451,9 +472,79 @@ func buildBorder(width float64, style string, color layout.Color) layout.Border 
 		return layout.DottedBorder(width, color)
 	case "double":
 		return layout.DoubleBorder(width, color)
+	case "groove", "inset":
+		return layout.SolidBorder(width, beveledColor(side, color, true))
+	case "ridge", "outset":
+		return layout.SolidBorder(width, beveledColor(side, color, false))
 	default:
 		return layout.SolidBorder(width, color)
 	}
+}
+
+// beveledColor picks the per-side color for a 3D border style.
+//
+// The `sunken` flag distinguishes the carved-into-surface look
+// (groove / inset) from the raised look (ridge / outset). Per CSS
+// Backgrounds L3 §4.1:
+//
+//   - groove / inset: top + left appear dark, bottom + right appear
+//     light (light source from bottom-right).
+//   - ridge / outset: top + left appear light, bottom + right appear
+//     dark (light source from top-left).
+//
+// Modulation is a fixed 30% lighten / darken from the source color in
+// linear sRGB; close enough to the spec's "based on the foreground
+// color" guidance and matches the visual weight of typical legacy
+// CSS that uses these styles.
+func beveledColor(side borderSide, base layout.Color, sunken bool) layout.Color {
+	topLeft := sunken
+	if side == borderTop || side == borderLeft {
+		if topLeft {
+			return darkenColor(base)
+		}
+		return lightenColor(base)
+	}
+	if topLeft {
+		return lightenColor(base)
+	}
+	return darkenColor(base)
+}
+
+// lightenColor returns the source color shifted toward white by 30%.
+// Operates in sRGB space (not linear) — adequate for UI bevels
+// where strict colorimetric correctness isn't expected.
+func lightenColor(c layout.Color) layout.Color {
+	if c.Space == layout.ColorSpaceCMYK {
+		// Approximate by reducing K (lightness inverse) by 30%.
+		return layout.CMYK(c.C, c.M, c.Y, clamp01(c.K*0.7))
+	}
+	return layout.RGB(
+		clamp01(c.R+(1-c.R)*0.3),
+		clamp01(c.G+(1-c.G)*0.3),
+		clamp01(c.B+(1-c.B)*0.3),
+	)
+}
+
+// darkenColor returns the source color shifted toward black by 30%.
+func darkenColor(c layout.Color) layout.Color {
+	if c.Space == layout.ColorSpaceCMYK {
+		return layout.CMYK(c.C, c.M, c.Y, clamp01(c.K+(1-c.K)*0.3))
+	}
+	return layout.RGB(
+		clamp01(c.R*0.7),
+		clamp01(c.G*0.7),
+		clamp01(c.B*0.7),
+	)
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
 }
 
 // convertBlockquote renders a <blockquote> as an indented block with a left border.

--- a/html/css_props.go
+++ b/html/css_props.go
@@ -1211,7 +1211,8 @@ var cssProperties = []cssProperty{
 	},
 	{
 		Name: "border-style", Category: "Borders",
-		Values: []string{"solid", "dashed", "dotted", "double", "none"},
+		Values: []string{"solid", "dashed", "dotted", "double", "none", "hidden", "groove", "ridge", "inset", "outset"},
+		Notes:  "groove/ridge/inset/outset are rendered as a single solid stroke per side with the spec's per-side dark/light color modulation, rather than the strict two-half-width split bevel.",
 		Apply: func(s *computedStyle, value string) {
 			s.BorderTopStyle = value
 			s.BorderRightStyle = value

--- a/html/properties.go
+++ b/html/properties.go
@@ -303,7 +303,8 @@ func parseColumnRule(val string, fontSize float64) (float64, string, layout.Colo
 	color := layout.ColorBlack
 	for _, p := range parts {
 		switch p {
-		case "solid", "dashed", "dotted", "double", "none", "hidden":
+		case "solid", "dashed", "dotted", "double", "none", "hidden",
+			"groove", "ridge", "inset", "outset":
 			style = p
 		default:
 			if c, ok := parseColor(p); ok {
@@ -849,9 +850,13 @@ func parseBorderFull(value string, fontSize float64) (float64, string, layout.Co
 
 	for _, p := range parts {
 		pl := strings.ToLower(p)
-		// Check for style keywords.
+		// Check for style keywords. groove/ridge/inset/outset are
+		// per-side beveled styles handled in buildBorderForSide; the
+		// shorthand parser stores the keyword verbatim and the
+		// per-side renderer dispatches to lighten/darken modulation.
 		switch pl {
-		case "solid", "dashed", "dotted", "double", "none", "hidden":
+		case "solid", "dashed", "dotted", "double", "none", "hidden",
+			"groove", "ridge", "inset", "outset":
 			style = pl
 			continue
 		case "thin":


### PR DESCRIPTION
## Summary

Closes the third-priority finding from the v0.8.0 spec-completeness audit. CSS Backgrounds L3 §4.1 defines 10 line styles for borders; Folio's parser accepted 6 and the 4 3D bevel styles silently collapsed to `solid`. The shorthand stored the keyword on `style.BorderTopStyle` etc., but `buildBorder`'s switch matched 3 keywords + default-solid, so `<div style="border: 4px ridge silver">` rendered flat.

Same shape as #287 / #288 / #289: a CSS spec value the parser dropped because the consumer-side primitive didn't exist.

## Implementation

- `buildBorder` → `buildBorderForSide(side, width, style, color)`. New `borderSide` enum (top / right / bottom / left). The single consumer (`buildCellBorders`) passes the side per call.
- New `beveledColor(side, base, sunken)` picks light-vs-dark modulation per CSS §4.1:
  - **groove / inset** → top + left dark, bottom + right light (sunken look)
  - **ridge / outset** → top + left light, bottom + right dark (raised look)
- New `lightenColor` / `darkenColor` / `clamp01` helpers do a fixed 30% sRGB shift. CMYK variant adjusts K proportionally.
- `parseBorderFull` and `parseColumnRule` whitelists extended to accept the four new keywords.
- `border-style` registry entry's `Values` doc + `Notes` updated to reflect the new acceptance and the rendering simplification (single solid stroke per side with side-modulated color, rather than the strict two-half-width split bevel that some high-DPI browsers draw).
- `docs/CSS_SUPPORT.md` regenerated.

## Rendering trade-off

Per CSS spec, `groove`/`ridge` are technically two parallel half-width lines per side — split-line bevels. Folio renders a single solid stroke in the modulated color. Visually indistinguishable for thin borders (≤2pt); less pronounced bevel for thick ones. `inset`/`outset` map exactly (single stroke is what the spec says).

This matches what most PDF renderers and browser-print pipelines do. The strict two-stroke variant can be a v0.9 follow-up if a user files specific feedback.

## Tests

`html/border_3d_styles_test.go` (5 functions, ~25 assertions):

- `TestParseBorderFullStyleKeywords` — shorthand accepts the full L3 §4.1 keyword set
- `TestBeveledColorMatrix` — 8-row table covering both styles × 4 sides for the modulation contract
- `TestBuildBorderForSide3DStyles` — 3D dispatch produces `SolidBorder` with width preserved AND top/bottom colors actually differ (the data-loss path that pre-fix had)
- `TestBuildBorderForSidePassthroughStyles` — regression guard that `solid`/`dashed`/`dotted`/`double`/`hidden`/unknown produce byte-identical output to pre-fix
- `TestBorderStyleEndToEndThroughConvert` — smoke test through `Convert()`

## Test plan

- [x] `go test ./...` — full suite green
- [x] `go generate ./html/...` — `docs/CSS_SUPPORT.md` regenerated; `TestCSSDocsInSync` passes
- [x] `golangci-lint run ./html/...` — 0 issues
- [x] `gofmt -l html/` — clean

## Out of scope

- Strict two-stroke split-line bevel for `groove`/`ridge` (CSS spec form). Would require renderer-level work in `layout/table.go drawStyledBorder`. Filed mentally for v0.9 if needed.
- `border-color` two-tone (CSS Backgrounds §4.3 syntax `border-color: red blue green yellow`) — pre-existing limitation, not in scope.
- `column-rule` 3D styles parse but render as solid (column-rule renderer is a separate path; consistent with pre-fix's accept-but-render-solid behaviour).