### PR TITLE
examples/html-to-pdf: add CI (#231)

### DIFF
--- a/examples/html-to-pdf/main.go
+++ b/examples/html-to-pdf/main.go
@@ -242,11 +242,14 @@ const reportHTML = `<!DOCTYPE html>
 </body>
 </html>`
 
-func main() {
-	result, err := html.ConvertFull(reportHTML, nil)
+// buildDocument runs the example's full HTML → PDF pipeline on the
+// supplied source and returns the assembled, ready-to-write Document.
+// Extracted from main() so the example test (main_test.go) can exercise
+// the same pipeline against an in-memory buffer instead of disk.
+func buildDocument(htmlSource string) (*document.Document, error) {
+	result, err := html.ConvertFull(htmlSource, nil)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "convert:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("convert: %w", err)
 	}
 
 	doc := document.NewDocument(document.PageSizeA4)
@@ -282,7 +285,15 @@ func main() {
 	if result.Metadata.Author != "" {
 		doc.Info.Author = result.Metadata.Author
 	}
+	return doc, nil
+}
 
+func main() {
+	doc, err := buildDocument(reportHTML)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	if err := doc.Save("report.pdf"); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/examples/html-to-pdf/main_test.go
+++ b/examples/html-to-pdf/main_test.go
@@ -6,129 +6,116 @@ package main
 import (
 	"bytes"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/carlos7ags/folio/reader"
 )
 
-// TestHTMLToPDFExampleProducesValidPDF runs the example's HTML → PDF
-// pipeline against the bundled reportHTML constant and asserts the
-// resulting bytes are a structurally plausible PDF. The example
-// previously had no CI of any kind — the reporter of issue #295 found
-// the multi-megabyte CJK blowup by running it on Ubuntu; nothing in
-// folio's automated tests would have caught the regression. This is
-// the smoke test that closes that gap for this example (issue #231).
-func TestHTMLToPDFExampleProducesValidPDF(t *testing.T) {
+// examplePDFBytes runs the example pipeline against the bundled
+// reportHTML constant once per test process and caches the result.
+// Each assertion below reads from the same byte slice, so the costly
+// HTML → layout → PDF conversion only runs a single time even though
+// the file declares several tests.
+var examplePDFBytes = sync.OnceValue(func() []byte {
 	doc, err := buildDocument(reportHTML)
 	if err != nil {
-		t.Fatalf("buildDocument: %v", err)
+		panic("buildDocument: " + err.Error())
 	}
-
 	var buf bytes.Buffer
 	if _, err := doc.WriteTo(&buf); err != nil {
-		t.Fatalf("WriteTo: %v", err)
+		panic("WriteTo: " + err.Error())
 	}
-	pdf := buf.Bytes()
+	return buf.Bytes()
+})
 
+// examplePDFReader returns a parsed PdfReader over the cached bytes.
+// Tests that need structural access (page count, /Info dict, etc.)
+// go through here rather than grepping the serialized text, which
+// has a documented false-positive: "Apex Capital Partners" appears
+// in both the <meta name="author"> AND the rendered body text, so a
+// regression dropping /Info /Author would slip past a substring scan.
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+// TestHTMLToPDFExampleProducesValidPDF asserts the example produces
+// a well-formed PDF of plausible size. The size floor catches the
+// regression where conversion silently bails and writes a near-empty
+// file; the header check catches the regression where the output
+// isn't even a PDF.
+func TestHTMLToPDFExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
 	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
 		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
 	}
-	// The example renders a fully-styled multi-section report; the
-	// output is unconditionally well above 5 KB even with the
-	// post-#300 font deduplication. A drop below this floor would
-	// mean the conversion bailed out and produced an empty PDF.
 	if len(pdf) < 5000 {
 		t.Errorf("output PDF is suspiciously small (%d bytes); expected >5 KB", len(pdf))
 	}
 }
 
-// TestHTMLToPDFExampleTwoPages locks in the page count. The HTML has
-// an explicit `.page-break { break-before: page }` div between the
-// dashboard and the leadership section; if the page-break CSS handling
-// regressed silently, this test would catch it as a single-page output.
+// TestHTMLToPDFExampleTwoPages asserts the example renders exactly
+// two pages by parsing the cross-reference table. Counts the leaves
+// of the page tree, so a regression that adds spurious page nodes or
+// drops the CSS page-break would surface here as 1 or 3+.
 func TestHTMLToPDFExampleTwoPages(t *testing.T) {
-	doc, err := buildDocument(reportHTML)
-	if err != nil {
-		t.Fatalf("buildDocument: %v", err)
-	}
-	var buf bytes.Buffer
-	if _, err := doc.WriteTo(&buf); err != nil {
-		t.Fatalf("WriteTo: %v", err)
-	}
-	pdf := buf.String()
-	// /Count <N> appears on the /Pages catalog root and lists the
-	// total page count for the document.
-	if !strings.Contains(pdf, "/Count 2") {
-		t.Errorf("expected /Count 2 in /Pages root; example HTML has one page-break and should produce two pages")
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got != 2 {
+		t.Errorf("PageCount = %d, want 2 (example has one CSS page-break)", got)
 	}
 }
 
-// TestHTMLToPDFExampleMetadataFromHTML verifies the converter pulls
-// /Info Title and Author from the document's <title> and
-// <meta name="author"> tags. The example deliberately sets defaults
-// on the Document and then lets ConvertFull's Metadata struct
-// override them; if that override silently breaks, the PDF's Info
-// dictionary would carry the placeholder values instead.
+// TestHTMLToPDFExampleMetadataFromHTML reads the /Info dictionary
+// directly and verifies Title and Author come from the <title> and
+// <meta name="author"> tags in the source HTML. The earlier substring
+// check would have passed even if /Info /Author were dropped entirely,
+// because "Apex Capital Partners" also appears in the rendered
+// .header-band div. Parsing the Info dict eliminates that ambiguity.
 func TestHTMLToPDFExampleMetadataFromHTML(t *testing.T) {
-	doc, err := buildDocument(reportHTML)
-	if err != nil {
-		t.Fatalf("buildDocument: %v", err)
+	r := examplePDFReader(t)
+	title, author, _, _, _ := r.Info()
+	if title != "Q4 2026 Quarterly Report" {
+		t.Errorf("/Info Title = %q, want %q (from <title> tag)", title, "Q4 2026 Quarterly Report")
 	}
-	var buf bytes.Buffer
-	if _, err := doc.WriteTo(&buf); err != nil {
-		t.Fatalf("WriteTo: %v", err)
-	}
-	pdf := buf.String()
-	if !strings.Contains(pdf, "Q4 2026 Quarterly Report") {
-		t.Error("PDF /Info missing title from <title> tag")
-	}
-	if !strings.Contains(pdf, "Apex Capital Partners") {
-		t.Error("PDF /Info missing author from <meta name=\"author\"> tag")
+	if author != "Apex Capital Partners" {
+		t.Errorf("/Info Author = %q, want %q (from <meta name=\"author\">)", author, "Apex Capital Partners")
 	}
 }
 
 // TestHTMLToPDFExampleFontDedupAcrossPages pins the document-level
-// font-sharing fix landed in #300 (commit 61dc047). The example styles
-// body text as Helvetica and headings as Helvetica-Bold across two
-// pages. Pre-fix, each variant appeared once per page (4 total font
-// dict entries); post-fix, each variant appears exactly once for the
-// whole document. The assertion checks both variants by name to keep
-// the signal specific — a generic "/BaseFont count" check would not
-// distinguish a per-page regression from a font-variant-count change.
+// font-sharing fix landed in #300 (commit 61dc047). The example
+// styles body text as Helvetica and headings as Helvetica-Bold across
+// two pages; each variant must appear exactly once in the PDF, not
+// twice (pre-fix per-page embedding). The trailing space narrows the
+// match so /Helvetica does not falsely fire on /Helvetica-Bold.
 func TestHTMLToPDFExampleFontDedupAcrossPages(t *testing.T) {
-	doc, err := buildDocument(reportHTML)
-	if err != nil {
-		t.Fatalf("buildDocument: %v", err)
-	}
-	var buf bytes.Buffer
-	if _, err := doc.WriteTo(&buf); err != nil {
-		t.Fatalf("WriteTo: %v", err)
-	}
-	pdf := buf.String()
-	cases := []string{"/BaseFont /Helvetica ", "/BaseFont /Helvetica-Bold"}
-	for _, marker := range cases {
-		got := strings.Count(pdf, marker)
-		if got != 1 {
+	pdf := string(examplePDFBytes())
+	for _, marker := range []string{"/BaseFont /Helvetica ", "/BaseFont /Helvetica-Bold"} {
+		if got := strings.Count(pdf, marker); got != 1 {
 			t.Errorf("count of %q = %d, want 1 (post-#300 single-embed-per-document)", marker, got)
 		}
 	}
 }
 
-// TestHTMLToPDFExampleLinkAnnotation verifies that the "Built with
-// Folio" anchor in the report footer produces a `/Subtype /Link`
-// annotation in the output. A regression that drops link-annotation
-// emission (or routes it through a different subtype) would mean the
-// example's clickable URL stops working — that's a real user-visible
-// degradation that the static rendering tests do not catch.
-func TestHTMLToPDFExampleLinkAnnotation(t *testing.T) {
-	doc, err := buildDocument(reportHTML)
-	if err != nil {
-		t.Fatalf("buildDocument: %v", err)
-	}
-	var buf bytes.Buffer
-	if _, err := doc.WriteTo(&buf); err != nil {
-		t.Fatalf("WriteTo: %v", err)
-	}
-	pdf := buf.String()
+// TestHTMLToPDFExampleLinkAnnotationTargetsRepo asserts not only that
+// a /Link annotation exists but that its URI action points at the
+// expected destination. A regression that emits links but mangles
+// their target (e.g. always-empty URI, hardcoded localhost, dropped
+// /A action) would pass the presence-only check but break end-user
+// behavior — the link no longer goes anywhere useful. Pinning the
+// URL specifically is what makes the assertion catch real failures.
+func TestHTMLToPDFExampleLinkAnnotationTargetsRepo(t *testing.T) {
+	pdf := string(examplePDFBytes())
 	if !strings.Contains(pdf, "/Subtype /Link") {
-		t.Error("expected at least one /Subtype /Link annotation from the <a href> in the report footer")
+		t.Fatal("no /Subtype /Link annotation; the <a href> in the footer should emit one")
+	}
+	const wantURL = "https://github.com/carlos7ags/folio"
+	if !strings.Contains(pdf, wantURL) {
+		t.Errorf("link URI %q not present in PDF; check that the <a href> destination survives layout/serialization", wantURL)
 	}
 }

--- a/examples/html-to-pdf/main_test.go
+++ b/examples/html-to-pdf/main_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestHTMLToPDFExampleProducesValidPDF runs the example's HTML → PDF
+// pipeline against the bundled reportHTML constant and asserts the
+// resulting bytes are a structurally plausible PDF. The example
+// previously had no CI of any kind — the reporter of issue #295 found
+// the multi-megabyte CJK blowup by running it on Ubuntu; nothing in
+// folio's automated tests would have caught the regression. This is
+// the smoke test that closes that gap for this example (issue #231).
+func TestHTMLToPDFExampleProducesValidPDF(t *testing.T) {
+	doc, err := buildDocument(reportHTML)
+	if err != nil {
+		t.Fatalf("buildDocument: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	pdf := buf.Bytes()
+
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	// The example renders a fully-styled multi-section report; the
+	// output is unconditionally well above 5 KB even with the
+	// post-#300 font deduplication. A drop below this floor would
+	// mean the conversion bailed out and produced an empty PDF.
+	if len(pdf) < 5000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >5 KB", len(pdf))
+	}
+}
+
+// TestHTMLToPDFExampleTwoPages locks in the page count. The HTML has
+// an explicit `.page-break { break-before: page }` div between the
+// dashboard and the leadership section; if the page-break CSS handling
+// regressed silently, this test would catch it as a single-page output.
+func TestHTMLToPDFExampleTwoPages(t *testing.T) {
+	doc, err := buildDocument(reportHTML)
+	if err != nil {
+		t.Fatalf("buildDocument: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	pdf := buf.String()
+	// /Count <N> appears on the /Pages catalog root and lists the
+	// total page count for the document.
+	if !strings.Contains(pdf, "/Count 2") {
+		t.Errorf("expected /Count 2 in /Pages root; example HTML has one page-break and should produce two pages")
+	}
+}
+
+// TestHTMLToPDFExampleMetadataFromHTML verifies the converter pulls
+// /Info Title and Author from the document's <title> and
+// <meta name="author"> tags. The example deliberately sets defaults
+// on the Document and then lets ConvertFull's Metadata struct
+// override them; if that override silently breaks, the PDF's Info
+// dictionary would carry the placeholder values instead.
+func TestHTMLToPDFExampleMetadataFromHTML(t *testing.T) {
+	doc, err := buildDocument(reportHTML)
+	if err != nil {
+		t.Fatalf("buildDocument: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	pdf := buf.String()
+	if !strings.Contains(pdf, "Q4 2026 Quarterly Report") {
+		t.Error("PDF /Info missing title from <title> tag")
+	}
+	if !strings.Contains(pdf, "Apex Capital Partners") {
+		t.Error("PDF /Info missing author from <meta name=\"author\"> tag")
+	}
+}
+
+// TestHTMLToPDFExampleFontDedupAcrossPages pins the document-level
+// font-sharing fix landed in #300 (commit 61dc047). The example styles
+// body text as Helvetica and headings as Helvetica-Bold across two
+// pages. Pre-fix, each variant appeared once per page (4 total font
+// dict entries); post-fix, each variant appears exactly once for the
+// whole document. The assertion checks both variants by name to keep
+// the signal specific — a generic "/BaseFont count" check would not
+// distinguish a per-page regression from a font-variant-count change.
+func TestHTMLToPDFExampleFontDedupAcrossPages(t *testing.T) {
+	doc, err := buildDocument(reportHTML)
+	if err != nil {
+		t.Fatalf("buildDocument: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	pdf := buf.String()
+	cases := []string{"/BaseFont /Helvetica ", "/BaseFont /Helvetica-Bold"}
+	for _, marker := range cases {
+		got := strings.Count(pdf, marker)
+		if got != 1 {
+			t.Errorf("count of %q = %d, want 1 (post-#300 single-embed-per-document)", marker, got)
+		}
+	}
+}
+
+// TestHTMLToPDFExampleLinkAnnotation verifies that the "Built with
+// Folio" anchor in the report footer produces a `/Subtype /Link`
+// annotation in the output. A regression that drops link-annotation
+// emission (or routes it through a different subtype) would mean the
+// example's clickable URL stops working — that's a real user-visible
+// degradation that the static rendering tests do not catch.
+func TestHTMLToPDFExampleLinkAnnotation(t *testing.T) {
+	doc, err := buildDocument(reportHTML)
+	if err != nil {
+		t.Fatalf("buildDocument: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	pdf := buf.String()
+	if !strings.Contains(pdf, "/Subtype /Link") {
+		t.Error("expected at least one /Subtype /Link annotation from the <a href> in the report footer")
+	}
+}


### PR DESCRIPTION
## Summary

First Phase 2 example test under the #231 umbrella. The \`examples/html-to-pdf\` example previously had no CI — it was the unwitting reproducer for the multi-MB CJK font cliff in #295, and nothing in folio's test suite would have caught either that bug or the per-page font duplication that the same PR (#300, commit 61dc047) fixed alongside.

## What this PR does

- **Refactors \`main.go\`**: extracts \`buildDocument(htmlSource string) (*document.Document, error)\` so the same pipeline \`main()\` calls can be exercised from a test against an in-memory buffer. No behavior change.
- **Adds \`main_test.go\`** with five tests, each pinning a specific user-visible property that was silently uncovered before:
  - \`TestHTMLToPDFExampleProducesValidPDF\` — \`%PDF-\` header + minimum-size floor
  - \`TestHTMLToPDFExampleTwoPages\` — CSS page-break renders two pages
  - \`TestHTMLToPDFExampleMetadataFromHTML\` — \`/Info\` Title and Author from \`<title>\` and \`<meta>\`
  - \`TestHTMLToPDFExampleFontDedupAcrossPages\` — Helvetica and Helvetica-Bold each appear exactly once in the document (pins #300 commit 61dc047)
  - \`TestHTMLToPDFExampleLinkAnnotation\` — the footer anchor produces a \`/Subtype /Link\` annotation

Pattern follows \`examples/cjk/main_test.go\` (the Phase 1 reference introduced in #245).

## Test plan

- [x] \`go test ./examples/html-to-pdf/...\` green
- [x] \`go test ./...\` green
- [x] \`golangci-lint run ./examples/html-to-pdf/...\` clean
- [x] \`gofmt -s -l ./examples/html-to-pdf/\` clean
- [x] \`go run ./examples/html-to-pdf\` still produces the same 11 KB / 2-page PDF as before the refactor

## Out of scope

The remaining items on #231's Phase 2 checklist (\`examples/report\`, \`examples/fonts\`, \`examples/sign\`, etc.) will land in follow-up PRs — one per example or small batches — so each PR is reviewable in isolation.