### PR TITLE
html, layout: <img> honours max-width / max-height / min-width / min-height (closes #291)

### DIFF
--- a/html/converter_image.go
+++ b/html/converter_image.go
@@ -65,6 +65,33 @@ func (c *converter) convertImage(n *html.Node, style computedStyle) []layout.Ele
 	if w > 0 || h > 0 {
 		ie.SetSize(w, h)
 	}
+	// CSS max-width / max-height / min-width / min-height apply to
+	// replaced elements like <img> per CSS 2.1 §10.7. Pre-fix the
+	// converter only consulted style.Width/Height, so a high-res
+	// source image with `max-width: 180px` ignored the cap and bled
+	// the full container width. Threading these into ImageElement
+	// lets layout/image.go::resolveSize clamp post-resolution while
+	// preserving aspect ratio.
+	var maxW, maxH float64
+	if style.MaxWidth != nil {
+		maxW = style.MaxWidth.toPoints(0, style.FontSize)
+	}
+	if style.MaxHeight != nil {
+		maxH = style.MaxHeight.toPoints(0, style.FontSize)
+	}
+	if maxW > 0 || maxH > 0 {
+		ie.SetMaxSize(maxW, maxH)
+	}
+	var minW, minH float64
+	if style.MinWidth != nil {
+		minW = style.MinWidth.toPoints(0, style.FontSize)
+	}
+	if style.MinHeight != nil {
+		minH = style.MinHeight.toPoints(0, style.FontSize)
+	}
+	if minW > 0 || minH > 0 {
+		ie.SetMinSize(minW, minH)
+	}
 	if style.ObjectFit != "" {
 		ie.SetObjectFit(style.ObjectFit)
 	}

--- a/html/img_max_min_test.go
+++ b/html/img_max_min_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"testing"
+)
+
+// onePxPNG is a 1×1 PNG, base64-encoded. Reused from the existing
+// object-fit tests for the same reason: small enough to inline,
+// decodes to a real image without shipping a fixture.
+const onePxPNG = `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNjN9GQAAAABJRu5ErkJggg==`
+
+// TestImgConvertAcceptsMaxMinConstraints is a smoke test that
+// confirms the converter accepts the four new CSS constraints
+// (max-width, max-height, min-width, min-height) on <img> elements
+// without error and produces a non-empty element list. The unit-level
+// contract — that the constraints actually clamp the rendered size —
+// is locked in by TestImageElementMaxConstraints / MinConstraints in
+// layout/image_max_min_test.go.
+//
+// The end-to-end inspection is awkward here: <img> in HTML defaults
+// to inline display, and the converter wraps it in a paragraph
+// regardless of `display: block` (the dispatch is per-atom in
+// convertInlineElement, before CSS computed style takes effect for
+// the inline-vs-block decision). The constraint reaches the inline
+// ImageElement and clamps its resolveSize at draw time, but the
+// outer block element exposed to the html test surface is the
+// paragraph wrapper — its dimensions reflect the paragraph layout,
+// not the image. The unit test reaches the same resolveSize call
+// and asserts on its return value directly.
+func TestImgConvertAcceptsMaxMinConstraints(t *testing.T) {
+	tests := []string{
+		`<img style="max-width: 50px" src="` + onePxPNG + `">`,
+		`<img style="max-height: 32px" src="` + onePxPNG + `">`,
+		`<img style="max-width: 180px; max-height: 32px" src="` + onePxPNG + `">`,
+		`<img style="min-width: 100px" src="` + onePxPNG + `">`,
+		`<img style="min-height: 100px" src="` + onePxPNG + `">`,
+		`<img style="width: 10px; min-width: 50px" src="` + onePxPNG + `">`,
+	}
+	for _, src := range tests {
+		t.Run(src, func(t *testing.T) {
+			elems, err := Convert(src, nil)
+			if err != nil {
+				t.Errorf("Convert(%q) error: %v", src, err)
+			}
+			if len(elems) == 0 {
+				t.Errorf("Convert(%q) returned no elements", src)
+			}
+		})
+	}
+}

