### PR TITLE
examples: add CI for merge, import-page, redact (#231)

### DIFF
--- a/examples/import-page/main.go
+++ b/examples/import-page/main.go
@@ -28,33 +28,24 @@ import (
 	"github.com/carlos7ags/folio/reader"
 )
 
-func main() {
-	// --- Load the template PDF ---
-	templatePath := findTemplate()
+// buildDocument loads the template PDF, extracts page 0, and renders
+// the three demo receipts on copies of it. Extracted from main() so
+// the example test (main_test.go) can exercise the import+overlay
+// pipeline against an in-memory buffer.
+func buildDocument(templatePath string) (*document.Document, error) {
 	templateBytes, err := os.ReadFile(templatePath)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "read:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("read template: %w", err)
 	}
-
 	r, err := reader.Parse(templateBytes)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "parse:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("parse template: %w", err)
 	}
-
-	// Extract the first page for importing.
-	// ExtractPageImport resolves all indirect references (fonts, images,
-	// color spaces) so the result is self-contained and independent of
-	// the source PdfReader.
 	imp, err := reader.ExtractPageImport(r, 0)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "extract:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("extract template page: %w", err)
 	}
-	fmt.Printf("Template: %.0fx%.0f pt\n", imp.Width, imp.Height)
 
-	// --- Fill in receipts from the template ---
 	receipts := []struct{ number, date, from, amount, method, work, period string }{
 		{"REC-001", "2026-03-15", "Apex Capital Partners", "$34,948.88", "Wire Transfer", "Q1 consulting services", "Jan — Mar 2026"},
 		{"REC-002", "2026-03-16", "Meridian Dynamics", "$12,500.00", "Check", "Software license — annual", "Mar 2026 — Mar 2027"},
@@ -82,6 +73,16 @@ func main() {
 		p.AddText(rec.period, font.Helvetica, 10, 310, 380) // on "Corresponding to the period of" line
 	}
 
+	return doc, nil
+}
+
+func main() {
+	templatePath := findTemplate()
+	doc, err := buildDocument(templatePath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	if err := doc.Save("receipts.pdf"); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/examples/import-page/main_test.go
+++ b/examples/import-page/main_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+// examplePDFBytes runs the example pipeline once per test process and
+// caches the result. The template file resolves via the same
+// findTemplate helper main() uses, so `go test ./examples/import-page/`
+// (cwd = package dir) and `go test ./...` (cwd = repo root) both work
+// — findTemplate's candidate list covers both.
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	doc, err := buildDocument(findTemplate())
+	if err != nil {
+		panic("buildDocument: " + err.Error())
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+func TestImportPageExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	// The example imports a 29 KB template three times plus overlay
+	// text per page; output is reliably >10 KB even with form-XObject
+	// deduplication.
+	if len(pdf) < 10000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >10 KB", len(pdf))
+	}
+}
+
+// TestImportPageExampleThreeReceipts pins the receipt count: the
+// example renders one page per receipt entry, and there are three
+// entries. A regression in the per-page ImportPage / AddText loop
+// (e.g. silently skipping iterations after the first) shows up as a
+// page count of 1.
+func TestImportPageExampleThreeReceipts(t *testing.T) {
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got != 3 {
+		t.Errorf("PageCount = %d, want 3 (one page per receipt entry)", got)
+	}
+}
+
+func TestImportPageExampleMetadataTitle(t *testing.T) {
+	r := examplePDFReader(t)
+	title, _, _, _, _ := r.Info()
+	if title != "Payment Receipts" {
+		t.Errorf("/Info Title = %q, want %q", title, "Payment Receipts")
+	}
+}
+
+// TestImportPageExampleOverlayTextPerPage verifies the overlay text
+// AddText'd on top of each imported template lands on the correct
+// page. Each page is a separate receipt with a unique receipt number,
+// payee, and amount; if ImportPage misroutes the overlay
+// (e.g. all pages render with the same data) the per-page text
+// extraction would show duplicate content.
+func TestImportPageExampleOverlayTextPerPage(t *testing.T) {
+	r := examplePDFReader(t)
+	cases := []struct {
+		page int
+		want []string
+	}{
+		{0, []string{"REC-001", "Apex Capital Partners", "$34,948.88"}},
+		{1, []string{"REC-002", "Meridian Dynamics", "$12,500.00"}},
+		{2, []string{"REC-003", "Northwind Technologies", "$8,750.00"}},
+	}
+	for _, tc := range cases {
+		page, err := r.Page(tc.page)
+		if err != nil {
+			t.Errorf("Page(%d): %v", tc.page, err)
+			continue
+		}
+		text, err := page.ExtractText()
+		if err != nil {
+			t.Errorf("page %d ExtractText: %v", tc.page, err)
+			continue
+		}
+		for _, want := range tc.want {
+			if !strings.Contains(text, want) {
+				t.Errorf("page %d overlay missing %q; ImportPage may be misrouting per-page receipt data. Text:\n%s",
+					tc.page, want, text)
+			}
+		}
+	}
+}

--- a/examples/merge/main.go
+++ b/examples/merge/main.go
@@ -27,6 +27,51 @@ import (
 	"github.com/carlos7ags/folio/reader"
 )
 
+// buildMergedPDF runs the example's full source-PDF construction +
+// merge pipeline and returns the merged PDF bytes. Extracted from
+// main() so the example test (main_test.go) can verify the merged
+// output without writing to disk.
+func buildMergedPDF() ([]byte, error) {
+	pdf1 := createReport("Q3 2026 Revenue Report", []string{
+		"Total revenue reached $25.1M, up 18% year-over-year.",
+		"Advisory services contributed $12.8M (51% of total).",
+		"New client acquisitions increased by 23 accounts.",
+	})
+
+	pdf2 := createReport("Q4 2026 Revenue Report", []string{
+		"Total revenue reached $28.3M, up 22% year-over-year.",
+		"Operating margin improved to 30%, driven by cost optimization.",
+		"Asia-Pacific region grew 31.7%, the fastest across all regions.",
+	})
+
+	pdf3 := createCoverPage("Annual Summary 2026", "Apex Capital Partners")
+
+	r1, err := reader.Parse(pdf1)
+	if err != nil {
+		return nil, fmt.Errorf("parse pdf1: %w", err)
+	}
+	r2, err := reader.Parse(pdf2)
+	if err != nil {
+		return nil, fmt.Errorf("parse pdf2: %w", err)
+	}
+	r3, err := reader.Parse(pdf3)
+	if err != nil {
+		return nil, fmt.Errorf("parse pdf3: %w", err)
+	}
+
+	merged, err := reader.Merge(r3, r1, r2)
+	if err != nil {
+		return nil, fmt.Errorf("merge: %w", err)
+	}
+	merged.SetInfo("Annual Summary 2026", "Apex Capital Partners")
+
+	var buf bytes.Buffer
+	if _, err := merged.WriteTo(&buf); err != nil {
+		return nil, fmt.Errorf("write merged: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 func main() {
 	// --- Create source PDFs ---
 	fmt.Println("Creating source PDFs...")

--- a/examples/merge/main_test.go
+++ b/examples/merge/main_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	pdf, err := buildMergedPDF()
+	if err != nil {
+		panic("buildMergedPDF: " + err.Error())
+	}
+	return pdf
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+func TestMergeExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 2000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >2 KB", len(pdf))
+	}
+}
+
+// TestMergeExampleCombinedPageCount pins the central behavior the
+// reader.Merge call is supposed to demonstrate: a cover (1 page) +
+// two single-page reports merged yields a 3-page document. A regression
+// where Merge silently drops the first or last source would surface
+// as a 1- or 2-page result.
+func TestMergeExampleCombinedPageCount(t *testing.T) {
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got != 3 {
+		t.Errorf("PageCount = %d, want 3 (cover + Q3 + Q4)", got)
+	}
+}
+
+func TestMergeExampleMetadataAppliedAfterMerge(t *testing.T) {
+	r := examplePDFReader(t)
+	title, author, _, _, _ := r.Info()
+	if title != "Annual Summary 2026" {
+		t.Errorf("/Info Title = %q, want %q (set via Modifier.SetInfo after Merge)", title, "Annual Summary 2026")
+	}
+	if author != "Apex Capital Partners" {
+		t.Errorf("/Info Author = %q, want %q", author, "Apex Capital Partners")
+	}
+}
+
+// TestMergeExamplePagesPreserveSourceText verifies the merged PDF
+// retained the distinguishing text from each source document on the
+// expected page index. The merge order in the example is
+// (cover, Q3 report, Q4 report); a regression that mis-orders the
+// merge or drops source content would land here.
+func TestMergeExamplePagesPreserveSourceText(t *testing.T) {
+	r := examplePDFReader(t)
+	cases := []struct {
+		page int
+		want string
+	}{
+		{0, "Annual Summary 2026"},            // cover
+		{1, "Q3 2026 Revenue Report"},         // first report (page index 1 after the cover)
+		{1, "Total revenue reached $25.1M"},   // Q3 body text
+		{2, "Q4 2026 Revenue Report"},         // second report
+		{2, "Asia-Pacific region grew 31.7%"}, // Q4 body text
+	}
+	for _, tc := range cases {
+		page, err := r.Page(tc.page)
+		if err != nil {
+			t.Errorf("Page(%d): %v", tc.page, err)
+			continue
+		}
+		text, err := page.ExtractText()
+		if err != nil {
+			t.Errorf("page %d ExtractText: %v", tc.page, err)
+			continue
+		}
+		if !strings.Contains(text, tc.want) {
+			t.Errorf("page %d text missing %q; merge may have re-ordered or lost source content. Extracted:\n%s",
+				tc.page, tc.want, text)
+		}
+	}
+}

--- a/examples/redact/main.go
+++ b/examples/redact/main.go
@@ -33,6 +33,33 @@ import (
 	"github.com/carlos7ags/folio/reader"
 )
 
+// buildRedactedPDF runs the example's full redaction pipeline and
+// returns the redacted PDF bytes — equivalent to what main() writes
+// to disk at the end of its --- Step 4 --- block (text + regex SSN
+// redaction with metadata stripping). Extracted so the example test
+// can verify the redacted output without writing to disk.
+func buildRedactedPDF() ([]byte, error) {
+	pdf := createSensitivePDF()
+	r, err := reader.Parse(pdf)
+	if err != nil {
+		return nil, fmt.Errorf("parse source: %w", err)
+	}
+	ssnPattern := regexp.MustCompile(`\d{3}-\d{2}-\d{4}`)
+	m, err := reader.RedactPattern(r, ssnPattern, &reader.RedactOptions{
+		FillColor:     [3]float64{0, 0, 0},
+		OverlayText:   "[SSN]",
+		StripMetadata: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("redact pattern: %w", err)
+	}
+	var buf bytes.Buffer
+	if _, err := m.WriteTo(&buf); err != nil {
+		return nil, fmt.Errorf("write redacted: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 func main() {
 	// --- Step 1: Create a PDF with sensitive content ---
 	fmt.Println("Creating PDF with sensitive content...")

--- a/examples/redact/main_test.go
+++ b/examples/redact/main_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+// examplePDFBytes runs the example's redaction pipeline once and
+// caches the resulting redacted bytes. Mirrors main()'s final write
+// (text + SSN-regex redaction with metadata stripping).
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	pdf, err := buildRedactedPDF()
+	if err != nil {
+		panic("buildRedactedPDF: " + err.Error())
+	}
+	return pdf
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+func TestRedactExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 1000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >1 KB", len(pdf))
+	}
+}
+
+func TestRedactExamplePreservesPageCount(t *testing.T) {
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got != 1 {
+		t.Errorf("PageCount = %d, want 1 (source has one page)", got)
+	}
+}
+
+// TestRedactExampleSSNNotInRawBytes is the central security guarantee
+// of this example: a regex-matched SSN must NOT appear anywhere in
+// the serialized PDF bytes after redaction. main() itself runs this
+// exact check at the tail of the redaction pipeline.
+//
+// Sanity precondition: extract the unredacted source's page text
+// (which decompresses the content stream) and confirm the SSN is
+// present there. Without this, a regression in createSensitivePDF
+// that drops the SSN string would let this test silently green. We
+// cannot use bytes.Contains on the raw source bytes for the
+// precondition because content streams are FlateDecode-compressed,
+// so the literal "987-65-4321" only appears in the decompressed
+// view.
+func TestRedactExampleSSNNotInRawBytes(t *testing.T) {
+	pdf := examplePDFBytes()
+	const ssn = "987-65-4321"
+
+	sourceR, err := reader.Parse(createSensitivePDF())
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+	srcPage, err := sourceR.Page(0)
+	if err != nil {
+		t.Fatalf("source Page(0): %v", err)
+	}
+	srcText, err := srcPage.ExtractText()
+	if err != nil {
+		t.Fatalf("source ExtractText: %v", err)
+	}
+	if !strings.Contains(srcText, ssn) {
+		t.Fatalf("createSensitivePDF lost its SSN literal; test no longer exercises the redactor")
+	}
+
+	if bytes.Contains(pdf, []byte(ssn)) {
+		t.Errorf("redacted PDF still contains SSN %q in raw bytes; reader.RedactPattern leaked the redacted glyph run", ssn)
+	}
+}
+
+// TestRedactExampleSSNNotInExtractedText asserts the SSN is gone from
+// the page's extractable text layer too. Raw-bytes absence is the
+// stronger property; extracted-text absence is a sanity check that
+// pdftotext-style consumers see the redaction.
+func TestRedactExampleSSNNotInExtractedText(t *testing.T) {
+	r := examplePDFReader(t)
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if strings.Contains(text, "987-65-4321") {
+		t.Errorf("extracted text still contains SSN; redaction did not remove the visible glyph run.\nText:\n%s", text)
+	}
+}
+
+// TestRedactExampleOverlayTextReplacesSSN verifies the OverlayText
+// option actually painted "[SSN]" over the redacted region. The
+// pre-redaction text does not contain "[SSN]"; after redaction with
+// OverlayText: "[SSN]", the page text should.
+func TestRedactExampleOverlayTextReplacesSSN(t *testing.T) {
+	r := examplePDFReader(t)
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	if !strings.Contains(text, "[SSN]") {
+		t.Errorf("extracted text missing overlay marker %q; reader.RedactPattern OverlayText option may have regressed.\nText:\n%s", "[SSN]", text)
+	}
+}
+
+// TestRedactExampleMetadataStripped pins the StripMetadata option:
+// after redaction, /Info Title and Author must be empty strings (or
+// missing entries that read as empty). createSensitivePDF sets both
+// "Employee Record" and "HR Department"; if StripMetadata regresses,
+// those leak through.
+func TestRedactExampleMetadataStripped(t *testing.T) {
+	r := examplePDFReader(t)
+	title, author, _, _, _ := r.Info()
+	if title != "" {
+		t.Errorf("/Info Title = %q after StripMetadata; expected empty", title)
+	}
+	if author != "" {
+		t.Errorf("/Info Author = %q after StripMetadata; expected empty", author)
+	}
+}


### PR DESCRIPTION
## Summary

Fourth batch of Phase 2 example tests under the #231 umbrella, after #301 (html-to-pdf), #302 (report), and #303 (hello/links/template). These three examples carry more substantive per-test assertions than the previous trivial-smoke batches — they exercise reader.Merge, reader.ExtractPageImport / ImportPage, and reader.RedactPattern respectively.

## Per-example coverage

**examples/merge** — \`reader.Merge\` over three source PDFs (cover + Q3 + Q4):
- header + size floor
- \`CombinedPageCount == 3\` (pins merge ordering / page-count contract)
- \`SetInfo\` on the returned Modifier lands on \`/Info\`
- each merged page carries the expected source body text (pins ordering + content survival)

**examples/import-page** — \`reader.ExtractPageImport\` + \`Page.ImportPage\` overlay:
- header + 10 KB floor (template plus three rendered pages)
- \`PageCount == 3\` (one per receipt entry)
- \`/Info\` Title
- per-page overlay text carries its specific receipt number / payee / amount (pins per-page \`ImportPage\` routing)

**examples/redact** — \`reader.RedactPattern\` with metadata strip:
- header + size floor
- \`PageCount == 1\` (preserved through redaction)
- SSN not in raw PDF bytes (the central security check main() itself runs; sanity precondition uses \`ExtractText\` on the unredacted source because content streams are FlateDecode-compressed)
- SSN not in extracted page text (consumer-visible text layer)
- \`OverlayText: "[SSN]"\` reaches the rendered text
- \`StripMetadata: true\` zeroes \`/Info\` Title and Author

## Refactor

Each \`main()\` now delegates to a small helper (\`buildMergedPDF\`, \`buildDocument\`, \`buildRedactedPDF\`) extracted for testability. No behavior change — each example still produces the same PDF on disk as before.

## Test plan

- [x] \`go test ./examples/merge/... ./examples/import-page/... ./examples/redact/...\` green
- [x] \`go test ./...\` green
- [x] \`golangci-lint run\` clean
- [x] \`gofmt -s -l\` clean
- [x] All three \`go run ./examples/X\` still produce identical PDFs to pre-refactor

## Remaining

After this lands, the #231 Phase 2 checklist still has: fonts, zugferd, sign, invoice, optimize, rtl, indic, showcase, forms, stress-tests.