### PR TITLE
layout: honor word-break:break-all in measureWords second pass

### DIFF
--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -1449,7 +1449,16 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 	if p.wordBreak != "keep-all" {
 		measured = breakCJKWords(measured)
 	}
-	measured = breakLongWords(measured, maxWidth)
+	// Mirror the dispatch in measureWords (above): word-break:break-all
+	// requires every word be split at character boundaries, not just the
+	// over-long ones. Calling only breakLongWords here let break-all
+	// silently degrade to default break behavior whenever re-measurement
+	// was performed by this code path.
+	if p.wordBreak == "break-all" {
+		measured = breakAllWords(measured, maxWidth)
+	} else {
+		measured = breakLongWords(measured, maxWidth)
+	}
 	return measured, maxFontSize
 }
 

--- a/layout/paragraph_break_all_test.go
+++ b/layout/paragraph_break_all_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// TestMeasureWordsBreakAll is a regression test for the bug where
+// measureWords ignored word-break:break-all and only ever called
+// breakLongWords. With break-all set, every multi-rune word in the
+// returned slice must already be split at character boundaries so the
+// word-wrap algorithm can place a break between any two characters.
+//
+// This mirrors the dispatch already present in (*Paragraph).Layout.
+func TestMeasureWordsBreakAll(t *testing.T) {
+	p := NewParagraph("abcd efgh", font.Helvetica, 12).SetWordBreak("break-all")
+
+	words, _ := p.measureWords(400)
+	if len(words) == 0 {
+		t.Fatal("expected at least one measured word")
+	}
+	for i, w := range words {
+		if w.LineBreak {
+			continue
+		}
+		if utf8.RuneCountInString(w.Text) != 1 {
+			t.Errorf("word %d: expected single rune under break-all, got %q (%d runes)",
+				i, w.Text, utf8.RuneCountInString(w.Text))
+		}
+	}
+}
+
+// TestMeasureWordsDefaultBreakingUnchanged is the control case: with
+// wordBreak unset, multi-rune words must remain intact. This guards
+// against the fix accidentally firing on the default code path.
+func TestMeasureWordsDefaultBreakingUnchanged(t *testing.T) {
+	p := NewParagraph("abcd efgh", font.Helvetica, 12)
+
+	words, _ := p.measureWords(400)
+	multiRune := 0
+	for _, w := range words {
+		if utf8.RuneCountInString(w.Text) > 1 {
+			multiRune++
+		}
+	}
+	if multiRune != 2 {
+		t.Errorf("expected 2 multi-rune words under default breaking, got %d", multiRune)
+	}
+}
+
+// TestMeasureWordsBreakAllKeepAllStillBreaks ensures break-all wins
+// over the keep-all guard at the top of the function (which only
+// gates breakCJKWords). This documents the precedence of the two
+// wordBreak modes the user can pick.
+func TestMeasureWordsBreakAllPrecedence(t *testing.T) {
+	// keep-all is its own mode; combining is undefined per spec, but
+	// break-all is what the user explicitly asked for here.
+	p := NewParagraph("abcd", font.Helvetica, 12).SetWordBreak("break-all")
+	words, _ := p.measureWords(400)
+	for i, w := range words {
+		if utf8.RuneCountInString(w.Text) != 1 {
+			t.Errorf("word %d: %q not split under break-all", i, w.Text)
+		}
+	}
+}


### PR DESCRIPTION
## Description

`(*Paragraph).Layout` already dispatches on `wordBreak` and calls
  `breakAllWords` when set to `break-all`. The parallel
  `(*Paragraph).measureWords` — used by `PlanLayout`, i.e. the actual
  render path — only ever called `breakLongWords`, so paragraphs
  rendered through the document pipeline silently lost `break-all` and
  fell back to default breaking.

  Fix mirrors the existing dispatch at the second site.

  Tests in `layout/paragraph_break_all_test.go` call `measureWords`
  directly and assert per-rune splitting under `break-all`, with a
  control case for default mode. Fail on `main`, pass on this branch.

<img width="1275" height="1650" alt="break_all_BUGGY-1" src="https://github.com/user-attachments/assets/e87c0de2-44e4-4fe4-bf10-650b3154d622" />

### Fix
<img width="1275" height="1650" alt="break_all_FIXED-1" src="https://github.com/user-attachments/assets/490ea05c-e8d2-404a-80ba-6c267f3ac50c" />


## Related issue

Closes #

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)
