### PR TITLE
examples: add CI for hello, links, template (#231)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,9 @@ node_modules/
 # OS
 .DS_Store
 Thumbs.db
-template
+
+# Scratch / build artefacts produced by example runs and ad-hoc
+# template experiments at repo root. The leading slash keeps the
+# rule anchored to the root so it does not accidentally hide files
+# under examples/template/ or anywhere else nested.
+/template

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -18,6 +18,18 @@ import (
 )
 
 func main() {
+	if err := buildDocument().Save("hello.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created hello.pdf")
+}
+
+// buildDocument assembles the one-page hello PDF and returns the
+// ready-to-write Document. Extracted from main() so the example test
+// (main_test.go) can exercise the same construction against an
+// in-memory buffer instead of disk.
+func buildDocument() *document.Document {
 	doc := document.NewDocument(document.PageSizeLetter)
 	doc.Info.Title = "Hello World"
 	doc.Info.Author = "Folio"
@@ -28,10 +40,5 @@ func main() {
 			"Folio is a pure-Go library for creating, reading, and signing PDF documents.",
 		font.Helvetica, 12,
 	))
-
-	if err := doc.Save("hello.pdf"); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("Created hello.pdf")
+	return doc
 }

--- a/examples/hello/main_test.go
+++ b/examples/hello/main_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	var buf bytes.Buffer
+	if _, err := buildDocument().WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+// TestHelloExampleProducesValidPDF is the smoke test for folio's
+// most-trivial example. The example only emits a heading and one
+// paragraph; the size floor is intentionally lower than larger
+// examples because there is genuinely less content to produce.
+func TestHelloExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 1000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >1 KB", len(pdf))
+	}
+}
+
+func TestHelloExampleSinglePage(t *testing.T) {
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got != 1 {
+		t.Errorf("PageCount = %d, want 1", got)
+	}
+}
+
+func TestHelloExampleMetadataInInfoDict(t *testing.T) {
+	r := examplePDFReader(t)
+	title, author, _, _, _ := r.Info()
+	if title != "Hello World" {
+		t.Errorf("/Info Title = %q, want %q", title, "Hello World")
+	}
+	if author != "Folio" {
+		t.Errorf("/Info Author = %q, want %q", author, "Folio")
+	}
+}
+
+// TestHelloExampleHeadingAndParagraphContent reads the page-1 content
+// stream and asserts the literal text the example emits appears in
+// the rendered text. Heading + paragraph are the only two visible
+// elements; if either layout primitive silently drops its content,
+// this is where it surfaces.
+func TestHelloExampleHeadingAndParagraphContent(t *testing.T) {
+	r := examplePDFReader(t)
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	for _, want := range []string{"Hello, Folio!", "pure-Go library"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("page text missing %q; extracted:\n%s", want, text)
+		}
+	}
+}

--- a/examples/links/main.go
+++ b/examples/links/main.go
@@ -29,6 +29,19 @@ import (
 )
 
 func main() {
+	doc := buildDocument()
+	if err := doc.Save("links.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "save: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created links.pdf")
+}
+
+// buildDocument assembles the multi-page links showcase and returns
+// the ready-to-write Document. Extracted from main() so the example
+// test (main_test.go) can exercise the same construction against an
+// in-memory buffer instead of disk.
+func buildDocument() *document.Document {
 	doc := document.NewDocument(document.PageSizeLetter)
 	doc.Info.Title = "Folio Links Showcase"
 	doc.Info.Author = "Folio"
@@ -232,11 +245,7 @@ hr { margin: 6px 0; }
 		PageIndex: 1, Type: document.DestFit,
 	})
 
-	if err := doc.Save("links.pdf"); err != nil {
-		fmt.Fprintf(os.Stderr, "save: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("Created links.pdf")
+	return doc
 }
 
 // sectionHeading creates a small bold heading.

--- a/examples/links/main_test.go
+++ b/examples/links/main_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	var buf bytes.Buffer
+	if _, err := buildDocument().WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+func TestLinksExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 5000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >5 KB", len(pdf))
+	}
+}
+
+func TestLinksExampleTwoPages(t *testing.T) {
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got != 2 {
+		t.Errorf("PageCount = %d, want 2 (HTML page + layout API page)", got)
+	}
+}
+
+func TestLinksExampleMetadataInInfoDict(t *testing.T) {
+	r := examplePDFReader(t)
+	title, author, _, _, _ := r.Info()
+	if title != "Folio Links Showcase" {
+		t.Errorf("/Info Title = %q, want %q", title, "Folio Links Showcase")
+	}
+	if author != "Folio" {
+		t.Errorf("/Info Author = %q, want %q", author, "Folio")
+	}
+}
+
+// TestLinksExampleEmitsLinkAnnotations is the central regression check
+// for this example. The HTML and the layout-API pages together
+// declare ~15 different link destinations; a count well above 5 is
+// the floor that distinguishes "links rendered" from "links silently
+// dropped." Pinning a specific number is too brittle because future
+// example tweaks may add or remove links, but the floor catches the
+// catastrophic failure mode that this example is designed to guard.
+func TestLinksExampleEmitsLinkAnnotations(t *testing.T) {
+	pdf := string(examplePDFBytes())
+	got := strings.Count(pdf, "/Subtype /Link")
+	if got < 5 {
+		t.Errorf("/Subtype /Link count = %d, want >=5 (HTML + layout-API links)", got)
+	}
+}
+
+// TestLinksExampleHTMLLinkTargetsPreserved asserts a specific external
+// URL from the HTML survives end-to-end through the PDF /Link
+// /A /URI action. The example deliberately exercises external
+// hyperlinks via <a href>; this catches a regression where the URI
+// action is dropped or hardcoded to about:blank, which a
+// presence-only annotation count cannot detect.
+func TestLinksExampleHTMLLinkTargetsPreserved(t *testing.T) {
+	pdf := string(examplePDFBytes())
+	for _, want := range []string{
+		"https://github.com/carlos7ags/folio",
+		"https://pkg.go.dev",
+	} {
+		if !strings.Contains(pdf, want) {
+			t.Errorf("link URI %q not present in PDF; HTML <a href> may have lost its destination through layout/serialization", want)
+		}
+	}
+}