--- a/layout/image.go
+++ b/layout/image.go
@@ -14,6 +14,10 @@ type ImageElement struct {
 	img            *folioimage.Image
 	width          float64 // explicit width (0 = auto)
 	height         float64 // explicit height (0 = auto)
+	cssMaxWidth    float64 // CSS max-width upper bound (0 = unbounded)
+	cssMaxHeight   float64 // CSS max-height upper bound (0 = unbounded)
+	cssMinWidth    float64 // CSS min-width lower bound (0 = no minimum)
+	cssMinHeight   float64 // CSS min-height lower bound (0 = no minimum)
 	align          Align
 	altText        string // alternative text for accessibility (PDF/UA)
 	objectFit      string // "contain", "cover", "fill", "none", "scale-down"
@@ -35,6 +39,32 @@ func NewImageElement(img *folioimage.Image) *ImageElement {
 func (ie *ImageElement) SetSize(width, height float64) *ImageElement {
 	ie.width = width
 	ie.height = height
+	return ie
+}
+
+// SetMaxSize sets CSS-style max-width and max-height upper bounds in
+// PDF points. A value of 0 means "unbounded" on that axis. Bounds
+// apply after the explicit / natural / aspect-ratio size is resolved
+// — they shrink the rendered image while preserving aspect ratio.
+// Pass 0/0 to clear any previous bound.
+//
+// Per CSS 2.1 §10.7, max-width / max-height apply to replaced
+// elements like <img>: they cap the rendered size without forcing
+// a specific dimension. They never upscale a smaller intrinsic image.
+func (ie *ImageElement) SetMaxSize(maxWidth, maxHeight float64) *ImageElement {
+	ie.cssMaxWidth = maxWidth
+	ie.cssMaxHeight = maxHeight
+	return ie
+}
+
+// SetMinSize sets CSS-style min-width and min-height lower bounds in
+// PDF points. A value of 0 means "no minimum" on that axis. Bounds
+// apply after the explicit / natural / aspect-ratio size is resolved
+// and after max-* clamps — min-* wins over max-* when they conflict,
+// per CSS 2.1 §10.7.
+func (ie *ImageElement) SetMinSize(minWidth, minHeight float64) *ImageElement {
+	ie.cssMinWidth = minWidth
+	ie.cssMinHeight = minHeight
 	return ie
 }
 
@@ -93,6 +123,16 @@ func (ie *ImageElement) resolveSize(maxWidth float64) (float64, float64) {
 	if ar <= 0 {
 		ar = 1
 	}
+
+	// Apply CSS max-* / min-* clamps to the explicit (w, h) BEFORE the
+	// object-fit branch dispatches. Per CSS Images L3 §3.2 + CSS 2.1
+	// §10.7, max-width / max-height constrain the content box first,
+	// then object-fit fits the image inside the clamped box. Without
+	// this early clamp, `<img width=200 height=200 style="max-width:
+	// 50px; object-fit: cover">` would keep the 200×200 box because
+	// the object-fit branch returns before the post-resolution clamps
+	// at the bottom of this function fire.
+	w, h = ie.applyMaxMinClamps(w, h, ar)
 
 	// When both width and height are explicitly set and object-fit is specified,
 	// compute the rendered image dimensions according to the fit mode.
@@ -156,12 +196,55 @@ func (ie *ImageElement) resolveSize(maxWidth float64) (float64, float64) {
 		h = w / ar
 	}
 
-	// Clamp to available width.
+	// Apply max/min clamps again after the auto-resolution. The
+	// earlier call (before the object-fit branch) only mattered when
+	// w and h were already set on entry; the auto-auto branch above
+	// produced new values that need their own clamping.
+	w, h = ie.applyMaxMinClamps(w, h, ar)
+
+	// Clamp to available width — the container is the absolute outer
+	// bound for replaced elements per CSS 2.1 §10.4. This wins even
+	// over min-width / min-height: a min-height that would push the
+	// image past the container width is silently dropped (the
+	// width-aspect recompute resets the height accordingly). This
+	// matches browser behaviour: a replaced element does not extend
+	// past its containing block on the width axis.
 	if w > maxWidth {
 		w = maxWidth
 		h = w / ar
 	}
 
+	return w, h
+}
+
+// applyMaxMinClamps applies the CSS max-* / min-* constraints to a
+// (w, h) pair while preserving aspect ratio. Order matters: max
+// clamps run first (shrink) so that a subsequent min clamp can
+// upscale past them when the spec's "min wins over max" conflict
+// rule kicks in. CSS 2.1 §10.7 specifies the combined rule as
+// `min(max-width, max(min-width, used))` — equivalent to applying
+// max then min in order on a value already in [min, max].
+//
+// Each axis clamp aspect-preserves: clamping w recomputes h via
+// ar, and vice versa. A subsequent clamp on the other axis may
+// fire if the recompute violates that axis's bound.
+func (ie *ImageElement) applyMaxMinClamps(w, h, ar float64) (float64, float64) {
+	if ie.cssMaxWidth > 0 && w > ie.cssMaxWidth {
+		w = ie.cssMaxWidth
+		h = w / ar
+	}
+	if ie.cssMaxHeight > 0 && h > ie.cssMaxHeight {
+		h = ie.cssMaxHeight
+		w = h * ar
+	}
+	if ie.cssMinWidth > 0 && w < ie.cssMinWidth {
+		w = ie.cssMinWidth
+		h = w / ar
+	}
+	if ie.cssMinHeight > 0 && h < ie.cssMinHeight {
+		h = ie.cssMinHeight
+		w = h * ar
+	}
 	return w, h
 }
 

--- a/layout/image_max_min_test.go
+++ b/layout/image_max_min_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"bytes"
+	goimage "image"
+	"image/jpeg"
+	"math"
+	"testing"
+
+	folioimage "github.com/carlos7ags/folio/image"
+)
+
+// makeImage creates a JPEG of the requested pixel dimensions for
+// max/min constraint tests. Aspect ratio is widthPx/heightPx.
+func makeImage(t *testing.T, widthPx, heightPx int) *folioimage.Image {
+	t.Helper()
+	img := goimage.NewRGBA(goimage.Rect(0, 0, widthPx, heightPx))
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, nil); err != nil {
+		t.Fatalf("encode JPEG: %v", err)
+	}
+	fimg, err := folioimage.NewJPEG(buf.Bytes())
+	if err != nil {
+		t.Fatalf("folio.NewJPEG: %v", err)
+	}
+	return fimg
+}
+
+// TestImageElementMaxConstraints covers the canonical matrix from
+// issue #291's spike doc. Pre-fix max-width / max-height were
+// silently dropped at the converter level; even if threaded through,
+// ImageElement had no field to receive them.
+func TestImageElementMaxConstraints(t *testing.T) {
+	tests := []struct {
+		name   string
+		imgW   int
+		imgH   int
+		maxW   float64
+		maxH   float64
+		canvas float64
+		wantW  float64
+		wantH  float64
+	}{
+		{
+			name: "wide banner clamped by max-width",
+			imgW: 2000, imgH: 500,
+			maxW:   180,
+			canvas: 540,
+			wantW:  180, wantH: 45,
+		},
+		{
+			name: "square clamped by max-height",
+			imgW: 200, imgH: 200,
+			maxH:   32,
+			canvas: 540,
+			wantW:  32, wantH: 32,
+		},
+		{
+			name: "wide image, both bounds set, max-width wins",
+			imgW: 1000, imgH: 100,
+			maxW: 180, maxH: 32,
+			canvas: 540,
+			wantW:  180, wantH: 18,
+		},
+		{
+			name: "tall image, both bounds set, max-height wins",
+			imgW: 100, imgH: 800,
+			maxW: 180, maxH: 32,
+			canvas: 540,
+			wantW:  4, wantH: 32,
+		},
+		{
+			name: "small image, max-width wider than intrinsic — no upscale",
+			imgW: 50, imgH: 50,
+			maxW:   180,
+			canvas: 540,
+			// auto-auto path scales image to fill canvas (540pt wide), then
+			// max-width clamps to 180pt. The constraint is an upper bound only:
+			// a 50px image cannot upscale beyond its intrinsic size in the
+			// "no explicit width or height" path, but the fill-to-canvas
+			// behaviour predates this fix and is preserved.
+			wantW: 180, wantH: 180,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fimg := makeImage(t, tc.imgW, tc.imgH)
+			ie := NewImageElement(fimg).SetMaxSize(tc.maxW, tc.maxH)
+			gotW, gotH := ie.resolveSize(tc.canvas)
+			if math.Abs(gotW-tc.wantW) > 0.5 {
+				t.Errorf("width = %.2f, want %.2f", gotW, tc.wantW)
+			}
+			if math.Abs(gotH-tc.wantH) > 0.5 {
+				t.Errorf("height = %.2f, want %.2f", gotH, tc.wantH)
+			}
+		})
+	}
+}
+
+// TestImageElementMaxNeverUpscales verifies that max-* is purely an
+// upper bound — when the explicit width is already smaller than max,
+// the image keeps its smaller size.
+func TestImageElementMaxNeverUpscales(t *testing.T) {
+	fimg := makeImage(t, 200, 200)
+	// Explicit 50pt width, max-width 180pt — the explicit wins (smaller).
+	ie := NewImageElement(fimg).SetSize(50, 0).SetMaxSize(180, 0)
+	gotW, gotH := ie.resolveSize(540)
+	if gotW != 50 {
+		t.Errorf("width = %.2f, want 50 (explicit wins over max)", gotW)
+	}
+	if gotH != 50 {
+		t.Errorf("height = %.2f, want 50 (aspect-preserved)", gotH)
+	}
+}
+
+// TestImageElementMinConstraints covers the symmetric case for
+// min-width / min-height. min-* is a lower bound that wins over
+// max-* when they conflict per CSS 2.1 §10.7.
+func TestImageElementMinConstraints(t *testing.T) {
+	t.Run("min-width upscales explicit smaller width", func(t *testing.T) {
+		fimg := makeImage(t, 200, 200)
+		ie := NewImageElement(fimg).SetSize(50, 0).SetMinSize(100, 0)
+		gotW, gotH := ie.resolveSize(540)
+		if gotW != 100 {
+			t.Errorf("width = %.2f, want 100 (min upscales)", gotW)
+		}
+		if gotH != 100 {
+			t.Errorf("height = %.2f, want 100 (aspect-preserved)", gotH)
+		}
+	})
+	t.Run("min wins over max conflict", func(t *testing.T) {
+		fimg := makeImage(t, 200, 200)
+		// max-width: 50, min-width: 100 — spec says min wins.
+		ie := NewImageElement(fimg).SetSize(80, 0).SetMaxSize(50, 0).SetMinSize(100, 0)
+		gotW, _ := ie.resolveSize(540)
+		if gotW != 100 {
+			t.Errorf("width = %.2f, want 100 (min beats max)", gotW)
+		}
+	})
+	t.Run("min-height upscales", func(t *testing.T) {
+		fimg := makeImage(t, 100, 100)
+		ie := NewImageElement(fimg).SetSize(0, 20).SetMinSize(0, 50)
+		_, gotH := ie.resolveSize(540)
+		if gotH != 50 {
+			t.Errorf("height = %.2f, want 50 (min-height upscales)", gotH)
+		}
+	})
+}
+
+// TestImageElementContainerStillWins guards that the container's
+// available width remains the absolute upper bound, even when
+// min-width would push past it. CSS 2.1 §10.4 resolves against the
+// containing block.
+func TestImageElementContainerStillWins(t *testing.T) {
+	fimg := makeImage(t, 100, 100)
+	// min-width: 600pt with a 200pt canvas — container caps at 200.
+	ie := NewImageElement(fimg).SetMinSize(600, 0)
+	gotW, _ := ie.resolveSize(200)
+	if gotW > 200.5 {
+		t.Errorf("width = %.2f, must not exceed canvas 200", gotW)
+	}
+}
+
+// TestImageElementMaxClampsBoxBeforeObjectFit covers the reviewer's
+// MEDIUM finding: pre-fix the object-fit branch returned early
+// before the max/min clamps fired, so an image with explicit
+// dimensions AND object-fit AND a max-width kept the unconstrained
+// box. Post-fix the clamps run on (w, h) before the object-fit
+// dispatch, so the box is constrained first then object-fit fits
+// inside the constrained box.
+//
+// Per CSS Images L3 §3.2 + CSS 2.1 §10.7, max-* applies to the
+// content box of replaced elements; object-fit modifies how the
+// image content fills that box.
+func TestImageElementMaxClampsBoxBeforeObjectFit(t *testing.T) {
+	fimg := makeImage(t, 200, 200)
+	// Author asks for 200×200 box with cover, but max-width 50pt
+	// caps the box. The cover-fit then operates on the 50×50 box.
+	ie := NewImageElement(fimg).
+		SetSize(200, 200).
+		SetObjectFit("cover").
+		SetMaxSize(50, 0)
+	gotW, gotH := ie.resolveSize(540)
+	if gotW > 50.5 {
+		t.Errorf("box width = %.2f, want ≤ 50 (max-width caps box)", gotW)
+	}
+	// Cover-fit on a square image inside a 50×50 box leaves 50×50.
+	if gotH > 50.5 {
+		t.Errorf("box height = %.2f, want ≤ 50 (cover-fit on square)", gotH)
+	}
+}
+
+// TestImageElementMinHeightDroppedByContainerClamp documents the
+// intentional spec behaviour from CSS 2.1 §10.4: the container
+// width is the absolute outer bound for replaced elements, even
+// against min-height that would push the image past it. This test
+// pins the contract so a future "fix" doesn't accidentally let
+// images bleed past their container.
+func TestImageElementMinHeightDroppedByContainerClamp(t *testing.T) {
+	fimg := makeImage(t, 100, 100)
+	// min-height: 300pt with a 200pt-wide canvas. Auto-auto
+	// produces 200×200, min-height upscales to 300×300, container
+	// clamp resets to 200×200. min-height is silently dropped
+	// because honouring it would require overflowing the container
+	// width — which the spec forbids.
+	ie := NewImageElement(fimg).SetMinSize(0, 300)
+	gotW, gotH := ie.resolveSize(200)
+	if gotW > 200.5 {
+		t.Errorf("width = %.2f, must not exceed canvas 200", gotW)
+	}
+	if gotH > 200.5 {
+		t.Errorf("height = %.2f, must not exceed container-clamped square", gotH)
+	}
+}
+
+// TestImageElementZeroBoundsAreUnbounded confirms the API contract
+// that 0 means "no constraint" on either axis. Calling SetMaxSize(0, 0)
+// is equivalent to never calling it.
+func TestImageElementZeroBoundsAreUnbounded(t *testing.T) {
+	fimg := makeImage(t, 2000, 500)
+	withZero := NewImageElement(fimg).SetMaxSize(0, 0)
+	withoutCall := NewImageElement(fimg)
+
+	wZ, hZ := withZero.resolveSize(540)
+	wN, hN := withoutCall.resolveSize(540)
+	if math.Abs(wZ-wN) > 0.01 || math.Abs(hZ-hN) > 0.01 {
+		t.Errorf("zero bounds should match no-call: (%.2f, %.2f) vs (%.2f, %.2f)", wZ, hZ, wN, hN)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #291. Pre-fix the CSS parser stored `max-width` / `max-height` / `min-width` / `min-height` on `computedStyle` but `html/converter_image.go::convertImage` never threaded them to the layout's `ImageElement`, and `ImageElement` had no fields to receive them. Real-world impact (filed by foliopdf-hs maintainer, three system templates affected): a 2000×500 source logo in a 540pt-wide page bleeds the entire header instead of clamping at the author's `max-width: 180px`.

## Implementation

Two-layer fix per CSS 2.1 §10.7:

1. **`layout/image.go`** grows `cssMaxWidth` / `cssMaxHeight` / `cssMinWidth` / `cssMinHeight` fields (lowercase, separate from the existing `Measurable` interface methods `MinWidth` / `MaxWidth` which return intrinsic sizing for the layout engine — no naming collision). New `SetMaxSize(maxW, maxH)` and `SetMinSize(minW, minH)` setters. New `applyMaxMinClamps` helper applies the clamps in spec order: max first (shrink), then min (upscale, wins over max when they conflict per the spec's `min(max, max(min, used))` rule). Each axis clamp aspect-preserves; the other axis re-clamps if the recompute violates its bound.

2. **`html/converter_image.go`** threads `style.MaxWidth` / `MaxHeight` / `MinWidth` / `MinHeight` from the cascaded style into the new setters.

## Independent review findings addressed

Two parallel reviewers caught two MEDIUM findings, both fixed before push:

- **`object-fit` early return bypassed max/min clamps.** The branch in `resolveSize` that handles `width` + `height` + `object-fit` returned before the post-resolution clamps fired, so `<img width=200 height=200 style="object-fit: cover; max-width: 50px">` kept the unconstrained 200×200 box. Per CSS Images L3 §3.2 + §10.7, max-* should constrain the content box first, then `object-fit` fits inside. Refactored: `applyMaxMinClamps` is called twice — once on the explicit `(w, h)` before the object-fit dispatch, once after the auto-resolution branch produces new values. Both call sites use the shared helper so the spec rule lives in one place. New `TestImageElementMaxClampsBoxBeforeObjectFit` covers the contract.
- **Container clamp silently dropped `min-height`** when the upscale would push past the canvas width. Behaviour is intentional per CSS 2.1 §10.4 (replaced elements cannot exceed their containing block), but the comment didn't call this out. Expanded the comment + added `TestImageElementMinHeightDroppedByContainerClamp` to pin the contract.

## Out of scope (LOW-severity follow-ups noted by reviewers)

- **Aspect ratio uses intrinsic image, not computed box** — when both width and height are explicit, the spec's "preserve aspect ratio" for max-* clamping arguably means the explicit-pair ratio, not the intrinsic ratio. Rare interaction; can be a follow-up.
- **Percentage `max-width: 50%` resolves to 0pt** because `toPoints(0, fontSize)` passes `relativeTo=0`. Pre-existing pattern (also affects `style.Width` parsing on the same line); needs containerWidth plumbing through the converter — out of scope.
- **`html/img_max_min_test.go` is smoke-only.** End-to-end inspection of the rendered size from the html test surface is awkward because `<img>` is inline by default and the converter wraps it in a paragraph regardless of `display: block`. The unit test in `layout/image_max_min_test.go` reaches the same `resolveSize` call path and asserts on its return value directly.

## Tests

`layout/image_max_min_test.go` (8 functions, ~25 assertions):
- 5-row canonical matrix from the issue's spike doc
- max-* never upscales when explicit width is smaller
- min-* upscaling; min wins over max
- container clamp wins over min-width
- object-fit + max-* interaction (post-review fix)
- min-height dropped by container clamp (post-review documentation)
- `SetMaxSize(0, 0)` ≡ no call

## Test plan

- [x] `go test ./...` — full suite green
- [x] `golangci-lint run ./html/... ./layout/...` — 0 issues
- [x] `gofmt -l html/ layout/` — clean