### PR TITLE
layout: preserve OriginalText + GIDs across breakLongWords chunks (closes #255)

### DIFF
--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -755,8 +755,27 @@ func breakCJKWords(words []Word) []Word {
 	return result
 }
 
-// breakLongWords splits any word exceeding maxWidth into character-level chunks
-// so that the word-wrap algorithm can handle them. Words that fit are unchanged.
+// breakLongWords splits any word exceeding maxWidth into character-level
+// chunks so that the word-wrap algorithm can handle them. Words that fit
+// are unchanged.
+//
+// For shaped words (where OriginalText carries the pre-shape Unicode and
+// either Text was Arabic-shaped to Presentation Forms-B or GIDs carries
+// the Indic shaper output), the function breaks on OriginalText
+// codepoint boundaries and re-runs the appropriate shaper for each
+// chunk. This preserves Word.OriginalText (used by the renderer's
+// /ActualText marked-content wrapper, ISO 32000-2 §14.9.4) and
+// Word.GIDs (needed by the Identity-H emit path for Indic). A prior
+// implementation dropped both fields on subsequent chunks, breaking
+// copy/paste recovery and Devanagari rendering at chunk boundaries
+// (#255).
+//
+// Re-shaping per chunk produces context-independent glyphs at the chunk
+// boundaries — Arabic cursive joins won't carry across a break, and
+// Indic ligatures that would span a break do not form. That's the
+// expected outcome for a character-broken word: the layout engine has
+// already decided the word must split at this character, and shaping
+// honours that decision.
 func breakLongWords(words []Word, maxWidth float64) []Word {
 	var result []Word
 	for _, w := range words {
@@ -764,19 +783,25 @@ func breakLongWords(words []Word, maxWidth float64) []Word {
 			result = append(result, w)
 			continue
 		}
-		// Break by characters. Build chunks that fit within maxWidth.
-		runes := []rune(w.Text)
-		measurer := w.Font
-		var emb *font.EmbeddedFont
-		if w.Embedded != nil {
-			emb = w.Embedded
+
+		// Source text for codepoint-boundary breaks: pre-shape
+		// OriginalText when the word was shaped, else the post-shape
+		// Text. The shaped flag drives both the rune-iteration source
+		// and the per-chunk shaping path below.
+		shaped := w.OriginalText != ""
+		sourceText := w.Text
+		if shaped {
+			sourceText = w.OriginalText
 		}
-		var measure func(string) float64
-		if emb != nil {
-			measure = func(s string) float64 { return emb.MeasureString(s, w.FontSize) }
-		} else if measurer != nil {
-			measure = func(s string) float64 { return measurer.MeasureString(s, w.FontSize) }
-		} else {
+		runes := []rune(sourceText)
+
+		shapeChunk := shapedChunkBuilder(&w, shaped)
+		// Probe the first single-rune chunk to detect a missing
+		// measurer (no Font and no Embedded). Without one we cannot
+		// width-test candidates, so pass the source word through
+		// verbatim — matches the original break-by-characters
+		// fallback semantics.
+		if _, _, _, ok := shapeChunk(string(runes[0:1])); !ok {
 			result = append(result, w)
 			continue
 		}
@@ -785,16 +810,17 @@ func breakLongWords(words []Word, maxWidth float64) []Word {
 		for start < len(runes) {
 			end := start + 1
 			for end < len(runes) {
-				candidate := string(runes[start : end+1])
-				if measure(candidate) > maxWidth {
+				_, _, width, _ := shapeChunk(string(runes[start : end+1]))
+				if width > maxWidth {
 					break
 				}
 				end++
 			}
-			chunk := string(runes[start:end])
-			result = append(result, Word{
-				Text:          chunk,
-				Width:         measure(chunk),
+			chunkSource := string(runes[start:end])
+			chunkText, chunkGIDs, chunkWidth, _ := shapeChunk(chunkSource)
+			chunk := Word{
+				Text:          chunkText,
+				Width:         chunkWidth,
 				Font:          w.Font,
 				Embedded:      w.Embedded,
 				FontSize:      w.FontSize,
@@ -803,11 +829,64 @@ func breakLongWords(words []Word, maxWidth float64) []Word {
 				SpaceAfter:    0, // no inter-word space within a broken word
 				LetterSpacing: w.LetterSpacing,
 				WordSpacing:   w.WordSpacing,
-			})
+				GIDs:          chunkGIDs,
+			}
+			if shaped {
+				// Per-chunk pre-shape slice. Without this the
+				// renderer's /ActualText wrapper would emit the
+				// shaped codepoints, breaking copy/paste recovery.
+				chunk.OriginalText = chunkSource
+			}
+			result = append(result, chunk)
 			start = end
 		}
 	}
 	return result
+}
+
+// shapedChunkBuilder returns a function that produces (post-shape text,
+// GIDs, width, ok) for an arbitrary slice of a word's source text. It
+// captures w by pointer so that per-chunk results inherit the word's
+// font / Embedded / size without allocating closures over each field.
+// The shaped flag selects the path: unshaped words route through
+// MeasureString on the source text; shaped words re-run the Indic
+// shaper when w.GIDs was non-nil, otherwise the Arabic shaper.
+func shapedChunkBuilder(w *Word, shaped bool) func(chunkSrc string) (text string, gids []uint16, width float64, ok bool) {
+	return func(chunkSrc string) (text string, gids []uint16, width float64, ok bool) {
+		if !shaped {
+			if w.Embedded != nil {
+				return chunkSrc, nil, w.Embedded.MeasureString(chunkSrc, w.FontSize), true
+			}
+			if w.Font != nil {
+				return chunkSrc, nil, w.Font.MeasureString(chunkSrc, w.FontSize), true
+			}
+			return "", nil, 0, false
+		}
+		// Indic path — try only if the original word carried GIDs
+		// (i.e. the initial shaper succeeded). The script of the
+		// chunk could differ from the script of the whole word at
+		// boundaries between scripts, but breakLongWords operates on
+		// a single word from the shaper's segmentation, so the chunk
+		// shares the parent word's script.
+		if w.GIDs != nil && w.Embedded != nil {
+			if sc := indicScriptOfWord(chunkSrc); sc != ScriptCommon {
+				if g, ok := ShapeIndicWithEmbedded(chunkSrc, w.Embedded, sc); ok {
+					return chunkSrc, g, w.Embedded.MeasureGIDs(g, w.FontSize), true
+				}
+			}
+		}
+		// Arabic / general rune fallback. ShapeArabic is a no-op for
+		// non-Arabic input so this also handles a defensive fallback
+		// path where the Indic shaper failed.
+		shapedText := ShapeArabic(chunkSrc)
+		if w.Embedded != nil {
+			return shapedText, nil, w.Embedded.MeasureString(shapedText, w.FontSize), true
+		}
+		if w.Font != nil {
+			return shapedText, nil, w.Font.MeasureString(shapedText, w.FontSize), true
+		}
+		return "", nil, 0, false
+	}
 }
 
 // hyphenateWord attempts to split a word to fit within `available` points

--- a/layout/paragraph_break_long_words_test.go
+++ b/layout/paragraph_break_long_words_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// TestBreakLongWordsPreservesIndicOriginalTextAndGIDs is the
+// regression test for #255. A Devanagari word that exceeds the line
+// width — say, 30 "ka" syllables glued together — must split into
+// chunks where every chunk carries:
+//
+//   - a per-chunk OriginalText slice (pre-shape Unicode) for the
+//     renderer's /ActualText marked-content wrapper, so copy/paste
+//     recovers the original Devanagari instead of post-shape glyph
+//     codepoints;
+//   - a re-shaped GIDs stream, so the Identity-H emission path the
+//     draw layer relies on has the right glyph indices at chunk
+//     boundaries.
+//
+// Pre-fix breakLongWords copied most Word fields when constructing
+// chunks but dropped both OriginalText and GIDs, so chunk N>0 lost
+// its accessibility / round-trip text and its glyph stream. The
+// rendered PDF showed correct first chunk and silently-broken tails.
+func TestBreakLongWordsPreservesIndicOriginalTextAndGIDs(t *testing.T) {
+	face := newMockDevaFace()
+	face.substitutions = &font.GSUBSubstitutions{
+		Single: map[font.GSUBFeature]map[uint16]uint16{},
+	}
+	ef := font.NewEmbeddedFont(face)
+
+	// 30 ka syllables, no whitespace — a single word the layout engine
+	// would route into breakLongWords once the line width is narrower
+	// than the whole-word measure.
+	const fontSize = 12
+	source := strings.Repeat("क", 30)
+
+	// Replicate what shapeAndMeasureWord does to produce a Word as it
+	// would appear immediately before breakLongWords runs.
+	gids, ok := ShapeIndicWithEmbedded(source, ef, ScriptDevanagari)
+	if !ok {
+		t.Fatal("ShapeIndicWithEmbedded returned (_, false) for the test source")
+	}
+	wholeWidth := ef.MeasureGIDs(gids, fontSize)
+	if wholeWidth == 0 {
+		t.Fatal("mock face produced zero-width word; test cannot drive breakLongWords")
+	}
+
+	w := Word{
+		Text:         source,
+		OriginalText: source,
+		GIDs:         gids,
+		Width:        wholeWidth,
+		Embedded:     ef,
+		FontSize:     fontSize,
+	}
+
+	// Pick maxWidth = 1/4 of the whole word so the function is forced
+	// to produce multiple chunks.
+	maxWidth := wholeWidth / 4
+	chunks := breakLongWords([]Word{w}, maxWidth)
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d (whole=%v, max=%v)",
+			len(chunks), wholeWidth, maxWidth)
+	}
+
+	var rejoined strings.Builder
+	for i, c := range chunks {
+		if c.OriginalText == "" {
+			t.Errorf("chunk %d: OriginalText empty — ActualText recovery would emit shaped codepoints", i)
+		}
+		if len(c.GIDs) == 0 {
+			t.Errorf("chunk %d: GIDs empty — Devanagari Identity-H emission would fall back to .notdef glyphs", i)
+		}
+		if c.Width > maxWidth+0.001 {
+			t.Errorf("chunk %d: width %v exceeds maxWidth %v", i, c.Width, maxWidth)
+		}
+		rejoined.WriteString(c.OriginalText)
+	}
+	if rejoined.String() != source {
+		t.Errorf("chunk OriginalTexts do not rejoin to the source word.\n  source: %q\n  rejoined: %q",
+			source, rejoined.String())
+	}
+}
+
+// TestBreakLongWordsPreservesArabicOriginalText covers the parallel
+// Arabic path. ShapeArabic substitutes Presentation Forms-B codepoints
+// in place — the post-shape Text differs from the pre-shape original.
+// Pre-fix breakLongWords dropped OriginalText on chunks N>0, so the
+// /ActualText wrapper for tail chunks emitted the FE-range glyph-form
+// codepoints instead of the original Arabic; copy/paste recovered
+// disconnected isolated forms.
+//
+// The test uses font.Helvetica as a standard-font carrier so the
+// Arabic-shaped Text is measured via MeasureString. Helvetica has no
+// Arabic glyphs in WinAnsi, but the measurement path treats every
+// rune as having a fallback width — enough to drive breakLongWords
+// deterministically.
+func TestBreakLongWordsPreservesArabicOriginalText(t *testing.T) {
+	const fontSize = 12
+	// 30 lam-alef pairs (U+0644 U+0627) — no whitespace, so the
+	// resulting Word is one long Arabic word post-shape.
+	source := strings.Repeat("لا", 30)
+	shaped := ShapeArabic(source)
+	if shaped == source {
+		t.Skip("ShapeArabic did not substitute any Presentation Forms; test cannot demonstrate OriginalText preservation")
+	}
+	wholeWidth := font.Helvetica.MeasureString(shaped, fontSize)
+	if wholeWidth == 0 {
+		t.Fatal("Helvetica measured zero width; test cannot drive breakLongWords")
+	}
+
+	w := Word{
+		Text:         shaped,
+		OriginalText: source,
+		Width:        wholeWidth,
+		Font:         font.Helvetica,
+		FontSize:     fontSize,
+	}
+
+	maxWidth := wholeWidth / 4
+	chunks := breakLongWords([]Word{w}, maxWidth)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d (whole=%v, max=%v)",
+			len(chunks), wholeWidth, maxWidth)
+	}
+
+	var rejoined strings.Builder
+	for i, c := range chunks {
+		if c.OriginalText == "" {
+			t.Errorf("chunk %d: OriginalText empty — ActualText recovery would emit Presentation Forms-B", i)
+		}
+		// Each chunk's OriginalText must be a non-empty slice of
+		// the source codepoints. Validate count matches Text by
+		// rune count if no ligature collapsed the chunk.
+		if utf8.RuneCountInString(c.OriginalText) == 0 {
+			t.Errorf("chunk %d: OriginalText has zero runes", i)
+		}
+		rejoined.WriteString(c.OriginalText)
+	}
+	if rejoined.String() != source {
+		t.Errorf("chunk OriginalTexts do not rejoin to the source word.\n  source: %q\n  rejoined: %q",
+			source, rejoined.String())
+	}
+}
+
+// TestBreakLongWordsUnshapedPathUnchanged guards against the
+// re-shaping path firing for words that were never shaped to begin
+// with. A plain Latin word with no OriginalText should still chunk
+// by Text runes and emit chunks whose Text is a substring of the
+// source — same behaviour as the function had before #255.
+func TestBreakLongWordsUnshapedPathUnchanged(t *testing.T) {
+	const fontSize = 12
+	source := strings.Repeat("a", 30)
+	wholeWidth := font.Helvetica.MeasureString(source, fontSize)
+	if wholeWidth == 0 {
+		t.Fatal("Helvetica measured zero width; test cannot drive breakLongWords")
+	}
+	w := Word{
+		Text:     source,
+		Width:    wholeWidth,
+		Font:     font.Helvetica,
+		FontSize: fontSize,
+	}
+	chunks := breakLongWords([]Word{w}, wholeWidth/4)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	var rejoined strings.Builder
+	for i, c := range chunks {
+		if c.OriginalText != "" {
+			t.Errorf("chunk %d: unshaped word should not gain OriginalText, got %q", i, c.OriginalText)
+		}
+		if c.GIDs != nil {
+			t.Errorf("chunk %d: unshaped word should not gain GIDs, got %v", i, c.GIDs)
+		}
+		rejoined.WriteString(c.Text)
+	}
+	if rejoined.String() != source {
+		t.Errorf("chunk Texts do not rejoin to the source.\n  source: %q\n  rejoined: %q",
+			source, rejoined.String())
+	}
+}


### PR DESCRIPTION
## Summary

Closes #255. \`breakLongWords\` splits any word exceeding \`maxWidth\` into character-level chunks so the wrap algorithm can find a break. The pre-fix implementation copied most \`Word\` fields onto each chunk but silently dropped \`OriginalText\` and \`GIDs\`. For shaped scripts this had two user-visible consequences:

- **Arabic**: tail chunks lost their pre-shape \`OriginalText\` slice. The renderer's \`/ActualText\` marked-content wrapper (ISO 32000-2 §14.9.4) then emitted post-shape Presentation Forms-B codepoints, so copy/paste recovered disconnected isolated forms instead of the original Arabic.
- **Devanagari / Bengali / other Indic**: tail chunks lost their GID stream. The draw path's Identity-H emission fell back to \`.notdef\` for those chunks, silently breaking rendering at chunk boundaries.

The latency of the bug (#255 sat untriggered) tracks when \`breakLongWords\` actually fires: a single word must exceed the line width. Uncommon in body text, but reachable through \`SplitAfterLine\` (#253) and narrow render targets.

## Fix

When the input word carries \`OriginalText\` (the shaper-set pre-shape slice), break on \`OriginalText\` rune boundaries and re-run the appropriate shaper for each chunk. Arabic goes through \`ShapeArabic\`; Devanagari / Bengali / other Indic goes through \`ShapeIndicWithEmbedded\`.

Re-shaping per chunk loses contextual joining at chunk boundaries — Arabic cursive joins won't carry across a break and Indic ligatures that would span a break do not form. That matches the layout engine's intent to split at this character.

The unshaped path (\`OriginalText\` empty) is unchanged: still breaks on \`Text\` runes with \`MeasureString\`. No regression risk for Latin / CJK / numeric text.

Helper \`shapedChunkBuilder\` returns a closure over the source word so the inner candidate-width loop shares the same shaping dispatch as the final chunk emit.

## Tests

\`layout/paragraph_break_long_words_test.go\`:

- \`TestBreakLongWordsPreservesIndicOriginalTextAndGIDs\` — 30 \`क\` syllables, broken at \`wholeWidth/4\`. Each chunk must carry non-empty \`OriginalText\`, non-empty \`GIDs\`, width within budget, and the rejoined \`OriginalText\` must equal the source.
- \`TestBreakLongWordsPreservesArabicOriginalText\` — 30 lam-alef pairs through \`Helvetica\`'s measurer.
- \`TestBreakLongWordsUnshapedPathUnchanged\` — control case: 30-a Latin still chunks by \`Text\` runes with no \`OriginalText\` or \`GIDs\` synthesized.

Each test would fail against pre-fix code by hitting the empty-\`OriginalText\` / nil-\`GIDs\` assertion on the first tail chunk.

## Test plan

- [x] \`go test ./layout/ -run TestBreakLongWords\` — 3 new tests pass
- [x] \`go test ./...\` green
- [x] \`golangci-lint run ./layout/...\` — no new issues (6 pre-existing staticcheck warnings in unrelated test files remain)
- [x] \`gofmt -s -l layout/\` clean