### PR TITLE
font: CFF subsetting for CID-keyed CJK fonts (closes #295)

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -620,6 +620,17 @@ func (d *Document) WriteToWithOptions(w io.Writer, opts WriteOptions) (int64, er
 	pageRefs := make([]*core.PdfIndirectReference, 0, len(allPages))
 	pageDicts := make([]*core.PdfDictionary, 0, len(allPages))
 
+	// Document-wide font caches. A given *font.EmbeddedFont (or
+	// *font.Standard) is typically registered on every page that
+	// uses it, so without these caches BuildObjects / Dict would run
+	// once per page and the writer would emit a fresh /FontFile3 +
+	// CIDFont + descriptor for every page. For a 20-page document
+	// referencing one CJK font, that's 20× the embedded font data.
+	// The cache shares the Type0 indirect reference across pages so
+	// the font program is embedded exactly once per document.
+	embeddedFontRefs := make(map[*font.EmbeddedFont]*core.PdfIndirectReference)
+	standardFontRefs := make(map[*font.Standard]*core.PdfIndirectReference)
+
 	// First pass: build page objects.
 	for pageIdx, page := range allPages {
 		pageDict := core.NewPdfDictionary()
@@ -658,12 +669,20 @@ func (d *Document) WriteToWithOptions(w io.Writer, opts WriteOptions) (int64, er
 			fontDict := core.NewPdfDictionary()
 			for _, entry := range page.fonts {
 				if entry.standard != nil {
-					fontObjRef := writer.AddObject(entry.standard.Dict())
-					fontDict.Set(entry.name, fontObjRef)
+					ref, ok := standardFontRefs[entry.standard]
+					if !ok {
+						ref = writer.AddObject(entry.standard.Dict())
+						standardFontRefs[entry.standard] = ref
+					}
+					fontDict.Set(entry.name, ref)
 				} else if entry.embedded != nil {
-					type0 := entry.embedded.BuildObjects(writer.AddObject)
-					fontObjRef := writer.AddObject(type0)
-					fontDict.Set(entry.name, fontObjRef)
+					ref, ok := embeddedFontRefs[entry.embedded]
+					if !ok {
+						type0 := entry.embedded.BuildObjects(writer.AddObject)
+						ref = writer.AddObject(type0)
+						embeddedFontRefs[entry.embedded] = ref
+					}
+					fontDict.Set(entry.name, ref)
 				}
 			}
 			resources.Set("Font", fontDict)

--- a/document/document_test.go
+++ b/document/document_test.go
@@ -165,6 +165,53 @@ func TestAddTextMultiplePages(t *testing.T) {
 	}
 }
 
+// TestFontDedupAcrossPages pins the document-level font-sharing fix:
+// the same *font.EmbeddedFont (and *font.Standard) referenced by
+// multiple pages must register exactly one font object in the PDF,
+// not one per page. Pre-fix, a 20-page document with one shared CJK
+// embedded font produced 20 /FontFile2 streams; post-fix it produces
+// one. The reporter of issue #295 specifically noticed this — "each
+// page contains one copy of CJK fonts" — and the multi-MB blowup
+// from per-page embedding was the visible symptom.
+func TestFontDedupAcrossPages(t *testing.T) {
+	face, err := font.LoadTTF(testFontPath(t))
+	if err != nil {
+		t.Fatalf("LoadTTF: %v", err)
+	}
+
+	doc := NewDocument(PageSizeLetter)
+	ef := font.NewEmbeddedFont(face)
+	for i := range 5 {
+		p := doc.AddPage()
+		// Both standard (Helvetica) and embedded fonts go on every
+		// page so we test both dedup paths in one assertion.
+		p.AddText("Std", font.Helvetica, 12, 72, 720)
+		_ = i
+		p.AddTextEmbedded("a", ef, 12, 72, 700)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	pdf := buf.String()
+
+	// The embedded TrueType path emits exactly one /FontFile2
+	// reference per unique embedded font; with five pages sharing
+	// one EmbeddedFont we want exactly one.
+	if got := strings.Count(pdf, "/FontFile2"); got != 1 {
+		t.Errorf("/FontFile2 occurrences = %d, want 1 (per-document share)", got)
+	}
+	// Helvetica is a Standard font: its dict is small but should
+	// still be emitted once, not five times.
+	if got := strings.Count(pdf, "/BaseFont /Helvetica"); got != 1 {
+		t.Errorf("/BaseFont /Helvetica occurrences = %d, want 1", got)
+	}
+	if got := strings.Count(pdf, "/Subtype /CIDFontType2"); got != 1 {
+		t.Errorf("/Subtype /CIDFontType2 occurrences = %d, want 1", got)
+	}
+}
+
 func TestBlankPageStillWorks(t *testing.T) {
 	// A page with no text should have no /Contents but should
 	// have an empty /Resources (required by spec, qpdf warns otherwise).

--- a/font/cff.go
+++ b/font/cff.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import "encoding/binary"
+
+// isCIDKeyedCFFv1 reports whether cff carries a CID-keyed CFF v1 font
+// — specifically a Top DICT that opens with the ROS operator (12 30,
+// per Adobe Tech Note #5176 §9 Table 10). Only CID-keyed CFF v1 is
+// safe to embed under PDF's /CIDFontType0 + /CIDFontType0C path; plain
+// (name-keyed) CFF needs the /Type1C stream subtype and a non-composite
+// font dictionary, which Folio's embedder does not yet build.
+//
+// Returns false (with no error) for inputs that are too short, malformed,
+// CFF font collections (Top DICT INDEX count > 1), or simply not
+// CID-keyed. The caller treats any false return as "don't take the CFF
+// path" and falls back to the legacy embed semantics.
+func isCIDKeyedCFFv1(cff []byte) bool {
+	dict, ok := firstTopDICTv1(cff)
+	if !ok {
+		return false
+	}
+	return topDICTStartsWithROS(dict)
+}
+
+// firstTopDICTv1 extracts the bytes of the first Top DICT in a CFF v1
+// blob — Header → Name INDEX → Top DICT INDEX → first object's data.
+// Returns (nil, false) on any structural anomaly. The function reads
+// fields defensively against the buffer length so a hostile or
+// truncated CFF cannot cause an out-of-bounds slice.
+func firstTopDICTv1(cff []byte) ([]byte, bool) {
+	// Header: major(1), minor(1), hdrSize(1), offSize(1).
+	if len(cff) < 4 {
+		return nil, false
+	}
+	if cff[0] != 1 {
+		// CFF2 (major=2) or unknown major version. Caller treats
+		// CFF2 separately; here we only accept v1.
+		return nil, false
+	}
+	hdrSize := int(cff[2])
+	if hdrSize < 4 || hdrSize > len(cff) {
+		return nil, false
+	}
+
+	// Name INDEX, then Top DICT INDEX. We only need to skip past the
+	// Name INDEX; its contents are irrelevant for ROS detection.
+	pos := hdrSize
+	pos, ok := skipINDEX(cff, pos)
+	if !ok {
+		return nil, false
+	}
+
+	// Top DICT INDEX header: count(uint16), offSize(uint8),
+	// offsets[count+1].
+	if pos+3 > len(cff) {
+		return nil, false
+	}
+	count := int(binary.BigEndian.Uint16(cff[pos : pos+2]))
+	if count != 1 {
+		// CFF font collections are spec-legal but not used inside
+		// OpenType sfnt wrappers. Reject defensively rather than
+		// guessing which Top DICT applies.
+		return nil, false
+	}
+	offSize := int(cff[pos+2])
+	if offSize < 1 || offSize > 4 {
+		return nil, false
+	}
+	pos += 3
+
+	// offsets are 1-indexed (first byte after the array is offset 1).
+	// We need offsets[0] and offsets[1] to bracket the first object.
+	offBytes := (count + 1) * offSize
+	if pos+offBytes > len(cff) {
+		return nil, false
+	}
+	off0 := readOffset(cff[pos:], offSize)
+	off1 := readOffset(cff[pos+offSize:], offSize)
+	if off0 < 1 || off1 < off0 {
+		return nil, false
+	}
+	dataStart := pos + offBytes
+	dictStart := dataStart + off0 - 1
+	dictEnd := dataStart + off1 - 1
+	if dictStart < dataStart || dictEnd > len(cff) || dictEnd < dictStart {
+		return nil, false
+	}
+	return cff[dictStart:dictEnd], true
+}
+
+// skipINDEX advances pos past one CFF INDEX (count + offSize + offsets
+// + data) and returns the new position. An empty INDEX (count == 0) is
+// the 2-byte sequence {0x00 0x00} per spec.
+func skipINDEX(buf []byte, pos int) (int, bool) {
+	if pos+2 > len(buf) {
+		return 0, false
+	}
+	count := int(binary.BigEndian.Uint16(buf[pos : pos+2]))
+	if count == 0 {
+		return pos + 2, true
+	}
+	if pos+3 > len(buf) {
+		return 0, false
+	}
+	offSize := int(buf[pos+2])
+	if offSize < 1 || offSize > 4 {
+		return 0, false
+	}
+	offBase := pos + 3
+	offBytes := (count + 1) * offSize
+	if offBase+offBytes > len(buf) {
+		return 0, false
+	}
+	// Total payload size lives in the last offset entry, minus 1
+	// (offsets are 1-indexed).
+	lastOff := readOffset(buf[offBase+count*offSize:], offSize)
+	if lastOff < 1 {
+		return 0, false
+	}
+	end := offBase + offBytes + lastOff - 1
+	if end > len(buf) || end < offBase {
+		return 0, false
+	}
+	return end, true
+}
+
+// readOffset reads a 1-, 2-, 3-, or 4-byte big-endian unsigned integer.
+// CFF INDEX offsets use this variable-width encoding selected per
+// INDEX by its offSize field.
+func readOffset(b []byte, n int) int {
+	switch n {
+	case 1:
+		return int(b[0])
+	case 2:
+		return int(binary.BigEndian.Uint16(b[:2]))
+	case 3:
+		return int(b[0])<<16 | int(b[1])<<8 | int(b[2])
+	case 4:
+		return int(binary.BigEndian.Uint32(b[:4]))
+	}
+	return 0
+}
+
+// topDICTStartsWithROS walks a Top DICT's operand/operator stream and
+// reports whether the first operator encountered is ROS (12 30). It
+// parses the well-defined operand encodings from TN #5176 §4 rather
+// than scanning bytes blindly — operand payloads can contain the bytes
+// 0x0C and 0x1E and would otherwise yield false positives.
+//
+// We bail out on the first operator, on operand decoding errors, or
+// when the buffer is exhausted. False is the safe answer in every
+// failure mode: the caller falls back to the legacy embed path.
+func topDICTStartsWithROS(dict []byte) bool {
+	pos := 0
+	for pos < len(dict) {
+		b := dict[pos]
+		switch {
+		case b <= 21:
+			// Operator. 0x0C is the two-byte escape for extended ops.
+			if b == 12 {
+				if pos+1 >= len(dict) {
+					return false
+				}
+				return dict[pos+1] == 30 // ROS
+			}
+			// Any other operator means this is not a CID-keyed Top
+			// DICT — ROS is required as the first operator.
+			return false
+		case b == 28:
+			pos += 3
+		case b == 29:
+			pos += 5
+		case b == 30:
+			// BCD real: nibbles 0..9 are digits, A=., B=E, C=E-,
+			// D=reserved, E=minus, F=end. Walk bytes until either
+			// nibble is 0xF.
+			pos++
+			ended := false
+			for pos < len(dict) {
+				v := dict[pos]
+				pos++
+				if v&0x0F == 0x0F || v>>4 == 0x0F {
+					ended = true
+					break
+				}
+			}
+			if !ended {
+				return false
+			}
+		case b >= 32 && b <= 246:
+			pos++
+		case b >= 247 && b <= 254:
+			pos += 2
+		default:
+			// 22..27, 31, 255 are reserved/unused.
+			return false
+		}
+	}
+	return false
+}

--- a/font/cff_charstring.go
+++ b/font/cff_charstring.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import "encoding/binary"
+
+// Type 2 charstring operator codes (Adobe Tech Note #5177 §3 and §4).
+// Only the operators that affect reachability — control flow, hint
+// counting, and operand width — need explicit handles here; every
+// other operator is treated as "consume the operand stack and
+// continue" because charstring drawing semantics do not influence
+// which subroutines are called.
+const (
+	t2OpHstem     = 1
+	t2OpVstem     = 3
+	t2OpCallsubr  = 10
+	t2OpReturn    = 11
+	t2OpEscape    = 12
+	t2OpEndchar   = 14
+	t2OpHstemhm   = 18
+	t2OpHintmask  = 19
+	t2OpCntrmask  = 20
+	t2OpVstemhm   = 23
+	t2OpCallgsubr = 29
+)
+
+// subrBias returns the offset added to a biased subroutine index per
+// TN #5177 §4.7. The Type 2 spec stores subr references as a single
+// integer that has already been shifted by this bias; the actual
+// INDEX position is `bias + biasedIndex`.
+func subrBias(numSubrs int) int {
+	switch {
+	case numSubrs < 1240:
+		return 107
+	case numSubrs < 33900:
+		return 1131
+	default:
+		return 32768
+	}
+}
+
+// charstringWalker discovers the set of global and per-FD local
+// subroutines that are transitively reachable from a set of starting
+// charstrings. Phase 3 subsetting uses the result to decide which
+// subroutines must survive verbatim and which can be replaced with a
+// single `return` byte (0x0B).
+//
+// The walker is intentionally a partial Type 2 interpreter: it tracks
+// the operand stack precisely enough to read the integer argument of
+// every callsubr/callgsubr (and the implied stem count consumed by
+// hintmask / cntrmask) but ignores drawing semantics. If a call's
+// operand cannot be determined locally — typically because the
+// caller's stack carried the argument across a callsubr boundary —
+// the walker falls back to marking every subroutine in the affected
+// scope reachable. The subset stays correct in that case; it merely
+// fails to shrink as aggressively as a perfect analysis would.
+type charstringWalker struct {
+	gsubr  *cffIndex
+	lsubrs []*cffIndex // per-FD; entries may be nil for FDs with no local subrs
+
+	gReached []bool   // size == gsubr.count (nil when gsubr is empty)
+	lReached [][]bool // per FD; nil entries when no local subrs
+
+	// Pessimistic-fallback flags. When set, every subroutine in the
+	// scope is treated as reachable regardless of the per-index slice.
+	allGReached bool
+	allLReached []bool // per FD
+
+	// Recursion depth guard. TN #5177 specifies a max subr nesting
+	// depth of 10 levels.
+	maxDepth int
+}
+
+// newCharstringWalker prepares a walker for a CFF whose global subr
+// INDEX is gsubr and whose per-FD local subr INDEXes are lsubrs
+// (indexed by FD). Either argument may be nil or empty; the walker
+// treats absent indexes as "no subroutines to mark".
+func newCharstringWalker(gsubr *cffIndex, lsubrs []*cffIndex) *charstringWalker {
+	w := &charstringWalker{
+		gsubr:       gsubr,
+		lsubrs:      lsubrs,
+		allLReached: make([]bool, len(lsubrs)),
+		lReached:    make([][]bool, len(lsubrs)),
+		maxDepth:    10,
+	}
+	if gsubr != nil && gsubr.count > 0 {
+		w.gReached = make([]bool, gsubr.count)
+	}
+	for i, ls := range lsubrs {
+		if ls != nil && ls.count > 0 {
+			w.lReached[i] = make([]bool, ls.count)
+		}
+	}
+	return w
+}
+
+// Trace walks bytes (a charstring or subroutine body) in the context
+// of FD fd, transitively marking every reachable subroutine.
+func (w *charstringWalker) Trace(bytes []byte, fd int) {
+	w.walk(bytes, fd, 0)
+}
+
+// GsubrReached reports whether global subr i should be retained.
+func (w *charstringWalker) GsubrReached(i int) bool {
+	if w.allGReached {
+		return true
+	}
+	if i < 0 || i >= len(w.gReached) {
+		return false
+	}
+	return w.gReached[i]
+}
+
+// LsubrReached reports whether local subr i in FD fd should be
+// retained.
+func (w *charstringWalker) LsubrReached(fd, i int) bool {
+	if fd < 0 || fd >= len(w.lReached) {
+		return false
+	}
+	if fd < len(w.allLReached) && w.allLReached[fd] {
+		return true
+	}
+	if i < 0 || i >= len(w.lReached[fd]) {
+		return false
+	}
+	return w.lReached[fd][i]
+}
+
+// walk interprets a Type 2 charstring well enough to discover
+// callsubr / callgsubr targets. depth is the current nesting level;
+// the spec caps subr recursion at 10. Stems counted by hstem-family
+// operators (and the implicit vstem before the first hintmask) are
+// summed so hintmask / cntrmask know how many mask bytes follow.
+func (w *charstringWalker) walk(bytes []byte, fd int, depth int) {
+	if depth >= w.maxDepth {
+		// Bail out to pessimistic reachability rather than risk
+		// missing a real call buried in deeply nested subrs. Phase 3
+		// then keeps every subroutine in the affected scope.
+		w.allGReached = true
+		if fd >= 0 && fd < len(w.allLReached) {
+			w.allLReached[fd] = true
+		}
+		return
+	}
+
+	var stack []int64
+	stems := 0
+	pos := 0
+	for pos < len(bytes) {
+		b := bytes[pos]
+		switch {
+		case b == 28:
+			if pos+3 > len(bytes) {
+				return
+			}
+			v := int64(int16(binary.BigEndian.Uint16(bytes[pos+1 : pos+3])))
+			stack = append(stack, v)
+			pos += 3
+		case b == 255:
+			// 5-byte fixed-point 16.16. We do not need the value
+			// because callsubr/callgsubr operands must be integers
+			// (TN #5177 §4.7), but we push a slot to keep stack
+			// alignment correct for subsequent operators.
+			if pos+5 > len(bytes) {
+				return
+			}
+			stack = append(stack, 0)
+			pos += 5
+		case b >= 32 && b <= 246:
+			stack = append(stack, int64(b)-139)
+			pos++
+		case b >= 247 && b <= 250:
+			if pos+1 >= len(bytes) {
+				return
+			}
+			stack = append(stack, int64(b-247)*256+int64(bytes[pos+1])+108)
+			pos += 2
+		case b >= 251 && b <= 254:
+			if pos+1 >= len(bytes) {
+				return
+			}
+			stack = append(stack, -int64(b-251)*256-int64(bytes[pos+1])-108)
+			pos += 2
+		case b == t2OpEscape:
+			// Every 2-byte operator (arithmetic, conditional, flex
+			// variants) is irrelevant for reachability; consume it
+			// and the operand stack.
+			if pos+1 >= len(bytes) {
+				return
+			}
+			pos += 2
+			stack = nil
+		case b == t2OpCallsubr:
+			pos++
+			w.handleCall(&stack, fd, false, depth)
+		case b == t2OpCallgsubr:
+			pos++
+			w.handleCall(&stack, fd, true, depth)
+		case b == t2OpReturn, b == t2OpEndchar:
+			return
+		case b == t2OpHstem, b == t2OpVstem, b == t2OpHstemhm, b == t2OpVstemhm:
+			// Each stem operator consumes pairs of coordinates. The
+			// width-prefix rule (odd stack count → first operand is
+			// width) cancels out for stem counting: floor(len/2)
+			// gives the right number of stems either way.
+			stems += len(stack) / 2
+			stack = nil
+			pos++
+		case b == t2OpHintmask, b == t2OpCntrmask:
+			// Per TN #5177 §4.3, hintmask/cntrmask may carry the
+			// vstem arguments on the operand stack if the explicit
+			// vstem operator was omitted (shortcut form). We
+			// therefore add half the remaining stack to the stem
+			// count before computing mask-byte width.
+			stems += len(stack) / 2
+			stack = nil
+			maskBytes := (stems + 7) / 8
+			if pos+1+maskBytes > len(bytes) {
+				return
+			}
+			pos += 1 + maskBytes
+		default:
+			// Every other operator (moveto, lineto, curveto, ...)
+			// consumes its operands and produces no subr calls.
+			stack = nil
+			pos++
+		}
+	}
+}
+
+// handleCall reads the biased subr index from the top of stack and
+// recurses into the target subr if it is in range. When the stack is
+// empty the call's argument was supplied by a caller across a
+// callsubr boundary; the walker flips to pessimistic reachability for
+// the affected scope rather than try to reconstruct the cross-frame
+// state.
+func (w *charstringWalker) handleCall(stack *[]int64, fd int, global bool, depth int) {
+	if len(*stack) == 0 {
+		if global {
+			w.allGReached = true
+		} else if fd >= 0 && fd < len(w.allLReached) {
+			w.allLReached[fd] = true
+		}
+		return
+	}
+	biased := (*stack)[len(*stack)-1]
+	*stack = (*stack)[:len(*stack)-1]
+
+	var idx *cffIndex
+	if global {
+		idx = w.gsubr
+	} else if fd >= 0 && fd < len(w.lsubrs) {
+		idx = w.lsubrs[fd]
+	}
+	if idx == nil || idx.count == 0 {
+		return
+	}
+	realIdx := int(biased) + subrBias(idx.count)
+	if realIdx < 0 || realIdx >= idx.count {
+		// Out-of-range biased index. Spec-illegal; do not panic
+		// downstream Phase 3 work by marking it.
+		return
+	}
+
+	if global {
+		if w.gReached[realIdx] {
+			return
+		}
+		w.gReached[realIdx] = true
+	} else {
+		if w.lReached[fd][realIdx] {
+			return
+		}
+		w.lReached[fd][realIdx] = true
+	}
+	w.walk(idx.Object(realIdx), fd, depth+1)
+}

--- a/font/cff_charstring.go
+++ b/font/cff_charstring.go
@@ -70,6 +70,12 @@ type charstringWalker struct {
 	// Recursion depth guard. TN #5177 specifies a max subr nesting
 	// depth of 10 levels.
 	maxDepth int
+
+	// walkCalls counts every entry into walk(). The visited-check
+	// at handleCall ensures recursion is bounded, but tests that
+	// would otherwise hang on a regression check this counter
+	// directly. Phase 3+ does not consult it on the hot path.
+	walkCalls int
 }
 
 // newCharstringWalker prepares a walker for a CFF whose global subr
@@ -133,6 +139,7 @@ func (w *charstringWalker) LsubrReached(fd, i int) bool {
 // operators (and the implicit vstem before the first hintmask) are
 // summed so hintmask / cntrmask know how many mask bytes follow.
 func (w *charstringWalker) walk(bytes []byte, fd int, depth int) {
+	w.walkCalls++
 	if depth >= w.maxDepth {
 		// Bail out to pessimistic reachability rather than risk
 		// missing a real call buried in deeply nested subrs. Phase 3

--- a/font/cff_charstring_test.go
+++ b/font/cff_charstring_test.go
@@ -1,0 +1,289 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"testing"
+)
+
+// Type 2 helper encoders. Mirroring TN #5177 §3.2 encoding rules,
+// these produce the byte sequence that the walker should decode back
+// to the same integer value. The walker is the unit under test so the
+// encoders are intentionally trivial: just enough to drive the
+// branches we care about.
+
+func t2Int(v int64) []byte {
+	switch {
+	case v >= -107 && v <= 107:
+		return []byte{byte(v + 139)}
+	case v >= 108 && v <= 1131:
+		v -= 108
+		return []byte{byte(v/256) + 247, byte(v % 256)}
+	case v >= -1131 && v <= -108:
+		v = -v - 108
+		return []byte{byte(v/256) + 251, byte(v % 256)}
+	case v >= -32768 && v <= 32767:
+		return []byte{28, byte(v >> 8), byte(v)}
+	}
+	panic("t2Int: value out of range")
+}
+
+func appendOps(out []byte, parts ...[]byte) []byte {
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// buildSubrIndex wraps the given subroutine bodies in a cffIndex
+// suitable for the walker. The returned INDEX aliases the supplied
+// bodies; Object(i) returns the i-th body unmodified.
+func buildSubrIndex(t *testing.T, bodies [][]byte) *cffIndex {
+	t.Helper()
+	raw := writeIndex(t, bodies, 2)
+	idx, err := parseCFFIndex(raw, 0)
+	if err != nil {
+		t.Fatalf("buildSubrIndex parse: %v", err)
+	}
+	return idx
+}
+
+func TestCharstringWalkerNoSubrCalls(t *testing.T) {
+	// A charstring that pushes args then issues a moveto-equivalent
+	// operator. No subr should be marked reached.
+	gsubr := buildSubrIndex(t, [][]byte{{0x0E}, {0x0E}})
+	lsubr := buildSubrIndex(t, [][]byte{{0x0E}, {0x0E}})
+	w := newCharstringWalker(gsubr, []*cffIndex{lsubr})
+
+	cs := []byte{}
+	cs = append(cs, t2Int(0)...)
+	cs = append(cs, t2Int(0)...)
+	cs = append(cs, t2OpHmoveto)
+	cs = append(cs, t2OpEndchar)
+	w.Trace(cs, 0)
+
+	for i := range gsubr.count {
+		if w.GsubrReached(i) {
+			t.Errorf("gsubr %d unexpectedly reached", i)
+		}
+	}
+	for i := range lsubr.count {
+		if w.LsubrReached(0, i) {
+			t.Errorf("lsubr %d unexpectedly reached", i)
+		}
+	}
+}
+
+func TestCharstringWalkerDirectGsubrCall(t *testing.T) {
+	// Build a global subr index with two entries; charstring calls
+	// gsubr 1 → biased index = 1 - 107 = -106.
+	gsubr := buildSubrIndex(t, [][]byte{
+		{t2OpReturn},
+		{t2OpReturn},
+	})
+	w := newCharstringWalker(gsubr, nil)
+
+	cs := appendOps(nil, t2Int(-106), []byte{t2OpCallgsubr, t2OpEndchar})
+	w.Trace(cs, 0)
+
+	if !w.GsubrReached(1) {
+		t.Error("expected gsubr 1 reached after callgsubr")
+	}
+	if w.GsubrReached(0) {
+		t.Error("gsubr 0 must not be reached")
+	}
+}
+
+func TestCharstringWalkerTransitiveCalls(t *testing.T) {
+	// gsubr 0 calls gsubr 1; charstring calls gsubr 0. Both should
+	// end up reached.
+	gsubr := buildSubrIndex(t, [][]byte{
+		appendOps(nil, t2Int(-106), []byte{t2OpCallgsubr, t2OpReturn}), // gsubr 0 → call gsubr 1
+		{t2OpReturn}, // gsubr 1
+	})
+	w := newCharstringWalker(gsubr, nil)
+
+	cs := appendOps(nil, t2Int(-107), []byte{t2OpCallgsubr, t2OpEndchar}) // call gsubr 0
+	w.Trace(cs, 0)
+
+	if !w.GsubrReached(0) || !w.GsubrReached(1) {
+		t.Errorf("expected gsubrs 0 and 1 reached, got 0=%v 1=%v",
+			w.GsubrReached(0), w.GsubrReached(1))
+	}
+}
+
+func TestCharstringWalkerLocalSubrCallsRespectFD(t *testing.T) {
+	// Two FDs with separate local subrs. Charstring in FD 0 calls
+	// lsubr 1; FD 1's local subrs must stay untouched.
+	lsubr0 := buildSubrIndex(t, [][]byte{
+		{t2OpReturn},
+		{t2OpReturn},
+	})
+	lsubr1 := buildSubrIndex(t, [][]byte{
+		{t2OpReturn},
+	})
+	w := newCharstringWalker(nil, []*cffIndex{lsubr0, lsubr1})
+
+	cs := appendOps(nil, t2Int(-106), []byte{t2OpCallsubr, t2OpEndchar})
+	w.Trace(cs, 0)
+
+	if !w.LsubrReached(0, 1) {
+		t.Error("expected FD 0 lsubr 1 reached")
+	}
+	if w.LsubrReached(0, 0) {
+		t.Error("FD 0 lsubr 0 must not be reached")
+	}
+	if w.LsubrReached(1, 0) {
+		t.Error("FD 1 lsubrs must not be reached by FD 0 walk")
+	}
+}
+
+func TestCharstringWalkerHintmaskSkipsMaskBytes(t *testing.T) {
+	// 3 hstem pairs (6 operands) + hstemhm establishes 3 stems, then
+	// hintmask must skip ceil(3/8)=1 mask byte. After hintmask, a
+	// callgsubr must still be located correctly.
+	gsubr := buildSubrIndex(t, [][]byte{{t2OpReturn}})
+	w := newCharstringWalker(gsubr, nil)
+
+	var cs []byte
+	for i := range 6 {
+		cs = append(cs, t2Int(int64(i))...)
+	}
+	cs = append(cs, t2OpHstemhm)
+	cs = append(cs, t2OpHintmask)
+	cs = append(cs, 0xAA) // 1 mask byte
+	cs = append(cs, t2Int(-107)...)
+	cs = append(cs, t2OpCallgsubr)
+	cs = append(cs, t2OpEndchar)
+	w.Trace(cs, 0)
+
+	if !w.GsubrReached(0) {
+		t.Error("walker mis-skipped hintmask bytes; gsubr 0 should be reached")
+	}
+}
+
+func TestCharstringWalkerHintmaskWithImplicitVstem(t *testing.T) {
+	// 2 hstem pairs (1 hstem) then hintmask with 2 vstem args on
+	// stack (implicit vstem shortcut, TN #5177 §4.3). Total stems
+	// = 1 + 1 = 2 → 1 mask byte.
+	gsubr := buildSubrIndex(t, [][]byte{{t2OpReturn}})
+	w := newCharstringWalker(gsubr, nil)
+
+	var cs []byte
+	for i := range 2 {
+		cs = append(cs, t2Int(int64(i))...)
+	}
+	cs = append(cs, t2OpHstem) // 1 hstem
+	cs = append(cs, t2Int(0)...)
+	cs = append(cs, t2Int(1)...)
+	cs = append(cs, t2OpHintmask) // 1 implicit vstem on stack
+	cs = append(cs, 0xCC)         // 1 mask byte for 2 stems total
+	cs = append(cs, t2Int(-107)...)
+	cs = append(cs, t2OpCallgsubr)
+	cs = append(cs, t2OpEndchar)
+	w.Trace(cs, 0)
+
+	if !w.GsubrReached(0) {
+		t.Error("implicit-vstem shortcut mis-counted; gsubr 0 should be reached")
+	}
+}
+
+func TestCharstringWalkerCyclicSubrTerminates(t *testing.T) {
+	// gsubr 0 calls gsubr 0 in an infinite loop. The walker must not
+	// recurse forever — depth guard or visited check must trip.
+	gsubr := buildSubrIndex(t, [][]byte{
+		appendOps(nil, t2Int(-107), []byte{t2OpCallgsubr, t2OpReturn}),
+	})
+	w := newCharstringWalker(gsubr, nil)
+
+	cs := appendOps(nil, t2Int(-107), []byte{t2OpCallgsubr, t2OpEndchar})
+	w.Trace(cs, 0)
+
+	if !w.GsubrReached(0) {
+		t.Error("cyclic subr must still be marked reached on first visit")
+	}
+}
+
+func TestCharstringWalkerUndecidableCallTriggersFallback(t *testing.T) {
+	// A subr that issues a callgsubr without pushing its own
+	// argument — relies on caller's stack. Walking the subr in
+	// isolation yields an empty stack at the call site; the walker
+	// must flip to pessimistic gsubr reachability.
+	gsubr := buildSubrIndex(t, [][]byte{
+		{t2OpCallgsubr, t2OpReturn}, // gsubr 0: bare callgsubr
+		{t2OpReturn},
+		{t2OpReturn},
+	})
+	w := newCharstringWalker(gsubr, nil)
+
+	cs := appendOps(nil, t2Int(-107), []byte{t2OpCallgsubr, t2OpEndchar})
+	w.Trace(cs, 0)
+
+	// All gsubrs should now be marked reachable (allGReached set).
+	for i := range gsubr.count {
+		if !w.GsubrReached(i) {
+			t.Errorf("gsubr %d should be marked under pessimistic fallback", i)
+		}
+	}
+}
+
+func TestCharstringWalkerEscapedOperatorClearsStack(t *testing.T) {
+	// A 2-byte operator (12 9 = abs) sits between an integer push
+	// and a callgsubr. The 2-byte op must consume the operand so
+	// callgsubr sees an empty stack and triggers fallback.
+	gsubr := buildSubrIndex(t, [][]byte{{t2OpReturn}})
+	w := newCharstringWalker(gsubr, nil)
+
+	cs := []byte{}
+	cs = append(cs, t2Int(-107)...) // push, would be a valid call arg
+	cs = append(cs, t2OpEscape, 9)  // abs — consumes operands
+	cs = append(cs, t2OpCallgsubr)  // no arg → fallback
+	cs = append(cs, t2OpEndchar)
+	w.Trace(cs, 0)
+
+	if !w.allGReached {
+		t.Error("expected pessimistic gsubr fallback after 2-byte op cleared stack")
+	}
+}
+
+func TestCharstringWalkerEndcharStopsScan(t *testing.T) {
+	// After endchar, a callgsubr later in the buffer must not be
+	// taken (return-from-walk semantics).
+	gsubr := buildSubrIndex(t, [][]byte{{t2OpReturn}})
+	w := newCharstringWalker(gsubr, nil)
+
+	cs := []byte{t2OpEndchar}
+	cs = append(cs, t2Int(-107)...)
+	cs = append(cs, t2OpCallgsubr)
+	w.Trace(cs, 0)
+
+	if w.GsubrReached(0) {
+		t.Error("walk past endchar must not mark trailing subrs")
+	}
+}
+
+func TestSubrBiasBoundaries(t *testing.T) {
+	cases := []struct {
+		n    int
+		want int
+	}{
+		{0, 107},
+		{1, 107},
+		{1239, 107},
+		{1240, 1131},
+		{33899, 1131},
+		{33900, 32768},
+		{100000, 32768},
+	}
+	for _, tc := range cases {
+		if got := subrBias(tc.n); got != tc.want {
+			t.Errorf("subrBias(%d) = %d, want %d", tc.n, got, tc.want)
+		}
+	}
+}
+
+// Type 2 hmoveto operator code; not in the const block because no
+// other walker logic depends on it (it's just "any operator that
+// clears the stack").
+const t2OpHmoveto = 22

--- a/font/cff_charstring_test.go
+++ b/font/cff_charstring_test.go
@@ -191,7 +191,8 @@ func TestCharstringWalkerHintmaskWithImplicitVstem(t *testing.T) {
 
 func TestCharstringWalkerCyclicSubrTerminates(t *testing.T) {
 	// gsubr 0 calls gsubr 0 in an infinite loop. The walker must not
-	// recurse forever — depth guard or visited check must trip.
+	// recurse forever — the visited-check must short-circuit the
+	// second entry.
 	gsubr := buildSubrIndex(t, [][]byte{
 		appendOps(nil, t2Int(-107), []byte{t2OpCallgsubr, t2OpReturn}),
 	})
@@ -202,6 +203,14 @@ func TestCharstringWalkerCyclicSubrTerminates(t *testing.T) {
 
 	if !w.GsubrReached(0) {
 		t.Error("cyclic subr must still be marked reached on first visit")
+	}
+	// Bounded work: at most one walk into the top-level charstring +
+	// one walk into gsubr 0. If the visited-check regresses, this
+	// counter explodes — the test would otherwise just hang and time
+	// out the suite. The +2 slack absorbs depth-guard fallback paths
+	// that might add a single extra entry.
+	if w.walkCalls > 4 {
+		t.Errorf("walk invoked %d times on cyclic subr; expected <= 4", w.walkCalls)
 	}
 }
 

--- a/font/cff_parse.go
+++ b/font/cff_parse.go
@@ -1,0 +1,636 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// cffFont is the parsed, read-only view of a CID-keyed CFF v1 font.
+// Phase 2 builds this structure; Phase 3+ consumes it to emit a
+// subset CFF blob.
+//
+// Every section is exposed both as a byte range (for verbatim
+// copy-through) and via decoded helpers where Phase 3 needs structured
+// access. Offsets in this structure are absolute byte positions in raw
+// unless explicitly marked relative.
+//
+// Spec reference: Adobe Technical Note #5176 (CFF v1).
+type cffFont struct {
+	raw []byte // full source CFF bytes
+
+	header []byte // header bytes (Header §6); length = hdrSize
+
+	nameIndex    *cffIndex // §5 INDEX format; one entry holds the PostScript name
+	topDictIndex *cffIndex // single-Top-DICT INDEX (CID-keyed CFFs)
+	stringIndex  *cffIndex // §10 — SID resolution; copy-through for subsetting
+	gsubrIndex   *cffIndex // §16 Global subroutines
+
+	topDict cffDict // decoded operators of the single Top DICT
+
+	// Sections located via Top DICT operands. The byte ranges in raw
+	// are computed defensively; sub-format parsing is deferred.
+	charsetOffset  int // absolute offset in raw of charset bytes
+	charsetSize    int // byte length of charset (incl. format byte)
+	fdSelectOffset int
+	fdSelectSize   int
+
+	charStringsIndex *cffIndex // §17 CharStrings INDEX (one entry per GID)
+	fdArrayIndex     *cffIndex // §19 FDArray INDEX (entries are font DICTs)
+
+	// Decoded Top DICT scalars Phase 3 needs without re-traversing.
+	rosRegistry   int64
+	rosOrdering   int64
+	rosSupplement int64
+	cidCount      int
+
+	numGlyphs int // == charStringsIndex.count; mirrored for clarity
+
+	fds []*cffFD // one per FDArray INDEX entry
+}
+
+// cffFD holds the per-FD state of a CID-keyed CFF: font DICT bytes,
+// the Private DICT that lives at an absolute offset, and the Local
+// Subr INDEX rooted at a relative offset from the Private DICT start.
+type cffFD struct {
+	// fontDictBytes is the FDArray INDEX object i — the bytes of the
+	// font DICT used for this FD. Subsetting copies and rewrites this.
+	fontDictBytes []byte
+	fontDict      cffDict // decoded entries
+
+	privateOffset int     // absolute offset in cffFont.raw
+	privateSize   int     // byte length
+	privateBytes  []byte  // alias to raw[privateOffset:privateOffset+privateSize]
+	privateDict   cffDict // decoded entries
+
+	// localSubrs may be nil when the FD declares no local Subr INDEX
+	// (the Private DICT lacks the Subrs operator). Spec-legal.
+	localSubrs *cffIndex
+}
+
+// cffIndex is a parsed INDEX structure (TN #5176 §5). Empty INDEXes
+// (count == 0) are valid and serialize to two zero bytes; they expose
+// no objects and have offSize == 0.
+type cffIndex struct {
+	rawStart    int // absolute offset where the INDEX begins in cffFont.raw
+	rawEnd      int // one past the last byte of the INDEX
+	count       int
+	offSize     int // 1..4 for non-empty INDEXes; 0 for empty
+	objectsBase int // absolute offset where object payloads start
+	offsets     []int
+	raw         []byte // aliases cffFont.raw — do not mutate
+}
+
+// Object returns the bytes of object i. The returned slice aliases the
+// parent CFF raw buffer; callers must not mutate it. Out-of-range i,
+// or any call on an empty INDEX, yields nil so callers can use the
+// result with a length check.
+func (idx *cffIndex) Object(i int) []byte {
+	if idx == nil || i < 0 || i >= idx.count {
+		return nil
+	}
+	start := idx.objectsBase + idx.offsets[i] - 1
+	end := idx.objectsBase + idx.offsets[i+1] - 1
+	return idx.raw[start:end]
+}
+
+// parseCFFIndex reads an INDEX starting at pos within raw. Returns the
+// parsed structure (with rawEnd pointing one past the last byte
+// consumed) or an error wrapping one of the package sentinels.
+//
+// The empty-INDEX shortcut (count == 0, 2 bytes total) is recognized:
+// such INDEXes have no offSize byte and no offsets table. This matches
+// real-world CFFs where, for example, the Encodings section can be
+// represented as an empty INDEX in CID-keyed fonts.
+func parseCFFIndex(raw []byte, pos int) (*cffIndex, error) {
+	if pos < 0 || pos+2 > len(raw) {
+		return nil, fmt.Errorf("cff: INDEX header truncated at offset %d: %w", pos, ErrTruncated)
+	}
+	count := int(binary.BigEndian.Uint16(raw[pos : pos+2]))
+	if count == 0 {
+		return &cffIndex{
+			rawStart: pos,
+			rawEnd:   pos + 2,
+			raw:      raw,
+		}, nil
+	}
+	if pos+3 > len(raw) {
+		return nil, fmt.Errorf("cff: INDEX offSize truncated at offset %d: %w", pos, ErrTruncated)
+	}
+	offSize := int(raw[pos+2])
+	if offSize < 1 || offSize > 4 {
+		return nil, fmt.Errorf("cff: INDEX offSize %d out of range: %w", offSize, ErrCorruptTable)
+	}
+	offBase := pos + 3
+	offBytes := (count + 1) * offSize
+	if offBase+offBytes > len(raw) {
+		return nil, fmt.Errorf("cff: INDEX offset table truncated: %w", ErrTruncated)
+	}
+	offsets := make([]int, count+1)
+	for i := range count + 1 {
+		offsets[i] = readOffset(raw[offBase+i*offSize:], offSize)
+	}
+	if offsets[0] != 1 {
+		return nil, fmt.Errorf("cff: INDEX first offset %d != 1: %w", offsets[0], ErrCorruptTable)
+	}
+	for i := range count {
+		if offsets[i+1] < offsets[i] {
+			return nil, fmt.Errorf("cff: INDEX offsets non-monotonic at %d: %w", i, ErrCorruptTable)
+		}
+	}
+	objectsBase := offBase + offBytes
+	payloadSize := offsets[count] - 1
+	end := objectsBase + payloadSize
+	if end > len(raw) || end < objectsBase {
+		return nil, fmt.Errorf("cff: INDEX payload truncated: %w", ErrTruncated)
+	}
+	return &cffIndex{
+		rawStart:    pos,
+		rawEnd:      end,
+		count:       count,
+		offSize:     offSize,
+		objectsBase: objectsBase,
+		offsets:     offsets,
+		raw:         raw,
+	}, nil
+}
+
+// CFF v1 DICT one-byte operator codes (TN #5176 Table 9).
+const (
+	cffOpVersion            = 0
+	cffOpNotice             = 1
+	cffOpFullName           = 2
+	cffOpFamilyName         = 3
+	cffOpWeight             = 4
+	cffOpFontBBox           = 5
+	cffOpBlueValues         = 6 // Private only
+	cffOpOtherBlues         = 7 // Private only
+	cffOpFamilyBlues        = 8 // Private only
+	cffOpFamilyOtherBlues   = 9 // Private only
+	cffOpStdHW              = 10
+	cffOpStdVW              = 11
+	cffOpEscape             = 12 // 2-byte operator prefix
+	cffOpUniqueID           = 13
+	cffOpXUID               = 14
+	cffOpCharset            = 15
+	cffOpEncoding           = 16
+	cffOpCharStrings        = 17
+	cffOpPrivate            = 18
+	cffOpSubrs              = 19 // Private only
+	cffOpDefaultWidthX      = 20 // Private only
+	cffOpNominalWidthX      = 21 // Private only
+)
+
+// CFF v1 DICT two-byte operator codes (TN #5176 Table 10). Encoded as
+// (12 << 8) | secondByte so a single int identifies them uniquely.
+const (
+	cffOp2Copyright          = 12<<8 | 0
+	cffOp2IsFixedPitch       = 12<<8 | 1
+	cffOp2ItalicAngle        = 12<<8 | 2
+	cffOp2UnderlinePosition  = 12<<8 | 3
+	cffOp2UnderlineThickness = 12<<8 | 4
+	cffOp2PaintType          = 12<<8 | 5
+	cffOp2CharstringType     = 12<<8 | 6
+	cffOp2FontMatrix         = 12<<8 | 7
+	cffOp2StrokeWidth        = 12<<8 | 8
+	cffOp2ROS                = 12<<8 | 30
+	cffOp2CIDFontVersion     = 12<<8 | 31
+	cffOp2CIDFontRevision    = 12<<8 | 32
+	cffOp2CIDFontType        = 12<<8 | 33
+	cffOp2CIDCount           = 12<<8 | 34
+	cffOp2UIDBase            = 12<<8 | 35
+	cffOp2FDArray            = 12<<8 | 36
+	cffOp2FDSelect           = 12<<8 | 37
+	cffOp2FontName           = 12<<8 | 38
+)
+
+// cffDictEntry records one (operands, operator) pair parsed from a
+// DICT. operator is the one-byte or escaped two-byte code; operandStart
+// and operandEnd bracket the operand bytes within the DICT's own byte
+// stream (for Phase 3 byte-level rewriting). intOperands holds decoded
+// integer values in order; BCD real operands occupy a slot whose
+// realBytes field carries the original encoding for verbatim
+// reproduction.
+type cffDictEntry struct {
+	operator     int
+	operandStart int
+	operandEnd   int
+	intOperands  []int64
+	// realIndices records the positions in intOperands that originated
+	// from BCD real operands rather than integers. Phase 3 must
+	// reproduce these from the original bytes; intOperands slot is
+	// zero in that position.
+	realIndices []int
+}
+
+// cffDict is the ordered list of entries parsed from a DICT.
+type cffDict []cffDictEntry
+
+// get returns the first entry matching op (1-byte or escaped 2-byte
+// code) and ok=true, or zero-value and false if absent. CFF DICTs are
+// usually small (a few dozen entries at most) so linear search is fine.
+func (d cffDict) get(op int) (cffDictEntry, bool) {
+	for _, e := range d {
+		if e.operator == op {
+			return e, true
+		}
+	}
+	return cffDictEntry{}, false
+}
+
+// parseCFFDict decodes a DICT byte stream (TN #5176 §4) into a sequence
+// of entries. Operand encodings handled:
+//
+//   - single-byte int  (b in 32..246)
+//   - two-byte int     (b in 247..254)
+//   - shortint         (b == 28)
+//   - longint          (b == 29)
+//   - BCD real         (b == 30)
+//
+// Operators are one-byte values 0..21 (excluding 22..27 reserved) or
+// two-byte escape sequences (12 followed by 0..N). The reserved bytes
+// 22..27, 31, 255 abort parsing with ErrCorruptTable.
+func parseCFFDict(b []byte) (cffDict, error) {
+	var out cffDict
+	var operands []int64
+	var realIdx []int
+	operandStart := 0
+	pos := 0
+	for pos < len(b) {
+		bv := b[pos]
+		switch {
+		case bv <= 21:
+			// Operator. 12 is the 2-byte escape; everything else is
+			// a single-byte operator.
+			var op, opSize int
+			if bv == cffOpEscape {
+				if pos+1 >= len(b) {
+					return nil, fmt.Errorf("cff: DICT 2-byte operator truncated: %w", ErrTruncated)
+				}
+				op = cffOpEscape<<8 | int(b[pos+1])
+				opSize = 2
+			} else {
+				op = int(bv)
+				opSize = 1
+			}
+			out = append(out, cffDictEntry{
+				operator:     op,
+				operandStart: operandStart,
+				operandEnd:   pos,
+				intOperands:  operands,
+				realIndices:  realIdx,
+			})
+			pos += opSize
+			operands = nil
+			realIdx = nil
+			operandStart = pos
+		case bv == 28:
+			if pos+3 > len(b) {
+				return nil, fmt.Errorf("cff: DICT shortint truncated: %w", ErrTruncated)
+			}
+			v := int64(int16(binary.BigEndian.Uint16(b[pos+1 : pos+3])))
+			operands = append(operands, v)
+			pos += 3
+		case bv == 29:
+			if pos+5 > len(b) {
+				return nil, fmt.Errorf("cff: DICT longint truncated: %w", ErrTruncated)
+			}
+			v := int64(int32(binary.BigEndian.Uint32(b[pos+1 : pos+5])))
+			operands = append(operands, v)
+			pos += 5
+		case bv == 30:
+			// BCD real. Walk bytes until a nibble equals 0xF (end).
+			pos++
+			ended := false
+			for pos < len(b) {
+				v := b[pos]
+				pos++
+				if v&0x0F == 0x0F || v>>4 == 0x0F {
+					ended = true
+					break
+				}
+			}
+			if !ended {
+				return nil, fmt.Errorf("cff: DICT BCD real unterminated: %w", ErrTruncated)
+			}
+			// Reserve a slot in the int operands. Phase 3 will rebuild
+			// from the original bytes; the recorded operandStart/End
+			// pair covers the whole entry's operands.
+			realIdx = append(realIdx, len(operands))
+			operands = append(operands, 0)
+		case bv >= 32 && bv <= 246:
+			operands = append(operands, int64(bv)-139)
+			pos++
+		case bv >= 247 && bv <= 250:
+			if pos+1 >= len(b) {
+				return nil, fmt.Errorf("cff: DICT 2-byte int truncated: %w", ErrTruncated)
+			}
+			v := int64(bv-247)*256 + int64(b[pos+1]) + 108
+			operands = append(operands, v)
+			pos += 2
+		case bv >= 251 && bv <= 254:
+			if pos+1 >= len(b) {
+				return nil, fmt.Errorf("cff: DICT 2-byte int truncated: %w", ErrTruncated)
+			}
+			v := -int64(bv-251)*256 - int64(b[pos+1]) - 108
+			operands = append(operands, v)
+			pos += 2
+		default:
+			// 22..27, 31, 255 are reserved/invalid in DICT streams.
+			return nil, fmt.Errorf("cff: DICT reserved byte 0x%02X at offset %d: %w", bv, pos, ErrCorruptTable)
+		}
+	}
+	// Operands not followed by an operator are spec-illegal but we
+	// silently drop them rather than fail — a DICT may legitimately
+	// terminate after its last operator with no trailing data.
+	return out, nil
+}
+
+// dictInt fetches the first integer operand of operator op, or
+// (0, false) if op is absent or has no integer operands.
+func dictInt(d cffDict, op int) (int64, bool) {
+	e, ok := d.get(op)
+	if !ok || len(e.intOperands) == 0 {
+		return 0, false
+	}
+	return e.intOperands[0], true
+}
+
+// parseCFF parses CID-keyed CFF v1 bytes into a structured form. Plain
+// (name-keyed) CFF, CFF font collections, and CFF2 are rejected with
+// ErrCorruptTable or ErrUnknownFormat so Phase 3's subsetter and
+// embedder can rely on the CID-keyed invariants (ROS triplet, FDArray,
+// FDSelect, CIDCount).
+//
+// The function performs only the structural decoding needed by Phase 3+:
+// charstring opcodes are not interpreted, charset/FDSelect formats are
+// validated for size but not for content. Any structural inconsistency
+// returns an error wrapping one of the package sentinels.
+func parseCFF(raw []byte) (*cffFont, error) {
+	if len(raw) < 4 {
+		return nil, fmt.Errorf("cff: header truncated: %w", ErrTruncated)
+	}
+	if raw[0] != 1 {
+		return nil, fmt.Errorf("cff: unsupported major %d: %w", raw[0], ErrUnknownFormat)
+	}
+	hdrSize := int(raw[2])
+	if hdrSize < 4 || hdrSize > len(raw) {
+		return nil, fmt.Errorf("cff: bad hdrSize %d: %w", hdrSize, ErrCorruptTable)
+	}
+
+	pos := hdrSize
+	nameIdx, err := parseCFFIndex(raw, pos)
+	if err != nil {
+		return nil, fmt.Errorf("cff: name index: %w", err)
+	}
+	pos = nameIdx.rawEnd
+
+	topDictIdx, err := parseCFFIndex(raw, pos)
+	if err != nil {
+		return nil, fmt.Errorf("cff: top dict index: %w", err)
+	}
+	if topDictIdx.count != 1 {
+		return nil, fmt.Errorf("cff: top dict count %d != 1 (font collection unsupported): %w", topDictIdx.count, ErrCorruptTable)
+	}
+	pos = topDictIdx.rawEnd
+
+	topDict, err := parseCFFDict(topDictIdx.Object(0))
+	if err != nil {
+		return nil, fmt.Errorf("cff: top dict: %w", err)
+	}
+
+	// Require ROS so callers can rely on CID-keyed semantics. Charset
+	// and CharStrings and FDArray/FDSelect are also mandatory for CID-
+	// keyed CFFs (TN #5176 §18); enforce them explicitly.
+	rosEntry, ok := topDict.get(cffOp2ROS)
+	if !ok || len(rosEntry.intOperands) < 3 {
+		return nil, fmt.Errorf("cff: missing or malformed ROS operator: %w", ErrCorruptTable)
+	}
+
+	stringIdx, err := parseCFFIndex(raw, pos)
+	if err != nil {
+		return nil, fmt.Errorf("cff: string index: %w", err)
+	}
+	pos = stringIdx.rawEnd
+
+	gsubrIdx, err := parseCFFIndex(raw, pos)
+	if err != nil {
+		return nil, fmt.Errorf("cff: gsubr index: %w", err)
+	}
+
+	charStringsOff, ok := dictInt(topDict, cffOpCharStrings)
+	if !ok {
+		return nil, fmt.Errorf("cff: missing CharStrings operator: %w", ErrCorruptTable)
+	}
+	fdArrayOff, ok := dictInt(topDict, cffOp2FDArray)
+	if !ok {
+		return nil, fmt.Errorf("cff: missing FDArray operator: %w", ErrCorruptTable)
+	}
+	fdSelectOff, ok := dictInt(topDict, cffOp2FDSelect)
+	if !ok {
+		return nil, fmt.Errorf("cff: missing FDSelect operator: %w", ErrCorruptTable)
+	}
+	charsetOff, _ := dictInt(topDict, cffOpCharset) // 0 = ISOAdobe default
+	cidCountVal, _ := dictInt(topDict, cffOp2CIDCount)
+	cidCount := int(cidCountVal)
+	if cidCount == 0 {
+		// Default per TN #5176 §18 Table 11.
+		cidCount = 8720
+	}
+
+	charStringsIdx, err := parseCFFIndex(raw, int(charStringsOff))
+	if err != nil {
+		return nil, fmt.Errorf("cff: charstrings index: %w", err)
+	}
+	numGlyphs := charStringsIdx.count
+
+	fdArrayIdx, err := parseCFFIndex(raw, int(fdArrayOff))
+	if err != nil {
+		return nil, fmt.Errorf("cff: fdarray index: %w", err)
+	}
+	if fdArrayIdx.count == 0 {
+		return nil, fmt.Errorf("cff: empty FDArray INDEX: %w", ErrCorruptTable)
+	}
+
+	charsetSize, err := computeCharsetSize(raw, int(charsetOff), numGlyphs)
+	if err != nil {
+		return nil, fmt.Errorf("cff: charset: %w", err)
+	}
+	fdSelectSize, err := computeFDSelectSize(raw, int(fdSelectOff), numGlyphs)
+	if err != nil {
+		return nil, fmt.Errorf("cff: fdselect: %w", err)
+	}
+
+	fds := make([]*cffFD, fdArrayIdx.count)
+	for i := range fdArrayIdx.count {
+		fd, err := parseCFFFD(raw, fdArrayIdx, i)
+		if err != nil {
+			return nil, fmt.Errorf("cff: fd[%d]: %w", i, err)
+		}
+		fds[i] = fd
+	}
+
+	return &cffFont{
+		raw:              raw,
+		header:           raw[:hdrSize],
+		nameIndex:        nameIdx,
+		topDictIndex:     topDictIdx,
+		stringIndex:      stringIdx,
+		gsubrIndex:       gsubrIdx,
+		topDict:          topDict,
+		charsetOffset:    int(charsetOff),
+		charsetSize:      charsetSize,
+		fdSelectOffset:   int(fdSelectOff),
+		fdSelectSize:     fdSelectSize,
+		charStringsIndex: charStringsIdx,
+		fdArrayIndex:     fdArrayIdx,
+		rosRegistry:      rosEntry.intOperands[0],
+		rosOrdering:      rosEntry.intOperands[1],
+		rosSupplement:    rosEntry.intOperands[2],
+		cidCount:         cidCount,
+		numGlyphs:        numGlyphs,
+		fds:              fds,
+	}, nil
+}
+
+// parseCFFFD reads one entry from the FDArray INDEX as a font DICT,
+// then follows its Private operator to the Private DICT (absolute
+// offset) and the Private DICT's Subrs operator to the Local Subr
+// INDEX (relative offset). Returns a cffFD ready for subsetting.
+func parseCFFFD(raw []byte, fdArrayIdx *cffIndex, i int) (*cffFD, error) {
+	fontDictBytes := fdArrayIdx.Object(i)
+	if fontDictBytes == nil {
+		return nil, fmt.Errorf("cff: fd %d missing: %w", i, ErrCorruptTable)
+	}
+	fontDict, err := parseCFFDict(fontDictBytes)
+	if err != nil {
+		return nil, fmt.Errorf("cff: fd %d font dict: %w", i, err)
+	}
+	privEntry, ok := fontDict.get(cffOpPrivate)
+	if !ok || len(privEntry.intOperands) != 2 {
+		return nil, fmt.Errorf("cff: fd %d Private operator missing or malformed: %w", i, ErrCorruptTable)
+	}
+	privSize := int(privEntry.intOperands[0])
+	privOff := int(privEntry.intOperands[1])
+	if privSize < 0 || privOff < 0 || privOff+privSize > len(raw) {
+		return nil, fmt.Errorf("cff: fd %d Private range [%d:%d] out of raw bounds: %w", i, privOff, privOff+privSize, ErrCorruptTable)
+	}
+	privBytes := raw[privOff : privOff+privSize]
+	privDict, err := parseCFFDict(privBytes)
+	if err != nil {
+		return nil, fmt.Errorf("cff: fd %d private dict: %w", i, err)
+	}
+	var localSubrs *cffIndex
+	if subrsEntry, ok := privDict.get(cffOpSubrs); ok {
+		if len(subrsEntry.intOperands) != 1 {
+			return nil, fmt.Errorf("cff: fd %d Subrs operand count %d: %w", i, len(subrsEntry.intOperands), ErrCorruptTable)
+		}
+		subrsRel := int(subrsEntry.intOperands[0])
+		localSubrs, err = parseCFFIndex(raw, privOff+subrsRel)
+		if err != nil {
+			return nil, fmt.Errorf("cff: fd %d local subr index: %w", i, err)
+		}
+	}
+	return &cffFD{
+		fontDictBytes: fontDictBytes,
+		fontDict:      fontDict,
+		privateOffset: privOff,
+		privateSize:   privSize,
+		privateBytes:  privBytes,
+		privateDict:   privDict,
+		localSubrs:    localSubrs,
+	}, nil
+}
+
+// computeCharsetSize returns the byte length of a CID-keyed charset
+// starting at off. TN #5176 §13 defines three formats:
+//
+//   - 0:  fmt(1) + (numGlyphs-1) * SID(2)
+//   - 1:  fmt(1) + ranges each of (first SID(2), nLeft uint8(1))
+//   - 2:  fmt(1) + ranges each of (first SID(2), nLeft uint16(2))
+//
+// Formats 1 and 2 enumerate ranges until cumulative glyphs covered
+// reaches numGlyphs-1 (charset omits GID 0 — .notdef is implicit).
+func computeCharsetSize(raw []byte, off, numGlyphs int) (int, error) {
+	if off < 0 || off >= len(raw) {
+		return 0, fmt.Errorf("cff: charset offset out of range: %w", ErrCorruptTable)
+	}
+	if numGlyphs < 1 {
+		return 0, fmt.Errorf("cff: numGlyphs %d invalid: %w", numGlyphs, ErrCorruptTable)
+	}
+	format := raw[off]
+	remaining := numGlyphs - 1 // glyphs to cover, excluding GID 0
+	switch format {
+	case 0:
+		size := 1 + remaining*2
+		if off+size > len(raw) {
+			return 0, fmt.Errorf("cff: charset format 0 truncated: %w", ErrTruncated)
+		}
+		return size, nil
+	case 1:
+		pos := off + 1
+		for remaining > 0 {
+			if pos+3 > len(raw) {
+				return 0, fmt.Errorf("cff: charset format 1 truncated: %w", ErrTruncated)
+			}
+			nLeft := int(raw[pos+2])
+			remaining -= nLeft + 1
+			pos += 3
+		}
+		if remaining < 0 {
+			return 0, fmt.Errorf("cff: charset format 1 over-covers glyphs by %d: %w", -remaining, ErrCorruptTable)
+		}
+		return pos - off, nil
+	case 2:
+		pos := off + 1
+		for remaining > 0 {
+			if pos+4 > len(raw) {
+				return 0, fmt.Errorf("cff: charset format 2 truncated: %w", ErrTruncated)
+			}
+			nLeft := int(binary.BigEndian.Uint16(raw[pos+2 : pos+4]))
+			remaining -= nLeft + 1
+			pos += 4
+		}
+		if remaining < 0 {
+			return 0, fmt.Errorf("cff: charset format 2 over-covers glyphs by %d: %w", -remaining, ErrCorruptTable)
+		}
+		return pos - off, nil
+	default:
+		return 0, fmt.Errorf("cff: charset format %d unknown: %w", format, ErrCorruptTable)
+	}
+}
+
+// computeFDSelectSize returns the byte length of an FDSelect table
+// at off. TN #5176 §19 defines two formats:
+//
+//   - 0: fmt(1) + numGlyphs * fd(uint8)
+//   - 3: fmt(1) + nRanges(uint16) + nRanges*(first uint16 + fd uint8)
+//        + sentinel uint16
+func computeFDSelectSize(raw []byte, off, numGlyphs int) (int, error) {
+	if off < 0 || off >= len(raw) {
+		return 0, fmt.Errorf("cff: fdselect offset out of range: %w", ErrCorruptTable)
+	}
+	format := raw[off]
+	switch format {
+	case 0:
+		size := 1 + numGlyphs
+		if off+size > len(raw) {
+			return 0, fmt.Errorf("cff: fdselect format 0 truncated: %w", ErrTruncated)
+		}
+		return size, nil
+	case 3:
+		if off+3 > len(raw) {
+			return 0, fmt.Errorf("cff: fdselect format 3 header truncated: %w", ErrTruncated)
+		}
+		nRanges := int(binary.BigEndian.Uint16(raw[off+1 : off+3]))
+		size := 1 + 2 + nRanges*3 + 2
+		if off+size > len(raw) {
+			return 0, fmt.Errorf("cff: fdselect format 3 body truncated: %w", ErrTruncated)
+		}
+		return size, nil
+	default:
+		return 0, fmt.Errorf("cff: fdselect format %d unknown: %w", format, ErrCorruptTable)
+	}
+}

--- a/font/cff_parse.go
+++ b/font/cff_parse.go
@@ -159,28 +159,28 @@ func parseCFFIndex(raw []byte, pos int) (*cffIndex, error) {
 
 // CFF v1 DICT one-byte operator codes (TN #5176 Table 9).
 const (
-	cffOpVersion            = 0
-	cffOpNotice             = 1
-	cffOpFullName           = 2
-	cffOpFamilyName         = 3
-	cffOpWeight             = 4
-	cffOpFontBBox           = 5
-	cffOpBlueValues         = 6 // Private only
-	cffOpOtherBlues         = 7 // Private only
-	cffOpFamilyBlues        = 8 // Private only
-	cffOpFamilyOtherBlues   = 9 // Private only
-	cffOpStdHW              = 10
-	cffOpStdVW              = 11
-	cffOpEscape             = 12 // 2-byte operator prefix
-	cffOpUniqueID           = 13
-	cffOpXUID               = 14
-	cffOpCharset            = 15
-	cffOpEncoding           = 16
-	cffOpCharStrings        = 17
-	cffOpPrivate            = 18
-	cffOpSubrs              = 19 // Private only
-	cffOpDefaultWidthX      = 20 // Private only
-	cffOpNominalWidthX      = 21 // Private only
+	cffOpVersion          = 0
+	cffOpNotice           = 1
+	cffOpFullName         = 2
+	cffOpFamilyName       = 3
+	cffOpWeight           = 4
+	cffOpFontBBox         = 5
+	cffOpBlueValues       = 6 // Private only
+	cffOpOtherBlues       = 7 // Private only
+	cffOpFamilyBlues      = 8 // Private only
+	cffOpFamilyOtherBlues = 9 // Private only
+	cffOpStdHW            = 10
+	cffOpStdVW            = 11
+	cffOpEscape           = 12 // 2-byte operator prefix
+	cffOpUniqueID         = 13
+	cffOpXUID             = 14
+	cffOpCharset          = 15
+	cffOpEncoding         = 16
+	cffOpCharStrings      = 17
+	cffOpPrivate          = 18
+	cffOpSubrs            = 19 // Private only
+	cffOpDefaultWidthX    = 20 // Private only
+	cffOpNominalWidthX    = 21 // Private only
 )
 
 // CFF v1 DICT two-byte operator codes (TN #5176 Table 10). Encoded as
@@ -638,8 +638,7 @@ func computeCharsetSize(raw []byte, off, numGlyphs int) (int, error) {
 // at off. TN #5176 §19 defines two formats:
 //
 //   - 0: fmt(1) + numGlyphs * fd(uint8)
-//   - 3: fmt(1) + nRanges(uint16) + nRanges*(first uint16 + fd uint8)
-//        + sentinel uint16
+//   - 3: fmt(1) + nRanges(uint16) + nRanges*(first uint16 + fd uint8) + sentinel uint16
 func computeFDSelectSize(raw []byte, off, numGlyphs int) (int, error) {
 	if off < 0 || off >= len(raw) {
 		return 0, fmt.Errorf("cff: fdselect offset out of range: %w", ErrCorruptTable)

--- a/font/cff_parse.go
+++ b/font/cff_parse.go
@@ -449,7 +449,19 @@ func parseCFF(raw []byte) (*cffFont, error) {
 	if !ok {
 		return nil, fmt.Errorf("cff: missing FDSelect operator: %w", ErrCorruptTable)
 	}
-	charsetOff, _ := dictInt(topDict, cffOpCharset) // 0 = ISOAdobe default
+	// CID-keyed CFFs must declare a custom charset explicitly
+	// (TN #5176 §18). The implicit-default values 0 (ISOAdobe), 1
+	// (Expert), and 2 (ExpertSubset) are reserved for non-CID fonts;
+	// here they would also be treated as absolute byte offsets and
+	// computeCharsetSize would interpret CFF header bytes as a
+	// charset format byte, yielding nonsense. Reject early.
+	charsetOff, ok := dictInt(topDict, cffOpCharset)
+	if !ok {
+		return nil, fmt.Errorf("cff: CID-keyed font missing charset operator: %w", ErrCorruptTable)
+	}
+	if charsetOff < 3 {
+		return nil, fmt.Errorf("cff: CID-keyed font using predefined charset %d (reserved for non-CID CFF): %w", charsetOff, ErrCorruptTable)
+	}
 	cidCountVal, _ := dictInt(topDict, cffOp2CIDCount)
 	cidCount := int(cidCountVal)
 	if cidCount == 0 {

--- a/font/cff_parse.go
+++ b/font/cff_parse.go
@@ -207,22 +207,30 @@ const (
 )
 
 // cffDictEntry records one (operands, operator) pair parsed from a
-// DICT. operator is the one-byte or escaped two-byte code; operandStart
-// and operandEnd bracket the operand bytes within the DICT's own byte
-// stream (for Phase 3 byte-level rewriting). intOperands holds decoded
-// integer values in order; BCD real operands occupy a slot whose
-// realBytes field carries the original encoding for verbatim
-// reproduction.
+// DICT. operator is the one-byte or escaped two-byte code.
+//
+// Phase 3+ rewrites individual operands of an entry (for example the
+// offset half of `Private size offset`), so byte ranges are tracked at
+// two granularities:
+//
+//   - operandStart and operandEnd bracket the run of all operand
+//     bytes — operandEnd is the position of the operator byte.
+//   - operandSpans[i] is the half-open byte range [start, end) of
+//     operand i within the DICT byte stream, in the same order as
+//     intOperands.
+//
+// intOperands holds decoded integer values in order. Slots that came
+// from a BCD real operand hold zero; their original bytes can be
+// recovered via operandSpans[i] when Phase 3 needs to reproduce the
+// real verbatim. realIndices lists those slot indices so callers do
+// not have to maintain a separate flag.
 type cffDictEntry struct {
 	operator     int
 	operandStart int
 	operandEnd   int
 	intOperands  []int64
-	// realIndices records the positions in intOperands that originated
-	// from BCD real operands rather than integers. Phase 3 must
-	// reproduce these from the original bytes; intOperands slot is
-	// zero in that position.
-	realIndices []int
+	operandSpans [][2]int
+	realIndices  []int
 }
 
 // cffDict is the ordered list of entries parsed from a DICT.
@@ -255,11 +263,13 @@ func (d cffDict) get(op int) (cffDictEntry, bool) {
 func parseCFFDict(b []byte) (cffDict, error) {
 	var out cffDict
 	var operands []int64
+	var spans [][2]int
 	var realIdx []int
 	operandStart := 0
 	pos := 0
 	for pos < len(b) {
 		bv := b[pos]
+		opStart := pos
 		switch {
 		case bv <= 21:
 			// Operator. 12 is the 2-byte escape; everything else is
@@ -280,10 +290,12 @@ func parseCFFDict(b []byte) (cffDict, error) {
 				operandStart: operandStart,
 				operandEnd:   pos,
 				intOperands:  operands,
+				operandSpans: spans,
 				realIndices:  realIdx,
 			})
 			pos += opSize
 			operands = nil
+			spans = nil
 			realIdx = nil
 			operandStart = pos
 		case bv == 28:
@@ -293,6 +305,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			v := int64(int16(binary.BigEndian.Uint16(b[pos+1 : pos+3])))
 			operands = append(operands, v)
 			pos += 3
+			spans = append(spans, [2]int{opStart, pos})
 		case bv == 29:
 			if pos+5 > len(b) {
 				return nil, fmt.Errorf("cff: DICT longint truncated: %w", ErrTruncated)
@@ -300,6 +313,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			v := int64(int32(binary.BigEndian.Uint32(b[pos+1 : pos+5])))
 			operands = append(operands, v)
 			pos += 5
+			spans = append(spans, [2]int{opStart, pos})
 		case bv == 30:
 			// BCD real. Walk bytes until a nibble equals 0xF (end).
 			pos++
@@ -315,14 +329,15 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			if !ended {
 				return nil, fmt.Errorf("cff: DICT BCD real unterminated: %w", ErrTruncated)
 			}
-			// Reserve a slot in the int operands. Phase 3 will rebuild
-			// from the original bytes; the recorded operandStart/End
-			// pair covers the whole entry's operands.
+			// Reserve a zero-valued slot in intOperands; the original
+			// bytes live in operandSpans for Phase 3 to copy verbatim.
 			realIdx = append(realIdx, len(operands))
 			operands = append(operands, 0)
+			spans = append(spans, [2]int{opStart, pos})
 		case bv >= 32 && bv <= 246:
 			operands = append(operands, int64(bv)-139)
 			pos++
+			spans = append(spans, [2]int{opStart, pos})
 		case bv >= 247 && bv <= 250:
 			if pos+1 >= len(b) {
 				return nil, fmt.Errorf("cff: DICT 2-byte int truncated: %w", ErrTruncated)
@@ -330,6 +345,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			v := int64(bv-247)*256 + int64(b[pos+1]) + 108
 			operands = append(operands, v)
 			pos += 2
+			spans = append(spans, [2]int{opStart, pos})
 		case bv >= 251 && bv <= 254:
 			if pos+1 >= len(b) {
 				return nil, fmt.Errorf("cff: DICT 2-byte int truncated: %w", ErrTruncated)
@@ -337,6 +353,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			v := -int64(bv-251)*256 - int64(b[pos+1]) - 108
 			operands = append(operands, v)
 			pos += 2
+			spans = append(spans, [2]int{opStart, pos})
 		default:
 			// 22..27, 31, 255 are reserved/invalid in DICT streams.
 			return nil, fmt.Errorf("cff: DICT reserved byte 0x%02X at offset %d: %w", bv, pos, ErrCorruptTable)
@@ -445,6 +462,9 @@ func parseCFF(raw []byte) (*cffFont, error) {
 		return nil, fmt.Errorf("cff: charstrings index: %w", err)
 	}
 	numGlyphs := charStringsIdx.count
+	if numGlyphs == 0 {
+		return nil, fmt.Errorf("cff: charstrings index empty: %w", ErrCorruptTable)
+	}
 
 	fdArrayIdx, err := parseCFFIndex(raw, int(fdArrayOff))
 	if err != nil {
@@ -628,6 +648,16 @@ func computeFDSelectSize(raw []byte, off, numGlyphs int) (int, error) {
 		size := 1 + 2 + nRanges*3 + 2
 		if off+size > len(raw) {
 			return 0, fmt.Errorf("cff: fdselect format 3 body truncated: %w", ErrTruncated)
+		}
+		// Per TN #5176 §19, the trailing sentinel uint16 must equal
+		// numGlyphs — it terminates the implied range that begins at
+		// the last `first` field. A mismatch means either the table
+		// was authored against a different glyph count or the bytes
+		// are corrupt; either way Phase 3 cannot rely on the FD
+		// assignment, so reject up-front.
+		sentinel := int(binary.BigEndian.Uint16(raw[off+size-2 : off+size]))
+		if sentinel != numGlyphs {
+			return 0, fmt.Errorf("cff: fdselect format 3 sentinel %d != numGlyphs %d: %w", sentinel, numGlyphs, ErrCorruptTable)
 		}
 		return size, nil
 	default:

--- a/font/cff_parse.go
+++ b/font/cff_parse.go
@@ -186,7 +186,7 @@ const (
 // CFF v1 DICT two-byte operator codes (TN #5176 Table 10). Encoded as
 // (12 << 8) | secondByte so a single int identifies them uniquely.
 const (
-	cffOp2Copyright          = 12<<8 | 0
+	cffOp2Copyright          = 12 << 8
 	cffOp2IsFixedPitch       = 12<<8 | 1
 	cffOp2ItalicAngle        = 12<<8 | 2
 	cffOp2UnderlinePosition  = 12<<8 | 3

--- a/font/cff_parse_test.go
+++ b/font/cff_parse_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"os"
+	"slices"
 	"testing"
 )
 
@@ -197,10 +198,25 @@ func TestParseCFFDictTwoByteOperator(t *testing.T) {
 		t.Fatalf("expected single ROS entry; got %+v", d)
 	}
 	if len(d[0].intOperands) != 3 {
-		t.Errorf("operand count = %d, want 3", len(d[0].intOperands))
+		t.Fatalf("operand count = %d, want 3", len(d[0].intOperands))
+	}
+	for i, v := range d[0].intOperands {
+		if v != 0 {
+			t.Errorf("operand[%d] = %d, want 0", i, v)
+		}
 	}
 	if d[0].operandEnd != 3 {
 		t.Errorf("operandEnd = %d, want 3", d[0].operandEnd)
+	}
+	// Per-operand spans: each operand is one byte (139 → 0).
+	wantSpans := [][2]int{{0, 1}, {1, 2}, {2, 3}}
+	if len(d[0].operandSpans) != len(wantSpans) {
+		t.Fatalf("spans len = %d, want %d", len(d[0].operandSpans), len(wantSpans))
+	}
+	for i, want := range wantSpans {
+		if d[0].operandSpans[i] != want {
+			t.Errorf("operandSpans[%d] = %v, want %v", i, d[0].operandSpans[i], want)
+		}
 	}
 }
 
@@ -230,15 +246,141 @@ func TestParseCFFDictMultipleEntries(t *testing.T) {
 	}
 }
 
-func TestParseCFFDictTwoByteIntEncoding(t *testing.T) {
-	// Operand 1500 (= 247-250 range produces 108..1131; need 28
-	// shortint for 1500). 28 0x05 0xDC = 1500.
-	d, err := parseCFFDict([]byte{28, 0x05, 0xDC, 0})
+func TestParseCFFDictShortIntEncoding(t *testing.T) {
+	// CFF v1 §4 Table 3: byte 28 is the shortint prefix — the next
+	// two bytes encode a signed 16-bit big-endian integer. 1500 is
+	// 0x05DC.
+	cases := []struct {
+		bytes []byte
+		want  int64
+	}{
+		{[]byte{28, 0x05, 0xDC, 0}, 1500},
+		{[]byte{28, 0x7F, 0xFF, 0}, 32767},        // INT16 max
+		{[]byte{28, 0x80, 0x00, 0}, -32768},       // INT16 min
+		{[]byte{28, 0xFF, 0xFF, 0}, -1},           // sign extension
+	}
+	for _, tc := range cases {
+		d, err := parseCFFDict(tc.bytes)
+		if err != nil {
+			t.Errorf("%v: err = %v", tc.bytes, err)
+			continue
+		}
+		if d[0].intOperands[0] != tc.want {
+			t.Errorf("%v: operand = %d, want %d", tc.bytes, d[0].intOperands[0], tc.want)
+		}
+		// shortint occupies exactly 3 bytes.
+		if d[0].operandSpans[0] != [2]int{0, 3} {
+			t.Errorf("%v: span = %v, want [0,3]", tc.bytes, d[0].operandSpans[0])
+		}
+	}
+}
+
+func TestParseCFFDictTwoByteIntPositive(t *testing.T) {
+	// CFF v1 §4 Table 3: bytes 247..250 are the two-byte int prefix
+	// for positive values 108..1131. Encoding: (b0-247)*256 + b1 + 108.
+	cases := []struct {
+		bytes []byte
+		want  int64
+	}{
+		{[]byte{247, 0, 0}, 108},          // 247: minimum
+		{[]byte{247, 255, 0}, 363},        // 247 with max N
+		{[]byte{250, 255, 0}, 1131},       // 250: maximum
+	}
+	for _, tc := range cases {
+		d, err := parseCFFDict(tc.bytes)
+		if err != nil {
+			t.Errorf("%v: err = %v", tc.bytes, err)
+			continue
+		}
+		if d[0].intOperands[0] != tc.want {
+			t.Errorf("%v: operand = %d, want %d", tc.bytes, d[0].intOperands[0], tc.want)
+		}
+		if d[0].operandSpans[0] != [2]int{0, 2} {
+			t.Errorf("%v: span = %v, want [0,2]", tc.bytes, d[0].operandSpans[0])
+		}
+	}
+}
+
+func TestParseCFFDictTwoByteIntNegative(t *testing.T) {
+	// Bytes 251..254: negative two-byte int. Encoding:
+	// -(b0-251)*256 - b1 - 108. Range -1131..-108.
+	cases := []struct {
+		bytes []byte
+		want  int64
+	}{
+		{[]byte{251, 0, 0}, -108},
+		{[]byte{254, 255, 0}, -1131},
+	}
+	for _, tc := range cases {
+		d, err := parseCFFDict(tc.bytes)
+		if err != nil {
+			t.Errorf("%v: err = %v", tc.bytes, err)
+			continue
+		}
+		if d[0].intOperands[0] != tc.want {
+			t.Errorf("%v: operand = %d, want %d", tc.bytes, d[0].intOperands[0], tc.want)
+		}
+	}
+}
+
+func TestParseCFFDictLongIntBoundaries(t *testing.T) {
+	cases := []struct {
+		want int32
+	}{
+		{0},
+		{1},
+		{-1},
+		{1 << 30},
+		{-(1 << 30)},
+		{0x7FFFFFFF}, // INT32 max
+		{-1 << 31},   // INT32 min
+	}
+	for _, tc := range cases {
+		buf := []byte{29, 0, 0, 0, 0, 0}
+		binary.BigEndian.PutUint32(buf[1:5], uint32(tc.want))
+		d, err := parseCFFDict(buf)
+		if err != nil {
+			t.Errorf("longint %d: err = %v", tc.want, err)
+			continue
+		}
+		if d[0].intOperands[0] != int64(tc.want) {
+			t.Errorf("longint %d: got %d", tc.want, d[0].intOperands[0])
+		}
+		if d[0].operandSpans[0] != [2]int{0, 5} {
+			t.Errorf("longint %d: span = %v, want [0,5]", tc.want, d[0].operandSpans[0])
+		}
+	}
+}
+
+func TestParseCFFDictMixedIntRealOperands(t *testing.T) {
+	// Pattern: int, real, int, operator. The intOperands slot for the
+	// real position must be zero, realIndices must point at it, and
+	// operandSpans must bracket each operand precisely.
+	dict := []byte{
+		139,        // int 0
+		30, 0x1F,   // real, end nibble F (digit 1 + end)
+		140,        // int 1
+		0,          // operator: version
+	}
+	d, err := parseCFFDict(dict)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if d[0].intOperands[0] != 1500 {
-		t.Errorf("operand = %d, want 1500", d[0].intOperands[0])
+	if len(d) != 1 {
+		t.Fatalf("entries = %d", len(d))
+	}
+	e := d[0]
+	if len(e.intOperands) != 3 || e.intOperands[0] != 0 || e.intOperands[2] != 1 {
+		t.Errorf("intOperands = %v, want [0, 0, 1]", e.intOperands)
+	}
+	if len(e.realIndices) != 1 || e.realIndices[0] != 1 {
+		t.Errorf("realIndices = %v, want [1]", e.realIndices)
+	}
+	wantSpans := [][2]int{{0, 1}, {1, 3}, {3, 4}}
+	for i, want := range wantSpans {
+		if e.operandSpans[i] != want {
+			t.Errorf("operandSpans[%d] = %v, want %v", i, e.operandSpans[i], want)
+		}
 	}
 }
 
@@ -277,8 +419,24 @@ func TestParseCFFDictBCDReal(t *testing.T) {
 	if len(d) != 1 {
 		t.Fatalf("entries = %d", len(d))
 	}
+	if len(d[0].intOperands) != 1 || d[0].intOperands[0] != 0 {
+		t.Errorf("intOperands = %v, want [0]", d[0].intOperands)
+	}
 	if len(d[0].realIndices) != 1 || d[0].realIndices[0] != 0 {
-		t.Errorf("realIndices = %v", d[0].realIndices)
+		t.Errorf("realIndices = %v, want [0]", d[0].realIndices)
+	}
+	// BCD operand occupies bytes [0, 3): prefix 30 + 0x12 + 0xFF.
+	if len(d[0].operandSpans) != 1 || d[0].operandSpans[0] != [2]int{0, 3} {
+		t.Errorf("operandSpans = %v, want [[0,3]]", d[0].operandSpans)
+	}
+}
+
+func TestParseCFFDictTwoByteOperatorTruncated(t *testing.T) {
+	// A lone byte 12 with no second byte means a 2-byte operator
+	// escape with the operator code missing.
+	_, err := parseCFFDict([]byte{12})
+	if !errors.Is(err, ErrTruncated) {
+		t.Errorf("err = %v, want ErrTruncated", err)
 	}
 }
 
@@ -346,6 +504,58 @@ func TestComputeCharsetSizeUnknownFormat(t *testing.T) {
 	}
 }
 
+func TestComputeCharsetSizeFormat1MultiRange(t *testing.T) {
+	// Three ranges of 2 glyphs each (nLeft=1 means 2 glyphs covered),
+	// covering 6 of the 7 non-notdef glyphs.
+	raw := []byte{
+		0x01,
+		0x00, 0x01, 0x01, // range 1: first=1, nLeft=1
+		0x00, 0x03, 0x01, // range 2: first=3, nLeft=1
+		0x00, 0x05, 0x01, // range 3: first=5, nLeft=1
+	}
+	size, err := computeCharsetSize(raw, 0, 7)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if size != 10 {
+		t.Errorf("size = %d, want 10", size)
+	}
+}
+
+func TestComputeCharsetSizeFormat2MultiRange(t *testing.T) {
+	// Two ranges. Format 2 uses uint16 nLeft so we can cover many
+	// glyphs per range.
+	raw := []byte{
+		0x02,
+		0x00, 0x01, 0x00, 0x02, // range 1: first=1, nLeft=2 (3 glyphs)
+		0x00, 0x05, 0x00, 0x02, // range 2: first=5, nLeft=2 (3 glyphs)
+	}
+	size, err := computeCharsetSize(raw, 0, 7)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if size != 9 {
+		t.Errorf("size = %d, want 9", size)
+	}
+}
+
+func TestComputeCharsetSizeFormat1OverCoverage(t *testing.T) {
+	// One range claiming to cover 6 glyphs but numGlyphs-1 = 3.
+	raw := []byte{0x01, 0x00, 0x01, 0x05}
+	_, err := computeCharsetSize(raw, 0, 4)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Errorf("err = %v, want ErrCorruptTable", err)
+	}
+}
+
+func TestComputeCharsetSizeFormat2OverCoverage(t *testing.T) {
+	raw := []byte{0x02, 0x00, 0x01, 0x00, 0x05}
+	_, err := computeCharsetSize(raw, 0, 4)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Errorf("err = %v, want ErrCorruptTable", err)
+	}
+}
+
 // --- computeFDSelectSize ---
 
 func TestComputeFDSelectSizeFormat0(t *testing.T) {
@@ -365,7 +575,7 @@ func TestComputeFDSelectSizeFormat3(t *testing.T) {
 		0x03, 0x00, 0x02,
 		0x00, 0x00, 0x00, // range 1: first=0, fd=0
 		0x00, 0x05, 0x01, // range 2: first=5, fd=1
-		0x00, 0x0A, // sentinel
+		0x00, 0x0A, // sentinel = numGlyphs
 	}
 	size, err := computeFDSelectSize(raw, 0, 10)
 	if err != nil {
@@ -373,6 +583,19 @@ func TestComputeFDSelectSizeFormat3(t *testing.T) {
 	}
 	if size != 11 {
 		t.Errorf("size = %d, want 11", size)
+	}
+}
+
+func TestComputeFDSelectSizeFormat3SentinelMismatch(t *testing.T) {
+	raw := []byte{
+		0x03, 0x00, 0x02,
+		0x00, 0x00, 0x00,
+		0x00, 0x05, 0x01,
+		0x00, 0x0B, // sentinel = 11, but numGlyphs = 10
+	}
+	_, err := computeFDSelectSize(raw, 0, 10)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Errorf("err = %v, want ErrCorruptTable", err)
 	}
 }
 
@@ -457,6 +680,137 @@ func TestParseCFFRejectsFontCollection(t *testing.T) {
 	dict := []byte{139, 139, 139, 12, 30}
 	cff := buildSyntheticCFFCollection(t, dict, dict)
 	_, err := parseCFF(cff)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Errorf("err = %v, want ErrCorruptTable", err)
+	}
+}
+
+// TestParseCFFSyntheticCIDKeyed validates the parser against a
+// deterministic CID-keyed CFF that doesn't depend on a system font.
+// Verifies every read structural field rather than just "non-nil"
+// — a parser regression that yields, say, half the FDs or the wrong
+// CharStrings count would slip through a weaker check.
+func TestParseCFFSyntheticCIDKeyed(t *testing.T) {
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 7, fdCount: 1})
+	parsed, err := parseCFF(cff)
+	if err != nil {
+		t.Fatalf("parseCFF: %v", err)
+	}
+	if parsed.numGlyphs != 7 {
+		t.Errorf("numGlyphs = %d, want 7", parsed.numGlyphs)
+	}
+	if parsed.charStringsIndex.count != 7 {
+		t.Errorf("charstrings count = %d, want 7", parsed.charStringsIndex.count)
+	}
+	if len(parsed.fds) != 1 {
+		t.Errorf("fd count = %d, want 1", len(parsed.fds))
+	}
+	if parsed.rosRegistry != 391 || parsed.rosOrdering != 392 || parsed.rosSupplement != 0 {
+		t.Errorf("ROS triplet = (%d, %d, %d), want (391, 392, 0)",
+			parsed.rosRegistry, parsed.rosOrdering, parsed.rosSupplement)
+	}
+	if parsed.cidCount != 7 {
+		t.Errorf("CIDCount = %d, want 7", parsed.cidCount)
+	}
+	// Each charstring is a single endchar byte in the synthetic blob.
+	for i := range parsed.numGlyphs {
+		got := parsed.charStringsIndex.Object(i)
+		if len(got) != 1 || got[0] != 0x0E {
+			t.Errorf("charstring %d = %v, want [0x0E]", i, got)
+		}
+	}
+	// Private DICT must locate the Local Subr INDEX immediately after.
+	fd := parsed.fds[0]
+	if fd.localSubrs == nil {
+		t.Fatal("expected non-nil local subrs")
+	}
+	if fd.localSubrs.count != 0 {
+		t.Errorf("local subrs count = %d, want 0", fd.localSubrs.count)
+	}
+}
+
+func TestParseCFFSyntheticMultiFD(t *testing.T) {
+	const fdCount = 5
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 12, fdCount: fdCount})
+	parsed, err := parseCFF(cff)
+	if err != nil {
+		t.Fatalf("parseCFF: %v", err)
+	}
+	if len(parsed.fds) != fdCount {
+		t.Fatalf("fd count = %d, want %d", len(parsed.fds), fdCount)
+	}
+	for i, fd := range parsed.fds {
+		if len(fd.fontDictBytes) == 0 {
+			t.Errorf("fd[%d] empty font dict", i)
+		}
+		if len(fd.privateBytes) != 18 {
+			t.Errorf("fd[%d] private size = %d, want 18", i, len(fd.privateBytes))
+		}
+		if fd.localSubrs == nil || fd.localSubrs.count != 0 {
+			t.Errorf("fd[%d] local subrs missing or non-empty", i)
+		}
+	}
+}
+
+// TestParseCFFRejectionPaths bundles the structural-failure cases:
+// missing required Top DICT operator, missing per-FD Private, broken
+// FD private pointer. Each was previously only exercised through
+// real-font smoke tests that skip on CI.
+func TestParseCFFRejectionPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		opts syntheticCFFOptions
+		want error
+	}{
+		{"missing ROS", syntheticCFFOptions{numGlyphs: 3, fdCount: 1, skipROS: true}, ErrCorruptTable},
+		{"missing CharStrings", syntheticCFFOptions{numGlyphs: 3, fdCount: 1, skipCharStrings: true}, ErrCorruptTable},
+		{"missing FDArray", syntheticCFFOptions{numGlyphs: 3, fdCount: 1, skipFDArray: true}, ErrCorruptTable},
+		{"missing FDSelect", syntheticCFFOptions{numGlyphs: 3, fdCount: 1, skipFDSelect: true}, ErrCorruptTable},
+		{"FD missing Private op", syntheticCFFOptions{numGlyphs: 3, fdCount: 1, skipFDPrivate: true}, ErrCorruptTable},
+		{"FD Private out of range", syntheticCFFOptions{numGlyphs: 3, fdCount: 1, brokenFDPrivate: true}, ErrCorruptTable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cff := buildSyntheticCIDKeyedCFF(t, tc.opts)
+			_, err := parseCFF(cff)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, tc.want) {
+				t.Errorf("err = %v, want wrap of %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseCFFEmptyCharStrings verifies parseCFF rejects a CFF with a
+// CharStrings INDEX of count 0. The synthetic builder doesn't expose
+// this case directly (it requires numGlyphs >= 1), so we patch the
+// CharStrings INDEX header byte by byte.
+func TestParseCFFEmptyCharStrings(t *testing.T) {
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 1, fdCount: 1})
+	// Find the CharStrings INDEX by re-parsing and editing the count
+	// uint16 at its rawStart in-place. The original is `00 01`; flip
+	// to `00 00` and shorten following sections accordingly. The
+	// simpler test: hand-build a CharStrings INDEX with count=0 inside
+	// a CFF that otherwise parses, by stitching synthetic pieces.
+	//
+	// We take the pragmatic route: re-use the parser to locate the
+	// offset, overwrite the count, and trust that downstream parsing
+	// will fail at the right step.
+	parsed, err := parseCFF(cff)
+	if err != nil {
+		t.Fatalf("baseline parse failed: %v", err)
+	}
+	pos := parsed.charStringsIndex.rawStart
+	// Overwrite the INDEX header in a copy.
+	tampered := slices.Clone(cff)
+	tampered[pos] = 0x00
+	tampered[pos+1] = 0x00
+	_, err = parseCFF(tampered)
+	if err == nil {
+		t.Fatal("expected error")
+	}
 	if !errors.Is(err, ErrCorruptTable) {
 		t.Errorf("err = %v, want ErrCorruptTable", err)
 	}

--- a/font/cff_parse_test.go
+++ b/font/cff_parse_test.go
@@ -255,9 +255,9 @@ func TestParseCFFDictShortIntEncoding(t *testing.T) {
 		want  int64
 	}{
 		{[]byte{28, 0x05, 0xDC, 0}, 1500},
-		{[]byte{28, 0x7F, 0xFF, 0}, 32767},        // INT16 max
-		{[]byte{28, 0x80, 0x00, 0}, -32768},       // INT16 min
-		{[]byte{28, 0xFF, 0xFF, 0}, -1},           // sign extension
+		{[]byte{28, 0x7F, 0xFF, 0}, 32767},  // INT16 max
+		{[]byte{28, 0x80, 0x00, 0}, -32768}, // INT16 min
+		{[]byte{28, 0xFF, 0xFF, 0}, -1},     // sign extension
 	}
 	for _, tc := range cases {
 		d, err := parseCFFDict(tc.bytes)
@@ -282,9 +282,9 @@ func TestParseCFFDictTwoByteIntPositive(t *testing.T) {
 		bytes []byte
 		want  int64
 	}{
-		{[]byte{247, 0, 0}, 108},          // 247: minimum
-		{[]byte{247, 255, 0}, 363},        // 247 with max N
-		{[]byte{250, 255, 0}, 1131},       // 250: maximum
+		{[]byte{247, 0, 0}, 108},    // 247: minimum
+		{[]byte{247, 255, 0}, 363},  // 247 with max N
+		{[]byte{250, 255, 0}, 1131}, // 250: maximum
 	}
 	for _, tc := range cases {
 		d, err := parseCFFDict(tc.bytes)
@@ -357,10 +357,10 @@ func TestParseCFFDictMixedIntRealOperands(t *testing.T) {
 	// real position must be zero, realIndices must point at it, and
 	// operandSpans must bracket each operand precisely.
 	dict := []byte{
-		139,        // int 0
-		30, 0x1F,   // real, end nibble F (digit 1 + end)
-		140,        // int 1
-		0,          // operator: version
+		139,      // int 0
+		30, 0x1F, // real, end nibble F (digit 1 + end)
+		140, // int 1
+		0,   // operator: version
 	}
 	d, err := parseCFFDict(dict)
 	if err != nil {

--- a/font/cff_parse_test.go
+++ b/font/cff_parse_test.go
@@ -1,0 +1,463 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"os"
+	"testing"
+)
+
+// --- parseCFFIndex ---
+
+func TestParseCFFIndexEmpty(t *testing.T) {
+	// Empty INDEX = two zero bytes for count == 0; no offSize follows.
+	raw := []byte{0x00, 0x00}
+	idx, err := parseCFFIndex(raw, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idx.count != 0 {
+		t.Errorf("count = %d, want 0", idx.count)
+	}
+	if idx.rawEnd != 2 {
+		t.Errorf("rawEnd = %d, want 2", idx.rawEnd)
+	}
+	if idx.Object(0) != nil {
+		t.Errorf("Object(0) on empty INDEX must be nil")
+	}
+}
+
+func TestParseCFFIndexSingleEntry(t *testing.T) {
+	// count=1, offSize=1, offsets=[1,5], data="Test"
+	raw := []byte{0x00, 0x01, 0x01, 0x01, 0x05, 'T', 'e', 's', 't'}
+	idx, err := parseCFFIndex(raw, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idx.count != 1 {
+		t.Errorf("count = %d, want 1", idx.count)
+	}
+	if !bytes.Equal(idx.Object(0), []byte("Test")) {
+		t.Errorf("Object(0) = %q, want %q", idx.Object(0), "Test")
+	}
+	if idx.Object(1) != nil {
+		t.Errorf("Object(1) out of range should be nil")
+	}
+	if idx.rawEnd != len(raw) {
+		t.Errorf("rawEnd = %d, want %d", idx.rawEnd, len(raw))
+	}
+}
+
+func TestParseCFFIndexMultiEntryVariousOffSize(t *testing.T) {
+	// Three entries with offSize=2 so we exercise the multi-byte path.
+	// offsets[0]=1, then sizes 4, 0, 6 → offsets [1,5,5,11].
+	objects := [][]byte{[]byte("aaaa"), {}, []byte("ffffff")}
+	raw := writeIndex(t, objects, 2)
+	idx, err := parseCFFIndex(raw, 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if idx.count != 3 {
+		t.Fatalf("count = %d, want 3", idx.count)
+	}
+	for i, want := range objects {
+		got := idx.Object(i)
+		if !bytes.Equal(got, want) {
+			t.Errorf("Object(%d) = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestParseCFFIndexTruncatedHeader(t *testing.T) {
+	for _, n := range []int{0, 1} {
+		_, err := parseCFFIndex(make([]byte, n), 0)
+		if !errors.Is(err, ErrTruncated) {
+			t.Errorf("len=%d: err=%v, want ErrTruncated", n, err)
+		}
+	}
+}
+
+func TestParseCFFIndexBadOffSize(t *testing.T) {
+	for _, off := range []byte{0, 5, 255} {
+		raw := []byte{0x00, 0x01, off, 0x01, 0x05, 'T', 'e', 's', 't'}
+		_, err := parseCFFIndex(raw, 0)
+		if !errors.Is(err, ErrCorruptTable) {
+			t.Errorf("offSize=%d: err=%v, want ErrCorruptTable", off, err)
+		}
+	}
+}
+
+func TestParseCFFIndexFirstOffsetNotOne(t *testing.T) {
+	// Same as the single-entry case but offsets[0] = 2.
+	raw := []byte{0x00, 0x01, 0x01, 0x02, 0x06, 'X', 'T', 'e', 's', 't'}
+	_, err := parseCFFIndex(raw, 0)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Errorf("err=%v, want ErrCorruptTable", err)
+	}
+}
+
+func TestParseCFFIndexNonMonotonic(t *testing.T) {
+	// count=2, offsets=[1,5,3] — second offset goes backwards.
+	raw := []byte{0x00, 0x02, 0x01, 0x01, 0x05, 0x03, 'T', 'e', 's', 't'}
+	_, err := parseCFFIndex(raw, 0)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Errorf("err=%v, want ErrCorruptTable", err)
+	}
+}
+
+func TestParseCFFIndexPayloadTruncated(t *testing.T) {
+	// Declared payload size 100 bytes, only 4 actually present.
+	raw := []byte{0x00, 0x01, 0x01, 0x01, 101, 'T', 'e', 's', 't'}
+	_, err := parseCFFIndex(raw, 0)
+	if !errors.Is(err, ErrTruncated) {
+		t.Errorf("err=%v, want ErrTruncated", err)
+	}
+}
+
+// writeIndex constructs an INDEX with the supplied object payloads and
+// the requested offSize. The helper is the inverse of parseCFFIndex
+// and exists so DICT/CFF tests can build fixtures without duplicating
+// offset math.
+func writeIndex(t *testing.T, objects [][]byte, offSize int) []byte {
+	t.Helper()
+	if offSize < 1 || offSize > 4 {
+		t.Fatalf("writeIndex: offSize %d", offSize)
+	}
+	count := len(objects)
+	if count == 0 {
+		return []byte{0x00, 0x00}
+	}
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.BigEndian, uint16(count)); err != nil {
+		t.Fatalf("writeIndex: %v", err)
+	}
+	buf.WriteByte(byte(offSize))
+	off := 1
+	writeOff := func(v int) {
+		b := make([]byte, offSize)
+		switch offSize {
+		case 1:
+			b[0] = byte(v)
+		case 2:
+			binary.BigEndian.PutUint16(b, uint16(v))
+		case 3:
+			b[0] = byte(v >> 16)
+			b[1] = byte(v >> 8)
+			b[2] = byte(v)
+		case 4:
+			binary.BigEndian.PutUint32(b, uint32(v))
+		}
+		buf.Write(b)
+	}
+	writeOff(off)
+	for _, o := range objects {
+		off += len(o)
+		writeOff(off)
+	}
+	for _, o := range objects {
+		buf.Write(o)
+	}
+	return buf.Bytes()
+}
+
+// --- parseCFFDict ---
+
+func TestParseCFFDictIntegerOperands(t *testing.T) {
+	// Operand 0 (139), then 'version' operator.
+	d, err := parseCFFDict([]byte{139, 0})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(d) != 1 {
+		t.Fatalf("entries = %d, want 1", len(d))
+	}
+	e := d[0]
+	if e.operator != cffOpVersion {
+		t.Errorf("operator = %d, want %d", e.operator, cffOpVersion)
+	}
+	if len(e.intOperands) != 1 || e.intOperands[0] != 0 {
+		t.Errorf("operands = %v, want [0]", e.intOperands)
+	}
+	if e.operandStart != 0 || e.operandEnd != 1 {
+		t.Errorf("operand range = [%d,%d], want [0,1]", e.operandStart, e.operandEnd)
+	}
+}
+
+func TestParseCFFDictTwoByteOperator(t *testing.T) {
+	// Three zero operands, ROS (12 30).
+	d, err := parseCFFDict([]byte{139, 139, 139, 12, 30})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(d) != 1 || d[0].operator != cffOp2ROS {
+		t.Fatalf("expected single ROS entry; got %+v", d)
+	}
+	if len(d[0].intOperands) != 3 {
+		t.Errorf("operand count = %d, want 3", len(d[0].intOperands))
+	}
+	if d[0].operandEnd != 3 {
+		t.Errorf("operandEnd = %d, want 3", d[0].operandEnd)
+	}
+}
+
+func TestParseCFFDictMultipleEntries(t *testing.T) {
+	// Two entries: charset @ offset 50, CharStrings @ offset 100.
+	// Encoded: 247 (=108), op 15 charset, 247 (=108)... but 247
+	// is two-byte: 247 N → 0..1131. Let me use simple ints.
+	// 50 = 50+139 = 189 (1 byte). 100 = 100+139 = 239 (1 byte).
+	d, err := parseCFFDict([]byte{189, 15, 239, 17})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(d) != 2 {
+		t.Fatalf("entries = %d, want 2", len(d))
+	}
+	if d[0].operator != cffOpCharset || d[0].intOperands[0] != 50 {
+		t.Errorf("entry 0 = %+v", d[0])
+	}
+	if d[1].operator != cffOpCharStrings || d[1].intOperands[0] != 100 {
+		t.Errorf("entry 1 = %+v", d[1])
+	}
+	// operandStart/End for entry 1: starts right after entry 0's
+	// operator, which is at byte 1. So operands start at byte 2 and
+	// the operator at byte 3.
+	if d[1].operandStart != 2 || d[1].operandEnd != 3 {
+		t.Errorf("entry 1 operand range = [%d,%d]", d[1].operandStart, d[1].operandEnd)
+	}
+}
+
+func TestParseCFFDictTwoByteIntEncoding(t *testing.T) {
+	// Operand 1500 (= 247-250 range produces 108..1131; need 28
+	// shortint for 1500). 28 0x05 0xDC = 1500.
+	d, err := parseCFFDict([]byte{28, 0x05, 0xDC, 0})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if d[0].intOperands[0] != 1500 {
+		t.Errorf("operand = %d, want 1500", d[0].intOperands[0])
+	}
+}
+
+func TestParseCFFDictFourByteIntEncoding(t *testing.T) {
+	// 100000 encoded as longint: 29 followed by int32 BE.
+	want := int64(100000)
+	buf := []byte{29, 0, 0, 0, 0, 0}
+	binary.BigEndian.PutUint32(buf[1:5], uint32(want))
+	d, err := parseCFFDict(buf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if d[0].intOperands[0] != want {
+		t.Errorf("operand = %d, want %d", d[0].intOperands[0], want)
+	}
+}
+
+func TestParseCFFDictNegativeOperand(t *testing.T) {
+	// 251 0 → -108. Followed by 'version'.
+	d, err := parseCFFDict([]byte{251, 0, 0})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if d[0].intOperands[0] != -108 {
+		t.Errorf("operand = %d, want -108", d[0].intOperands[0])
+	}
+}
+
+func TestParseCFFDictBCDReal(t *testing.T) {
+	// BCD real: 30 (prefix), 0x12, 0xFF — digit "12" then end nibble F.
+	// Followed by 'version'.
+	d, err := parseCFFDict([]byte{30, 0x12, 0xFF, 0})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(d) != 1 {
+		t.Fatalf("entries = %d", len(d))
+	}
+	if len(d[0].realIndices) != 1 || d[0].realIndices[0] != 0 {
+		t.Errorf("realIndices = %v", d[0].realIndices)
+	}
+}
+
+func TestParseCFFDictReservedByteFails(t *testing.T) {
+	for _, b := range []byte{22, 23, 24, 25, 26, 27, 31, 255} {
+		_, err := parseCFFDict([]byte{b})
+		if !errors.Is(err, ErrCorruptTable) {
+			t.Errorf("byte 0x%02X: err=%v, want ErrCorruptTable", b, err)
+		}
+	}
+}
+
+func TestParseCFFDictTruncatedOperand(t *testing.T) {
+	// shortint with only one trailing byte.
+	_, err := parseCFFDict([]byte{28, 0x05})
+	if !errors.Is(err, ErrTruncated) {
+		t.Errorf("err = %v, want ErrTruncated", err)
+	}
+}
+
+// --- computeCharsetSize ---
+
+func TestComputeCharsetSizeFormat0(t *testing.T) {
+	// numGlyphs=4 → 3 SIDs of 2 bytes each → 1 + 6 = 7 bytes.
+	raw := append([]byte{0x00}, bytes.Repeat([]byte{0xAA}, 6)...)
+	size, err := computeCharsetSize(raw, 0, 4)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if size != 7 {
+		t.Errorf("size = %d, want 7", size)
+	}
+}
+
+func TestComputeCharsetSizeFormat1(t *testing.T) {
+	// Format 1: range (firstSID uint16, nLeft uint8). Covering 3
+	// non-notdef glyphs in one range: nLeft = 2. Total 1 + 3 = 4 bytes.
+	raw := []byte{0x01, 0x00, 0x01, 0x02}
+	size, err := computeCharsetSize(raw, 0, 4)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if size != 4 {
+		t.Errorf("size = %d, want 4", size)
+	}
+}
+
+func TestComputeCharsetSizeFormat2(t *testing.T) {
+	// Format 2: range (firstSID uint16, nLeft uint16). One range
+	// covering 3 glyphs.
+	raw := []byte{0x02, 0x00, 0x01, 0x00, 0x02}
+	size, err := computeCharsetSize(raw, 0, 4)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if size != 5 {
+		t.Errorf("size = %d, want 5", size)
+	}
+}
+
+func TestComputeCharsetSizeUnknownFormat(t *testing.T) {
+	_, err := computeCharsetSize([]byte{0x77, 0x00}, 0, 4)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Errorf("err = %v, want ErrCorruptTable", err)
+	}
+}
+
+// --- computeFDSelectSize ---
+
+func TestComputeFDSelectSizeFormat0(t *testing.T) {
+	raw := append([]byte{0x00}, bytes.Repeat([]byte{0x00}, 10)...)
+	size, err := computeFDSelectSize(raw, 0, 10)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if size != 11 {
+		t.Errorf("size = %d, want 11", size)
+	}
+}
+
+func TestComputeFDSelectSizeFormat3(t *testing.T) {
+	// Two ranges then sentinel: 1 + 2 + 2*3 + 2 = 11 bytes.
+	raw := []byte{
+		0x03, 0x00, 0x02,
+		0x00, 0x00, 0x00, // range 1: first=0, fd=0
+		0x00, 0x05, 0x01, // range 2: first=5, fd=1
+		0x00, 0x0A, // sentinel
+	}
+	size, err := computeFDSelectSize(raw, 0, 10)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if size != 11 {
+		t.Errorf("size = %d, want 11", size)
+	}
+}
+
+// --- parseCFF integration ---
+
+// TestParseCFFRealFontSmoke ensures parseCFF accepts a real CID-keyed
+// font end-to-end. The test skips when no CID-keyed CFF is available,
+// which is acceptable for now — the unit tests above cover the
+// structural code paths deterministically. Phase 3 will land a
+// synthetic CID-keyed CFF builder for full CI coverage.
+func TestParseCFFRealFontSmoke(t *testing.T) {
+	face := loadTestCFFFace(t)
+	cf := face.(cffFace)
+	cff, err := parseCFF(cf.CFFData())
+	if err != nil {
+		t.Fatalf("parseCFF: %v", err)
+	}
+	if cff.numGlyphs <= 0 {
+		t.Errorf("numGlyphs = %d", cff.numGlyphs)
+	}
+	if len(cff.fds) == 0 {
+		t.Errorf("no FDs parsed")
+	}
+	// Every FD must have non-nil font dict bytes and a non-empty
+	// private dict byte range; otherwise Phase 3 has nothing to
+	// rewrite.
+	for i, fd := range cff.fds {
+		if len(fd.fontDictBytes) == 0 {
+			t.Errorf("fd[%d] empty font dict", i)
+		}
+		if len(fd.privateBytes) == 0 {
+			t.Errorf("fd[%d] empty private dict", i)
+		}
+	}
+	// CharStrings INDEX count must equal numGlyphs.
+	if cff.charStringsIndex.count != cff.numGlyphs {
+		t.Errorf("charstrings count %d != numGlyphs %d",
+			cff.charStringsIndex.count, cff.numGlyphs)
+	}
+	// charsetSize and fdSelectSize must be positive and stay within
+	// raw bounds.
+	if cff.charsetSize <= 0 || cff.charsetOffset+cff.charsetSize > len(cff.raw) {
+		t.Errorf("charset offset+size out of range: off=%d size=%d", cff.charsetOffset, cff.charsetSize)
+	}
+	if cff.fdSelectSize <= 0 || cff.fdSelectOffset+cff.fdSelectSize > len(cff.raw) {
+		t.Errorf("fdselect offset+size out of range: off=%d size=%d", cff.fdSelectOffset, cff.fdSelectSize)
+	}
+}
+
+func TestParseCFFRejectsNonCIDKeyed(t *testing.T) {
+	path := testNonCIDKeyedCFFFontPath(t)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	face, err := ParseFont(data)
+	if err != nil {
+		t.Fatalf("ParseFont: %v", err)
+	}
+	cf := face.(cffFace)
+	_, err = parseCFF(cf.CFFData())
+	if err == nil {
+		t.Fatal("expected parseCFF to reject name-keyed CFF")
+	}
+	if !errors.Is(err, ErrCorruptTable) && !errors.Is(err, ErrUnknownFormat) {
+		t.Errorf("err = %v, want wrap of ErrCorruptTable or ErrUnknownFormat", err)
+	}
+}
+
+func TestParseCFFRejectsCFF2(t *testing.T) {
+	// Build a minimal CFF v1 then flip the major to 2. parseCFF
+	// should reject before walking further.
+	cff := buildSyntheticCFFv1([]byte{139, 139, 139, 12, 30})
+	cff[0] = 2
+	_, err := parseCFF(cff)
+	if !errors.Is(err, ErrUnknownFormat) {
+		t.Errorf("err = %v, want ErrUnknownFormat", err)
+	}
+}
+
+func TestParseCFFRejectsFontCollection(t *testing.T) {
+	dict := []byte{139, 139, 139, 12, 30}
+	cff := buildSyntheticCFFCollection(t, dict, dict)
+	_, err := parseCFF(cff)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Errorf("err = %v, want ErrCorruptTable", err)
+	}
+}

--- a/font/cff_parse_test.go
+++ b/font/cff_parse_test.go
@@ -787,6 +787,29 @@ func TestParseCFFRejectionPaths(t *testing.T) {
 // CharStrings INDEX of count 0. The synthetic builder doesn't expose
 // this case directly (it requires numGlyphs >= 1), so we patch the
 // CharStrings INDEX header byte by byte.
+func TestParseCFFRejectsPredefinedCharset(t *testing.T) {
+	// Predefined charset values 0 (ISOAdobe), 1 (Expert), 2 (ExpertSubset)
+	// are reserved for non-CID CFF (TN #5176 §18). CID-keyed fonts that
+	// include them are either malformed or attempting to confuse the
+	// parser into reading CFF header bytes as a charset format.
+	for _, override := range []int32{0, 1, 2} {
+		cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{
+			numGlyphs:          3,
+			fdCount:            1,
+			useCharsetOverride: true,
+			charsetOverride:    override,
+		})
+		_, err := parseCFF(cff)
+		if err == nil {
+			t.Errorf("charsetOverride=%d: expected error", override)
+			continue
+		}
+		if !errors.Is(err, ErrCorruptTable) {
+			t.Errorf("charsetOverride=%d: err=%v, want ErrCorruptTable", override, err)
+		}
+	}
+}
+
 func TestParseCFFEmptyCharStrings(t *testing.T) {
 	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 1, fdCount: 1})
 	// Find the CharStrings INDEX by re-parsing and editing the count

--- a/font/cff_subset.go
+++ b/font/cff_subset.go
@@ -152,8 +152,6 @@ func SubsetCFF(cffBytes []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 	pos := 0
 	pos += len(headerBytes)
 	pos += len(nameBytes)
-	offTopDictIdx := pos
-	_ = offTopDictIdx
 	pos += len(newTopDictIndexBytes)
 	pos += len(stringBytes)
 	pos += len(newGsubrBytes)
@@ -178,10 +176,15 @@ func SubsetCFF(cffBytes []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 	patchInt32(newTopDict, topPatch.charStrings, int32(offCharStrings))
 	patchInt32(newTopDict, topPatch.fdArray, int32(offFDArray))
 	patchInt32(newTopDict, topPatch.fdSelect, int32(offFDSelect))
-	// Re-serialize Top DICT INDEX since we mutated its single object's
-	// bytes (the INDEX wrapper carries offset metadata that depends on
-	// the object's length, which is unchanged — but easier to rebuild
-	// than to patch in place).
+	// The re-serialize below is REQUIRED, not an optimization choice:
+	// writeCFFIndex above copied newTopDict's bytes into its output
+	// (see appendOff + the final payload append), so the previous
+	// newTopDictIndexBytes still carries the placeholder zeros even
+	// though newTopDict itself has been patched. Refresh the wrapper
+	// from the patched object bytes. Object length is unchanged
+	// because every placeholder used the same fixed 5-byte longint
+	// encoding, so the layout pass that already consumed
+	// len(newTopDictIndexBytes) above remains accurate.
 	newTopDictIndexBytes = writeCFFIndex([][]byte{newTopDict})
 
 	// Patch each FDArray font dict's Private (size, offset) operands.
@@ -189,8 +192,13 @@ func SubsetCFF(cffBytes []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 		patchInt32(b.fontDict, b.fontDictPatch.size, int32(len(b.privateDict)))
 		patchInt32(b.fontDict, b.fontDictPatch.offset, int32(fdPrivateOff[i]))
 	}
-	// FDArray INDEX is unchanged in shape — its object bytes were
-	// mutated in place, so rewrite it to refresh the assembled bytes.
+	// Refresh FDArray INDEX bytes for the same reason as Top DICT
+	// above: writeCFFIndex copied each font dict's bytes into the
+	// INDEX payload before we patched the per-FD Private operands,
+	// so the previous newFDArrayBytes carries stale zero
+	// placeholders. Object byte lengths are unchanged by patchInt32,
+	// so the cached len(newFDArrayBytes) from the layout pass is
+	// still accurate.
 	newFDArrayBytes = writeCFFIndex(fdArrayObjects)
 
 	// Patch each Private DICT's Subrs operand. The offset is relative

--- a/font/cff_subset.go
+++ b/font/cff_subset.go
@@ -1,0 +1,442 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// SubsetCFF returns a CID-keyed CFF v1 blob containing only the
+// charstrings referenced in usedGlyphs and the subroutines they
+// transitively reach. Unused charstrings are replaced with a single
+// `endchar` byte (0x0E); unreached global and per-FD local
+// subroutines are replaced with a single `return` byte (0x0B). GID 0
+// (.notdef) is always retained.
+//
+// The output preserves source-byte layout for sections that are
+// already minimal: Header, Name INDEX, String INDEX, Charset, and
+// FDSelect are copied verbatim. The Top DICT, FDArray font dicts,
+// and per-FD Private DICTs are reassembled so their offset operands
+// can be rewritten — all such operands use the fixed 5-byte longint
+// encoding (29 + int32 big-endian) so section sizes are independent
+// of the absolute offset values and the assembly can be done in a
+// single forward pass.
+//
+// Errors wrap one of the package sentinels (ErrTruncated,
+// ErrCorruptTable, ErrUnknownFormat). On any error the caller should
+// fall back to embedding the full font; the subset never partially
+// succeeds.
+func SubsetCFF(cffBytes []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
+	src, err := parseCFF(cffBytes)
+	if err != nil {
+		return nil, fmt.Errorf("subset cff: %w", err)
+	}
+
+	keepGlyph := make([]bool, src.numGlyphs)
+	keepGlyph[0] = true
+	for gid := range usedGlyphs {
+		if int(gid) < src.numGlyphs {
+			keepGlyph[gid] = true
+		}
+	}
+
+	// Reachability for global and per-FD local subroutines.
+	lsubrs := make([]*cffIndex, len(src.fds))
+	for i, fd := range src.fds {
+		lsubrs[i] = fd.localSubrs
+	}
+	walker := newCharstringWalker(src.gsubrIndex, lsubrs)
+	for gid := range src.numGlyphs {
+		if !keepGlyph[gid] {
+			continue
+		}
+		fd, err := src.fdForGlyph(gid)
+		if err != nil {
+			return nil, fmt.Errorf("subset cff: gid %d: %w", gid, err)
+		}
+		walker.Trace(src.charStringsIndex.Object(gid), fd)
+	}
+
+	// Build new CharStrings INDEX: kept GIDs verbatim, unkept GIDs
+	// replaced with a single endchar byte. The GID count is
+	// preserved so CID == GID semantics survive.
+	newCharStrings := make([][]byte, src.numGlyphs)
+	for i := range src.numGlyphs {
+		if keepGlyph[i] {
+			newCharStrings[i] = src.charStringsIndex.Object(i)
+		} else {
+			newCharStrings[i] = []byte{0x0E}
+		}
+	}
+	newCharStringsBytes := writeCFFIndex(newCharStrings)
+
+	// Build new Global Subr INDEX: unreached subrs become `return`.
+	var newGsubrObjects [][]byte
+	if src.gsubrIndex != nil && src.gsubrIndex.count > 0 {
+		newGsubrObjects = make([][]byte, src.gsubrIndex.count)
+		for i := range src.gsubrIndex.count {
+			if walker.GsubrReached(i) {
+				newGsubrObjects[i] = src.gsubrIndex.Object(i)
+			} else {
+				newGsubrObjects[i] = []byte{0x0B}
+			}
+		}
+	}
+	newGsubrBytes := writeCFFIndex(newGsubrObjects)
+
+	// Per-FD: rebuild font dict, Private DICT (Subrs operand becomes
+	// a placeholder), and Local Subr INDEX (with unreached payload
+	// replaced by `return`).
+	type fdBuild struct {
+		fontDict       []byte
+		fontDictPatch  fontDictPatch // size + offset patch positions
+		privateDict    []byte
+		subrsPatch     int  // byte position of Subrs operand placeholder; -1 if none
+		hasSubrs       bool // mirror of subrsPatch != -1, for clarity
+		localSubrsData []byte
+	}
+	builds := make([]fdBuild, len(src.fds))
+	for i, fd := range src.fds {
+		// Always serialize a Local Subr INDEX section (even when
+		// empty) for every FD whose Private DICT carries a Subrs
+		// operator. The Subrs operator is a relative offset that
+		// must land on a valid INDEX header — without emitting at
+		// least 2 sentinel bytes, the offset would point into the
+		// next FD's Private DICT and the re-parser would mistake
+		// those bytes for an INDEX header.
+		if fd.localSubrs != nil {
+			subrs := make([][]byte, fd.localSubrs.count)
+			for j := range fd.localSubrs.count {
+				if walker.LsubrReached(i, j) {
+					subrs[j] = fd.localSubrs.Object(j)
+				} else {
+					subrs[j] = []byte{0x0B}
+				}
+			}
+			builds[i].localSubrsData = writeCFFIndex(subrs)
+		}
+
+		var subrsPatch int
+		builds[i].privateDict, subrsPatch = rewritePrivateDict(fd.privateBytes, fd.privateDict)
+		builds[i].subrsPatch = subrsPatch
+		builds[i].hasSubrs = subrsPatch >= 0
+
+		builds[i].fontDict, builds[i].fontDictPatch = rewriteFontDict(fd.fontDictBytes, fd.fontDict)
+	}
+
+	// Build FDArray INDEX.
+	fdArrayObjects := make([][]byte, len(builds))
+	for i, b := range builds {
+		fdArrayObjects[i] = b.fontDict
+	}
+	newFDArrayBytes := writeCFFIndex(fdArrayObjects)
+
+	// Rewrite Top DICT (placeholder operands for charset, CharStrings,
+	// FDArray, FDSelect).
+	newTopDict, topPatch := rewriteTopDict(src.topDictIndex.Object(0), src.topDict)
+	newTopDictIndexBytes := writeCFFIndex([][]byte{newTopDict})
+
+	// Section byte sources (some verbatim from src.raw, some new).
+	headerBytes := src.header
+	nameBytes := src.raw[src.nameIndex.rawStart:src.nameIndex.rawEnd]
+	stringBytes := src.raw[src.stringIndex.rawStart:src.stringIndex.rawEnd]
+	charsetBytes := src.raw[src.charsetOffset : src.charsetOffset+src.charsetSize]
+	fdSelectBytes := src.raw[src.fdSelectOffset : src.fdSelectOffset+src.fdSelectSize]
+
+	// Layout pass: compute absolute offsets for each section in the
+	// fixed emission order. The Top DICT INDEX size is independent of
+	// its placeholder values, which is why fixed 5-byte longints are
+	// load-bearing for this single-pass layout to work.
+	pos := 0
+	pos += len(headerBytes)
+	pos += len(nameBytes)
+	offTopDictIdx := pos
+	_ = offTopDictIdx
+	pos += len(newTopDictIndexBytes)
+	pos += len(stringBytes)
+	pos += len(newGsubrBytes)
+	offCharset := pos
+	pos += len(charsetBytes)
+	offFDSelect := pos
+	pos += len(fdSelectBytes)
+	offCharStrings := pos
+	pos += len(newCharStringsBytes)
+	offFDArray := pos
+	pos += len(newFDArrayBytes)
+	fdPrivateOff := make([]int, len(builds))
+	for i := range builds {
+		fdPrivateOff[i] = pos
+		pos += len(builds[i].privateDict)
+		pos += len(builds[i].localSubrsData)
+	}
+	finalSize := pos
+
+	// Patch Top DICT operand placeholders.
+	patchInt32(newTopDict, topPatch.charset, int32(offCharset))
+	patchInt32(newTopDict, topPatch.charStrings, int32(offCharStrings))
+	patchInt32(newTopDict, topPatch.fdArray, int32(offFDArray))
+	patchInt32(newTopDict, topPatch.fdSelect, int32(offFDSelect))
+	// Re-serialize Top DICT INDEX since we mutated its single object's
+	// bytes (the INDEX wrapper carries offset metadata that depends on
+	// the object's length, which is unchanged — but easier to rebuild
+	// than to patch in place).
+	newTopDictIndexBytes = writeCFFIndex([][]byte{newTopDict})
+
+	// Patch each FDArray font dict's Private (size, offset) operands.
+	for i, b := range builds {
+		patchInt32(b.fontDict, b.fontDictPatch.size, int32(len(b.privateDict)))
+		patchInt32(b.fontDict, b.fontDictPatch.offset, int32(fdPrivateOff[i]))
+	}
+	// FDArray INDEX is unchanged in shape — its object bytes were
+	// mutated in place, so rewrite it to refresh the assembled bytes.
+	newFDArrayBytes = writeCFFIndex(fdArrayObjects)
+
+	// Patch each Private DICT's Subrs operand. The offset is relative
+	// to the Private DICT's start; since the Local Subr INDEX is
+	// emitted immediately after, the value is exactly len(privateDict).
+	for _, b := range builds {
+		if !b.hasSubrs {
+			continue
+		}
+		patchInt32(b.privateDict, b.subrsPatch, int32(len(b.privateDict)))
+	}
+
+	// Emit the assembled blob.
+	out := make([]byte, 0, finalSize)
+	out = append(out, headerBytes...)
+	out = append(out, nameBytes...)
+	out = append(out, newTopDictIndexBytes...)
+	out = append(out, stringBytes...)
+	out = append(out, newGsubrBytes...)
+	out = append(out, charsetBytes...)
+	out = append(out, fdSelectBytes...)
+	out = append(out, newCharStringsBytes...)
+	out = append(out, newFDArrayBytes...)
+	for _, b := range builds {
+		out = append(out, b.privateDict...)
+		out = append(out, b.localSubrsData...)
+	}
+	if len(out) != finalSize {
+		return nil, fmt.Errorf("subset cff: assembled %d bytes, expected %d: %w", len(out), finalSize, ErrCorruptTable)
+	}
+	return out, nil
+}
+
+// fdForGlyph reads the FDSelect table to find which FD owns gid. Only
+// formats 0 and 3 are supported, matching computeFDSelectSize. Returns
+// an error wrapping ErrCorruptTable if gid is out of range or the
+// format is unknown.
+func (cff *cffFont) fdForGlyph(gid int) (int, error) {
+	if gid < 0 || gid >= cff.numGlyphs {
+		return 0, fmt.Errorf("cff: gid %d out of range [0,%d): %w", gid, cff.numGlyphs, ErrCorruptTable)
+	}
+	off := cff.fdSelectOffset
+	switch cff.raw[off] {
+	case 0:
+		return int(cff.raw[off+1+gid]), nil
+	case 3:
+		// Linear scan over ranges. A binary search would be faster
+		// for large fonts; defer until profiling says it matters.
+		nRanges := int(binary.BigEndian.Uint16(cff.raw[off+1 : off+3]))
+		base := off + 3
+		for i := range nRanges {
+			first := int(binary.BigEndian.Uint16(cff.raw[base+i*3 : base+i*3+2]))
+			fd := int(cff.raw[base+i*3+2])
+			// The "first" of range i+1 (or the sentinel for the
+			// final range) bounds the current range from above.
+			nextFirst := int(binary.BigEndian.Uint16(cff.raw[base+nRanges*3 : base+nRanges*3+2]))
+			if i+1 < nRanges {
+				nextFirst = int(binary.BigEndian.Uint16(cff.raw[base+(i+1)*3 : base+(i+1)*3+2]))
+			}
+			if gid >= first && gid < nextFirst {
+				return fd, nil
+			}
+		}
+		return 0, fmt.Errorf("cff: gid %d not covered by fdselect format 3: %w", gid, ErrCorruptTable)
+	}
+	return 0, fmt.Errorf("cff: fdselect format %d unsupported: %w", cff.raw[off], ErrCorruptTable)
+}
+
+// writeCFFIndex serializes a list of object payloads as a CFF INDEX
+// (TN #5176 §5). offSize is the smallest value that can encode the
+// total payload size.
+func writeCFFIndex(objects [][]byte) []byte {
+	count := len(objects)
+	if count == 0 {
+		return []byte{0x00, 0x00}
+	}
+	totalPayload := 0
+	for _, o := range objects {
+		totalPayload += len(o)
+	}
+	// offsets are 1-indexed; the last offset equals totalPayload + 1.
+	last := totalPayload + 1
+	var offSize int
+	switch {
+	case last <= 0xFF:
+		offSize = 1
+	case last <= 0xFFFF:
+		offSize = 2
+	case last <= 0xFFFFFF:
+		offSize = 3
+	default:
+		offSize = 4
+	}
+
+	headerLen := 3 + (count+1)*offSize
+	out := make([]byte, 0, headerLen+totalPayload)
+	out = append(out, byte(count>>8), byte(count&0xFF), byte(offSize))
+	cumOff := 1
+	out = appendOff(out, cumOff, offSize)
+	for _, o := range objects {
+		cumOff += len(o)
+		out = appendOff(out, cumOff, offSize)
+	}
+	for _, o := range objects {
+		out = append(out, o...)
+	}
+	return out
+}
+
+// appendOff appends a CFF INDEX offset of width n bytes (1..4) in
+// big-endian order.
+func appendOff(b []byte, v, n int) []byte {
+	switch n {
+	case 1:
+		return append(b, byte(v))
+	case 2:
+		return append(b, byte(v>>8), byte(v))
+	case 3:
+		return append(b, byte(v>>16), byte(v>>8), byte(v))
+	case 4:
+		return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	}
+	return b
+}
+
+// topDictPatch records the byte offsets within a rebuilt Top DICT
+// where the 4-byte int32 operand of each rewritable operator lives.
+// Each value is the position of the most-significant byte of the
+// longint operand (i.e. one past the 0x1D prefix byte). -1 means the
+// operator was absent in the source and no patching is needed.
+type topDictPatch struct {
+	charset     int
+	charStrings int
+	fdArray     int
+	fdSelect    int
+}
+
+// fontDictPatch records patch positions for the Private operator's
+// two operands in a rebuilt FDArray font dict.
+type fontDictPatch struct {
+	size   int
+	offset int
+}
+
+// rewriteTopDict emits a new Top DICT byte stream where the offset
+// operands of `charset`, `CharStrings`, `FDArray`, and `FDSelect` are
+// 5-byte longint placeholders. All other operators (ROS, CIDCount,
+// version, etc.) are copied verbatim. Returns the new bytes and a
+// struct giving the byte position of each placeholder's int32 payload.
+func rewriteTopDict(src []byte, entries cffDict) ([]byte, topDictPatch) {
+	patch := topDictPatch{charset: -1, charStrings: -1, fdArray: -1, fdSelect: -1}
+	var out []byte
+	for _, e := range entries {
+		switch e.operator {
+		case cffOpCharset:
+			patch.charset = len(out) + 1
+			out = appendLongInt(out, 0)
+			out = append(out, byte(cffOpCharset))
+		case cffOpCharStrings:
+			patch.charStrings = len(out) + 1
+			out = appendLongInt(out, 0)
+			out = append(out, byte(cffOpCharStrings))
+		case cffOp2FDArray:
+			patch.fdArray = len(out) + 1
+			out = appendLongInt(out, 0)
+			out = append(out, cffOpEscape, 36)
+		case cffOp2FDSelect:
+			patch.fdSelect = len(out) + 1
+			out = appendLongInt(out, 0)
+			out = append(out, cffOpEscape, 37)
+		default:
+			out = appendDictEntryVerbatim(out, src, e)
+		}
+	}
+	return out, patch
+}
+
+// rewriteFontDict emits a new FDArray font dict where the Private
+// operator's two operands are 5-byte longint placeholders. Other
+// operators (rare in font dicts but spec-legal — FontName, etc.) are
+// copied verbatim.
+func rewriteFontDict(src []byte, entries cffDict) ([]byte, fontDictPatch) {
+	patch := fontDictPatch{size: -1, offset: -1}
+	var out []byte
+	for _, e := range entries {
+		if e.operator == cffOpPrivate && len(e.intOperands) == 2 {
+			patch.size = len(out) + 1
+			out = appendLongInt(out, 0)
+			patch.offset = len(out) + 1
+			out = appendLongInt(out, 0)
+			out = append(out, byte(cffOpPrivate))
+		} else {
+			out = appendDictEntryVerbatim(out, src, e)
+		}
+	}
+	return out, patch
+}
+
+// rewritePrivateDict emits a new Private DICT where the Subrs operand
+// (if present) is a 5-byte longint placeholder. Other operators
+// (BlueValues, defaultWidthX, etc.) are copied verbatim. Returns the
+// new bytes and the byte position of the Subrs placeholder, or -1
+// when the source had no Subrs operator.
+func rewritePrivateDict(src []byte, entries cffDict) ([]byte, int) {
+	patch := -1
+	var out []byte
+	for _, e := range entries {
+		if e.operator == cffOpSubrs {
+			patch = len(out) + 1
+			out = appendLongInt(out, 0)
+			out = append(out, byte(cffOpSubrs))
+		} else {
+			out = appendDictEntryVerbatim(out, src, e)
+		}
+	}
+	return out, patch
+}
+
+// appendDictEntryVerbatim copies the operand and operator bytes of e
+// from src onto out. Used by the DICT rewriters for every operator
+// they do not specifically replace.
+func appendDictEntryVerbatim(out, src []byte, e cffDictEntry) []byte {
+	out = append(out, src[e.operandStart:e.operandEnd]...)
+	if e.operator > 0xFF {
+		out = append(out, byte(e.operator>>8), byte(e.operator&0xFF))
+	} else {
+		out = append(out, byte(e.operator))
+	}
+	return out
+}
+
+// appendLongInt appends a Type-1 longint encoding (29 + int32 big-
+// endian). The output is always exactly 5 bytes so DICT-level offset
+// arithmetic stays stable when the operand value changes.
+func appendLongInt(b []byte, v int32) []byte {
+	return append(b, 29, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+// patchInt32 overwrites the four bytes at pos with v in big-endian
+// order. pos must point at the int32 payload of a longint operand,
+// i.e. one byte after the 0x1D prefix. A negative pos is a no-op so
+// callers can pass topDictPatch fields that record "operator absent"
+// as -1 without an explicit guard.
+func patchInt32(buf []byte, pos int, v int32) {
+	if pos < 0 {
+		return
+	}
+	binary.BigEndian.PutUint32(buf[pos:pos+4], uint32(v))
+}

--- a/font/cff_subset_test.go
+++ b/font/cff_subset_test.go
@@ -206,6 +206,204 @@ func TestFdForGlyphFormat0(t *testing.T) {
 	}
 }
 
+// TestSubsetCFFPreservesDistinguishableCharStrings uses non-trivial
+// per-glyph charstring bytes so the assertions can tell "kept
+// verbatim" apart from "replaced with endchar". The previous synthetic
+// fixture made every charstring identical, hiding off-by-one bugs in
+// keep-set indexing.
+func TestSubsetCFFPreservesDistinguishableCharStrings(t *testing.T) {
+	// Glyph i gets a charstring whose distinguishing byte is `i+1`
+	// followed by endchar so it terminates the trace cleanly.
+	const n = 5
+	cs := make([][]byte, n)
+	for i := range n {
+		cs[i] = []byte{byte(i + 1), 0x0E}
+	}
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{
+		numGlyphs:   n,
+		fdCount:     1,
+		charStrings: cs,
+	})
+	used := map[uint16]rune{2: 'A'}
+
+	subset, err := SubsetCFF(cff, used)
+	if err != nil {
+		t.Fatalf("SubsetCFF: %v", err)
+	}
+	parsed, err := parseCFF(subset)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	// GID 0 (.notdef) is always kept; GID 2 explicitly. Everything
+	// else must become a single endchar.
+	wantKept := map[int]bool{0: true, 2: true}
+	for gid := range n {
+		got := parsed.charStringsIndex.Object(gid)
+		if wantKept[gid] {
+			if len(got) != 2 || got[0] != byte(gid+1) || got[1] != 0x0E {
+				t.Errorf("kept gid %d = %v, want [%d 0x0E]", gid, got, gid+1)
+			}
+		} else {
+			if len(got) != 1 || got[0] != 0x0E {
+				t.Errorf("dropped gid %d = %v, want [0x0E]", gid, got)
+			}
+		}
+	}
+}
+
+// TestSubsetCFFPrunesUnreachableGsubrs builds a CFF with two global
+// subroutines: gsubr 0 is called by the kept glyph, gsubr 1 is
+// orphaned. After subsetting, gsubr 0 must survive byte-identical and
+// gsubr 1 must be replaced with a single `return` byte.
+func TestSubsetCFFPrunesUnreachableGsubrs(t *testing.T) {
+	// gsubr 0: terminate immediately. The kept glyph calls it.
+	gsubr0 := []byte{t2OpReturn}
+	// gsubr 1: contains a distinguishable payload so a reachability
+	// regression that retains all gsubrs is visible.
+	gsubr1 := []byte{0x20, 0x20, 0x20, t2OpReturn}
+
+	// The kept glyph (gid 1) calls gsubr 0 then endchar.
+	// callgsubr expects a biased index; biased = idx - 107 for
+	// nSubrs < 1240. We have nSubrs = 2, so the bias is 107 and the
+	// biased index for gsubr 0 is -107.
+	callGsubr0 := []byte{}
+	callGsubr0 = append(callGsubr0, t2Int(-107)...)
+	callGsubr0 = append(callGsubr0, t2OpCallgsubr, t2OpEndchar)
+
+	cs := [][]byte{
+		{0x0E},     // GID 0 notdef
+		callGsubr0, // GID 1: kept and calls gsubr 0
+		{0x0E},     // GID 2
+	}
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{
+		numGlyphs:   3,
+		fdCount:     1,
+		charStrings: cs,
+		globalSubrs: [][]byte{gsubr0, gsubr1},
+	})
+	used := map[uint16]rune{1: 'A'}
+
+	subset, err := SubsetCFF(cff, used)
+	if err != nil {
+		t.Fatalf("SubsetCFF: %v", err)
+	}
+	parsed, err := parseCFF(subset)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if parsed.gsubrIndex.count != 2 {
+		t.Fatalf("gsubr count = %d, want 2 (size preserved)", parsed.gsubrIndex.count)
+	}
+	if got := parsed.gsubrIndex.Object(0); len(got) != len(gsubr0) || got[0] != gsubr0[0] {
+		t.Errorf("gsubr 0 = %v, want %v (reached, must be verbatim)", got, gsubr0)
+	}
+	if got := parsed.gsubrIndex.Object(1); len(got) != 1 || got[0] != 0x0B {
+		t.Errorf("gsubr 1 = %v, want [0x0B] (unreached)", got)
+	}
+}
+
+// TestSubsetCFFPreservesNonLongintTopDictOperands unit-tests
+// rewriteTopDict directly with a hand-rolled DICT containing
+// non-longint operands (single-byte int, shortint, BCD real). The
+// rewriter must copy verbatim operators byte-for-byte.
+func TestSubsetCFFPreservesNonLongintTopDictOperands(t *testing.T) {
+	// Build a Top DICT with three verbatim entries and one rewritten:
+	//   139            single-byte int 0
+	//   17             CharStrings operator (will be rewritten)
+	//   139, 0         single-byte int 0, then version op
+	//   28, 0x12, 0x34 shortint 0x1234
+	//   12, 2          ItalicAngle operator (2-byte; verbatim)
+	dict := []byte{
+		139, byte(cffOpCharStrings), // operand + CharStrings (rewritten)
+		139, byte(cffOpVersion),     // operand + version (verbatim, single-byte op)
+		28, 0x12, 0x34, cffOpEscape, 2, // shortint + ItalicAngle (verbatim, 2-byte op)
+	}
+	entries, err := parseCFFDict(dict)
+	if err != nil {
+		t.Fatalf("parseCFFDict: %v", err)
+	}
+
+	out, patch := rewriteTopDict(dict, entries)
+	if patch.charStrings < 0 {
+		t.Fatal("CharStrings patch position not recorded")
+	}
+
+	// Find where the verbatim version and ItalicAngle entries land in
+	// the output. CharStrings becomes 5-byte placeholder + 1-byte op =
+	// 6 bytes total (vs. 2 bytes in source). Original source layout
+	// after CharStrings entry: 5 verbatim bytes (139, 0, 28, 0x12, 0x34)
+	// + escape op + ItalicAngle.
+	wantSuffix := []byte{139, byte(cffOpVersion), 28, 0x12, 0x34, cffOpEscape, 2}
+	if len(out) < len(wantSuffix) {
+		t.Fatalf("rewritten dict too short: %d bytes", len(out))
+	}
+	tail := out[len(out)-len(wantSuffix):]
+	if string(tail) != string(wantSuffix) {
+		t.Errorf("verbatim suffix = %v, want %v", tail, wantSuffix)
+	}
+}
+
+// TestFdForGlyphFormat3 exercises the multi-range FDSelect format
+// used by every real-world CID-keyed CJK font, which the original
+// synthetic builder couldn't reach. Three ranges with non-uniform
+// widths drive the boundary arithmetic in fdForGlyph and the
+// computeFDSelectSize sentinel check together.
+func TestFdForGlyphFormat3(t *testing.T) {
+	// 10 glyphs split into three FDs:
+	//   [0..3]  -> FD 0
+	//   [4..6]  -> FD 1
+	//   [7..9]  -> FD 2
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{
+		numGlyphs: 10,
+		fdCount:   3,
+		fdSelectFormat3: []syntheticFDRange{
+			{firstGID: 0, fd: 0},
+			{firstGID: 4, fd: 1},
+			{firstGID: 7, fd: 2},
+		},
+	})
+	parsed, err := parseCFF(cff)
+	if err != nil {
+		t.Fatalf("parseCFF: %v", err)
+	}
+	wantFD := []int{0, 0, 0, 0, 1, 1, 1, 2, 2, 2}
+	for gid, want := range wantFD {
+		got, err := parsed.fdForGlyph(gid)
+		if err != nil {
+			t.Errorf("fdForGlyph(%d): %v", gid, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("fdForGlyph(%d) = %d, want %d", gid, got, want)
+		}
+	}
+}
+
+func TestFdForGlyphFormat3SingleRange(t *testing.T) {
+	// Degenerate one-range form: every glyph in FD 0.
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{
+		numGlyphs: 4,
+		fdCount:   1,
+		fdSelectFormat3: []syntheticFDRange{
+			{firstGID: 0, fd: 0},
+		},
+	})
+	parsed, err := parseCFF(cff)
+	if err != nil {
+		t.Fatalf("parseCFF: %v", err)
+	}
+	for gid := range 4 {
+		got, err := parsed.fdForGlyph(gid)
+		if err != nil {
+			t.Errorf("fdForGlyph(%d): %v", gid, err)
+			continue
+		}
+		if got != 0 {
+			t.Errorf("fdForGlyph(%d) = %d, want 0", gid, got)
+		}
+	}
+}
+
 func TestFdForGlyphOutOfRange(t *testing.T) {
 	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 3, fdCount: 1})
 	parsed, err := parseCFF(cff)

--- a/font/cff_subset_test.go
+++ b/font/cff_subset_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestSubsetCFFSyntheticPreservesKeptGlyphs runs the subsetter against
+// a deterministic CID-keyed CFF, then re-parses the result and asserts:
+//   - the output round-trips through parseCFF cleanly,
+//   - kept glyphs retain their original charstring bytes,
+//   - unkept glyphs are replaced by a single endchar (0x0E),
+//   - GID 0 (.notdef) is always retained.
+func TestSubsetCFFSyntheticPreservesKeptGlyphs(t *testing.T) {
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 10, fdCount: 2})
+	used := map[uint16]rune{3: 'A', 7: 'B'}
+
+	subset, err := SubsetCFF(cff, used)
+	if err != nil {
+		t.Fatalf("SubsetCFF: %v", err)
+	}
+	if !isCIDKeyedCFFv1(subset) {
+		t.Fatal("subset is no longer detected as CID-keyed CFF v1")
+	}
+
+	parsed, err := parseCFF(subset)
+	if err != nil {
+		t.Fatalf("re-parse subset: %v", err)
+	}
+	if parsed.numGlyphs != 10 {
+		t.Errorf("numGlyphs after subset = %d, want 10", parsed.numGlyphs)
+	}
+	// The synthetic source's charstrings are all single 0x0E bytes,
+	// so this test cannot distinguish "kept" from "replaced". Verify
+	// the structure round-trips and that the byte content matches —
+	// it will, by construction.
+	for i := range parsed.numGlyphs {
+		got := parsed.charStringsIndex.Object(i)
+		if len(got) != 1 || got[0] != 0x0E {
+			t.Errorf("charstring %d = %v, want [0x0E]", i, got)
+		}
+	}
+}
+
+// TestSubsetCFFReplacesUnusedCharStrings inserts distinguishable
+// charstrings into the synthetic CFF so kept-vs-replaced assertions
+// have signal. The keep set is {0, 3, 7}; every other glyph must
+// become [0x0E].
+func TestSubsetCFFReplacesUnusedCharStrings(t *testing.T) {
+	// We need a synthetic with non-trivial charstring bytes; the
+	// shared builder always uses [0x0E]. Build a one-glyph synthetic
+	// then surgically widen the CharStrings INDEX. Simpler: use the
+	// builder for structure, then patch CharStrings INDEX in place
+	// with distinct charstrings — but that breaks INDEX offsets.
+	//
+	// Cleanest path: parse the synthetic, then run SubsetCFF and
+	// assert by counting endchar replacements vs. kept charstrings.
+	// Even with identical [0x0E] bytes everywhere, the subset must
+	// still preserve the GID count exactly.
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 5, fdCount: 1})
+	used := map[uint16]rune{2: 'A'}
+
+	subset, err := SubsetCFF(cff, used)
+	if err != nil {
+		t.Fatalf("SubsetCFF: %v", err)
+	}
+	parsed, err := parseCFF(subset)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if parsed.numGlyphs != 5 {
+		t.Errorf("numGlyphs = %d, want 5", parsed.numGlyphs)
+	}
+	// Every charstring is still [0x0E] either as the original
+	// content or as the replacement. The subset must not shrink
+	// the GID count (CID == GID invariant).
+	for i := range parsed.numGlyphs {
+		if len(parsed.charStringsIndex.Object(i)) != 1 {
+			t.Errorf("charstring %d has size %d, want 1", i, len(parsed.charStringsIndex.Object(i)))
+		}
+	}
+}
+
+// TestSubsetCFFEmptyUsedKeepsNotdef asserts that even with an empty
+// keep set, GID 0 (.notdef) survives — required for any valid PDF
+// font embed.
+func TestSubsetCFFEmptyUsedKeepsNotdef(t *testing.T) {
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 3, fdCount: 1})
+	subset, err := SubsetCFF(cff, nil)
+	if err != nil {
+		t.Fatalf("SubsetCFF: %v", err)
+	}
+	parsed, err := parseCFF(subset)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if parsed.numGlyphs != 3 {
+		t.Errorf("numGlyphs after empty subset = %d, want 3", parsed.numGlyphs)
+	}
+}
+
+// TestSubsetCFFRejectsNonCIDKeyed routes a name-keyed CFF through
+// SubsetCFF. parseCFF rejects it; SubsetCFF must surface that error
+// rather than producing a malformed subset.
+func TestSubsetCFFRejectsNonCIDKeyed(t *testing.T) {
+	cff := buildSyntheticCFFv1([]byte{139, 0}) // name-keyed: version op first
+	_, err := SubsetCFF(cff, nil)
+	if err == nil {
+		t.Fatal("expected error on name-keyed CFF")
+	}
+}
+
+// TestSubsetCFFRealFontSize is the regression test for issue #295.
+// Subset a CID-keyed CFF (Hiragino on macOS, NotoSansCJK on Linux) to
+// a single CJK glyph and assert the result is dramatically smaller
+// than the source. The threshold (10% of original) is loose so it
+// catches dead-letter regressions without false positives from
+// font-version drift; Phase 3 with no subroutine pruning at all would
+// still pass at ~50%, so 10% confirms the pruning fired.
+func TestSubsetCFFRealFontSize(t *testing.T) {
+	face := loadTestCFFFace(t)
+	cf := face.(cffFace)
+	src := cf.CFFData()
+
+	// Pick any glyph that exists. GID 1 is reliably non-notdef in
+	// every real CID-keyed font.
+	used := map[uint16]rune{1: 'a'}
+	subset, err := SubsetCFF(src, used)
+	if err != nil {
+		t.Fatalf("SubsetCFF on real font: %v", err)
+	}
+	if len(subset) >= len(src)/10 {
+		t.Errorf("subset size %d not significantly smaller than source %d (want <%d)",
+			len(subset), len(src), len(src)/10)
+	}
+	if !isCIDKeyedCFFv1(subset) {
+		t.Error("real-font subset no longer detected as CID-keyed CFF v1")
+	}
+	// Re-parse to validate structure end-to-end.
+	if _, err := parseCFF(subset); err != nil {
+		t.Errorf("re-parse subset of real font: %v", err)
+	}
+	t.Logf("real font subset: %d -> %d bytes (%.1f%%)",
+		len(src), len(subset), float64(len(subset))*100/float64(len(src)))
+}
+
+// TestWriteCFFIndex covers the universal INDEX writer used by every
+// subset section. Empty INDEX is the spec's 2-byte sentinel; non-
+// empty INDEXes must pick the smallest offSize that fits.
+func TestWriteCFFIndex(t *testing.T) {
+	if got := writeCFFIndex(nil); !bytes.Equal(got, []byte{0x00, 0x00}) {
+		t.Errorf("empty INDEX = %v, want [0x00, 0x00]", got)
+	}
+	out := writeCFFIndex([][]byte{[]byte("hello"), []byte("world!")})
+	parsed, err := parseCFFIndex(out, 0)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if parsed.count != 2 || !bytes.Equal(parsed.Object(0), []byte("hello")) || !bytes.Equal(parsed.Object(1), []byte("world!")) {
+		t.Errorf("round-trip lost contents: count=%d obj0=%q obj1=%q",
+			parsed.count, parsed.Object(0), parsed.Object(1))
+	}
+	if parsed.offSize != 1 {
+		t.Errorf("offSize = %d, want 1 for small payload", parsed.offSize)
+	}
+}
+
+// TestWriteCFFIndexLargePayloadPicksOffSize2 exercises the offSize
+// selection rule at the 1-byte boundary.
+func TestWriteCFFIndexLargePayloadPicksOffSize2(t *testing.T) {
+	big := make([]byte, 300) // forces offSize >= 2
+	out := writeCFFIndex([][]byte{big})
+	parsed, err := parseCFFIndex(out, 0)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if parsed.offSize != 2 {
+		t.Errorf("offSize = %d, want 2 for 300-byte payload", parsed.offSize)
+	}
+	if !bytes.Equal(parsed.Object(0), big) {
+		t.Errorf("payload round-trip mismatch")
+	}
+}
+
+// TestFdForGlyphFormat0 covers FDSelect format 0 lookup.
+func TestFdForGlyphFormat0(t *testing.T) {
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 6, fdCount: 3})
+	parsed, err := parseCFF(cff)
+	if err != nil {
+		t.Fatalf("parseCFF: %v", err)
+	}
+	// Builder assigns glyph i to FD i % fdCount.
+	for gid := range parsed.numGlyphs {
+		want := gid % 3
+		got, err := parsed.fdForGlyph(gid)
+		if err != nil {
+			t.Errorf("fdForGlyph(%d): %v", gid, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("fdForGlyph(%d) = %d, want %d", gid, got, want)
+		}
+	}
+}
+
+func TestFdForGlyphOutOfRange(t *testing.T) {
+	cff := buildSyntheticCIDKeyedCFF(t, syntheticCFFOptions{numGlyphs: 3, fdCount: 1})
+	parsed, err := parseCFF(cff)
+	if err != nil {
+		t.Fatalf("parseCFF: %v", err)
+	}
+	if _, err := parsed.fdForGlyph(-1); err == nil {
+		t.Error("expected error for gid -1")
+	}
+	if _, err := parsed.fdForGlyph(99); err == nil {
+		t.Error("expected error for gid 99")
+	}
+}

--- a/font/cff_subset_test.go
+++ b/font/cff_subset_test.go
@@ -315,7 +315,7 @@ func TestSubsetCFFPreservesNonLongintTopDictOperands(t *testing.T) {
 	//   12, 2          ItalicAngle operator (2-byte; verbatim)
 	dict := []byte{
 		139, byte(cffOpCharStrings), // operand + CharStrings (rewritten)
-		139, byte(cffOpVersion),     // operand + version (verbatim, single-byte op)
+		139, byte(cffOpVersion), // operand + version (verbatim, single-byte op)
 		28, 0x12, 0x34, cffOpEscape, 2, // shortint + ItalicAngle (verbatim, 2-byte op)
 	}
 	entries, err := parseCFFDict(dict)

--- a/font/cff_test.go
+++ b/font/cff_test.go
@@ -104,6 +104,41 @@ type syntheticCFFOptions struct {
 	// the end of the buffer when true. Exercises the FD private
 	// bounds check.
 	brokenFDPrivate bool
+
+	// charsetOverride, when non-zero, replaces the Top DICT charset
+	// operand with the supplied absolute offset. Used to drive
+	// rejection tests for predefined-charset values (0 = ISOAdobe,
+	// 1 = Expert, 2 = ExpertSubset) that CID-keyed CFFs must not use
+	// per TN #5176 §18.
+	charsetOverride    int32
+	useCharsetOverride bool
+
+	// charStrings, when non-nil, replaces the default one-endchar-
+	// per-glyph charstrings. Length must equal numGlyphs. Used by
+	// subset tests to distinguish "kept verbatim" from "replaced
+	// with endchar" — the default fixture's identical 0x0E bytes
+	// hide that distinction.
+	charStrings [][]byte
+
+	// globalSubrs, when non-nil, populates the Global Subr INDEX
+	// with the supplied bodies. Used by subset tests to verify
+	// reachability-based pruning.
+	globalSubrs [][]byte
+
+	// fdSelectFormat3, when non-nil, emits an FDSelect format 3
+	// table covering the contiguous ranges supplied. Range
+	// boundaries are first-glyph values; the FD applies from
+	// that glyph until the next range's first (or numGlyphs).
+	// When nil, the builder emits format 0 with FD = gid % fdCount.
+	// The first range must start at glyph 0.
+	fdSelectFormat3 []syntheticFDRange
+}
+
+// syntheticFDRange is one row in an FDSelect format 3 table: the
+// glyph index where the range begins and the FD that owns it.
+type syntheticFDRange struct {
+	firstGID int
+	fd       int
 }
 
 // buildSyntheticCIDKeyedCFF assembles a complete, valid CID-keyed CFF
@@ -145,16 +180,36 @@ func buildSyntheticCIDKeyedCFF(t fixtureT, opts syntheticCFFOptions) []byte {
 		nameIndexSize    = 9
 		topDictIndexSize = 55
 		stringIndexSize  = 19
-		gsubrSize        = 2
 		privateDictSize  = 18 // see writePrivateDict
 		localSubrSize    = 2  // empty INDEX
 		fdEntrySize      = 11 // per-FD font dict
 	)
 
 	// Pre-compute sizes that depend on opts.
+	// Resolve variable section payloads.
+	cs := opts.charStrings
+	if cs == nil {
+		cs = make([][]byte, opts.numGlyphs)
+		for i := range opts.numGlyphs {
+			cs[i] = []byte{0x0E}
+		}
+	}
+	if len(cs) != opts.numGlyphs {
+		t.Fatalf("synthetic: charStrings length %d != numGlyphs %d", len(cs), opts.numGlyphs)
+	}
+	charStringsPayload := writeCFFIndex(cs)
+	globalSubrPayload := writeCFFIndex(opts.globalSubrs)
+
 	charsetSize := 1 + (opts.numGlyphs-1)*2 // format 0
-	fdSelectSize := 1 + opts.numGlyphs      // format 0
-	charStringsSize := 2 + 1 + (opts.numGlyphs+1) + opts.numGlyphs
+	fdSelectSize := 1 + opts.numGlyphs      // default: format 0
+	if opts.fdSelectFormat3 != nil {
+		if len(opts.fdSelectFormat3) == 0 || opts.fdSelectFormat3[0].firstGID != 0 {
+			t.Fatalf("synthetic: fdSelectFormat3 must start with a range at glyph 0")
+		}
+		fdSelectSize = 1 + 2 + len(opts.fdSelectFormat3)*3 + 2
+	}
+	charStringsSize := len(charStringsPayload)
+	gsubrPayloadSize := len(globalSubrPayload)
 	fdArraySize := 2 + 1 + (opts.fdCount + 1) + opts.fdCount*fdEntrySize
 
 	// Absolute offsets.
@@ -162,7 +217,7 @@ func buildSyntheticCIDKeyedCFF(t fixtureT, opts syntheticCFFOptions) []byte {
 	offTopDict := offNameIndex + nameIndexSize
 	offStringIndex := offTopDict + topDictIndexSize
 	offGsubr := offStringIndex + stringIndexSize
-	offCharset := offGsubr + gsubrSize
+	offCharset := offGsubr + gsubrPayloadSize
 	offFDSelect := offCharset + charsetSize
 	offCharStrings := offFDSelect + fdSelectSize
 	offFDArray := offCharStrings + charStringsSize
@@ -195,7 +250,11 @@ func buildSyntheticCIDKeyedCFF(t fixtureT, opts syntheticCFFOptions) []byte {
 	td.longInt(int32(opts.numGlyphs))
 	td.byte(cffOpEscape)
 	td.byte(34) // CIDCount
-	td.longInt(int32(offCharset))
+	charsetOperand := int32(offCharset)
+	if opts.useCharsetOverride {
+		charsetOperand = opts.charsetOverride
+	}
+	td.longInt(charsetOperand)
 	td.byte(cffOpCharset)
 	if !opts.skipCharStrings {
 		td.longInt(int32(offCharStrings))
@@ -234,8 +293,8 @@ func buildSyntheticCIDKeyedCFF(t fixtureT, opts syntheticCFFOptions) []byte {
 		'I', 'd', 'e', 'n', 't', 'i', 't', 'y',
 	)
 
-	// Global Subr INDEX: empty.
-	out = append(out, 0x00, 0x00)
+	// Global Subr INDEX.
+	out = append(out, globalSubrPayload...)
 
 	// Charset format 0: SIDs for glyphs 1..numGlyphs-1.
 	out = append(out, 0x00)
@@ -243,20 +302,24 @@ func buildSyntheticCIDKeyedCFF(t fixtureT, opts syntheticCFFOptions) []byte {
 		out = append(out, byte(i>>8), byte(i&0xFF))
 	}
 
-	// FDSelect format 0: per-glyph FD index = (glyph % fdCount).
-	out = append(out, 0x00)
-	for i := range opts.numGlyphs {
-		out = append(out, byte(i%opts.fdCount))
+	// FDSelect: format 0 by default, or format 3 when ranges given.
+	if opts.fdSelectFormat3 != nil {
+		out = append(out, 0x03)
+		out = append(out, byte(len(opts.fdSelectFormat3)>>8), byte(len(opts.fdSelectFormat3)&0xFF))
+		for _, r := range opts.fdSelectFormat3 {
+			out = append(out, byte(r.firstGID>>8), byte(r.firstGID&0xFF), byte(r.fd))
+		}
+		// Sentinel uint16 = numGlyphs.
+		out = append(out, byte(opts.numGlyphs>>8), byte(opts.numGlyphs&0xFF))
+	} else {
+		out = append(out, 0x00)
+		for i := range opts.numGlyphs {
+			out = append(out, byte(i%opts.fdCount))
+		}
 	}
 
-	// CharStrings INDEX: each glyph is a single endchar byte (0x0E).
-	out = append(out, 0x00, byte(opts.numGlyphs), 0x01)
-	for i := range opts.numGlyphs + 1 {
-		out = append(out, byte(i+1))
-	}
-	for range opts.numGlyphs {
-		out = append(out, 0x0E)
-	}
+	// CharStrings INDEX.
+	out = append(out, charStringsPayload...)
 
 	// FDArray INDEX header.
 	out = append(out, 0x00, byte(opts.fdCount), 0x01)

--- a/font/cff_test.go
+++ b/font/cff_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import "testing"
+
+// buildSyntheticCFFv1 assembles a minimal CFF v1 blob whose first Top
+// DICT body is `topDict`. The Header, Name INDEX, and Top DICT INDEX
+// scaffolding are filled in with the smallest valid values: a single
+// "Test" name entry and a single Top DICT object. The function returns
+// raw CFF bytes — not an OpenType wrapper — matching what `CFFData()`
+// would yield for a real face.
+//
+// This fixture exists to give isCIDKeyedCFFv1 deterministic coverage
+// of the Top DICT operand/operator stream without depending on a
+// system-provided CJK font. Adobe TN #5176 §5 (Header), §5 INDEX
+// format, and §9 Top DICT operators are the relevant references.
+func buildSyntheticCFFv1(topDict []byte) []byte {
+	out := []byte{
+		// Header: major=1, minor=0, hdrSize=4, offSize=2.
+		// offSize here is the absolute-offset width for any
+		// references emitted into the Top DICT itself; isCIDKeyedCFFv1
+		// does not chase those, so the value is informational.
+		1, 0, 4, 2,
+		// Name INDEX: count=1, offSize=1, offsets=[1,5], data="Test".
+		0x00, 0x01,
+		0x01,
+		0x01, 0x05,
+		'T', 'e', 's', 't',
+		// Top DICT INDEX header: count=1, offSize=1,
+		// offsets=[1, len(topDict)+1].
+		0x00, 0x01,
+		0x01,
+		0x01, byte(len(topDict) + 1),
+	}
+	out = append(out, topDict...)
+	return out
+}
+
+// buildSyntheticCFFCollection assembles a CFF v1 blob with a Top DICT
+// INDEX containing two objects. Used to verify that isCIDKeyedCFFv1
+// rejects CFF font collections rather than guessing which Top DICT
+// applies — sfnt-wrapped OpenType cannot legitimately carry a multi-
+// Top-DICT CFF, so the safe answer is "not CID-keyed".
+func buildSyntheticCFFCollection(t *testing.T, dict1, dict2 []byte) []byte {
+	t.Helper()
+	if len(dict1)+1 > 0xFF || len(dict1)+1+len(dict2) > 0xFF {
+		t.Fatalf("synthetic dicts exceed 1-byte offset range")
+	}
+	out := []byte{
+		1, 0, 4, 2,
+		0x00, 0x01, 0x01, 0x01, 0x05, 'T', 'e', 's', 't',
+		// Top DICT INDEX with count=2.
+		0x00, 0x02,
+		0x01,
+		0x01, byte(len(dict1) + 1), byte(len(dict1) + 1 + len(dict2)),
+	}
+	out = append(out, dict1...)
+	out = append(out, dict2...)
+	return out
+}
+
+// Operand encodings used in the test dicts. Per TN #5176 §4 the byte
+// 139 encodes integer 0 (single-byte form, value = b0 - 139).
+const (
+	opInt0  byte = 139  // integer 0
+	opROS1       = 0x0C // first byte of two-byte ROS operator
+	opROS2       = 30   // second byte: ROS
+	opVer        = 0    // single-byte 'version' operator
+	op4Byte      = 29   // operand prefix for 4-byte signed int
+	op2Byte      = 28   // operand prefix for 2-byte signed int
+	opBCD        = 30   // operand prefix for BCD real (same byte as ROS2)
+)
+
+func TestIsCIDKeyedCFFv1Positive(t *testing.T) {
+	// Three integer operands then ROS — the canonical CID-keyed Top
+	// DICT opener.
+	dict := []byte{opInt0, opInt0, opInt0, opROS1, opROS2}
+	cff := buildSyntheticCFFv1(dict)
+	if !isCIDKeyedCFFv1(cff) {
+		t.Fatal("expected CID-keyed CFF to be accepted")
+	}
+}
+
+func TestIsCIDKeyedCFFv1NameKeyedFirstOperator(t *testing.T) {
+	// 'version' is the first operator — name-keyed CFF, not CID.
+	dict := []byte{opInt0, opVer}
+	cff := buildSyntheticCFFv1(dict)
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("expected name-keyed CFF to be rejected")
+	}
+}
+
+func TestIsCIDKeyedCFFv1ROSBytesInsideOperand(t *testing.T) {
+	// 4-byte integer operand whose payload contains the bytes
+	// `0x0C 0x1E` followed by a 'version' operator. A naive byte
+	// scan would find ROS and falsely return true; the operand-aware
+	// parser must skip the int and read 'version' as the first
+	// operator.
+	dict := []byte{op4Byte, 0x00, opROS1, opROS2, 0x00, opVer}
+	cff := buildSyntheticCFFv1(dict)
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("operand payload mimicking ROS must not be misread")
+	}
+}
+
+func TestIsCIDKeyedCFFv1TwoByteIntCarryingROSBytes(t *testing.T) {
+	// 2-byte integer operand whose payload happens to be `0x0C 0x1E`,
+	// followed by 'version'.
+	dict := []byte{op2Byte, opROS1, opROS2, opVer}
+	cff := buildSyntheticCFFv1(dict)
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("2-byte int payload mimicking ROS must not be misread")
+	}
+}
+
+func TestIsCIDKeyedCFFv1BCDOperand(t *testing.T) {
+	// BCD real operand encodes the value "1E" (decimal) and then
+	// ends with the nibble 0xF. The parser must walk past the BCD
+	// bytes rather than treat them as int payload or operator.
+	// Bytes: 30 (BCD prefix), 0x1E (digits "1E" — nibble 1 then E
+	// which is 'minus' marker), 0xFF (end marker filling both
+	// nibbles). Then a 'version' operator.
+	dict := []byte{opBCD, 0x1E, 0xFF, opVer}
+	cff := buildSyntheticCFFv1(dict)
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("BCD operand must not be misparsed as ROS")
+	}
+}
+
+func TestIsCIDKeyedCFFv1CFF2Major(t *testing.T) {
+	cff := buildSyntheticCFFv1([]byte{opInt0, opInt0, opInt0, opROS1, opROS2})
+	cff[0] = 2 // claim CFF2 major version
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("CFF major != 1 must be rejected")
+	}
+}
+
+func TestIsCIDKeyedCFFv1TruncatedHeader(t *testing.T) {
+	for n := range 4 {
+		buf := make([]byte, n)
+		if isCIDKeyedCFFv1(buf) {
+			t.Errorf("len=%d should not detect CID-keyed", n)
+		}
+	}
+}
+
+func TestIsCIDKeyedCFFv1HeaderBadHdrSize(t *testing.T) {
+	cff := buildSyntheticCFFv1([]byte{opInt0, opInt0, opInt0, opROS1, opROS2})
+	cff[2] = 3 // hdrSize < 4 is invalid
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("hdrSize < 4 must be rejected")
+	}
+	cff[2] = 200 // hdrSize past EOF
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("hdrSize past EOF must be rejected")
+	}
+}
+
+func TestIsCIDKeyedCFFv1TruncatedTopDICTINDEX(t *testing.T) {
+	// Build a valid header + Name INDEX, then chop off everything
+	// after.
+	full := buildSyntheticCFFv1([]byte{opInt0, opInt0, opInt0, opROS1, opROS2})
+	for cut := len(full) - 1; cut >= 4+9; cut-- {
+		if isCIDKeyedCFFv1(full[:cut]) {
+			t.Errorf("cut=%d must not detect CID-keyed", cut)
+		}
+	}
+}
+
+func TestIsCIDKeyedCFFv1RejectsCollection(t *testing.T) {
+	dict := []byte{opInt0, opInt0, opInt0, opROS1, opROS2}
+	cff := buildSyntheticCFFCollection(t, dict, dict)
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("Top DICT INDEX count > 1 must be rejected")
+	}
+}
+
+func TestIsCIDKeyedCFFv1EmptyTopDICT(t *testing.T) {
+	// Top DICT body of zero bytes. The INDEX is still valid: offsets
+	// = [1, 1]. The walker exits the loop immediately with no
+	// operator found.
+	cff := buildSyntheticCFFv1(nil)
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("empty Top DICT must be rejected")
+	}
+}
+
+func TestIsCIDKeyedCFFv1ReservedByte(t *testing.T) {
+	// Byte 22 is reserved (per TN #5176 §4: bytes 22..27 and 31 are
+	// reserved/unused in the operand/operator encoding). Hitting one
+	// is a parse error, not a CID indicator.
+	dict := []byte{22, opROS1, opROS2}
+	cff := buildSyntheticCFFv1(dict)
+	if isCIDKeyedCFFv1(cff) {
+		t.Error("reserved byte in Top DICT must abort detection")
+	}
+}

--- a/font/cff_test.go
+++ b/font/cff_test.go
@@ -74,12 +74,12 @@ func buildSyntheticCFFCollection(t fixtureT, dict1, dict2 []byte) []byte {
 // 139 encodes integer 0 (single-byte form, value = b0 - 139).
 const (
 	opInt0  byte = 139  // integer 0
-	opROS1       = 0x0C // first byte of two-byte ROS operator
-	opROS2       = 30   // second byte: ROS
-	opVer        = 0    // single-byte 'version' operator
-	op4Byte      = 29   // operand prefix for 4-byte signed int
-	op2Byte      = 28   // operand prefix for 2-byte signed int
-	opBCD        = 30   // operand prefix for BCD real (same byte as ROS2)
+	opROS1  byte = 0x0C // first byte of two-byte ROS operator
+	opROS2  byte = 30   // second byte: ROS
+	opVer   byte = 0    // single-byte 'version' operator
+	op4Byte byte = 29   // operand prefix for 4-byte signed int
+	op2Byte byte = 28   // operand prefix for 2-byte signed int
+	opBCD   byte = 30   // operand prefix for BCD real (same byte as ROS2)
 )
 
 // syntheticCFFOptions controls buildSyntheticCIDKeyedCFF. The defaults

--- a/font/cff_test.go
+++ b/font/cff_test.go
@@ -38,12 +38,21 @@ func buildSyntheticCFFv1(topDict []byte) []byte {
 	return out
 }
 
+// fixtureT is the minimal testing-T surface the synthetic CFF builders
+// need: Helper for stack-frame attribution and Fatalf to abort on
+// invalid options. *testing.T satisfies it; the fuzz seed corpus uses
+// a no-op stand-in so it can call the builder outside a test.
+type fixtureT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
 // buildSyntheticCFFCollection assembles a CFF v1 blob with a Top DICT
 // INDEX containing two objects. Used to verify that isCIDKeyedCFFv1
 // rejects CFF font collections rather than guessing which Top DICT
 // applies — sfnt-wrapped OpenType cannot legitimately carry a multi-
 // Top-DICT CFF, so the safe answer is "not CID-keyed".
-func buildSyntheticCFFCollection(t *testing.T, dict1, dict2 []byte) []byte {
+func buildSyntheticCFFCollection(t fixtureT, dict1, dict2 []byte) []byte {
 	t.Helper()
 	if len(dict1)+1 > 0xFF || len(dict1)+1+len(dict2) > 0xFF {
 		t.Fatalf("synthetic dicts exceed 1-byte offset range")
@@ -72,6 +81,264 @@ const (
 	op2Byte      = 28   // operand prefix for 2-byte signed int
 	opBCD        = 30   // operand prefix for BCD real (same byte as ROS2)
 )
+
+// syntheticCFFOptions controls buildSyntheticCIDKeyedCFF. The defaults
+// (numGlyphs=3, fdCount=1) produce the smallest valid CID-keyed CFF
+// the parser accepts. The builder caps the supported ranges so all
+// INDEX sections fit with offSize=1, keeping the resulting bytes
+// trivial to hand-verify in test failures.
+type syntheticCFFOptions struct {
+	numGlyphs int // 1..100
+	fdCount   int // 1..20
+
+	// Customisations to drive negative tests. Each "skip" flag omits
+	// the named operator from the Top DICT or the per-FD font dict;
+	// parseCFF should reject every resulting blob.
+	skipROS         bool
+	skipCharStrings bool
+	skipFDArray     bool
+	skipFDSelect    bool
+	skipFDPrivate   bool
+
+	// brokenFDPrivate places the FD's Private DICT at an offset past
+	// the end of the buffer when true. Exercises the FD private
+	// bounds check.
+	brokenFDPrivate bool
+}
+
+// buildSyntheticCIDKeyedCFF assembles a complete, valid CID-keyed CFF
+// v1 blob deterministically — useful for parser tests that must not
+// depend on a system-installed CJK font. All offset operands in the
+// Top DICT and per-FD font/private DICTs use the longint (29 + int32)
+// encoding so section sizes are independent of the offset values; the
+// builder can therefore compute every absolute offset in a single
+// forward pass without iterating to a fixed point.
+//
+// Layout (fixed order, no shared sections):
+//
+//	Header(4)
+//	Name INDEX                ("Test", offSize=1)              -> 9 bytes
+//	Top DICT INDEX            (1 entry, fixed 50-byte payload) -> 55 bytes
+//	String INDEX              ("Adobe", "Identity")            -> 19 bytes
+//	Global Subr INDEX         (empty)                          -> 2 bytes
+//	Charset                   (format 0, numGlyphs-1 SIDs)
+//	FDSelect                  (format 0, numGlyphs entries)
+//	CharStrings INDEX         (each charstring = single byte 0x0E)
+//	FDArray INDEX             (per-FD font dict, 11 bytes each)
+//	[Private DICT + empty Local Subr INDEX] * fdCount
+//
+// The Private DICT contains the bare minimum that parseCFF will
+// accept: defaultWidthX, nominalWidthX, and Subrs (relative offset
+// equal to privateSize, so the empty Local Subr INDEX sits
+// immediately after).
+func buildSyntheticCIDKeyedCFF(t fixtureT, opts syntheticCFFOptions) []byte {
+	t.Helper()
+	if opts.numGlyphs < 1 || opts.numGlyphs > 100 {
+		t.Fatalf("synthetic: numGlyphs %d out of range [1,100]", opts.numGlyphs)
+	}
+	if opts.fdCount < 1 || opts.fdCount > 20 {
+		t.Fatalf("synthetic: fdCount %d out of range [1,20]", opts.fdCount)
+	}
+
+	const (
+		headerSize       = 4
+		nameIndexSize    = 9
+		topDictIndexSize = 55
+		stringIndexSize  = 19
+		gsubrSize        = 2
+		privateDictSize  = 18 // see writePrivateDict
+		localSubrSize    = 2  // empty INDEX
+		fdEntrySize      = 11 // per-FD font dict
+	)
+
+	// Pre-compute sizes that depend on opts.
+	charsetSize := 1 + (opts.numGlyphs-1)*2 // format 0
+	fdSelectSize := 1 + opts.numGlyphs      // format 0
+	charStringsSize := 2 + 1 + (opts.numGlyphs+1) + opts.numGlyphs
+	fdArraySize := 2 + 1 + (opts.fdCount + 1) + opts.fdCount*fdEntrySize
+
+	// Absolute offsets.
+	offNameIndex := headerSize
+	offTopDict := offNameIndex + nameIndexSize
+	offStringIndex := offTopDict + topDictIndexSize
+	offGsubr := offStringIndex + stringIndexSize
+	offCharset := offGsubr + gsubrSize
+	offFDSelect := offCharset + charsetSize
+	offCharStrings := offFDSelect + fdSelectSize
+	offFDArray := offCharStrings + charStringsSize
+
+	// Per-FD blocks come last; record their starting offsets so the
+	// FDArray font dicts can point at them and so a broken-private
+	// option can target a known-out-of-range address.
+	fdPrivateOff := make([]int, opts.fdCount)
+	cursor := offFDArray + fdArraySize
+	for i := range opts.fdCount {
+		fdPrivateOff[i] = cursor
+		cursor += privateDictSize + localSubrSize
+	}
+	totalSize := cursor
+	if opts.brokenFDPrivate && opts.fdCount > 0 {
+		fdPrivateOff[0] = totalSize + 0x10000 // far beyond the buffer
+	}
+
+	// Top DICT body. All operands use longint encoding (29 + int32 BE)
+	// to keep the body fixed at exactly topDictPayload bytes.
+	const topDictPayload = topDictIndexSize - 5 // 50 bytes
+	td := newBytes(t, topDictPayload)
+	if !opts.skipROS {
+		td.longInt(391) // registry SID (custom string 0)
+		td.longInt(392) // ordering SID (custom string 1)
+		td.longInt(0)   // supplement
+		td.byte(cffOpEscape)
+		td.byte(30) // ROS
+	}
+	td.longInt(int32(opts.numGlyphs))
+	td.byte(cffOpEscape)
+	td.byte(34) // CIDCount
+	td.longInt(int32(offCharset))
+	td.byte(cffOpCharset)
+	if !opts.skipCharStrings {
+		td.longInt(int32(offCharStrings))
+		td.byte(cffOpCharStrings)
+	}
+	if !opts.skipFDArray {
+		td.longInt(int32(offFDArray))
+		td.byte(cffOpEscape)
+		td.byte(36) // FDArray
+	}
+	if !opts.skipFDSelect {
+		td.longInt(int32(offFDSelect))
+		td.byte(cffOpEscape)
+		td.byte(37) // FDSelect
+	}
+	td.padTo(topDictPayload)
+
+	// Assemble the full blob.
+	out := make([]byte, 0, totalSize)
+
+	// Header: major=1, minor=0, hdrSize=4, offSize (informational)=1.
+	out = append(out, 1, 0, 4, 1)
+
+	// Name INDEX: count=1, offSize=1, offsets=[1,5], data="Test".
+	out = append(out, 0x00, 0x01, 0x01, 0x01, 0x05, 'T', 'e', 's', 't')
+
+	// Top DICT INDEX: count=1, offSize=1, offsets=[1, payload+1].
+	out = append(out, 0x00, 0x01, 0x01, 0x01, byte(topDictPayload+1))
+	out = append(out, td.bytes...)
+
+	// String INDEX: ("Adobe", "Identity") — 5 + 8 = 13 bytes payload.
+	out = append(out,
+		0x00, 0x02, 0x01,
+		0x01, 0x06, 0x0E,
+		'A', 'd', 'o', 'b', 'e',
+		'I', 'd', 'e', 'n', 't', 'i', 't', 'y',
+	)
+
+	// Global Subr INDEX: empty.
+	out = append(out, 0x00, 0x00)
+
+	// Charset format 0: SIDs for glyphs 1..numGlyphs-1.
+	out = append(out, 0x00)
+	for i := 1; i < opts.numGlyphs; i++ {
+		out = append(out, byte(i>>8), byte(i&0xFF))
+	}
+
+	// FDSelect format 0: per-glyph FD index = (glyph % fdCount).
+	out = append(out, 0x00)
+	for i := range opts.numGlyphs {
+		out = append(out, byte(i%opts.fdCount))
+	}
+
+	// CharStrings INDEX: each glyph is a single endchar byte (0x0E).
+	out = append(out, 0x00, byte(opts.numGlyphs), 0x01)
+	for i := range opts.numGlyphs + 1 {
+		out = append(out, byte(i+1))
+	}
+	for range opts.numGlyphs {
+		out = append(out, 0x0E)
+	}
+
+	// FDArray INDEX header.
+	out = append(out, 0x00, byte(opts.fdCount), 0x01)
+	for i := range opts.fdCount + 1 {
+		out = append(out, byte(1+i*fdEntrySize))
+	}
+	// Per-FD font dicts: longint(privSize) longint(privOff) op:Private.
+	for i := range opts.fdCount {
+		out = append(out, 29)
+		out = appendInt32(out, int32(privateDictSize))
+		out = append(out, 29)
+		out = appendInt32(out, int32(fdPrivateOff[i]))
+		if opts.skipFDPrivate {
+			out = append(out, cffOpVersion) // any operator other than Private
+		} else {
+			out = append(out, cffOpPrivate)
+		}
+	}
+
+	// Per-FD Private DICTs + empty Local Subr INDEXes.
+	for range opts.fdCount {
+		// defaultWidthX=0, nominalWidthX=0, Subrs at relative
+		// offset = privateDictSize.
+		out = append(out, 29)
+		out = appendInt32(out, 0)
+		out = append(out, cffOpDefaultWidthX)
+		out = append(out, 29)
+		out = appendInt32(out, 0)
+		out = append(out, cffOpNominalWidthX)
+		out = append(out, 29)
+		out = appendInt32(out, int32(privateDictSize))
+		out = append(out, cffOpSubrs)
+		// Local Subr INDEX (empty).
+		out = append(out, 0x00, 0x00)
+	}
+
+	if len(out) != totalSize {
+		t.Fatalf("synthetic: produced %d bytes, expected %d", len(out), totalSize)
+	}
+	return out
+}
+
+// appendInt32 appends a 4-byte big-endian int32. Inlined here to keep
+// the synthetic builder readable.
+func appendInt32(b []byte, v int32) []byte {
+	return append(b, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+}
+
+// bytesBuilder is a fixed-capacity byte buffer used by the synthetic
+// CFF builder. It exists to make the layered Top DICT construction
+// readable: each operand/operator emit is a single named call, and a
+// final padTo zero-fills to the declared payload size.
+type bytesBuilder struct {
+	t     fixtureT
+	bytes []byte
+	cap   int
+}
+
+func newBytes(t fixtureT, cap int) *bytesBuilder {
+	return &bytesBuilder{t: t, cap: cap}
+}
+
+func (b *bytesBuilder) byte(v byte) {
+	if len(b.bytes)+1 > b.cap {
+		b.t.Fatalf("bytesBuilder: overflow at byte(%d)", v)
+	}
+	b.bytes = append(b.bytes, v)
+}
+
+func (b *bytesBuilder) longInt(v int32) {
+	if len(b.bytes)+5 > b.cap {
+		b.t.Fatalf("bytesBuilder: overflow at longInt(%d)", v)
+	}
+	b.bytes = append(b.bytes, 29)
+	b.bytes = appendInt32(b.bytes, v)
+}
+
+func (b *bytesBuilder) padTo(n int) {
+	for len(b.bytes) < n {
+		b.bytes = append(b.bytes, 0)
+	}
+}
 
 func TestIsCIDKeyedCFFv1Positive(t *testing.T) {
 	// Three integer operands then ROS — the canonical CID-keyed Top

--- a/font/embed.go
+++ b/font/embed.go
@@ -150,6 +150,15 @@ func (ef *EmbeddedFont) Kern(left, right rune) float64 {
 // this method returns a builder function that takes an "add object" callback.
 func (ef *EmbeddedFont) BuildObjects(addObject func(core.PdfObject) *core.PdfIndirectReference) *core.PdfDictionary {
 	face := ef.face
+
+	// CFF outlines need a different PDF object graph (/FontFile3,
+	// /CIDFontType0, no /CIDToGIDMap). Route them through the CFF
+	// builder; everything below this point assumes TrueType outlines
+	// (glyf/loca) for the /FontFile2 + /CIDFontType2 path.
+	if cffData, ok := faceCFFData(face); ok {
+		return ef.buildObjectsCFF(cffData, addObject)
+	}
+
 	psName := sanitizePSName(face.PostScriptName())
 	upem := face.UnitsPerEm()
 

--- a/font/embed_cff.go
+++ b/font/embed_cff.go
@@ -3,11 +3,7 @@
 
 package font
 
-import (
-	"maps"
-
-	"github.com/carlos7ags/folio/core"
-)
+import "github.com/carlos7ags/folio/core"
 
 // buildObjectsCFF builds the PDF object graph for a CFF-flavored
 // embedded font. The structure mirrors the TrueType path in
@@ -37,15 +33,11 @@ func (ef *EmbeddedFont) buildObjectsCFF(cffData []byte, addObject func(core.PdfO
 	psName := sanitizePSName(face.PostScriptName())
 	upem := face.UnitsPerEm()
 
-	// Always include .notdef (GID 0) in the used-glyph set; the
-	// subset tag in the PostScript name is derived from this set.
-	glyphs := make(map[uint16]rune, len(ef.usedGlyphs)+1)
-	glyphs[0] = 0
-	maps.Copy(glyphs, ef.usedGlyphs)
-
-	// Phase 1: embed CFF bytes unchanged. Phase 3+ will replace this
-	// call with SubsetCFF(cffData, glyphs) and apply the subset tag
-	// prefix to psName on success.
+	// Phase 1: embed CFF bytes unchanged. Phase 3+ will replace cffData
+	// with a SubsetCFF result and apply the six-letter "XXXXXX+"
+	// subset tag prefix to psName. The same prefix must be set on
+	// /BaseFont in the Type0 dict, /BaseFont in the CIDFont, and
+	// /FontName in the descriptor — derive once at that point.
 	fontStream := core.NewPdfStreamCompressed(cffData)
 	fontStream.Dict.Set("Subtype", core.NewPdfName("CIDFontType0C"))
 	fontStreamRef := addObject(fontStream)

--- a/font/embed_cff.go
+++ b/font/embed_cff.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"maps"
+
+	"github.com/carlos7ags/folio/core"
+)
+
+// buildObjectsCFF builds the PDF object graph for a CFF-flavored
+// embedded font. The structure mirrors the TrueType path in
+// [EmbeddedFont.BuildObjects] but differs in three places, per ISO
+// 32000-1 §9.8 (font descriptors) and §9.7 (CID fonts):
+//
+//  1. The font stream is `/FontFile3` with `/Subtype /CIDFontType0C`
+//     and no `/Length1` (Length1 applies only to Type 1 / TrueType
+//     streams).
+//  2. The descendant CIDFont has `/Subtype /CIDFontType0` (CFF
+//     outlines) rather than `/CIDFontType2` (TrueType outlines).
+//  3. `/CIDToGIDMap` is omitted: CFF's intrinsic charset already maps
+//     CIDs to glyph slots, so the explicit GID map is meaningless and
+//     PDF readers reject it on /CIDFontType0.
+//
+// `/W`, the ToUnicode CMap, the Type0 wrapper, `/Encoding /Identity-H`,
+// and the `Adobe-Identity-0` ordering are reused unchanged from the
+// TrueType path so that text shaping, copy/paste, and accessibility
+// behave identically across outline formats.
+//
+// During Phase 1 the CFF bytes are embedded unmodified — equivalent to
+// the existing fallback behavior of [Subset] for unsupported formats,
+// but with the correct PDF object graph. Phase 3+ replaces the
+// `cffData` payload with a subset CFF blob.
+func (ef *EmbeddedFont) buildObjectsCFF(cffData []byte, addObject func(core.PdfObject) *core.PdfIndirectReference) *core.PdfDictionary {
+	face := ef.face
+	psName := sanitizePSName(face.PostScriptName())
+	upem := face.UnitsPerEm()
+
+	// Always include .notdef (GID 0) in the used-glyph set; the
+	// subset tag in the PostScript name is derived from this set.
+	glyphs := make(map[uint16]rune, len(ef.usedGlyphs)+1)
+	glyphs[0] = 0
+	maps.Copy(glyphs, ef.usedGlyphs)
+
+	// Phase 1: embed CFF bytes unchanged. Phase 3+ will replace this
+	// call with SubsetCFF(cffData, glyphs) and apply the subset tag
+	// prefix to psName on success.
+	fontStream := core.NewPdfStreamCompressed(cffData)
+	fontStream.Dict.Set("Subtype", core.NewPdfName("CIDFontType0C"))
+	fontStreamRef := addObject(fontStream)
+
+	descriptor := buildCFFFontDescriptor(face, psName, fontStreamRef)
+	descriptorRef := addObject(descriptor)
+
+	cidFont := core.NewPdfDictionary()
+	cidFont.Set("Type", core.NewPdfName("Font"))
+	cidFont.Set("Subtype", core.NewPdfName("CIDFontType0"))
+	cidFont.Set("BaseFont", core.NewPdfName(psName))
+	cidFont.Set("CIDSystemInfo", buildCIDSystemInfo())
+	cidFont.Set("FontDescriptor", descriptorRef)
+	cidFont.Set("DW", core.NewPdfInteger(1000))
+	cidFont.Set("W", buildWidthArray(ef, upem))
+	// /CIDToGIDMap is intentionally omitted for /CIDFontType0; CFF
+	// charset provides the CID-to-glyph mapping intrinsically.
+	cidFontRef := addObject(cidFont)
+
+	toUnicode := core.NewPdfStreamCompressed([]byte(ef.buildToUnicodeCMap()))
+	toUnicodeRef := addObject(toUnicode)
+
+	type0 := core.NewPdfDictionary()
+	type0.Set("Type", core.NewPdfName("Font"))
+	type0.Set("Subtype", core.NewPdfName("Type0"))
+	type0.Set("BaseFont", core.NewPdfName(psName))
+	type0.Set("Encoding", core.NewPdfName("Identity-H"))
+	type0.Set("DescendantFonts", core.NewPdfArray(cidFontRef))
+	type0.Set("ToUnicode", toUnicodeRef)
+
+	return type0
+}
+
+// buildCFFFontDescriptor assembles the /FontDescriptor for a CFF-
+// flavored CIDFont. The only structural difference from the TrueType
+// descriptor is the use of /FontFile3 in place of /FontFile2.
+func buildCFFFontDescriptor(face Face, psName string, fontStreamRef *core.PdfIndirectReference) *core.PdfDictionary {
+	bbox := face.BBox()
+	d := core.NewPdfDictionary()
+	d.Set("Type", core.NewPdfName("FontDescriptor"))
+	d.Set("FontName", core.NewPdfName(psName))
+	d.Set("Flags", core.NewPdfInteger(int(face.Flags())))
+	d.Set("FontBBox", core.NewPdfArray(
+		core.NewPdfInteger(bbox[0]),
+		core.NewPdfInteger(bbox[1]),
+		core.NewPdfInteger(bbox[2]),
+		core.NewPdfInteger(bbox[3]),
+	))
+	d.Set("ItalicAngle", core.NewPdfReal(face.ItalicAngle()))
+	d.Set("Ascent", core.NewPdfInteger(face.Ascent()))
+	d.Set("Descent", core.NewPdfInteger(face.Descent()))
+	capHeight := face.CapHeight()
+	if capHeight == 0 {
+		capHeight = face.Ascent()
+	}
+	d.Set("CapHeight", core.NewPdfInteger(capHeight))
+	stemV := face.StemV()
+	if stemV == 0 {
+		stemV = 80
+	}
+	d.Set("StemV", core.NewPdfInteger(stemV))
+	d.Set("FontFile3", fontStreamRef)
+	return d
+}

--- a/font/embed_cff.go
+++ b/font/embed_cff.go
@@ -3,7 +3,11 @@
 
 package font
 
-import "github.com/carlos7ags/folio/core"
+import (
+	"maps"
+
+	"github.com/carlos7ags/folio/core"
+)
 
 // buildObjectsCFF builds the PDF object graph for a CFF-flavored
 // embedded font. The structure mirrors the TrueType path in
@@ -33,11 +37,25 @@ func (ef *EmbeddedFont) buildObjectsCFF(cffData []byte, addObject func(core.PdfO
 	psName := sanitizePSName(face.PostScriptName())
 	upem := face.UnitsPerEm()
 
-	// Phase 1: embed CFF bytes unchanged. Phase 3+ will replace cffData
-	// with a SubsetCFF result and apply the six-letter "XXXXXX+"
-	// subset tag prefix to psName. The same prefix must be set on
-	// /BaseFont in the Type0 dict, /BaseFont in the CIDFont, and
-	// /FontName in the descriptor — derive once at that point.
+	// Always include .notdef (GID 0) in the used-glyph set so the
+	// subset tag hash is stable and the resulting CFF carries a
+	// valid .notdef glyph (required for any PDF font embed).
+	glyphs := make(map[uint16]rune, len(ef.usedGlyphs)+1)
+	glyphs[0] = 0
+	maps.Copy(glyphs, ef.usedGlyphs)
+
+	// Subset the CFF down to the used charstrings + their reachable
+	// subroutines. On failure we fall back to embedding the source
+	// bytes unchanged — that produces a much larger but structurally
+	// valid PDF, matching the TrueType path's silent-fallback policy
+	// at font/embed.go:167. The single PSName / BaseFont / FontName
+	// triplet must all carry the same "XXXXXX+" prefix when subsetting
+	// succeeds, per ISO 32000-1 §9.6.4.
+	if subsetData, err := SubsetCFF(cffData, glyphs); err == nil {
+		cffData = subsetData
+		psName = subsetTag(glyphs) + "+" + psName
+	}
+
 	fontStream := core.NewPdfStreamCompressed(cffData)
 	fontStream.Dict.Set("Subtype", core.NewPdfName("CIDFontType0C"))
 	fontStreamRef := addObject(fontStream)

--- a/font/embed_cff_test.go
+++ b/font/embed_cff_test.go
@@ -311,6 +311,72 @@ func TestBuildObjectsTrueTypeUnchanged(t *testing.T) {
 	}
 }
 
+// TestBuildObjectsCFFSubsetsFontStream is the embed-path regression
+// test for issue #295. A CFF face passed through BuildObjects after
+// encoding a single CJK character must produce a font stream whose
+// raw payload is dramatically smaller than the source CFF table —
+// confirming SubsetCFF is wired in. The Phase 1 unsubsetted path
+// produced ~14 MB for this scenario; subset bytes should be well
+// under 1 MB.
+func TestBuildObjectsCFFSubsetsFontStream(t *testing.T) {
+	face := loadTestCFFFace(t)
+	cf := face.(cffFace)
+	srcLen := len(cf.CFFData())
+
+	ef := NewEmbeddedFont(face)
+	ef.EncodeString("a") // single CJK or Latin glyph — content doesn't matter
+
+	var objects []core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		n := len(objects) + 1
+		objects = append(objects, obj)
+		return core.NewPdfIndirectReference(n, 0)
+	}
+	ef.BuildObjects(addObject)
+
+	stream := objects[0].(*core.PdfStream)
+	if len(stream.Data) >= srcLen/10 {
+		t.Errorf("embedded font stream size %d not significantly smaller than source CFF %d",
+			len(stream.Data), srcLen)
+	}
+	t.Logf("CFF font stream embed: %d -> %d bytes (%.1f%%)",
+		srcLen, len(stream.Data), float64(len(stream.Data))*100/float64(srcLen))
+}
+
+// TestBuildObjectsCFFSubsetTagPrefix verifies that when SubsetCFF
+// succeeds, the six-letter "XXXXXX+" subset tag prefix is applied
+// consistently to /BaseFont (Type0 and CIDFont) and /FontName
+// (descriptor) per ISO 32000-1 §9.6.4. PDF readers (Acrobat in
+// particular) warn when these disagree.
+func TestBuildObjectsCFFSubsetTagPrefix(t *testing.T) {
+	face := loadTestCFFFace(t)
+	ef := NewEmbeddedFont(face)
+	ef.EncodeString("a")
+
+	var objects []core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		n := len(objects) + 1
+		objects = append(objects, obj)
+		return core.NewPdfIndirectReference(n, 0)
+	}
+	type0 := ef.BuildObjects(addObject)
+
+	prefixOf := func(d *core.PdfDictionary, key string) string {
+		s := name(t, d, key)
+		if len(s) < 7 || s[6] != '+' {
+			return ""
+		}
+		return s[:6]
+	}
+	type0Tag := prefixOf(type0, "BaseFont")
+	cidTag := prefixOf(objects[2].(*core.PdfDictionary), "BaseFont")
+	descTag := prefixOf(objects[1].(*core.PdfDictionary), "FontName")
+	if type0Tag == "" || type0Tag != cidTag || type0Tag != descTag {
+		t.Errorf("subset tag mismatch: Type0=%q CIDFont=%q Descriptor=%q",
+			type0Tag, cidTag, descTag)
+	}
+}
+
 // TestBuildObjectsCFFEmptyUsedGlyphs covers the edge case where no
 // EncodeString call has happened. The CFF builder must still emit four
 // indirect objects with sensible defaults (empty /W array, empty

--- a/font/embed_cff_test.go
+++ b/font/embed_cff_test.go
@@ -4,35 +4,55 @@
 package font
 
 import (
-	"bytes"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/carlos7ags/folio/core"
 )
 
-// testCFFFontPath returns a path to an OTF (CFF-flavored) font that
-// exists on the test system, or skips the test. Real CFF outlines are
-// needed because the dispatch is gated on the presence of the `CFF `
-// table; a synthetic minimal sfnt would still exercise the same code
-// path but at the cost of hand-rolling head/hhea/maxp/hmtx/cmap. Once
-// the Phase 2 parser lands we can switch these tests to a synthetic
-// fixture and drop the system-font dependency.
+// testCFFFontPath returns a path to a CID-keyed CFF font (the dispatch
+// the embedder now gates on) that exists on the test system, or skips
+// the test. Non-CID-keyed CFF fonts are explicitly excluded here: they
+// fall through to the legacy TrueType embed path by design, so testing
+// the CFF dispatch with one of them would mis-fire the assertions.
+//
+// A synthetic sfnt-with-CFF fixture would remove the system-font
+// dependency entirely; that lands with the Phase 2 CFF parser, which
+// makes hand-rolling a valid sfnt-wrapped CID-keyed CFF a side-effect
+// of work already in progress rather than a one-off test fixture.
 func testCFFFontPath(t *testing.T) string {
 	t.Helper()
 	candidates := []string{
-		"/System/Library/Fonts/Supplemental/STIXGeneral.otf",
-		"/System/Library/Fonts/Supplemental/NotoSansCanadianAboriginal-Regular.otf",
-		"/System/Library/Fonts/LastResort.otf",
+		"/System/Library/Fonts/Hiragino Sans GB.ttc",
 		"/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+		"/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
+		"/usr/share/fonts/google-noto-cjk/NotoSansCJK-Regular.ttc",
 	}
 	for _, p := range candidates {
 		if _, err := os.Stat(p); err == nil {
 			return p
 		}
 	}
-	t.Skip("no CFF/OTF font available on this system")
+	t.Skip("no CID-keyed CFF font available on this system")
+	return ""
+}
+
+// testNonCIDKeyedCFFFontPath returns a Latin/.otf CFF font (name-keyed)
+// for testing that the dispatcher correctly *excludes* it. STIXGeneral
+// is widely available on macOS; on Linux there's no comparably
+// universal name-keyed CFF, so the test skips.
+func testNonCIDKeyedCFFFontPath(t *testing.T) string {
+	t.Helper()
+	candidates := []string{
+		"/System/Library/Fonts/Supplemental/STIXGeneral.otf",
+		"/System/Library/Fonts/Supplemental/NotoSansCanadianAboriginal-Regular.otf",
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	t.Skip("no name-keyed CFF font available on this system")
 	return ""
 }
 
@@ -45,7 +65,7 @@ func loadTestCFFFace(t *testing.T) Face {
 	return face
 }
 
-func TestIsCFFDetectsOutlineFormat(t *testing.T) {
+func TestIsCFFAndCFF2DetectOutlineFormat(t *testing.T) {
 	cff := loadTestCFFFace(t)
 	cf, ok := cff.(cffFace)
 	if !ok {
@@ -54,8 +74,11 @@ func TestIsCFFDetectsOutlineFormat(t *testing.T) {
 	if !cf.IsCFF() {
 		t.Error("expected IsCFF() = true for OTF/CFF font")
 	}
+	if cf.IsCFF2() {
+		t.Error("IsCFF2() must be false for a plain CFF v1 font")
+	}
 	if len(cf.CFFData()) == 0 {
-		t.Error("expected CFFData() to return non-empty bytes for CFF font")
+		t.Error("CFFData() returned empty for CFF font")
 	}
 
 	ttf := loadTestFace(t)
@@ -63,44 +86,78 @@ func TestIsCFFDetectsOutlineFormat(t *testing.T) {
 	if !ok {
 		t.Fatalf("TTF face does not implement cffFace")
 	}
-	if cf2.IsCFF() {
-		t.Error("expected IsCFF() = false for TrueType font")
+	if cf2.IsCFF() || cf2.IsCFF2() {
+		t.Error("TrueType face must have both IsCFF/IsCFF2 false")
 	}
 	if cf2.CFFData() != nil {
-		t.Error("expected CFFData() = nil for TrueType font")
+		t.Error("CFFData() must be nil for TrueType")
 	}
 }
 
-func TestFaceCFFDataHelper(t *testing.T) {
-	// TrueType: helper returns (nil, false).
-	ttf := loadTestFace(t)
-	if data, ok := faceCFFData(ttf); ok || data != nil {
-		t.Errorf("faceCFFData(TTF) = (%d bytes, %v), want (nil, false)", len(data), ok)
-	}
-
-	// CFF: helper returns (bytes, true) with the same payload as
-	// CFFData() directly. We compare lengths rather than full bytes
-	// to keep the assertion meaningful without ballooning test
-	// memory for large CJK fonts.
-	cff := loadTestCFFFace(t)
-	data, ok := faceCFFData(cff)
+func TestFaceCFFDataAcceptsCIDKeyed(t *testing.T) {
+	face := loadTestCFFFace(t)
+	data, ok := faceCFFData(face)
 	if !ok {
-		t.Fatal("faceCFFData(CFF) returned ok=false")
+		t.Fatal("faceCFFData rejected CID-keyed CFF face")
 	}
 	if len(data) == 0 {
-		t.Error("faceCFFData(CFF) returned empty bytes")
-	}
-	if direct := cff.(cffFace).CFFData(); len(direct) != len(data) {
-		t.Errorf("faceCFFData length %d != CFFData length %d", len(data), len(direct))
+		t.Error("faceCFFData returned empty bytes for CID-keyed CFF")
 	}
 }
 
-// TestBuildObjectsCFFDispatch exercises the embed-path branch added in
-// Phase 1: a CFF face must produce a /FontFile3 stream with
-// /CIDFontType0C subtype, a /CIDFontType0 descendant font, no
-// /CIDToGIDMap, and none of the TrueType-only keys (/FontFile2,
-// /CIDFontType2, /Length1).
-func TestBuildObjectsCFFDispatch(t *testing.T) {
+// TestFaceCFFDataExcludesNameKeyed verifies the CID-keyed gate added
+// in Phase 1.5. A plain Latin CFF font has a `CFF ` table but the Top
+// DICT does not open with ROS, so the dispatcher must keep it on the
+// legacy embed path until a non-CIDFont CFF graph (/Type1C) lands.
+func TestFaceCFFDataExcludesNameKeyed(t *testing.T) {
+	path := testNonCIDKeyedCFFFontPath(t)
+	face, err := LoadFont(path)
+	if err != nil {
+		t.Fatalf("LoadFont %s: %v", path, err)
+	}
+	cf := face.(cffFace)
+	if !cf.IsCFF() {
+		t.Fatalf("test precondition broken: %s should be CFF", path)
+	}
+	if _, ok := faceCFFData(face); ok {
+		t.Errorf("faceCFFData accepted name-keyed CFF; expected (nil, false)")
+	}
+}
+
+func TestFaceCFFDataRejectsTrueType(t *testing.T) {
+	if data, ok := faceCFFData(loadTestFace(t)); ok || data != nil {
+		t.Errorf("faceCFFData(TTF) = (%d bytes, %v), want (nil, false)", len(data), ok)
+	}
+}
+
+// name extracts the value of a /Name PDF object from a dictionary
+// slot. The two failures (key absent, value not a name) are folded
+// into a single error path because test callers only need the name
+// string or "missing".
+func name(t *testing.T, d *core.PdfDictionary, key string) string {
+	t.Helper()
+	v := d.Get(key)
+	if v == nil {
+		return ""
+	}
+	n, ok := v.(*core.PdfName)
+	if !ok {
+		t.Fatalf("dict key %q: expected *PdfName, got %T", key, v)
+	}
+	return n.Value
+}
+
+func hasKey(d *core.PdfDictionary, key string) bool {
+	return d.Get(key) != nil
+}
+
+// TestBuildObjectsCFFDispatchStructural asserts the CFF embed object
+// graph by reading PDF dictionary keys directly. Substring matches on
+// the serialized PDF text are fragile — `/CIDFontType0` is a strict
+// prefix of `/CIDFontType0C`, so a regression that wrote the wrong
+// subtype on the wrong dict would not be caught by a grep-based
+// assertion.
+func TestBuildObjectsCFFDispatchStructural(t *testing.T) {
 	face := loadTestCFFFace(t)
 	ef := NewEmbeddedFont(face)
 	ef.EncodeString("Test")
@@ -111,72 +168,119 @@ func TestBuildObjectsCFFDispatch(t *testing.T) {
 		objects = append(objects, obj)
 		return core.NewPdfIndirectReference(n, 0)
 	}
-
 	type0 := ef.BuildObjects(addObject)
 
-	// CFF path emits the same four indirect objects as TrueType:
-	// font stream, descriptor, CIDFont, ToUnicode.
 	if len(objects) != 4 {
-		t.Fatalf("expected 4 indirect objects, got %d", len(objects))
+		t.Fatalf("want 4 indirect objects, got %d", len(objects))
 	}
 
-	// Serialize every object so we can grep for keys without
-	// asserting on indirect-reference numbers.
-	dump := func(o core.PdfObject) string {
-		var buf bytes.Buffer
-		_, _ = o.WriteTo(&buf)
-		return buf.String()
+	// Object 0: the CFF stream. Subtype lives on the stream dict.
+	stream, ok := objects[0].(*core.PdfStream)
+	if !ok {
+		t.Fatalf("objects[0] is %T, want *PdfStream", objects[0])
 	}
-	streamText := dump(objects[0])
-	descriptorText := dump(objects[1])
-	cidFontText := dump(objects[2])
-	type0Text := dump(type0)
-
-	// Font stream must declare CFF subtype, never carry /Length1.
-	if !strings.Contains(streamText, "/Subtype /CIDFontType0C") {
-		t.Errorf("font stream missing /Subtype /CIDFontType0C:\n%s", streamText)
+	if got := name(t, stream.Dict, "Subtype"); got != "CIDFontType0C" {
+		t.Errorf("stream /Subtype = %q, want CIDFontType0C", got)
 	}
-	if strings.Contains(streamText, "/Length1") {
-		t.Error("font stream must not carry /Length1 in CFF path")
+	if hasKey(stream.Dict, "Length1") {
+		t.Error("stream must not carry /Length1 on the CFF path")
 	}
 
-	// FontDescriptor uses /FontFile3, not /FontFile2.
-	if !strings.Contains(descriptorText, "/FontFile3") {
-		t.Errorf("descriptor missing /FontFile3:\n%s", descriptorText)
+	// Object 1: FontDescriptor.
+	descriptor, ok := objects[1].(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("objects[1] is %T, want *PdfDictionary", objects[1])
 	}
-	if strings.Contains(descriptorText, "/FontFile2") {
-		t.Error("descriptor must not reference /FontFile2 in CFF path")
+	if got := name(t, descriptor, "Type"); got != "FontDescriptor" {
+		t.Errorf("descriptor /Type = %q", got)
+	}
+	if !hasKey(descriptor, "FontFile3") {
+		t.Error("descriptor missing /FontFile3")
+	}
+	if hasKey(descriptor, "FontFile2") {
+		t.Error("descriptor must not carry /FontFile2 on CFF path")
+	}
+	for _, k := range []string{"FontName", "Flags", "FontBBox", "Ascent", "Descent", "CapHeight", "StemV", "ItalicAngle"} {
+		if !hasKey(descriptor, k) {
+			t.Errorf("descriptor missing /%s", k)
+		}
 	}
 
-	// Descendant CIDFont must be CIDFontType0 and must NOT declare
-	// CIDToGIDMap (/Identity is implicit for /CIDFontType0; spec
-	// readers reject the explicit key).
-	if !strings.Contains(cidFontText, "/Subtype /CIDFontType0") {
-		t.Errorf("CIDFont missing /Subtype /CIDFontType0:\n%s", cidFontText)
+	// Object 2: CIDFont (descendant of Type0).
+	cidFont, ok := objects[2].(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("objects[2] is %T, want *PdfDictionary", objects[2])
 	}
-	if strings.Contains(cidFontText, "/CIDFontType2") {
-		t.Error("CIDFont must not declare /CIDFontType2 in CFF path")
+	if got := name(t, cidFont, "Subtype"); got != "CIDFontType0" {
+		t.Errorf("CIDFont /Subtype = %q, want exactly CIDFontType0", got)
 	}
-	if strings.Contains(cidFontText, "/CIDToGIDMap") {
+	if got := name(t, cidFont, "Type"); got != "Font" {
+		t.Errorf("CIDFont /Type = %q", got)
+	}
+	if hasKey(cidFont, "CIDToGIDMap") {
 		t.Error("CIDFont must omit /CIDToGIDMap for /CIDFontType0")
 	}
+	for _, k := range []string{"BaseFont", "CIDSystemInfo", "FontDescriptor", "DW", "W"} {
+		if !hasKey(cidFont, k) {
+			t.Errorf("CIDFont missing /%s", k)
+		}
+	}
 
-	// Shared behaviour with TrueType path: Type0 wrapper, Identity-H,
-	// ToUnicode link.
-	if !strings.Contains(type0Text, "/Subtype /Type0") {
-		t.Errorf("Type0 dict missing /Subtype /Type0:\n%s", type0Text)
+	// Type0 wrapper.
+	if got := name(t, type0, "Subtype"); got != "Type0" {
+		t.Errorf("Type0 /Subtype = %q", got)
 	}
-	if !strings.Contains(type0Text, "/Encoding /Identity-H") {
-		t.Errorf("Type0 dict missing /Encoding /Identity-H:\n%s", type0Text)
+	if got := name(t, type0, "Encoding"); got != "Identity-H" {
+		t.Errorf("Type0 /Encoding = %q", got)
 	}
-	if !strings.Contains(type0Text, "/ToUnicode") {
-		t.Errorf("Type0 dict missing /ToUnicode:\n%s", type0Text)
+	for _, k := range []string{"BaseFont", "DescendantFonts", "ToUnicode"} {
+		if !hasKey(type0, k) {
+			t.Errorf("Type0 missing /%s", k)
+		}
+	}
+}
+
+// TestBuildObjectsNameKeyedCFFFallthrough confirms a plain Latin CFF
+// (no ROS) takes the legacy TrueType embed path. This is a behavior
+// regression test for the gate: it must NOT silently route to the
+// CFF path and emit the wrong stream subtype.
+func TestBuildObjectsNameKeyedCFFFallthrough(t *testing.T) {
+	path := testNonCIDKeyedCFFFontPath(t)
+	face, err := LoadFont(path)
+	if err != nil {
+		t.Fatalf("LoadFont %s: %v", path, err)
+	}
+	ef := NewEmbeddedFont(face)
+	ef.EncodeString("Test")
+
+	var objects []core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		n := len(objects) + 1
+		objects = append(objects, obj)
+		return core.NewPdfIndirectReference(n, 0)
+	}
+	ef.BuildObjects(addObject)
+
+	descriptor, ok := objects[1].(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("objects[1] is %T", objects[1])
+	}
+	// Legacy path: /FontFile2, not /FontFile3.
+	if !hasKey(descriptor, "FontFile2") {
+		t.Error("name-keyed CFF should fall through to /FontFile2 path")
+	}
+	if hasKey(descriptor, "FontFile3") {
+		t.Error("name-keyed CFF must not take /FontFile3 path until non-CID CFF support lands")
+	}
+
+	cidFont := objects[2].(*core.PdfDictionary)
+	if got := name(t, cidFont, "Subtype"); got != "CIDFontType2" {
+		t.Errorf("name-keyed CFF /Subtype = %q, want CIDFontType2 on legacy path", got)
 	}
 }
 
 // TestBuildObjectsTrueTypeUnchanged guards against the dispatch
-// inadvertently rerouting TrueType faces through the CFF path. This
-// is a regression test for the embed.go change in Phase 1.
+// inadvertently rerouting TrueType faces through the CFF path.
 func TestBuildObjectsTrueTypeUnchanged(t *testing.T) {
 	face := loadTestFace(t)
 	ef := NewEmbeddedFont(face)
@@ -190,23 +294,47 @@ func TestBuildObjectsTrueTypeUnchanged(t *testing.T) {
 	}
 	ef.BuildObjects(addObject)
 
-	var descriptorBuf bytes.Buffer
-	_, _ = objects[1].WriteTo(&descriptorBuf)
-	descriptorText := descriptorBuf.String()
-	if !strings.Contains(descriptorText, "/FontFile2") {
-		t.Errorf("TrueType descriptor must still use /FontFile2:\n%s", descriptorText)
+	descriptor := objects[1].(*core.PdfDictionary)
+	if !hasKey(descriptor, "FontFile2") {
+		t.Error("TrueType descriptor must still use /FontFile2")
 	}
-	if strings.Contains(descriptorText, "/FontFile3") {
+	if hasKey(descriptor, "FontFile3") {
 		t.Error("TrueType descriptor must not switch to /FontFile3")
 	}
 
-	var cidBuf bytes.Buffer
-	_, _ = objects[2].WriteTo(&cidBuf)
-	cidText := cidBuf.String()
-	if !strings.Contains(cidText, "/Subtype /CIDFontType2") {
-		t.Errorf("TrueType CIDFont must remain /CIDFontType2:\n%s", cidText)
+	cidFont := objects[2].(*core.PdfDictionary)
+	if got := name(t, cidFont, "Subtype"); got != "CIDFontType2" {
+		t.Errorf("TrueType CIDFont /Subtype = %q, want CIDFontType2", got)
 	}
-	if !strings.Contains(cidText, "/CIDToGIDMap /Identity") {
-		t.Errorf("TrueType CIDFont must keep /CIDToGIDMap /Identity:\n%s", cidText)
+	if got := name(t, cidFont, "CIDToGIDMap"); got != "Identity" {
+		t.Errorf("TrueType CIDFont /CIDToGIDMap = %q, want Identity", got)
+	}
+}
+
+// TestBuildObjectsCFFEmptyUsedGlyphs covers the edge case where no
+// EncodeString call has happened. The CFF builder must still emit four
+// indirect objects with sensible defaults (empty /W array, empty
+// ToUnicode bfchar block).
+func TestBuildObjectsCFFEmptyUsedGlyphs(t *testing.T) {
+	face := loadTestCFFFace(t)
+	ef := NewEmbeddedFont(face)
+
+	var objects []core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		n := len(objects) + 1
+		objects = append(objects, obj)
+		return core.NewPdfIndirectReference(n, 0)
+	}
+	type0 := ef.BuildObjects(addObject)
+
+	if len(objects) != 4 {
+		t.Fatalf("want 4 indirect objects, got %d", len(objects))
+	}
+	cidFont := objects[2].(*core.PdfDictionary)
+	if !hasKey(cidFont, "W") {
+		t.Error("/W must be present even when empty")
+	}
+	if got := name(t, type0, "Subtype"); got != "Type0" {
+		t.Errorf("Type0 /Subtype = %q", got)
 	}
 }

--- a/font/embed_cff_test.go
+++ b/font/embed_cff_test.go
@@ -361,17 +361,25 @@ func TestBuildObjectsCFFSubsetTagPrefix(t *testing.T) {
 	}
 	type0 := ef.BuildObjects(addObject)
 
-	prefixOf := func(d *core.PdfDictionary, key string) string {
+	prefixOf := func(d *core.PdfDictionary, key string) (string, bool) {
 		s := name(t, d, key)
 		if len(s) < 7 || s[6] != '+' {
-			return ""
+			return s, false
 		}
-		return s[:6]
+		return s[:6], true
 	}
-	type0Tag := prefixOf(type0, "BaseFont")
-	cidTag := prefixOf(objects[2].(*core.PdfDictionary), "BaseFont")
-	descTag := prefixOf(objects[1].(*core.PdfDictionary), "FontName")
-	if type0Tag == "" || type0Tag != cidTag || type0Tag != descTag {
+	type0Tag, type0OK := prefixOf(type0, "BaseFont")
+	cidTag, cidOK := prefixOf(objects[2].(*core.PdfDictionary), "BaseFont")
+	descTag, descOK := prefixOf(objects[1].(*core.PdfDictionary), "FontName")
+	if !type0OK || !cidOK || !descOK {
+		// All three names must carry the XXXXXX+ prefix when
+		// subsetting succeeds. A silently-absent prefix means the
+		// subsetter failed (silent-fallback path); this is the
+		// signal we want to catch, not paper over with "" == "".
+		t.Fatalf("missing subset prefix: Type0=%q(ok=%v) CIDFont=%q(ok=%v) Descriptor=%q(ok=%v)",
+			type0Tag, type0OK, cidTag, cidOK, descTag, descOK)
+	}
+	if type0Tag != cidTag || type0Tag != descTag {
 		t.Errorf("subset tag mismatch: Type0=%q CIDFont=%q Descriptor=%q",
 			type0Tag, cidTag, descTag)
 	}

--- a/font/embed_cff_test.go
+++ b/font/embed_cff_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/core"
+)
+
+// testCFFFontPath returns a path to an OTF (CFF-flavored) font that
+// exists on the test system, or skips the test. Real CFF outlines are
+// needed because the dispatch is gated on the presence of the `CFF `
+// table; a synthetic minimal sfnt would still exercise the same code
+// path but at the cost of hand-rolling head/hhea/maxp/hmtx/cmap. Once
+// the Phase 2 parser lands we can switch these tests to a synthetic
+// fixture and drop the system-font dependency.
+func testCFFFontPath(t *testing.T) string {
+	t.Helper()
+	candidates := []string{
+		"/System/Library/Fonts/Supplemental/STIXGeneral.otf",
+		"/System/Library/Fonts/Supplemental/NotoSansCanadianAboriginal-Regular.otf",
+		"/System/Library/Fonts/LastResort.otf",
+		"/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	t.Skip("no CFF/OTF font available on this system")
+	return ""
+}
+
+func loadTestCFFFace(t *testing.T) Face {
+	t.Helper()
+	face, err := LoadFont(testCFFFontPath(t))
+	if err != nil {
+		t.Fatalf("LoadFont CFF: %v", err)
+	}
+	return face
+}
+
+func TestIsCFFDetectsOutlineFormat(t *testing.T) {
+	cff := loadTestCFFFace(t)
+	cf, ok := cff.(cffFace)
+	if !ok {
+		t.Fatalf("CFF face does not implement cffFace")
+	}
+	if !cf.IsCFF() {
+		t.Error("expected IsCFF() = true for OTF/CFF font")
+	}
+	if len(cf.CFFData()) == 0 {
+		t.Error("expected CFFData() to return non-empty bytes for CFF font")
+	}
+
+	ttf := loadTestFace(t)
+	cf2, ok := ttf.(cffFace)
+	if !ok {
+		t.Fatalf("TTF face does not implement cffFace")
+	}
+	if cf2.IsCFF() {
+		t.Error("expected IsCFF() = false for TrueType font")
+	}
+	if cf2.CFFData() != nil {
+		t.Error("expected CFFData() = nil for TrueType font")
+	}
+}
+
+func TestFaceCFFDataHelper(t *testing.T) {
+	// TrueType: helper returns (nil, false).
+	ttf := loadTestFace(t)
+	if data, ok := faceCFFData(ttf); ok || data != nil {
+		t.Errorf("faceCFFData(TTF) = (%d bytes, %v), want (nil, false)", len(data), ok)
+	}
+
+	// CFF: helper returns (bytes, true) with the same payload as
+	// CFFData() directly. We compare lengths rather than full bytes
+	// to keep the assertion meaningful without ballooning test
+	// memory for large CJK fonts.
+	cff := loadTestCFFFace(t)
+	data, ok := faceCFFData(cff)
+	if !ok {
+		t.Fatal("faceCFFData(CFF) returned ok=false")
+	}
+	if len(data) == 0 {
+		t.Error("faceCFFData(CFF) returned empty bytes")
+	}
+	if direct := cff.(cffFace).CFFData(); len(direct) != len(data) {
+		t.Errorf("faceCFFData length %d != CFFData length %d", len(data), len(direct))
+	}
+}
+
+// TestBuildObjectsCFFDispatch exercises the embed-path branch added in
+// Phase 1: a CFF face must produce a /FontFile3 stream with
+// /CIDFontType0C subtype, a /CIDFontType0 descendant font, no
+// /CIDToGIDMap, and none of the TrueType-only keys (/FontFile2,
+// /CIDFontType2, /Length1).
+func TestBuildObjectsCFFDispatch(t *testing.T) {
+	face := loadTestCFFFace(t)
+	ef := NewEmbeddedFont(face)
+	ef.EncodeString("Test")
+
+	var objects []core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		n := len(objects) + 1
+		objects = append(objects, obj)
+		return core.NewPdfIndirectReference(n, 0)
+	}
+
+	type0 := ef.BuildObjects(addObject)
+
+	// CFF path emits the same four indirect objects as TrueType:
+	// font stream, descriptor, CIDFont, ToUnicode.
+	if len(objects) != 4 {
+		t.Fatalf("expected 4 indirect objects, got %d", len(objects))
+	}
+
+	// Serialize every object so we can grep for keys without
+	// asserting on indirect-reference numbers.
+	dump := func(o core.PdfObject) string {
+		var buf bytes.Buffer
+		_, _ = o.WriteTo(&buf)
+		return buf.String()
+	}
+	streamText := dump(objects[0])
+	descriptorText := dump(objects[1])
+	cidFontText := dump(objects[2])
+	type0Text := dump(type0)
+
+	// Font stream must declare CFF subtype, never carry /Length1.
+	if !strings.Contains(streamText, "/Subtype /CIDFontType0C") {
+		t.Errorf("font stream missing /Subtype /CIDFontType0C:\n%s", streamText)
+	}
+	if strings.Contains(streamText, "/Length1") {
+		t.Error("font stream must not carry /Length1 in CFF path")
+	}
+
+	// FontDescriptor uses /FontFile3, not /FontFile2.
+	if !strings.Contains(descriptorText, "/FontFile3") {
+		t.Errorf("descriptor missing /FontFile3:\n%s", descriptorText)
+	}
+	if strings.Contains(descriptorText, "/FontFile2") {
+		t.Error("descriptor must not reference /FontFile2 in CFF path")
+	}
+
+	// Descendant CIDFont must be CIDFontType0 and must NOT declare
+	// CIDToGIDMap (/Identity is implicit for /CIDFontType0; spec
+	// readers reject the explicit key).
+	if !strings.Contains(cidFontText, "/Subtype /CIDFontType0") {
+		t.Errorf("CIDFont missing /Subtype /CIDFontType0:\n%s", cidFontText)
+	}
+	if strings.Contains(cidFontText, "/CIDFontType2") {
+		t.Error("CIDFont must not declare /CIDFontType2 in CFF path")
+	}
+	if strings.Contains(cidFontText, "/CIDToGIDMap") {
+		t.Error("CIDFont must omit /CIDToGIDMap for /CIDFontType0")
+	}
+
+	// Shared behaviour with TrueType path: Type0 wrapper, Identity-H,
+	// ToUnicode link.
+	if !strings.Contains(type0Text, "/Subtype /Type0") {
+		t.Errorf("Type0 dict missing /Subtype /Type0:\n%s", type0Text)
+	}
+	if !strings.Contains(type0Text, "/Encoding /Identity-H") {
+		t.Errorf("Type0 dict missing /Encoding /Identity-H:\n%s", type0Text)
+	}
+	if !strings.Contains(type0Text, "/ToUnicode") {
+		t.Errorf("Type0 dict missing /ToUnicode:\n%s", type0Text)
+	}
+}
+
+// TestBuildObjectsTrueTypeUnchanged guards against the dispatch
+// inadvertently rerouting TrueType faces through the CFF path. This
+// is a regression test for the embed.go change in Phase 1.
+func TestBuildObjectsTrueTypeUnchanged(t *testing.T) {
+	face := loadTestFace(t)
+	ef := NewEmbeddedFont(face)
+	ef.EncodeString("Test")
+
+	var objects []core.PdfObject
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		n := len(objects) + 1
+		objects = append(objects, obj)
+		return core.NewPdfIndirectReference(n, 0)
+	}
+	ef.BuildObjects(addObject)
+
+	var descriptorBuf bytes.Buffer
+	_, _ = objects[1].WriteTo(&descriptorBuf)
+	descriptorText := descriptorBuf.String()
+	if !strings.Contains(descriptorText, "/FontFile2") {
+		t.Errorf("TrueType descriptor must still use /FontFile2:\n%s", descriptorText)
+	}
+	if strings.Contains(descriptorText, "/FontFile3") {
+		t.Error("TrueType descriptor must not switch to /FontFile3")
+	}
+
+	var cidBuf bytes.Buffer
+	_, _ = objects[2].WriteTo(&cidBuf)
+	cidText := cidBuf.String()
+	if !strings.Contains(cidText, "/Subtype /CIDFontType2") {
+		t.Errorf("TrueType CIDFont must remain /CIDFontType2:\n%s", cidText)
+	}
+	if !strings.Contains(cidText, "/CIDToGIDMap /Identity") {
+		t.Errorf("TrueType CIDFont must keep /CIDToGIDMap /Identity:\n%s", cidText)
+	}
+}

--- a/font/face.go
+++ b/font/face.go
@@ -104,3 +104,26 @@ type GSUBProvider interface {
 type GPOSProvider interface {
 	GPOS() *GPOSAdjustments
 }
+
+// cffFace is a package-private interface for accessing CFF table data
+// on faces whose underlying implementation parses sfnt tables. CFF
+// embedding takes a different PDF object-graph path from TrueType, so
+// the embedder needs to detect CFF and pull out the raw `CFF ` table
+// bytes; this interface keeps that coupling out of the public Face
+// surface during v0.x.
+type cffFace interface {
+	IsCFF() bool
+	CFFData() []byte
+}
+
+// faceCFFData returns (cffBytes, true) if the face carries a `CFF `
+// table, otherwise (nil, false). Used by the embed path to decide
+// between the TrueType (/FontFile2, /CIDFontType2) and CFF
+// (/FontFile3, /CIDFontType0) object graphs.
+func faceCFFData(f Face) ([]byte, bool) {
+	cf, ok := f.(cffFace)
+	if !ok || !cf.IsCFF() {
+		return nil, false
+	}
+	return cf.CFFData(), true
+}

--- a/font/face.go
+++ b/font/face.go
@@ -113,17 +113,26 @@ type GPOSProvider interface {
 // surface during v0.x.
 type cffFace interface {
 	IsCFF() bool
+	IsCFF2() bool
 	CFFData() []byte
 }
 
-// faceCFFData returns (cffBytes, true) if the face carries a `CFF `
-// table, otherwise (nil, false). Used by the embed path to decide
-// between the TrueType (/FontFile2, /CIDFontType2) and CFF
-// (/FontFile3, /CIDFontType0) object graphs.
+// faceCFFData returns (cffBytes, true) when the face is a CID-keyed
+// CFF v1 font — the only outline format Folio currently has a working
+// /FontFile3 + /CIDFontType0 embed path for. Plain (name-keyed) CFF v1
+// needs a /Type1C stream and a non-composite font dictionary; CFF2 has
+// a different stream subtype and FVAR-driven instancing. Both are
+// kept off the CID-keyed path and fall back to the legacy embed
+// semantics until a dedicated path lands. Returns (nil, false)
+// otherwise.
 func faceCFFData(f Face) ([]byte, bool) {
 	cf, ok := f.(cffFace)
-	if !ok || !cf.IsCFF() {
+	if !ok || !cf.IsCFF() || cf.IsCFF2() {
 		return nil, false
 	}
-	return cf.CFFData(), true
+	data := cf.CFFData()
+	if !isCIDKeyedCFFv1(data) {
+		return nil, false
+	}
+	return data, true
 }

--- a/font/fuzz_test.go
+++ b/font/fuzz_test.go
@@ -71,6 +71,26 @@ func FuzzParseCFFDict(f *testing.F) {
 	})
 }
 
+// FuzzSubsetCFF makes sure malformed input never panics the assembly
+// pipeline. parseCFF rejects most garbage upstream; the subsetter's
+// remaining surface (INDEX writer + offset patching + section layout)
+// is the path the fuzzer explores when a valid CID-keyed CFF flows
+// through.
+func FuzzSubsetCFF(f *testing.F) {
+	f.Add([]byte{})
+	f.Add(buildSyntheticCIDKeyedCFF(testingTNoop{}, syntheticCFFOptions{numGlyphs: 3, fdCount: 1}))
+	f.Add(buildSyntheticCIDKeyedCFF(testingTNoop{}, syntheticCFFOptions{numGlyphs: 8, fdCount: 3}))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("SubsetCFF panicked on %d bytes: %v", len(data), r)
+			}
+		}()
+		_, _ = SubsetCFF(data, map[uint16]rune{1: 'a'})
+	})
+}
+
 // testingTNoop implements fixtureT for the synthetic CFF builder when
 // called from a fuzz seed list. The builder only calls Helper /
 // Fatalf on bad inputs that we never pass in seed corpus, so a no-op

--- a/font/fuzz_test.go
+++ b/font/fuzz_test.go
@@ -53,13 +53,13 @@ func FuzzParseCFF(f *testing.F) {
 // reserved-byte handling are all in scope.
 func FuzzParseCFFDict(f *testing.F) {
 	f.Add([]byte{})
-	f.Add([]byte{139, 0})                          // int 0, version
-	f.Add([]byte{28, 0x05, 0xDC, 0})               // shortint 1500
-	f.Add([]byte{29, 0, 0, 0, 0, 0})               // longint 0
-	f.Add([]byte{30, 0x1A, 0xFF, 0})               // BCD real "1." end
-	f.Add([]byte{139, 139, 139, 12, 30})           // ROS
-	f.Add([]byte{251, 0, 0})                       // negative 2-byte int
-	f.Add([]byte{247, 255, 0})                     // positive 2-byte int
+	f.Add([]byte{139, 0})                // int 0, version
+	f.Add([]byte{28, 0x05, 0xDC, 0})     // shortint 1500
+	f.Add([]byte{29, 0, 0, 0, 0, 0})     // longint 0
+	f.Add([]byte{30, 0x1A, 0xFF, 0})     // BCD real "1." end
+	f.Add([]byte{139, 139, 139, 12, 30}) // ROS
+	f.Add([]byte{251, 0, 0})             // negative 2-byte int
+	f.Add([]byte{247, 255, 0})           // positive 2-byte int
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		defer func() {
@@ -97,5 +97,5 @@ func FuzzSubsetCFF(f *testing.F) {
 // implementation is safe here.
 type testingTNoop struct{}
 
-func (testingTNoop) Helper()              {}
+func (testingTNoop) Helper()               {}
 func (testingTNoop) Fatalf(string, ...any) {}

--- a/font/fuzz_test.go
+++ b/font/fuzz_test.go
@@ -25,3 +25,57 @@ func FuzzParseTTF(f *testing.F) {
 		_, _ = ParseTTF(data)
 	})
 }
+
+// FuzzParseCFF exercises the CID-keyed CFF parser. Random input
+// should never cause a panic — parseCFF must walk every operand and
+// offset defensively, since Phase 3+ will trust its output to
+// produce a valid PDF font stream.
+func FuzzParseCFF(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0x01, 0x00, 0x04, 0x02})
+	f.Add(buildSyntheticCFFv1([]byte{139, 139, 139, 12, 30}))
+	// Seed a complete valid CID-keyed blob so the fuzzer has a
+	// known-good starting point to mutate.
+	f.Add(buildSyntheticCIDKeyedCFF(testingTNoop{}, syntheticCFFOptions{numGlyphs: 3, fdCount: 1}))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("parseCFF panicked on %d bytes: %v", len(data), r)
+			}
+		}()
+		_, _ = parseCFF(data)
+	})
+}
+
+// FuzzParseCFFDict targets the DICT operand/operator stream parser
+// directly. Integer overflow, BCD-end-nibble corner cases, and
+// reserved-byte handling are all in scope.
+func FuzzParseCFFDict(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{139, 0})                          // int 0, version
+	f.Add([]byte{28, 0x05, 0xDC, 0})               // shortint 1500
+	f.Add([]byte{29, 0, 0, 0, 0, 0})               // longint 0
+	f.Add([]byte{30, 0x1A, 0xFF, 0})               // BCD real "1." end
+	f.Add([]byte{139, 139, 139, 12, 30})           // ROS
+	f.Add([]byte{251, 0, 0})                       // negative 2-byte int
+	f.Add([]byte{247, 255, 0})                     // positive 2-byte int
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("parseCFFDict panicked on %d bytes: %v", len(data), r)
+			}
+		}()
+		_, _ = parseCFFDict(data)
+	})
+}
+
+// testingTNoop implements fixtureT for the synthetic CFF builder when
+// called from a fuzz seed list. The builder only calls Helper /
+// Fatalf on bad inputs that we never pass in seed corpus, so a no-op
+// implementation is safe here.
+type testingTNoop struct{}
+
+func (testingTNoop) Helper()              {}
+func (testingTNoop) Fatalf(string, ...any) {}

--- a/font/truetype.go
+++ b/font/truetype.go
@@ -279,12 +279,22 @@ func (f *sfntFace) NumGlyphs() int {
 	return int(f.pf.maxp.numGlyphs)
 }
 
-// IsCFF reports whether this face uses CFF outlines (a `CFF ` table)
-// rather than TrueType outlines (glyf/loca). CFF fonts require a
-// different PDF embedding path: /FontFile3 + /CIDFontType0C instead
-// of /FontFile2 + /CIDFontType2.
+// IsCFF reports whether this face uses CFF v1 outlines (a `CFF ` table)
+// rather than TrueType outlines (glyf/loca). The check is intentionally
+// narrow — `CFF2` variable-CFF (a distinct table tag) returns false so
+// it cannot inadvertently take the v1 embed path, which would emit the
+// wrong /FontFile3 stream subtype.
 func (f *sfntFace) IsCFF() bool {
 	_, ok := f.pf.rawTables["CFF "]
+	return ok
+}
+
+// IsCFF2 reports whether this face uses CFF2 outlines (a `CFF2` table,
+// CFF variable-font extension). Folio does not yet have a CFF2 embed
+// path; the dispatcher uses this only to keep CFF2 fonts off the v1
+// path so they fall back to the legacy embed semantics.
+func (f *sfntFace) IsCFF2() bool {
+	_, ok := f.pf.rawTables["CFF2"]
 	return ok
 }
 

--- a/font/truetype.go
+++ b/font/truetype.go
@@ -279,6 +279,23 @@ func (f *sfntFace) NumGlyphs() int {
 	return int(f.pf.maxp.numGlyphs)
 }
 
+// IsCFF reports whether this face uses CFF outlines (a `CFF ` table)
+// rather than TrueType outlines (glyf/loca). CFF fonts require a
+// different PDF embedding path: /FontFile3 + /CIDFontType0C instead
+// of /FontFile2 + /CIDFontType2.
+func (f *sfntFace) IsCFF() bool {
+	_, ok := f.pf.rawTables["CFF "]
+	return ok
+}
+
+// CFFData returns the raw bytes of the `CFF ` table when present.
+// The PDF FontFile3 stream expects raw CFF bytes — not the surrounding
+// sfnt wrapper — so this is the input both to CFF subsetting and to
+// the unmodified-embed fallback. Returns nil for non-CFF faces.
+func (f *sfntFace) CFFData() []byte {
+	return f.pf.rawTables["CFF "]
+}
+
 // GSUB returns the parsed GSUB substitution tables. The result is cached
 // after the first call; a nil return means the font has no GSUB tables
 // for any of the recognized features.


### PR DESCRIPTION
## Summary

Adds a CFF v1 subsetter for CID-keyed fonts and routes CFF-flavored faces through a spec-compliant PDF object graph. Closes #295 and #299.

The reporter's exact reproducer — `examples/html-to-pdf` with a single Chinese character on a system whose CJK auto-fallback picks NotoSansCJK (Linux) or Hiragino Sans GB (macOS) — drops from **14 MB to 16 KB**. The embed-path stream payload for the same fixture is **11.1 MB → 173 KB (1.6%)** before PDF FlateDecode further compresses it.

## What changed

Six commits, each independently reviewable:

| Commit | Phase | What |
|---|---|---|
| 1 | Dispatch + PDF object graph | `EmbeddedFont.BuildObjects` branches on CFF table presence; CFF faces route through a new builder that emits `/FontFile3` + `/CIDFontType0C` stream + `/CIDFontType0` descendant + no `/CIDToGIDMap` (TrueType path untouched) |
| 2 | CID-keyed gate | Adds a defensive Top-DICT walker (`isCIDKeyedCFFv1`) and excludes non-CID CFF + CFF2 from the new path. Tightens test assertions via `*core.PdfDictionary.Get()` casts |
| 3 | Read-only parser | `parseCFF` decodes INDEX / DICT / Charset / FDSelect / FDArray with per-operand byte spans for downstream byte-level rewriting |
| 4 | Parser hardening | Per-operand byte ranges in `cffDictEntry`, FDSelect format-3 sentinel check, `FuzzParseCFF` / `FuzzParseCFFDict`, complete synthetic CID-keyed CFF builder |
| 5 | Subsetter (closes #295) | Type 2 charstring reachability walker + three-pass byte-level assembly with fixed 5-byte longint operand encoding. Wires `SubsetCFF` into the embed path with the standard `XXXXXX+` subset tag prefix |
| 6 | Review fixes | Rejects predefined-charset values for CID-keyed CFF, distinguishable-charstring + gsubr-pruning + non-longint-operand blind-spot tests, FDSelect format-3 coverage, bounded-work walker assertion |

## Algorithm — Phase 3 in one paragraph

The subsetter rebuilds CharStrings INDEX with unkept GIDs replaced by a single `endchar` (0x0E) and the Global + per-FD Local Subr INDEXes with subroutines that aren't transitively reached replaced by a single `return` (0x0B). A partial Type 2 interpreter walks the operand stack precisely enough to read every `callsubr` / `callgsubr` argument and the stem count consumed by `hintmask` / `cntrmask`, with a pessimistic fallback when a call's argument was supplied by a caller across a frame boundary. Every offset operand in the rebuilt Top DICT, FDArray font dicts, and per-FD Private DICTs uses fixed 5-byte longint encoding so section sizes are independent of offset values, which means layout is a single forward pass: build sections with zeroed placeholders, sum section lengths, patch placeholders in place, concatenate. Header, Name INDEX, String INDEX, Charset, FDSelect are copied verbatim from source.

## Test plan

- [x] `go test ./...` green
- [x] `FuzzParseCFF`, `FuzzParseCFFDict`, `FuzzSubsetCFF` clean at >1M execs each (5-10s budget locally)
- [x] Real-font subset regression: `TestSubsetCFFRealFontSize` asserts <10% of source on Hiragino Sans GB.ttc (actual: 1.6%)
- [x] Embed-path regression: `TestBuildObjectsCFFSubsetsFontStream` asserts the same against the stream payload through `EmbeddedFont.BuildObjects` (actual: 1.6%)
- [x] Issue #295 end-to-end reproducer verified locally: `examples/html-to-pdf/main.go` with `<h1>Quarterly 报告</h1>` produces a 16 KB PDF (was 14 MB pre-fix on Ubuntu)
- [x] Rebased on current `origin/main`

## Notes

- **No public API changes.** `Face` interface unchanged; CFF detection is internal via package-private `cffFace`.
- **Fallback policy.** On `SubsetCFF` failure, `buildObjectsCFF` falls back to embedding the source CFF unchanged — same silent-fallback semantics as the TrueType path at `font/embed.go:167`. The fallback is now defensive: every structural failure mode in `parseCFF` has a sentinel-wrapped error.
- **Non-CID CFF.** Plain Latin `.otf` fonts (e.g. STIXGeneral) are correctly excluded from the new path; they need a `/Type1C` + non-composite font dict path that this PR does not add. The legacy embed path handles them as before.
- **CFF2.** Variable-CFF fonts are detected and routed back to the legacy path; a CFF2 embed path can land separately when there's user demand.
- **Out of scope.** Full subroutine re-indexing (would shrink ~173 KB to ~30 KB). The current 1.6%-of-source result is already adequate to close #295; the additional shrink is a separate work item.