--- a/examples/template/main.go
+++ b/examples/template/main.go
@@ -63,8 +63,11 @@ type Invoice struct {
 	Notes    string
 }
 
-func main() {
-	inv := Invoice{
+// sampleInvoice returns the demo invoice rendered by main(). Exported
+// to the example test (main_test.go) so the assertions read the same
+// values main() actually writes to disk.
+func sampleInvoice() Invoice {
+	return Invoice{
 		Number:   "1042",
 		Date:     time.Now().Format("January 2, 2006"),
 		Customer: "Globex Corporation",
@@ -76,8 +79,10 @@ func main() {
 		Total: 6488.00,
 		Notes: "Payment due within 30 days.",
 	}
+}
 
-	doc, err := tmpl.RenderDocument(invoiceTemplate, inv, nil)
+func main() {
+	doc, err := tmpl.RenderDocument(invoiceTemplate, sampleInvoice(), nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/template/main_test.go
+++ b/examples/template/main_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+	"github.com/carlos7ags/folio/tmpl"
+)
+
+// examplePDFBytes renders the example invoice once and caches the
+// result. The template + sampleInvoice + tmpl.RenderDocument pipeline
+// is what main() does on disk; the test exercises the same path
+// against an in-memory buffer.
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	doc, err := tmpl.RenderDocument(invoiceTemplate, sampleInvoice(), nil)
+	if err != nil {
+		panic("RenderDocument: " + err.Error())
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+func TestTemplateExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 1500 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >1.5 KB", len(pdf))
+	}
+}
+
+// TestTemplateExampleVariablesSubstituted is the central assertion
+// for this example: the {{.Number}}, {{.Customer}}, {{.Items}}
+// (via range), and the printf-formatted {{.Total}} placeholders in
+// the html/template must produce literal values in the rendered PDF.
+// A regression that skips substitution would leave raw "{{...}}"
+// markers in the page text — which we explicitly negative-assert on
+// — or drop the values entirely, which the positive assertions catch.
+func TestTemplateExampleVariablesSubstituted(t *testing.T) {
+	r := examplePDFReader(t)
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	for _, want := range []string{
+		"Invoice #1042",               // {{.Number}}
+		"Globex Corporation",          // {{.Customer}}
+		"Consulting (40 hrs)",         // {{range .Items}}
+		"$6488.00",                    // {{printf "%.2f" .Total}}
+		"Payment due within 30 days.", // {{.Notes}} under {{if .Notes}}
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("rendered text missing %q; html/template substitution may have regressed. Full text:\n%s", want, text)
+		}
+	}
+	// Negative assertion: no raw template markers leaked through.
+	for _, leak := range []string{"{{.", "{{range", "{{if"} {
+		if strings.Contains(text, leak) {
+			t.Errorf("raw template marker %q leaked into rendered PDF — substitution did not run", leak)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Third batch of Phase 2 example tests under the #231 umbrella, following #301 (html-to-pdf) and #302 (report). These three examples are small enough to bundle in one PR — each gets the established extract-\`buildDocument\`-then-test pattern.

## Per-example coverage

**examples/hello** (1 page, 37 LOC main):
- header + 1 KB floor
- \`PageCount() == 1\`
- \`/Info\` Title and Author
- page-1 \`ExtractText()\` contains the heading + paragraph the example emits

**examples/links** (2 pages, ~210 LOC main):
- header + 5 KB floor
- \`PageCount() == 2\`
- \`/Info\` Title and Author
- \`>= 5 /Subtype /Link\` annotations (link-rendered floor without brittle exact counts)
- specific URIs survive end-to-end (\`github.com/carlos7ags/folio\`, \`pkg.go.dev\`)

**examples/template** (\`tmpl.RenderDocument\` pipeline):
- header + 1.5 KB floor
- variables substituted (Invoice #, Customer, \`{{range .Items}}\`, printf-formatted Total, \`{{if .Notes}}\` conditional)
- negative assertion that raw \`{{...}}\`, \`{{range\`, \`{{if\` markers do NOT appear in rendered text (catches a regression that disables substitution silently)

## .gitignore drift fix

The long-standing \`template\` rule at \`.gitignore:50\` was unanchored — it caught any path or directory named \`template\` anywhere in the tree, including \`examples/template/main_test.go\` in this PR. Scoped to \`/template\` so it remains effective for ad-hoc root-level scratch dirs but stops swallowing nested example test files. The original \`examples/template/main.go\` was added before this rule existed (commit 6458229) which is why it slipped through.

## Test plan

- [x] \`go test ./examples/hello/... ./examples/links/... ./examples/template/...\` green
- [x] \`go test ./...\` green
- [x] \`golangci-lint run\` clean
- [x] \`gofmt -s -l\` clean
- [x] All three examples still produce the same PDFs as before refactor (\`go run ./examples/X\`)

## Out of scope

\`examples/optimize\` was on the original "small examples" candidate list but its assertions involve cross-fixture size comparisons (default vs packed vs swept etc.) that warrant a dedicated PR — keeping this batch focused.

After this lands, the remaining #231 Phase 2 items are: fonts, zugferd, sign, invoice, redact, import-page, merge, optimize, rtl, indic, showcase, forms, stress-tests.