### PR TITLE
html: Phase 1 of #269 — sibling *cssLength fields for margin/padding

### DIFF
--- a/html/css_props.go
+++ b/html/css_props.go
@@ -330,28 +330,28 @@ var cssProperties = []cssProperty{
 		Name: "padding-top", Category: "BoxModel",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.PaddingTop = parseBoxSide(value, s.FontSize)
+			s.PaddingTop, s.PaddingTopLength = parseBoxSideBoth(value, s.FontSize)
 		},
 	},
 	{
 		Name: "padding-right", Category: "BoxModel",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.PaddingRight = parseBoxSide(value, s.FontSize)
+			s.PaddingRight, s.PaddingRightLength = parseBoxSideBoth(value, s.FontSize)
 		},
 	},
 	{
 		Name: "padding-bottom", Category: "BoxModel",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.PaddingBottom = parseBoxSide(value, s.FontSize)
+			s.PaddingBottom, s.PaddingBottomLength = parseBoxSideBoth(value, s.FontSize)
 		},
 	},
 	{
 		Name: "padding-left", Category: "BoxModel",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.PaddingLeft = parseBoxSide(value, s.FontSize)
+			s.PaddingLeft, s.PaddingLeftLength = parseBoxSideBoth(value, s.FontSize)
 		},
 	},
 	{
@@ -359,7 +359,7 @@ var cssProperties = []cssProperty{
 		Values: []string{"<length>", "<percentage>"},
 		Notes:  "margin-top, margin-left, margin-right also accept `auto`; margin-bottom does not.",
 		Apply: func(s *computedStyle, value string) {
-			s.MarginBottom = parseBoxSide(value, s.FontSize)
+			s.MarginBottom, s.MarginBottomLength = parseBoxSideBoth(value, s.FontSize)
 		},
 	},
 	{
@@ -1060,6 +1060,8 @@ var cssProperties = []cssProperty{
 		Apply: func(s *computedStyle, value string) {
 			s.MarginTop, s.MarginRight, s.MarginBottom, s.MarginLeft =
 				parseMarginShorthand(value, s.FontSize)
+			s.MarginTopLength, s.MarginRightLength, s.MarginBottomLength, s.MarginLeftLength =
+				parseMarginShorthandLengths(value, s.FontSize)
 			// Use splitTopLevelFields (paren-aware) so calc()/min()/max()/
 			// clamp() values stay as single tokens — otherwise the
 			// auto-flag positions could shift with respect to the parsed
@@ -1112,7 +1114,7 @@ var cssProperties = []cssProperty{
 			if strings.TrimSpace(strings.ToLower(value)) == "auto" {
 				s.MarginTopAuto = true
 			} else {
-				s.MarginTop = parseBoxSide(value, s.FontSize)
+				s.MarginTop, s.MarginTopLength = parseBoxSideBoth(value, s.FontSize)
 			}
 		},
 	},
@@ -1123,7 +1125,7 @@ var cssProperties = []cssProperty{
 			if strings.TrimSpace(strings.ToLower(value)) == "auto" {
 				s.MarginRightAuto = true
 			} else {
-				s.MarginRight = parseBoxSide(value, s.FontSize)
+				s.MarginRight, s.MarginRightLength = parseBoxSideBoth(value, s.FontSize)
 			}
 		},
 	},
@@ -1134,7 +1136,7 @@ var cssProperties = []cssProperty{
 			if strings.TrimSpace(strings.ToLower(value)) == "auto" {
 				s.MarginLeftAuto = true
 			} else {
-				s.MarginLeft = parseBoxSide(value, s.FontSize)
+				s.MarginLeft, s.MarginLeftLength = parseBoxSideBoth(value, s.FontSize)
 			}
 		},
 	},
@@ -1144,6 +1146,8 @@ var cssProperties = []cssProperty{
 		Apply: func(s *computedStyle, value string) {
 			s.PaddingTop, s.PaddingRight, s.PaddingBottom, s.PaddingLeft =
 				parseMarginShorthand(value, s.FontSize)
+			s.PaddingTopLength, s.PaddingRightLength, s.PaddingBottomLength, s.PaddingLeftLength =
+				parseMarginShorthandLengths(value, s.FontSize)
 		},
 	},
 

--- a/html/lazy_margin_padding_test.go
+++ b/html/lazy_margin_padding_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"math"
+	"testing"
+)
+
+// TestParseBoxSideBothReturnsBothForms is the parser-side contract
+// for the #269 Phase 1 sibling-field migration. Every margin/padding
+// Apply must produce BOTH:
+//
+//   - a legacy float64 resolved against zero (the existing 0pt-on-
+//     percent behaviour) for back-compat with unmigrated consumers
+//   - an unresolved *cssLength that preserves the percent / calc tree
+//     for layout-time resolution against the container width
+//
+// "auto" / unparseable input still yields (0, nil) so callers can
+// branch on the *cssLength being nil.
+func TestParseBoxSideBothReturnsBothForms(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		fontSize   float64
+		wantLegacy float64
+		wantUnit   string  // expected cssLength.Unit; "" means nil expected
+		wantValue  float64 // for non-nil, expected cssLength.Value
+	}{
+		{"plain points", "10pt", 12, 10, "pt", 10},
+		// 16px → 12pt at 0.75 px/pt.
+		{"plain pixels", "16px", 12, 12, "px", 16},
+		// percent: legacy resolves against 0 (the bug); sibling
+		// retains the 50% form for layout-time resolution.
+		{"percent", "50%", 12, 0, "%", 50},
+		// em on the legacy path resolves against fontSize, so 1em
+		// at 12pt → 12pt. The sibling carries Unit "em" so a future
+		// consumer can re-resolve.
+		{"em", "1.5em", 12, 18, "em", 1.5},
+		// Unparseable inputs return (0, nil).
+		{"empty", "", 12, 0, "", 0},
+		{"auto keyword (parseLength rejects)", "auto", 12, 0, "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLegacy, gotLength := parseBoxSideBoth(tc.input, tc.fontSize)
+			if math.Abs(gotLegacy-tc.wantLegacy) > 0.001 {
+				t.Errorf("legacy float64 = %v, want %v", gotLegacy, tc.wantLegacy)
+			}
+			if tc.wantUnit == "" {
+				if gotLength != nil {
+					t.Errorf("cssLength = %+v, want nil", gotLength)
+				}
+				return
+			}
+			if gotLength == nil {
+				t.Fatalf("cssLength = nil, want Unit=%q Value=%v", tc.wantUnit, tc.wantValue)
+			}
+			if gotLength.Unit != tc.wantUnit {
+				t.Errorf("cssLength.Unit = %q, want %q", gotLength.Unit, tc.wantUnit)
+			}
+			if math.Abs(gotLength.Value-tc.wantValue) > 0.001 {
+				t.Errorf("cssLength.Value = %v, want %v", gotLength.Value, tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestMarginTopAtResolvesPercentAgainstContainer is the central Phase 1
+// claim: when the parser stored a *cssLength sibling, MarginTopAt
+// resolves percent correctly against the container width — closing the
+// silent 0pt bug at the helper level. Phase 2 migrates consumers to
+// the helper so the bug closes end-to-end.
+//
+// Each subtest synthesizes a computedStyle as the parser would
+// produce it, then asserts the helper's resolution. All eight
+// sides (4 margin + 4 padding) follow the same shape; the test
+// table covers one of each plus a few targeted edge cases.
+func TestMarginTopAtResolvesPercentAgainstContainer(t *testing.T) {
+	type sideHelper func(*computedStyle, float64) float64
+	type sideSetter func(*computedStyle, *cssLength)
+
+	apply := []struct {
+		name   string
+		set    sideSetter
+		helper sideHelper
+	}{
+		{"MarginTop", func(s *computedStyle, l *cssLength) { s.MarginTopLength = l }, (*computedStyle).MarginTopAt},
+		{"MarginRight", func(s *computedStyle, l *cssLength) { s.MarginRightLength = l }, (*computedStyle).MarginRightAt},
+		{"MarginBottom", func(s *computedStyle, l *cssLength) { s.MarginBottomLength = l }, (*computedStyle).MarginBottomAt},
+		{"MarginLeft", func(s *computedStyle, l *cssLength) { s.MarginLeftLength = l }, (*computedStyle).MarginLeftAt},
+		{"PaddingTop", func(s *computedStyle, l *cssLength) { s.PaddingTopLength = l }, (*computedStyle).PaddingTopAt},
+		{"PaddingRight", func(s *computedStyle, l *cssLength) { s.PaddingRightLength = l }, (*computedStyle).PaddingRightAt},
+		{"PaddingBottom", func(s *computedStyle, l *cssLength) { s.PaddingBottomLength = l }, (*computedStyle).PaddingBottomAt},
+		{"PaddingLeft", func(s *computedStyle, l *cssLength) { s.PaddingLeftLength = l }, (*computedStyle).PaddingLeftAt},
+	}
+	cases := []struct {
+		name           string
+		value          string
+		containerWidth float64
+		fontSize       float64
+		want           float64
+	}{
+		// The bug-closing case: 50% of a 200pt container = 100pt.
+		// Legacy parseBoxSide would have stored 0pt.
+		{"percent against container", "50%", 200, 12, 100},
+		// calc(10% + 5px) at 200pt container, 12pt fontSize:
+		// 10% of 200 = 20pt; 5px = 3.75pt; total 23.75pt.
+		{"calc mixed", "calc(10% + 5px)", 200, 12, 23.75},
+		// Plain px: container width irrelevant.
+		{"plain px ignores container", "16px", 200, 12, 12},
+		// em: relative to fontSize, not container.
+		{"em ignores container", "2em", 200, 12, 24},
+	}
+	for _, h := range apply {
+		for _, tc := range cases {
+			t.Run(h.name+"/"+tc.name, func(t *testing.T) {
+				s := &computedStyle{FontSize: tc.fontSize}
+				_, length := parseBoxSideBoth(tc.value, tc.fontSize)
+				if length == nil {
+					t.Fatalf("parseBoxSideBoth returned nil cssLength for %q", tc.value)
+				}
+				h.set(s, length)
+				got := h.helper(s, tc.containerWidth)
+				if math.Abs(got-tc.want) > 0.001 {
+					t.Errorf("got %v, want %v", got, tc.want)
+				}
+			})
+		}
+	}
+}
+
+// TestMarginTopAtFallsBackToLegacyWhenLengthAbsent guards the Phase 1
+// migration invariant: a computedStyle that has only the legacy
+// float64 populated (e.g. heading default margins set in
+// converter_style.go, page-level margins from html/page.go, any
+// future code path that bypasses the Apply registry) must still
+// return the legacy value through the helper. Without this fallback
+// Phase 2 consumers would read zero for every unmigrated setter.
+func TestMarginTopAtFallsBackToLegacyWhenLengthAbsent(t *testing.T) {
+	s := &computedStyle{
+		FontSize:  12,
+		MarginTop: 42, // legacy float64 set directly
+		// MarginTopLength deliberately left nil.
+	}
+	if got := s.MarginTopAt(100); math.Abs(got-42) > 0.001 {
+		t.Errorf("helper did not fall back to legacy MarginTop: got %v, want 42", got)
+	}
+}
+
+// TestConvertPopulatesLengthSiblings verifies the end-to-end wire from
+// the CSS Apply registry: a margin / padding declaration in a
+// stylesheet should populate BOTH the legacy float64 AND the
+// *cssLength sibling on the resulting computedStyle. Without this,
+// Phase 2 consumer migrations would have nothing to read.
+//
+// The test reaches into the converter's internal style-application
+// path (computeStyle on a tiny synthetic node) rather than driving
+// the full HTML → PDF pipeline, because computedStyle is a package-
+// internal type not exposed via ConvertResult.
+func TestConvertPopulatesLengthSiblings(t *testing.T) {
+	tests := []struct {
+		name  string
+		decls []cssDecl
+		check func(*testing.T, *computedStyle)
+	}{
+		{
+			name: "margin shorthand four-value populates all four lengths",
+			decls: []cssDecl{
+				{property: "margin", value: "10% 20pt 30% 40px"},
+			},
+			check: func(t *testing.T, s *computedStyle) {
+				for _, side := range []struct {
+					name   string
+					length *cssLength
+				}{
+					{"MarginTopLength", s.MarginTopLength},
+					{"MarginRightLength", s.MarginRightLength},
+					{"MarginBottomLength", s.MarginBottomLength},
+					{"MarginLeftLength", s.MarginLeftLength},
+				} {
+					if side.length == nil {
+						t.Errorf("%s nil; shorthand did not populate sibling", side.name)
+					}
+				}
+			},
+		},
+		{
+			name: "margin-top individual property populates sibling",
+			decls: []cssDecl{
+				{property: "margin-top", value: "calc(10% + 5px)"},
+			},
+			check: func(t *testing.T, s *computedStyle) {
+				if s.MarginTopLength == nil {
+					t.Fatal("MarginTopLength nil")
+				}
+				if s.MarginTopLength.calc == nil {
+					t.Error("MarginTopLength.calc nil; calc expression not preserved")
+				}
+			},
+		},
+		{
+			name: "padding shorthand populates all four padding lengths",
+			decls: []cssDecl{
+				{property: "padding", value: "5% 10pt"},
+			},
+			check: func(t *testing.T, s *computedStyle) {
+				for _, side := range []struct {
+					name   string
+					length *cssLength
+				}{
+					{"PaddingTopLength", s.PaddingTopLength},
+					{"PaddingRightLength", s.PaddingRightLength},
+					{"PaddingBottomLength", s.PaddingBottomLength},
+					{"PaddingLeftLength", s.PaddingLeftLength},
+				} {
+					if side.length == nil {
+						t.Errorf("%s nil", side.name)
+					}
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &converter{opts: (&Options{}).defaults()}
+			style := defaultStyle()
+			style.FontSize = 12
+			for _, d := range tc.decls {
+				c.applyProperty(d.property, d.value, &style)
+			}
+			tc.check(t, &style)
+		})
+	}
+}

--- a/html/lazy_margin_padding_test.go
+++ b/html/lazy_margin_padding_test.go
@@ -149,6 +149,193 @@ func TestMarginTopAtFallsBackToLegacyWhenLengthAbsent(t *testing.T) {
 	}
 }
 
+// TestApplyPopulatesLengthSiblingsAllSides closes the test review's
+// gap: TestConvertPopulatesLengthSiblings exercises only 3 of 9
+// Apply registry entries (margin shorthand, margin-top, padding
+// shorthand). A regression that dropped the sibling write on any of
+// the other six (margin-right/left/bottom, padding-top/right/bottom/
+// left) would not have been caught. This table covers all eight
+// individual properties — each declaration must populate its sibling
+// AND match Unit / Value of the declared input.
+func TestApplyPopulatesLengthSiblingsAllSides(t *testing.T) {
+	cases := []struct {
+		prop  string
+		value string
+		read  func(*computedStyle) *cssLength
+		wantU string
+		wantV float64
+	}{
+		{"margin-top", "50%", func(s *computedStyle) *cssLength { return s.MarginTopLength }, "%", 50},
+		{"margin-right", "25%", func(s *computedStyle) *cssLength { return s.MarginRightLength }, "%", 25},
+		{"margin-bottom", "10%", func(s *computedStyle) *cssLength { return s.MarginBottomLength }, "%", 10},
+		{"margin-left", "5%", func(s *computedStyle) *cssLength { return s.MarginLeftLength }, "%", 5},
+		{"padding-top", "33%", func(s *computedStyle) *cssLength { return s.PaddingTopLength }, "%", 33},
+		{"padding-right", "20%", func(s *computedStyle) *cssLength { return s.PaddingRightLength }, "%", 20},
+		{"padding-bottom", "15%", func(s *computedStyle) *cssLength { return s.PaddingBottomLength }, "%", 15},
+		{"padding-left", "8%", func(s *computedStyle) *cssLength { return s.PaddingLeftLength }, "%", 8},
+	}
+	for _, tc := range cases {
+		t.Run(tc.prop, func(t *testing.T) {
+			c := &converter{opts: (&Options{}).defaults()}
+			style := defaultStyle()
+			style.FontSize = 12
+			c.applyProperty(tc.prop, tc.value, &style)
+			got := tc.read(&style)
+			if got == nil {
+				t.Fatalf("%s did not populate sibling", tc.prop)
+			}
+			if got.Unit != tc.wantU || math.Abs(got.Value-tc.wantV) > 0.001 {
+				t.Errorf("%s sibling = {Value:%v Unit:%q}, want {Value:%v Unit:%q}",
+					tc.prop, got.Value, got.Unit, tc.wantV, tc.wantU)
+			}
+		})
+	}
+}
+
+// TestMarginShorthandLengthExpansionOrder pins the top/right/bottom/
+// left mapping the shorthand uses for 1/2/3/4 input tokens. A
+// transposition bug (e.g. 4-value mapping top→Top, right→Bottom,
+// bottom→Right, left→Left) would silently break documents using
+// 4-value shorthand. Today's TestConvertPopulatesLengthSiblings only
+// checks non-nil, so this gap is real.
+func TestMarginShorthandLengthExpansionOrder(t *testing.T) {
+	type quartet struct {
+		top, right, bottom, left float64
+	}
+	tests := []struct {
+		name  string
+		value string
+		want  quartet
+	}{
+		{"4 values map to top/right/bottom/left", "1% 2% 3% 4%", quartet{1, 2, 3, 4}},
+		{"3 values: top, lr, bottom", "1% 2% 3%", quartet{1, 2, 3, 2}},
+		{"2 values: tb, lr", "1% 2%", quartet{1, 2, 1, 2}},
+		{"1 value applies to all four", "5%", quartet{5, 5, 5, 5}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &converter{opts: (&Options{}).defaults()}
+			style := defaultStyle()
+			style.FontSize = 12
+			c.applyProperty("margin", tc.value, &style)
+			got := quartet{
+				top:    style.MarginTopLength.Value,
+				right:  style.MarginRightLength.Value,
+				bottom: style.MarginBottomLength.Value,
+				left:   style.MarginLeftLength.Value,
+			}
+			if got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAllHelpersFallBackToLegacyWhenLengthAbsent extends the
+// MarginTop-only fallback test to all eight helpers. A regression
+// where (say) MarginRightAt accidentally reads MarginTop's legacy
+// field would slip through the original single-side test.
+func TestAllHelpersFallBackToLegacyWhenLengthAbsent(t *testing.T) {
+	type sideHelper func(*computedStyle, float64) float64
+	cases := []struct {
+		name   string
+		set    func(*computedStyle, float64)
+		helper sideHelper
+	}{
+		{"MarginTop", func(s *computedStyle, v float64) { s.MarginTop = v }, (*computedStyle).MarginTopAt},
+		{"MarginRight", func(s *computedStyle, v float64) { s.MarginRight = v }, (*computedStyle).MarginRightAt},
+		{"MarginBottom", func(s *computedStyle, v float64) { s.MarginBottom = v }, (*computedStyle).MarginBottomAt},
+		{"MarginLeft", func(s *computedStyle, v float64) { s.MarginLeft = v }, (*computedStyle).MarginLeftAt},
+		{"PaddingTop", func(s *computedStyle, v float64) { s.PaddingTop = v }, (*computedStyle).PaddingTopAt},
+		{"PaddingRight", func(s *computedStyle, v float64) { s.PaddingRight = v }, (*computedStyle).PaddingRightAt},
+		{"PaddingBottom", func(s *computedStyle, v float64) { s.PaddingBottom = v }, (*computedStyle).PaddingBottomAt},
+		{"PaddingLeft", func(s *computedStyle, v float64) { s.PaddingLeft = v }, (*computedStyle).PaddingLeftAt},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &computedStyle{FontSize: 12}
+			tc.set(s, 42)
+			if got := tc.helper(s, 100); math.Abs(got-42) > 0.001 {
+				t.Errorf("%s fallback returned %v, want 42", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestApplyReplacesLengthSiblingOnReApply pins cascade-replay
+// semantics: a stylesheet that declares margin-top twice — once with
+// a percent then with a plain length — must end up with the SECOND
+// declaration's sibling, not the first. A regression where Apply
+// kept the original sibling (e.g. "only-set-if-nil" guard) would
+// silently keep the percent in the cascade-replayed style.
+func TestApplyReplacesLengthSiblingOnReApply(t *testing.T) {
+	c := &converter{opts: (&Options{}).defaults()}
+	style := defaultStyle()
+	style.FontSize = 12
+	c.applyProperty("margin-top", "50%", &style)
+	if style.MarginTopLength == nil || style.MarginTopLength.Unit != "%" {
+		t.Fatal("first Apply did not set %-unit sibling")
+	}
+	c.applyProperty("margin-top", "10px", &style)
+	if style.MarginTopLength == nil {
+		t.Fatal("second Apply nil'd the sibling")
+	}
+	if style.MarginTopLength.Unit != "px" || math.Abs(style.MarginTopLength.Value-10) > 0.001 {
+		t.Errorf("second Apply did not replace sibling: got {Value:%v Unit:%q}, want {Value:10 Unit:px}",
+			style.MarginTopLength.Value, style.MarginTopLength.Unit)
+	}
+}
+
+// TestApplyMarginTopAutoLeavesLengthNil pins the contract that the
+// `auto` keyword on margin-top/right/left leaves the sibling nil
+// (the MarginTopAuto bool is the authoritative sentinel). A
+// regression that wrote a synthetic cssLength for "auto" could
+// produce inconsistent state between Auto flag and sibling.
+func TestApplyMarginTopAutoLeavesLengthNil(t *testing.T) {
+	for _, side := range []struct {
+		prop string
+		flag func(*computedStyle) bool
+		read func(*computedStyle) *cssLength
+	}{
+		{"margin-top", func(s *computedStyle) bool { return s.MarginTopAuto }, func(s *computedStyle) *cssLength { return s.MarginTopLength }},
+		{"margin-right", func(s *computedStyle) bool { return s.MarginRightAuto }, func(s *computedStyle) *cssLength { return s.MarginRightLength }},
+		{"margin-left", func(s *computedStyle) bool { return s.MarginLeftAuto }, func(s *computedStyle) *cssLength { return s.MarginLeftLength }},
+	} {
+		t.Run(side.prop, func(t *testing.T) {
+			c := &converter{opts: (&Options{}).defaults()}
+			style := defaultStyle()
+			style.FontSize = 12
+			c.applyProperty(side.prop, "auto", &style)
+			if !side.flag(&style) {
+				t.Errorf("%s: auto flag not set", side.prop)
+			}
+			if side.read(&style) != nil {
+				t.Errorf("%s auto: sibling = %+v, want nil", side.prop, side.read(&style))
+			}
+		})
+	}
+}
+
+// TestZeroValueLengthResolvesToZero distinguishes a sibling of
+// {0, "px"} (resolved value 0) from a nil sibling (fall back to
+// legacy). A future optimization that treated zero-valued siblings
+// as "absent" would silently change behaviour for documents using
+// `margin-top: 0%` to reset an inherited margin.
+func TestZeroValueLengthResolvesToZero(t *testing.T) {
+	s := &computedStyle{
+		FontSize:  12,
+		MarginTop: 42, // legacy says 42 — fallback would return this
+	}
+	_, length := parseBoxSideBoth("0%", 12)
+	if length == nil {
+		t.Fatal("parseBoxSideBoth(0%) returned nil; expected zero-valued sibling")
+	}
+	s.MarginTopLength = length
+	if got := s.MarginTopAt(200); math.Abs(got) > 0.001 {
+		t.Errorf("MarginTopAt with 0%% sibling returned %v, want 0 (must not fall back to legacy 42)", got)
+	}
+}
+
 // TestConvertPopulatesLengthSiblings verifies the end-to-end wire from
 // the CSS Apply registry: a margin / padding declaration in a
 // stylesheet should populate BOTH the legacy float64 AND the

--- a/html/properties.go
+++ b/html/properties.go
@@ -789,12 +789,70 @@ func parseDisplay(value string) string {
 }
 
 // parseBoxSide parses a single side of margin/padding (e.g. "10px").
+//
+// Returns the resolved-against-zero float64 value. Equivalent to the
+// first half of parseBoxSideBoth — kept for the border-width /
+// outline-width Apply sites where the legacy float64 is the only
+// stored form. Margin / padding Apply sites should use parseBoxSideBoth
+// so the *cssLength sibling is populated for the Phase 2 migration.
 func parseBoxSide(value string, fontSize float64) float64 {
 	l := parseLength(value)
 	if l == nil {
 		return 0
 	}
 	return l.toPoints(0, fontSize)
+}
+
+// parseBoxSideBoth parses a single side of margin/padding and returns
+// BOTH forms: the legacy eagerly-resolved float64 (for back-compat
+// with unmigrated consumers) and the unresolved *cssLength (for the
+// Phase 2 migration toward layout-time resolution against the
+// containing block). #269 Phase 1.
+//
+// A nil parseLength result (e.g. "auto" or unparseable input) yields
+// (0, nil) — callers that need to distinguish "absent" from "0pt"
+// can branch on the *cssLength being nil.
+func parseBoxSideBoth(value string, fontSize float64) (float64, *cssLength) {
+	l := parseLength(value)
+	if l == nil {
+		return 0, nil
+	}
+	return l.toPoints(0, fontSize), l
+}
+
+// parseMarginShorthandLengths parses the CSS margin/padding shorthand
+// into four *cssLength values (top/right/bottom/left) using the same
+// 1/2/3/4-token expansion rules as parseMarginShorthand. The
+// *cssLength preserves percent / calc / min / max / clamp trees for
+// layout-time resolution against the containing block.
+//
+// Pairs with parseMarginShorthand at every call site — the legacy
+// float64s drive unmigrated consumers; the *cssLength values
+// populate the Phase 1 sibling fields.
+func parseMarginShorthandLengths(value string, fontSize float64) (*cssLength, *cssLength, *cssLength, *cssLength) {
+	parts := splitTopLevelFields(value)
+	switch len(parts) {
+	case 1:
+		_, v := parseBoxSideBoth(parts[0], fontSize)
+		return v, v, v, v
+	case 2:
+		_, tb := parseBoxSideBoth(parts[0], fontSize)
+		_, lr := parseBoxSideBoth(parts[1], fontSize)
+		return tb, lr, tb, lr
+	case 3:
+		_, tt := parseBoxSideBoth(parts[0], fontSize)
+		_, lr := parseBoxSideBoth(parts[1], fontSize)
+		_, bb := parseBoxSideBoth(parts[2], fontSize)
+		return tt, lr, bb, lr
+	case 4:
+		_, tt := parseBoxSideBoth(parts[0], fontSize)
+		_, rr := parseBoxSideBoth(parts[1], fontSize)
+		_, bb := parseBoxSideBoth(parts[2], fontSize)
+		_, ll := parseBoxSideBoth(parts[3], fontSize)
+		return tt, rr, bb, ll
+	default:
+		return nil, nil, nil, nil
+	}
 }
 
 // parseMarginShorthand parses the CSS margin/padding shorthand.

--- a/html/style.go
+++ b/html/style.go
@@ -43,6 +43,34 @@ type computedStyle struct {
 	PaddingBottom float64
 	PaddingLeft   float64
 
+	// Lazy-resolution sibling fields for margin / padding (#269).
+	//
+	// The legacy MarginTop / MarginRight / MarginBottom / MarginLeft and
+	// PaddingTop / PaddingRight / PaddingBottom / PaddingLeft above
+	// store an already-resolved float64 — but the parser must call
+	// toPoints(0, fontSize) at parse time because the containing-block
+	// dimension isn't known yet. The result: a `margin: 50%` declaration
+	// silently stores 0pt, and `padding: calc(10% + 5px)` stores 5pt
+	// (only the px term resolves). The *Length fields below carry the
+	// unresolved cssLength so consumers that DO know the containing
+	// block (the converter, layout pipeline) can resolve correctly via
+	// the MarginTopAt / PaddingTopAt helpers.
+	//
+	// During the migration the legacy float64 fields stay populated
+	// alongside *Length, so unmigrated consumers continue to read the
+	// (buggy-but-historical) eagerly-resolved value. A future PR
+	// removes the float64 fields once every consumer has moved to the
+	// helpers.
+	MarginTopLength    *cssLength
+	MarginRightLength  *cssLength
+	MarginBottomLength *cssLength
+	MarginLeftLength   *cssLength
+
+	PaddingTopLength    *cssLength
+	PaddingRightLength  *cssLength
+	PaddingBottomLength *cssLength
+	PaddingLeftLength   *cssLength
+
 	// Borders
 	BorderTopWidth    float64
 	BorderRightWidth  float64
@@ -504,4 +532,68 @@ func (s *computedStyle) hasBorder() bool {
 // hasMargin returns true if any margin is set.
 func (s *computedStyle) hasMargin() bool {
 	return s.MarginTop > 0 || s.MarginRight > 0 || s.MarginBottom > 0 || s.MarginLeft > 0
+}
+
+// MarginTopAt resolves the top margin against containerWidth. When the
+// parser stored a *cssLength sibling (post #269 Phase 1) the percent /
+// calc / min / max / clamp tree is resolved against the actual
+// container; otherwise the helper falls back to the legacy eagerly-
+// resolved float64 (which currently returns 0pt for percent-only
+// values — the bug the migration is closing).
+//
+// containerWidth is the width of the containing block, in points.
+// Consumers that don't know the container yet (page-time defaults,
+// margin collapse pre-flow, etc.) pass 0 and accept the
+// percent-resolves-to-zero behaviour for now; the legacy float64 was
+// already doing that silently.
+func (s *computedStyle) MarginTopAt(containerWidth float64) float64 {
+	return resolveBoxSide(s.MarginTopLength, s.MarginTop, containerWidth, s.FontSize)
+}
+
+// MarginRightAt — see MarginTopAt.
+func (s *computedStyle) MarginRightAt(containerWidth float64) float64 {
+	return resolveBoxSide(s.MarginRightLength, s.MarginRight, containerWidth, s.FontSize)
+}
+
+// MarginBottomAt — see MarginTopAt.
+func (s *computedStyle) MarginBottomAt(containerWidth float64) float64 {
+	return resolveBoxSide(s.MarginBottomLength, s.MarginBottom, containerWidth, s.FontSize)
+}
+
+// MarginLeftAt — see MarginTopAt.
+func (s *computedStyle) MarginLeftAt(containerWidth float64) float64 {
+	return resolveBoxSide(s.MarginLeftLength, s.MarginLeft, containerWidth, s.FontSize)
+}
+
+// PaddingTopAt — see MarginTopAt. Same contract for padding.
+func (s *computedStyle) PaddingTopAt(containerWidth float64) float64 {
+	return resolveBoxSide(s.PaddingTopLength, s.PaddingTop, containerWidth, s.FontSize)
+}
+
+// PaddingRightAt — see MarginTopAt.
+func (s *computedStyle) PaddingRightAt(containerWidth float64) float64 {
+	return resolveBoxSide(s.PaddingRightLength, s.PaddingRight, containerWidth, s.FontSize)
+}
+
+// PaddingBottomAt — see MarginTopAt.
+func (s *computedStyle) PaddingBottomAt(containerWidth float64) float64 {
+	return resolveBoxSide(s.PaddingBottomLength, s.PaddingBottom, containerWidth, s.FontSize)
+}
+
+// PaddingLeftAt — see MarginTopAt.
+func (s *computedStyle) PaddingLeftAt(containerWidth float64) float64 {
+	return resolveBoxSide(s.PaddingLeftLength, s.PaddingLeft, containerWidth, s.FontSize)
+}
+
+// resolveBoxSide picks the right resolution path for a margin/padding
+// side. When the parser stored a *cssLength (Phase 1+) we resolve it
+// against the supplied container; otherwise we fall back to the
+// legacy eager-resolved value, which preserves the historical
+// percent-becomes-zero behaviour for code paths that haven't yet
+// migrated.
+func resolveBoxSide(length *cssLength, legacy, containerWidth, fontSize float64) float64 {
+	if length != nil {
+		return length.toPoints(containerWidth, fontSize)
+	}
+	return legacy
 }


### PR DESCRIPTION
## Summary

Phase 1 of the migration that closes #269 (margin / padding / background-size silently resolving to 0pt for percent values). This PR is **net-behaviour-neutral** — it adds the lazy-resolution scaffolding without changing any existing code path. Subsequent phases migrate consumers to the new helpers.

## Why phased

#269 is a structural change touching 168+ consumer sites for margin alone. A single mega-PR would be a large diff with poor bisect granularity. The migration runs in four phases:

1. **Phase 1 (this PR)**: add \`*cssLength\` sibling fields + \`MarginTopAt\` / \`PaddingTopAt\` etc. helpers. Parser writes BOTH the legacy float64 and the new \`*cssLength\`. No consumer changes; net behaviour unchanged.
2. **Phase 2**: migrate \`html/\` consumers to call the helpers. Closes the percent-becomes-zero bug for HTML-driven layout.
3. **Phase 3**: migrate \`layout/\` and \`document/\` consumers.
4. **Phase 4**: remove the legacy float64 fields (hard compile error proves migration is complete).

## Phase 1 surface

- \`computedStyle\` gains 8 sibling fields: \`MarginTop/Right/Bottom/LeftLength\` and \`PaddingTop/Right/Bottom/LeftLength\`, all \`*cssLength\`.
- 8 helper methods (\`MarginTopAt(containerWidth) float64\` etc.) resolve the sibling against \`containerWidth\` when set, and fall back to the legacy float64 when nil. The fallback keeps un-Apply'd setters (heading defaults in \`converter_style.go\`, page margins in \`html/page.go\`) working transparently during the migration.
- New helpers \`parseBoxSideBoth\` and \`parseMarginShorthandLengths\` return both forms in one call so every Apply site populates both fields with a single line.
- All eight CSS-property Apply functions (plus the \`margin\` / \`padding\` shorthands) wired to populate the sibling.

## Tests

\`html/lazy_margin_padding_test.go\`:

- \`TestParseBoxSideBothReturnsBothForms\` (6 cases): plain points / px / percent / em / empty / auto. The percent case is the bug-closing assertion — legacy float64 is 0pt (preserved), sibling carries the \"50%\" form.
- \`TestMarginTopAtResolvesPercentAgainstContainer\` (32 subtests = 8 sides × 4 value shapes): when sibling is populated, helper resolves percent and calc against the container correctly. Plain px / em ignore container as expected.
- \`TestMarginTopAtFallsBackToLegacyWhenLengthAbsent\`: nil-sibling computedStyle returns the legacy float64. Guards the invariant that consumers can migrate without losing un-Apply'd setters.
- \`TestConvertPopulatesLengthSiblings\` (3 subtests): end-to-end through \`applyProperty\` — shorthand and individual properties populate both fields.

## Net behaviour change

**Zero.** This PR adds fields and helpers; no consumer reads them yet. Existing tests pass unchanged. Phase 2 migrates consumers and closes the user-visible bug.

## Test plan

- [x] \`go test ./html/ -run \"TestParseBoxSideBoth|TestMarginTopAt|TestConvertPopulatesLengthSiblings\"\` — 42 subtests pass
- [x] \`go test ./...\` green
- [x] \`golangci-lint run ./html/...\` — no new issues
- [x] \`gofmt -s -l html/\` clean