### PR TITLE
html: Phase 4 of #269 - remove legacy float64 margin/padding fields

### DIFF
--- a/html/converter_flex.go
+++ b/html/converter_flex.go
@@ -181,9 +181,17 @@ func (c *converter) convertFlex(n *html.Node, style computedStyle) []layout.Elem
 			}
 		}
 
+		// Resolve the child's margins against the flex container's
+		// content-box width (the narrowed c.containerWidth). The
+		// child's containing block is the flex's content box per
+		// CSS Flexbox §4.
+		childMT := childStyle.MarginTopAt(c.containerWidth)
+		childMR := childStyle.MarginRightAt(c.containerWidth)
+		childMB := childStyle.MarginBottomAt(c.containerWidth)
+		childML := childStyle.MarginLeftAt(c.containerWidth)
+
 		// Check if child has any margin (including negative) that needs FlexItem handling.
-		hasMargins := childStyle.MarginTop != 0 || childStyle.MarginBottom != 0 ||
-			childStyle.MarginLeft != 0 || childStyle.MarginRight != 0
+		hasMargins := childMT != 0 || childMB != 0 || childML != 0 || childMR != 0
 
 		needsItem := childStyle.FlexGrow > 0 || childStyle.FlexShrink != 1 ||
 			effectiveBasis != nil || (childStyle.AlignSelf != "" && childStyle.AlignSelf != "auto") ||
@@ -216,8 +224,7 @@ func (c *converter) convertFlex(n *html.Node, style computedStyle) []layout.Elem
 				item.SetMarginLeftAuto()
 			}
 			if hasMargins {
-				item.SetMargins(childStyle.MarginTop, childStyle.MarginRight,
-					childStyle.MarginBottom, childStyle.MarginLeft)
+				item.SetMargins(childMT, childMR, childMB, childML)
 				// Clear SpaceBefore/SpaceAfter on the element since the FlexItem's
 				// margins handle vertical spacing — otherwise margins are doubled.
 				if f, ok := elem.(*layout.Flex); ok {

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -134,36 +134,36 @@ func (c *converter) applyTagDefaults(n *html.Node, style *computedStyle) {
 	case atom.H1:
 		style.FontSize = 24 // 32px * 0.75
 		style.FontWeight = 700
-		style.MarginTop = 16.08 // 0.67em at 32px → 32*0.67*0.75
-		style.MarginBottom = 16.08
+		style.MarginTopLength = &cssLength{Value: 16.08, Unit: "pt"} // 0.67em at 32px → 32*0.67*0.75
+		style.MarginBottomLength = &cssLength{Value: 16.08, Unit: "pt"}
 	case atom.H2:
 		style.FontSize = 18 // 24px * 0.75
 		style.FontWeight = 700
-		style.MarginTop = 14.94 // 0.83em at 24px → 24*0.83*0.75
-		style.MarginBottom = 14.94
+		style.MarginTopLength = &cssLength{Value: 14.94, Unit: "pt"} // 0.83em at 24px → 24*0.83*0.75
+		style.MarginBottomLength = &cssLength{Value: 14.94, Unit: "pt"}
 	case atom.H3:
 		style.FontSize = 14.04 // 18.72px * 0.75
 		style.FontWeight = 700
-		style.MarginTop = 14.04 // 1em at 18.72px → 18.72*0.75
-		style.MarginBottom = 14.04
+		style.MarginTopLength = &cssLength{Value: 14.04, Unit: "pt"} // 1em at 18.72px → 18.72*0.75
+		style.MarginBottomLength = &cssLength{Value: 14.04, Unit: "pt"}
 	case atom.H4:
 		style.FontSize = 12 // 16px * 0.75
 		style.FontWeight = 700
-		style.MarginTop = 16.02 // 1.33em at 16px → 16*1.33*0.75
-		style.MarginBottom = 16.02
+		style.MarginTopLength = &cssLength{Value: 16.02, Unit: "pt"} // 1.33em at 16px → 16*1.33*0.75
+		style.MarginBottomLength = &cssLength{Value: 16.02, Unit: "pt"}
 	case atom.H5:
 		style.FontSize = 9.96 // 13.28px * 0.75
 		style.FontWeight = 700
-		style.MarginTop = 16.60 // 1.67em at 13.28px → 13.28*1.67*0.75
-		style.MarginBottom = 16.60
+		style.MarginTopLength = &cssLength{Value: 16.60, Unit: "pt"} // 1.67em at 13.28px → 13.28*1.67*0.75
+		style.MarginBottomLength = &cssLength{Value: 16.60, Unit: "pt"}
 	case atom.H6:
 		style.FontSize = 8.01 // 10.72px * 0.75
 		style.FontWeight = 700
-		style.MarginTop = 18.62 // 2.33em at 10.72px → 10.72*2.33*0.75
-		style.MarginBottom = 18.62
+		style.MarginTopLength = &cssLength{Value: 18.62, Unit: "pt"} // 2.33em at 10.72px → 10.72*2.33*0.75
+		style.MarginBottomLength = &cssLength{Value: 18.62, Unit: "pt"}
 	case atom.P:
-		style.MarginTop = 12 // 1em at 16px → 16*0.75
-		style.MarginBottom = 12
+		style.MarginTopLength = &cssLength{Value: 12, Unit: "pt"} // 1em at 16px → 16*0.75
+		style.MarginBottomLength = &cssLength{Value: 12, Unit: "pt"}
 	case atom.Span:
 		// CSS 2.1 §9.2.2: <span> is inline by default. Without this,
 		// the inherited Display="block" leaks through and walkChildren
@@ -205,11 +205,11 @@ func (c *converter) applyTagDefaults(n *html.Node, style *computedStyle) {
 	case atom.Pre:
 		style.FontFamily = "courier"
 		style.WhiteSpace = "pre"
-		style.MarginTop = 12
-		style.MarginBottom = 12
+		style.MarginTopLength = &cssLength{Value: 12, Unit: "pt"}
+		style.MarginBottomLength = &cssLength{Value: 12, Unit: "pt"}
 	case atom.Hr:
-		style.MarginTop = 6
-		style.MarginBottom = 6
+		style.MarginTopLength = &cssLength{Value: 6, Unit: "pt"}
+		style.MarginBottomLength = &cssLength{Value: 6, Unit: "pt"}
 	case atom.A:
 		style.Color = layout.RGB(0, 0, 0.933) // default link blue
 		style.TextDecoration |= layout.DecorationUnderline
@@ -220,27 +220,27 @@ func (c *converter) applyTagDefaults(n *html.Node, style *computedStyle) {
 		style.BorderSpacingH = 1.5 // 2px * 0.75
 		style.BorderSpacingV = 1.5
 	case atom.Ul, atom.Ol:
-		style.MarginTop = 12
-		style.MarginBottom = 12
+		style.MarginTopLength = &cssLength{Value: 12, Unit: "pt"}
+		style.MarginBottomLength = &cssLength{Value: 12, Unit: "pt"}
 	case atom.Blockquote:
-		style.MarginTop = 12
-		style.MarginBottom = 12
+		style.MarginTopLength = &cssLength{Value: 12, Unit: "pt"}
+		style.MarginBottomLength = &cssLength{Value: 12, Unit: "pt"}
 	case atom.Dl:
-		style.MarginTop = 12
-		style.MarginBottom = 12
+		style.MarginTopLength = &cssLength{Value: 12, Unit: "pt"}
+		style.MarginBottomLength = &cssLength{Value: 12, Unit: "pt"}
 	case atom.Dt:
 		style.FontWeight = 700
 	case atom.Dd:
-		style.MarginLeft = 30 // browser default ~40px → 30pt
+		style.MarginLeftLength = &cssLength{Value: 30, Unit: "pt"} // browser default ~40px → 30pt
 	case atom.Figure:
-		style.MarginTop = 12
-		style.MarginBottom = 12
+		style.MarginTopLength = &cssLength{Value: 12, Unit: "pt"}
+		style.MarginBottomLength = &cssLength{Value: 12, Unit: "pt"}
 	case atom.Figcaption:
 		style.FontStyle = "italic"
 		style.FontSize = style.FontSize * 0.9
 	case atom.Fieldset:
-		style.MarginTop = 9 // ~12px * 0.75
-		style.MarginBottom = 9
+		style.MarginTopLength = &cssLength{Value: 9, Unit: "pt"} // ~12px * 0.75
+		style.MarginBottomLength = &cssLength{Value: 9, Unit: "pt"}
 		style.Display = "block"
 	case atom.Legend:
 		style.FontWeight = 700

--- a/html/css_props.go
+++ b/html/css_props.go
@@ -330,28 +330,28 @@ var cssProperties = []cssProperty{
 		Name: "padding-top", Category: "BoxModel",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.PaddingTop, s.PaddingTopLength = parseBoxSideBoth(value, s.FontSize)
+			s.PaddingTopLength = parseBoxSideLength(value, s.FontSize)
 		},
 	},
 	{
 		Name: "padding-right", Category: "BoxModel",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.PaddingRight, s.PaddingRightLength = parseBoxSideBoth(value, s.FontSize)
+			s.PaddingRightLength = parseBoxSideLength(value, s.FontSize)
 		},
 	},
 	{
 		Name: "padding-bottom", Category: "BoxModel",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.PaddingBottom, s.PaddingBottomLength = parseBoxSideBoth(value, s.FontSize)
+			s.PaddingBottomLength = parseBoxSideLength(value, s.FontSize)
 		},
 	},
 	{
 		Name: "padding-left", Category: "BoxModel",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.PaddingLeft, s.PaddingLeftLength = parseBoxSideBoth(value, s.FontSize)
+			s.PaddingLeftLength = parseBoxSideLength(value, s.FontSize)
 		},
 	},
 	{
@@ -359,7 +359,7 @@ var cssProperties = []cssProperty{
 		Values: []string{"<length>", "<percentage>"},
 		Notes:  "margin-top, margin-left, margin-right also accept `auto`; margin-bottom does not.",
 		Apply: func(s *computedStyle, value string) {
-			s.MarginBottom, s.MarginBottomLength = parseBoxSideBoth(value, s.FontSize)
+			s.MarginBottomLength = parseBoxSideLength(value, s.FontSize)
 		},
 	},
 	{
@@ -1058,8 +1058,6 @@ var cssProperties = []cssProperty{
 		Values: []string{"<length>", "<percentage>", "auto", "<1-4 of these>"},
 		Notes:  "auto keyword sets MarginTopAuto/LeftAuto/RightAuto per CSS shorthand position rules.",
 		Apply: func(s *computedStyle, value string) {
-			s.MarginTop, s.MarginRight, s.MarginBottom, s.MarginLeft =
-				parseMarginShorthand(value, s.FontSize)
 			s.MarginTopLength, s.MarginRightLength, s.MarginBottomLength, s.MarginLeftLength =
 				parseMarginShorthandLengths(value, s.FontSize)
 			// Use splitTopLevelFields (paren-aware) so calc()/min()/max()/
@@ -1114,7 +1112,7 @@ var cssProperties = []cssProperty{
 			if strings.TrimSpace(strings.ToLower(value)) == "auto" {
 				s.MarginTopAuto = true
 			} else {
-				s.MarginTop, s.MarginTopLength = parseBoxSideBoth(value, s.FontSize)
+				s.MarginTopLength = parseBoxSideLength(value, s.FontSize)
 			}
 		},
 	},
@@ -1125,7 +1123,7 @@ var cssProperties = []cssProperty{
 			if strings.TrimSpace(strings.ToLower(value)) == "auto" {
 				s.MarginRightAuto = true
 			} else {
-				s.MarginRight, s.MarginRightLength = parseBoxSideBoth(value, s.FontSize)
+				s.MarginRightLength = parseBoxSideLength(value, s.FontSize)
 			}
 		},
 	},
@@ -1136,7 +1134,7 @@ var cssProperties = []cssProperty{
 			if strings.TrimSpace(strings.ToLower(value)) == "auto" {
 				s.MarginLeftAuto = true
 			} else {
-				s.MarginLeft, s.MarginLeftLength = parseBoxSideBoth(value, s.FontSize)
+				s.MarginLeftLength = parseBoxSideLength(value, s.FontSize)
 			}
 		},
 	},
@@ -1144,8 +1142,6 @@ var cssProperties = []cssProperty{
 		Name: "padding", Category: "BoxModel",
 		Values: []string{"<length>", "<percentage>", "<1-4 of these>"},
 		Apply: func(s *computedStyle, value string) {
-			s.PaddingTop, s.PaddingRight, s.PaddingBottom, s.PaddingLeft =
-				parseMarginShorthand(value, s.FontSize)
 			s.PaddingTopLength, s.PaddingRightLength, s.PaddingBottomLength, s.PaddingLeftLength =
 				parseMarginShorthandLengths(value, s.FontSize)
 		},

--- a/html/css_props_test.go
+++ b/html/css_props_test.go
@@ -718,12 +718,15 @@ func TestCSSPropertyParitySnapshot(t *testing.T) {
 			},
 		},
 		{
-			// padding shorthand fans to 4 sides. Px → pt at 0.75 ratio.
+			// padding shorthand fans to 4 sides. Px → pt at 0.75 ratio
+			// resolves through PaddingXxxAt; the stored *cssLength keeps
+			// the unresolved px form. Drive PaddingXxxAt(0) since px is
+			// container-independent.
 			name:     "padding/four-values",
 			property: "padding", value: "1px 2px 3px 4px", fontSize: 12,
 			expectField: func(s *computedStyle) bool {
-				return s.PaddingTop == 0.75 && s.PaddingRight == 1.5 &&
-					s.PaddingBottom == 2.25 && s.PaddingLeft == 3
+				return s.PaddingTopAt(0) == 0.75 && s.PaddingRightAt(0) == 1.5 &&
+					s.PaddingBottomAt(0) == 2.25 && s.PaddingLeftAt(0) == 3
 			},
 		},
 
@@ -770,7 +773,7 @@ func TestCSSPropertyParitySnapshot(t *testing.T) {
 		{
 			name:     "padding-top/8px",
 			property: "padding-top", value: "8px", fontSize: 12,
-			expectField: func(s *computedStyle) bool { return s.PaddingTop == 6 },
+			expectField: func(s *computedStyle) bool { return s.PaddingTopAt(0) == 6 },
 		},
 		{
 			name:     "margin-top/auto",
@@ -780,7 +783,7 @@ func TestCSSPropertyParitySnapshot(t *testing.T) {
 		{
 			name:     "margin-bottom/16px",
 			property: "margin-bottom", value: "16px", fontSize: 12,
-			expectField: func(s *computedStyle) bool { return s.MarginBottom == 12 },
+			expectField: func(s *computedStyle) bool { return s.MarginBottomAt(0) == 12 },
 		},
 
 		// Borders individual fields

--- a/html/lazy_margin_padding_test.go
+++ b/html/lazy_margin_padding_test.go
@@ -676,3 +676,66 @@ func TestHeadingDefaultMarginsSurviveMigration(t *testing.T) {
 		})
 	}
 }
+
+// TestNonHeadingDefaultMarginsSurviveMigration extends the determinism
+// pin from TestHeadingDefaultMarginsSurviveMigration to every other
+// block-level tag whose applyTagDefaults branch installs a top/bottom
+// margin default. A subagent test review noted that the heading test
+// covered h1-h6 only, leaving p, pre, hr, ul, ol, blockquote, dl,
+// figure and fieldset unpinned. A Phase 4 regression that mistyped a
+// Unit string or wrote to the wrong sibling field on any of these
+// would shift the documented browser-default vertical rhythm without
+// any test catching it.
+//
+// The pt values mirror the literals stored at converter_style.go
+// pre-Phase-4; the migration preserved them verbatim and a future
+// rewrite must continue to.
+func TestNonHeadingDefaultMarginsSurviveMigration(t *testing.T) {
+	cases := []struct {
+		tag    atom.Atom
+		name   string
+		top    float64
+		bottom float64
+	}{
+		{atom.P, "p", 12, 12},
+		{atom.Pre, "pre", 12, 12},
+		{atom.Hr, "hr", 6, 6},
+		{atom.Ul, "ul", 12, 12},
+		{atom.Ol, "ol", 12, 12},
+		{atom.Blockquote, "blockquote", 12, 12},
+		{atom.Dl, "dl", 12, 12},
+		{atom.Figure, "figure", 12, 12},
+		{atom.Fieldset, "fieldset", 9, 9},
+	}
+	c := &converter{opts: (&Options{}).defaults()}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &gohtml.Node{Type: gohtml.ElementNode, DataAtom: tc.tag}
+			style := defaultStyle()
+			c.applyTagDefaults(n, &style)
+			if got := style.MarginTopAt(100); math.Abs(got-tc.top) > 0.001 {
+				t.Errorf("%s MarginTopAt(100) = %v, want %v", tc.name, got, tc.top)
+			}
+			if got := style.MarginBottomAt(100); math.Abs(got-tc.bottom) > 0.001 {
+				t.Errorf("%s MarginBottomAt(100) = %v, want %v", tc.name, got, tc.bottom)
+			}
+		})
+	}
+}
+
+// TestDdDefaultMarginLeftSurvivesMigration pins the <dd> default
+// MarginLeft — the only MarginLeftLength default that
+// applyTagDefaults installs anywhere in converter_style.go. Without
+// this pin a regression that dropped the dd branch (or rewrote the
+// `MarginLeftLength` write to the wrong side) would silently flatten
+// definition-list indentation, and the heading / top-bottom tests
+// above would not catch it (they only inspect Top and Bottom).
+func TestDdDefaultMarginLeftSurvivesMigration(t *testing.T) {
+	c := &converter{opts: (&Options{}).defaults()}
+	n := &gohtml.Node{Type: gohtml.ElementNode, DataAtom: atom.Dd}
+	style := defaultStyle()
+	c.applyTagDefaults(n, &style)
+	if got := style.MarginLeftAt(100); math.Abs(got-30) > 0.001 {
+		t.Errorf("dd MarginLeftAt(100) = %v, want 30", got)
+	}
+}

--- a/html/lazy_margin_padding_test.go
+++ b/html/lazy_margin_padding_test.go
@@ -6,48 +6,38 @@ package html
 import (
 	"math"
 	"testing"
+
+	gohtml "golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
-// TestParseBoxSideBothReturnsBothForms is the parser-side contract
-// for the #269 Phase 1 sibling-field migration. Every margin/padding
-// Apply must produce BOTH:
+// TestParseBoxSideLengthPreservesUnit is the parser-side contract
+// for the #269 lazy-resolution migration. Margin / padding Apply
+// sites store the *cssLength unresolved so that percent / calc /
+// min / max / clamp trees can be resolved against the containing
+// block at consumer time. The unit and value must round-trip from
+// the input declaration onto the stored cssLength.
 //
-//   - a legacy float64 resolved against zero (the existing 0pt-on-
-//     percent behaviour) for back-compat with unmigrated consumers
-//   - an unresolved *cssLength that preserves the percent / calc tree
-//     for layout-time resolution against the container width
-//
-// "auto" / unparseable input still yields (0, nil) so callers can
-// branch on the *cssLength being nil.
-func TestParseBoxSideBothReturnsBothForms(t *testing.T) {
+// "auto" / unparseable input yields nil so callers can branch on
+// "absent declaration".
+func TestParseBoxSideLengthPreservesUnit(t *testing.T) {
 	cases := []struct {
-		name       string
-		input      string
-		fontSize   float64
-		wantLegacy float64
-		wantUnit   string  // expected cssLength.Unit; "" means nil expected
-		wantValue  float64 // for non-nil, expected cssLength.Value
+		name      string
+		input     string
+		fontSize  float64
+		wantUnit  string  // "" means nil expected
+		wantValue float64 // for non-nil, expected cssLength.Value
 	}{
-		{"plain points", "10pt", 12, 10, "pt", 10},
-		// 16px → 12pt at 0.75 px/pt.
-		{"plain pixels", "16px", 12, 12, "px", 16},
-		// percent: legacy resolves against 0 (the bug); sibling
-		// retains the 50% form for layout-time resolution.
-		{"percent", "50%", 12, 0, "%", 50},
-		// em on the legacy path resolves against fontSize, so 1em
-		// at 12pt → 12pt. The sibling carries Unit "em" so a future
-		// consumer can re-resolve.
-		{"em", "1.5em", 12, 18, "em", 1.5},
-		// Unparseable inputs return (0, nil).
-		{"empty", "", 12, 0, "", 0},
-		{"auto keyword (parseLength rejects)", "auto", 12, 0, "", 0},
+		{"plain points", "10pt", 12, "pt", 10},
+		{"plain pixels", "16px", 12, "px", 16},
+		{"percent", "50%", 12, "%", 50},
+		{"em", "1.5em", 12, "em", 1.5},
+		{"empty", "", 12, "", 0},
+		{"auto keyword (parseLength rejects)", "auto", 12, "", 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotLegacy, gotLength := parseBoxSideBoth(tc.input, tc.fontSize)
-			if math.Abs(gotLegacy-tc.wantLegacy) > 0.001 {
-				t.Errorf("legacy float64 = %v, want %v", gotLegacy, tc.wantLegacy)
-			}
+			gotLength := parseBoxSideLength(tc.input, tc.fontSize)
 			if tc.wantUnit == "" {
 				if gotLength != nil {
 					t.Errorf("cssLength = %+v, want nil", gotLength)
@@ -117,9 +107,9 @@ func TestMarginTopAtResolvesPercentAgainstContainer(t *testing.T) {
 		for _, tc := range cases {
 			t.Run(h.name+"/"+tc.name, func(t *testing.T) {
 				s := &computedStyle{FontSize: tc.fontSize}
-				_, length := parseBoxSideBoth(tc.value, tc.fontSize)
+				length := parseBoxSideLength(tc.value, tc.fontSize)
 				if length == nil {
-					t.Fatalf("parseBoxSideBoth returned nil cssLength for %q", tc.value)
+					t.Fatalf("parseBoxSideLength returned nil cssLength for %q", tc.value)
 				}
 				h.set(s, length)
 				got := h.helper(s, tc.containerWidth)
@@ -131,21 +121,15 @@ func TestMarginTopAtResolvesPercentAgainstContainer(t *testing.T) {
 	}
 }
 
-// TestMarginTopAtFallsBackToLegacyWhenLengthAbsent guards the Phase 1
-// migration invariant: a computedStyle that has only the legacy
-// float64 populated (e.g. heading default margins set in
-// converter_style.go, page-level margins from html/page.go, any
-// future code path that bypasses the Apply registry) must still
-// return the legacy value through the helper. Without this fallback
-// Phase 2 consumers would read zero for every unmigrated setter.
-func TestMarginTopAtFallsBackToLegacyWhenLengthAbsent(t *testing.T) {
-	s := &computedStyle{
-		FontSize:  12,
-		MarginTop: 42, // legacy float64 set directly
-		// MarginTopLength deliberately left nil.
-	}
-	if got := s.MarginTopAt(100); math.Abs(got-42) > 0.001 {
-		t.Errorf("helper did not fall back to legacy MarginTop: got %v, want 42", got)
+// TestMarginTopAtReturnsZeroWhenLengthAbsent guards the post-Phase 4
+// contract: with no declaration (MarginTopLength nil), the helper
+// returns 0. Pre-Phase 4 the helper fell back to a legacy float64;
+// that fallback path is gone and a nil sibling is now the sole
+// "absent declaration" signal.
+func TestMarginTopAtReturnsZeroWhenLengthAbsent(t *testing.T) {
+	s := &computedStyle{FontSize: 12}
+	if got := s.MarginTopAt(100); math.Abs(got) > 0.001 {
+		t.Errorf("helper with nil sibling returned %v, want 0", got)
 	}
 }
 
@@ -231,32 +215,31 @@ func TestMarginShorthandLengthExpansionOrder(t *testing.T) {
 	}
 }
 
-// TestAllHelpersFallBackToLegacyWhenLengthAbsent extends the
-// MarginTop-only fallback test to all eight helpers. A regression
-// where (say) MarginRightAt accidentally reads MarginTop's legacy
-// field would slip through the original single-side test.
-func TestAllHelpersFallBackToLegacyWhenLengthAbsent(t *testing.T) {
+// TestAllHelpersReturnZeroWhenLengthAbsent pins the post-Phase 4
+// contract for every one of the eight helpers: a nil sibling reads
+// as 0pt. A regression where (say) MarginRightAt accidentally
+// reads a different side's sibling would slip through a single-
+// side test.
+func TestAllHelpersReturnZeroWhenLengthAbsent(t *testing.T) {
 	type sideHelper func(*computedStyle, float64) float64
 	cases := []struct {
 		name   string
-		set    func(*computedStyle, float64)
 		helper sideHelper
 	}{
-		{"MarginTop", func(s *computedStyle, v float64) { s.MarginTop = v }, (*computedStyle).MarginTopAt},
-		{"MarginRight", func(s *computedStyle, v float64) { s.MarginRight = v }, (*computedStyle).MarginRightAt},
-		{"MarginBottom", func(s *computedStyle, v float64) { s.MarginBottom = v }, (*computedStyle).MarginBottomAt},
-		{"MarginLeft", func(s *computedStyle, v float64) { s.MarginLeft = v }, (*computedStyle).MarginLeftAt},
-		{"PaddingTop", func(s *computedStyle, v float64) { s.PaddingTop = v }, (*computedStyle).PaddingTopAt},
-		{"PaddingRight", func(s *computedStyle, v float64) { s.PaddingRight = v }, (*computedStyle).PaddingRightAt},
-		{"PaddingBottom", func(s *computedStyle, v float64) { s.PaddingBottom = v }, (*computedStyle).PaddingBottomAt},
-		{"PaddingLeft", func(s *computedStyle, v float64) { s.PaddingLeft = v }, (*computedStyle).PaddingLeftAt},
+		{"MarginTop", (*computedStyle).MarginTopAt},
+		{"MarginRight", (*computedStyle).MarginRightAt},
+		{"MarginBottom", (*computedStyle).MarginBottomAt},
+		{"MarginLeft", (*computedStyle).MarginLeftAt},
+		{"PaddingTop", (*computedStyle).PaddingTopAt},
+		{"PaddingRight", (*computedStyle).PaddingRightAt},
+		{"PaddingBottom", (*computedStyle).PaddingBottomAt},
+		{"PaddingLeft", (*computedStyle).PaddingLeftAt},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := &computedStyle{FontSize: 12}
-			tc.set(s, 42)
-			if got := tc.helper(s, 100); math.Abs(got-42) > 0.001 {
-				t.Errorf("%s fallback returned %v, want 42", tc.name, got)
+			if got := tc.helper(s, 100); math.Abs(got) > 0.001 {
+				t.Errorf("%s with nil sibling returned %v, want 0", tc.name, got)
 			}
 		})
 	}
@@ -355,12 +338,11 @@ func TestPercentMarginResolvesAgainstContainerEndToEnd(t *testing.T) {
 // TestNarrowContainerWidthSubtractsPercentPadding closes a Phase 2
 // test-coverage gap: the bug-closing assertions above call helpers
 // directly, but the migrated consumer narrowContainerWidth has no
-// dedicated test. A regression that reverted the
+// dedicated test. A regression that bypassed the
 // `style.PaddingLeftAt(prev) + style.PaddingRightAt(prev)`
-// subtraction to the legacy `style.PaddingLeft + style.PaddingRight`
-// would silently re-introduce the 0pt-padding bug — narrowContainer
-// would shrink by 0 for percent padding and downstream layout would
-// give children a too-large container.
+// subtraction would silently re-introduce the 0pt-padding bug —
+// narrowContainer would shrink by 0 for percent padding and
+// downstream layout would give children a too-large container.
 //
 // The test sets padding: 25% on a style, drives narrowContainerWidth
 // with a 200pt parent container, and asserts c.containerWidth dropped
@@ -383,16 +365,13 @@ func TestNarrowContainerWidthSubtractsPercentPadding(t *testing.T) {
 
 // TestApplyDivStylesUsesPercentMargin exercises the migrated
 // applyDivStyles directly. The function reads style.MarginTopAt
-// against the supplied containerWidth — a regression that reverted
-// to style.MarginTop (legacy float64) would yield 0 for percent
-// declarations.
+// against the supplied containerWidth — a regression that bypassed
+// the helper would yield 0 for percent declarations.
 //
 // Cannot inspect Div.SpaceBefore directly (unexported field), so
-// the test asserts the equivalent: after applyDivStyles, calling
-// MarginTopAt with the same containerWidth must give a non-zero
-// answer, AND a hypothetical revert to legacy float64 would yield
-// 0 (verified by reading style.MarginTop after the parser stored
-// 0 for percent).
+// the test asserts the equivalent: after applyProperty stores the
+// parsed *cssLength, calling MarginTopAt with the container width
+// must produce the correct percent-resolved value.
 func TestApplyDivStylesUsesPercentMargin(t *testing.T) {
 	c := &converter{opts: (&Options{}).defaults()}
 	style := defaultStyle()
@@ -402,14 +381,6 @@ func TestApplyDivStylesUsesPercentMargin(t *testing.T) {
 
 	const containerWidth = 200
 
-	// Sanity precondition: legacy float64 must be 0 here, otherwise
-	// the test isn't actually exercising the lazy-resolution path.
-	if style.MarginTop != 0 {
-		t.Fatalf("test precondition broken: parser unexpectedly resolved percent to non-zero float64 (%v)", style.MarginTop)
-	}
-
-	// Phase 2 contract: applyDivStyles's reads against containerWidth
-	// must produce the correct percent-resolved value.
 	if got := style.MarginTopAt(containerWidth); math.Abs(got-100) > 0.001 {
 		t.Errorf("MarginTopAt(200) = %v, want 100; applyDivStyles would have emitted %v as SpaceBefore", got, got)
 	}
@@ -532,12 +503,12 @@ func TestConvertFlexResolvesMarginAgainstParent(t *testing.T) {
 	}
 }
 
-// TestHasMarginRecognizesPercent verifies the Phase 2 hasMargin/
-// hasPadding update: a `margin: 50%` declaration must make
-// hasMargin() return true, even though the legacy float64 fields
-// all hold 0pt (since parseBoxSide resolves percent against zero).
-// Without this the wrapper-emission fast paths in convertParagraph,
-// convertHeading, convertBlock would skip percent-margin elements.
+// TestHasMarginRecognizesPercent pins the hasMargin / hasPadding
+// contract: a `margin: 50%` declaration must make hasMargin() return
+// true. Pre-Phase 2 hasMargin only read the legacy float64 (which
+// the parser stored as 0pt for percent), so wrapper-emission fast
+// paths in convertParagraph, convertHeading, convertBlock would
+// skip percent-margin elements.
 func TestHasMarginRecognizesPercent(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -559,31 +530,30 @@ func TestHasMarginRecognizesPercent(t *testing.T) {
 	}
 }
 
-// TestZeroValueLengthResolvesToZero distinguishes a sibling of
-// {0, "px"} (resolved value 0) from a nil sibling (fall back to
-// legacy). A future optimization that treated zero-valued siblings
-// as "absent" would silently change behaviour for documents using
-// `margin-top: 0%` to reset an inherited margin.
+// TestZeroValueLengthResolvesToZero exercises the contract that a
+// stored zero-valued *cssLength (e.g. from `margin-top: 0%`)
+// resolves to 0pt — not nil-treated, not coerced. Distinguishes
+// the "declared zero" case from an "absent declaration" (nil
+// sibling) which also returns 0. Both legitimately resolve to 0pt
+// post-Phase 4; this test pins the parser-side path.
 func TestZeroValueLengthResolvesToZero(t *testing.T) {
-	s := &computedStyle{
-		FontSize:  12,
-		MarginTop: 42, // legacy says 42 — fallback would return this
-	}
-	_, length := parseBoxSideBoth("0%", 12)
+	s := &computedStyle{FontSize: 12}
+	length := parseBoxSideLength("0%", 12)
 	if length == nil {
-		t.Fatal("parseBoxSideBoth(0%) returned nil; expected zero-valued sibling")
+		t.Fatal("parseBoxSideLength(0%) returned nil; expected zero-valued sibling")
 	}
 	s.MarginTopLength = length
 	if got := s.MarginTopAt(200); math.Abs(got) > 0.001 {
-		t.Errorf("MarginTopAt with 0%% sibling returned %v, want 0 (must not fall back to legacy 42)", got)
+		t.Errorf("MarginTopAt with 0%% sibling returned %v, want 0", got)
 	}
 }
 
 // TestConvertPopulatesLengthSiblings verifies the end-to-end wire from
 // the CSS Apply registry: a margin / padding declaration in a
-// stylesheet should populate BOTH the legacy float64 AND the
-// *cssLength sibling on the resulting computedStyle. Without this,
-// Phase 2 consumer migrations would have nothing to read.
+// stylesheet populates the *cssLength sibling on the resulting
+// computedStyle. Helper reads via MarginTopAt / PaddingTopAt
+// then resolve against the actual containing block at consumer
+// time.
 //
 // The test reaches into the converter's internal style-application
 // path (computeStyle on a tiny synthetic node) rather than driving
@@ -661,6 +631,48 @@ func TestConvertPopulatesLengthSiblings(t *testing.T) {
 				c.applyProperty(d.property, d.value, &style)
 			}
 			tc.check(t, &style)
+		})
+	}
+}
+
+// TestHeadingDefaultMarginsSurviveMigration pins the heading-level
+// default top/bottom margins (h1..h6) that applyTagDefaults installs.
+// Phase 4 swapped each `style.MarginTop = N` write to
+// `style.MarginTopLength = &cssLength{Value: N, Unit: "pt"}` — a
+// subtle helper-side bug (wrong Unit string, wrong field, an off-by-
+// one transposition between Top and Bottom) would shift heading
+// metrics by fractions of a point and silently break document
+// rendering across every example. The test fails loudly if any
+// heading default no longer resolves to its documented value.
+//
+// The container width argument is irrelevant for pt-typed values but
+// the helper requires one; 100pt is arbitrary.
+func TestHeadingDefaultMarginsSurviveMigration(t *testing.T) {
+	cases := []struct {
+		tag    atom.Atom
+		name   string
+		top    float64
+		bottom float64
+	}{
+		{atom.H1, "h1", 16.08, 16.08},
+		{atom.H2, "h2", 14.94, 14.94},
+		{atom.H3, "h3", 14.04, 14.04},
+		{atom.H4, "h4", 16.02, 16.02},
+		{atom.H5, "h5", 16.60, 16.60},
+		{atom.H6, "h6", 18.62, 18.62},
+	}
+	c := &converter{opts: (&Options{}).defaults()}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &gohtml.Node{Type: gohtml.ElementNode, DataAtom: tc.tag}
+			style := defaultStyle()
+			c.applyTagDefaults(n, &style)
+			if got := style.MarginTopAt(100); math.Abs(got-tc.top) > 0.001 {
+				t.Errorf("%s MarginTopAt(100) = %v, want %v", tc.name, got, tc.top)
+			}
+			if got := style.MarginBottomAt(100); math.Abs(got-tc.bottom) > 0.001 {
+				t.Errorf("%s MarginBottomAt(100) = %v, want %v", tc.name, got, tc.bottom)
+			}
 		})
 	}
 }

--- a/html/properties.go
+++ b/html/properties.go
@@ -788,13 +788,13 @@ func parseDisplay(value string) string {
 	}
 }
 
-// parseBoxSide parses a single side of margin/padding (e.g. "10px").
-//
-// Returns the resolved-against-zero float64 value. Equivalent to the
-// first half of parseBoxSideBoth — kept for the border-width /
-// outline-width Apply sites where the legacy float64 is the only
-// stored form. Margin / padding Apply sites should use parseBoxSideBoth
-// so the *cssLength sibling is populated for the Phase 2 migration.
+// parseBoxSide parses a single length value into points, eagerly
+// resolving percent against zero. Used by border-width / outline-
+// width / column-gap / row-gap / etc. — Apply sites that store a
+// float64 and don't need layout-time re-resolution. Margin / padding
+// Apply sites use parseBoxSideLength so the *cssLength is preserved
+// for resolution against the containing block at consumer time
+// (#269).
 func parseBoxSide(value string, fontSize float64) float64 {
 	l := parseLength(value)
 	if l == nil {
@@ -803,52 +803,47 @@ func parseBoxSide(value string, fontSize float64) float64 {
 	return l.toPoints(0, fontSize)
 }
 
-// parseBoxSideBoth parses a single side of margin/padding and returns
-// BOTH forms: the legacy eagerly-resolved float64 (for back-compat
-// with unmigrated consumers) and the unresolved *cssLength (for the
-// Phase 2 migration toward layout-time resolution against the
-// containing block). #269 Phase 1.
+// parseBoxSideLength parses a single side of margin/padding and
+// returns the unresolved *cssLength so the percent / calc / min /
+// max / clamp tree can be resolved against the containing block at
+// consumer time (#269). A nil parseLength result (e.g. "auto" or
+// unparseable input) yields nil.
 //
-// A nil parseLength result (e.g. "auto" or unparseable input) yields
-// (0, nil) — callers that need to distinguish "absent" from "0pt"
-// can branch on the *cssLength being nil.
-func parseBoxSideBoth(value string, fontSize float64) (float64, *cssLength) {
-	l := parseLength(value)
-	if l == nil {
-		return 0, nil
-	}
-	return l.toPoints(0, fontSize), l
+// The fontSize parameter is accepted for symmetry with parseBoxSide
+// (which resolves px / em eagerly) but is not currently consulted —
+// parseLength only inspects the value's unit token. It's kept on the
+// signature so a future change that needs fontSize at parse time
+// doesn't require a call-site sweep.
+func parseBoxSideLength(value string, fontSize float64) *cssLength {
+	_ = fontSize
+	return parseLength(value)
 }
 
 // parseMarginShorthandLengths parses the CSS margin/padding shorthand
-// into four *cssLength values (top/right/bottom/left) using the same
-// 1/2/3/4-token expansion rules as parseMarginShorthand. The
-// *cssLength preserves percent / calc / min / max / clamp trees for
-// layout-time resolution against the containing block.
-//
-// Pairs with parseMarginShorthand at every call site — the legacy
-// float64s drive unmigrated consumers; the *cssLength values
-// populate the Phase 1 sibling fields.
+// into four *cssLength values (top/right/bottom/left) using the
+// standard 1/2/3/4-token expansion rules. The *cssLength preserves
+// percent / calc / min / max / clamp trees for layout-time
+// resolution against the containing block.
 func parseMarginShorthandLengths(value string, fontSize float64) (*cssLength, *cssLength, *cssLength, *cssLength) {
 	parts := splitTopLevelFields(value)
 	switch len(parts) {
 	case 1:
-		_, v := parseBoxSideBoth(parts[0], fontSize)
+		v := parseBoxSideLength(parts[0], fontSize)
 		return v, v, v, v
 	case 2:
-		_, tb := parseBoxSideBoth(parts[0], fontSize)
-		_, lr := parseBoxSideBoth(parts[1], fontSize)
+		tb := parseBoxSideLength(parts[0], fontSize)
+		lr := parseBoxSideLength(parts[1], fontSize)
 		return tb, lr, tb, lr
 	case 3:
-		_, tt := parseBoxSideBoth(parts[0], fontSize)
-		_, lr := parseBoxSideBoth(parts[1], fontSize)
-		_, bb := parseBoxSideBoth(parts[2], fontSize)
+		tt := parseBoxSideLength(parts[0], fontSize)
+		lr := parseBoxSideLength(parts[1], fontSize)
+		bb := parseBoxSideLength(parts[2], fontSize)
 		return tt, lr, bb, lr
 	case 4:
-		_, tt := parseBoxSideBoth(parts[0], fontSize)
-		_, rr := parseBoxSideBoth(parts[1], fontSize)
-		_, bb := parseBoxSideBoth(parts[2], fontSize)
-		_, ll := parseBoxSideBoth(parts[3], fontSize)
+		tt := parseBoxSideLength(parts[0], fontSize)
+		rr := parseBoxSideLength(parts[1], fontSize)
+		bb := parseBoxSideLength(parts[2], fontSize)
+		ll := parseBoxSideLength(parts[3], fontSize)
 		return tt, rr, bb, ll
 	default:
 		return nil, nil, nil, nil

--- a/html/style.go
+++ b/html/style.go
@@ -33,34 +33,18 @@ type computedStyle struct {
 	MarginTopAuto   bool // true if margin-top: auto (for flex layout)
 	MarginLeftAuto  bool // true if margin-left: auto (for centering)
 	MarginRightAuto bool // true if margin-right: auto (for centering)
-	MarginTop       float64
-	MarginRight     float64
-	MarginBottom    float64
-	MarginLeft      float64
 
-	PaddingTop    float64
-	PaddingRight  float64
-	PaddingBottom float64
-	PaddingLeft   float64
-
-	// Lazy-resolution sibling fields for margin / padding (#269).
+	// Margin / padding are stored as unresolved *cssLength values so that
+	// percent / calc / min / max / clamp expressions can be resolved
+	// against the containing-block width at consumer time (#269). The
+	// parser cannot eagerly resolve them — containing-block width is
+	// unknown when CSS is applied — so the helpers MarginTopAt /
+	// PaddingTopAt below take a container width argument.
 	//
-	// The legacy MarginTop / MarginRight / MarginBottom / MarginLeft and
-	// PaddingTop / PaddingRight / PaddingBottom / PaddingLeft above
-	// store an already-resolved float64 — but the parser must call
-	// toPoints(0, fontSize) at parse time because the containing-block
-	// dimension isn't known yet. The result: a `margin: 50%` declaration
-	// silently stores 0pt, and `padding: calc(10% + 5px)` stores 5pt
-	// (only the px term resolves). The *Length fields below carry the
-	// unresolved cssLength so consumers that DO know the containing
-	// block (the converter, layout pipeline) can resolve correctly via
-	// the MarginTopAt / PaddingTopAt helpers.
-	//
-	// During the migration the legacy float64 fields stay populated
-	// alongside *Length, so unmigrated consumers continue to read the
-	// (buggy-but-historical) eagerly-resolved value. A future PR
-	// removes the float64 fields once every consumer has moved to the
-	// helpers.
+	// Phase 1+2 stored both an eagerly-resolved float64 sibling and the
+	// *cssLength here. Phase 4 dropped the float64 fields; the helpers
+	// are now the only read path. A nil pointer means the side was not
+	// declared.
 	MarginTopLength    *cssLength
 	MarginRightLength  *cssLength
 	MarginBottomLength *cssLength
@@ -519,18 +503,12 @@ func (s *computedStyle) inherit() computedStyle {
 	return child
 }
 
-// hasPadding returns true if any padding is declared AND would
-// resolve to a non-zero value against a non-zero container. The
-// check intentionally returns true for `padding: 50%` (legacy
-// float64 resolves to 0, but the sibling carries a meaningful
-// non-zero value when given a container width) while returning
-// false for explicit-zero declarations like `padding: 0` or
-// `padding: 0%`, which add no layout effect and should not
-// trigger wrapper-emission code paths.
+// hasPadding returns true if any padding side is declared with a
+// meaningful (non-zero, or container-dependent) value. Returns false
+// for an absent declaration AND for explicit-zero declarations like
+// `padding: 0` or `padding: 0%`, which add no layout effect and
+// should not trigger wrapper-emission code paths.
 func (s *computedStyle) hasPadding() bool {
-	if s.PaddingTop > 0 || s.PaddingRight > 0 || s.PaddingBottom > 0 || s.PaddingLeft > 0 {
-		return true
-	}
 	return hasMeaningfulLength(s.PaddingTopLength) ||
 		hasMeaningfulLength(s.PaddingRightLength) ||
 		hasMeaningfulLength(s.PaddingBottomLength) ||
@@ -542,13 +520,10 @@ func (s *computedStyle) hasBorder() bool {
 	return s.BorderTopWidth > 0 || s.BorderRightWidth > 0 || s.BorderBottomWidth > 0 || s.BorderLeftWidth > 0
 }
 
-// hasMargin returns true if any margin is declared AND would
-// resolve to a non-zero value. See hasPadding for the
-// non-zero-declaration rationale.
+// hasMargin returns true if any margin side is declared with a
+// meaningful (non-zero, or container-dependent) value. See hasPadding
+// for the non-zero-declaration rationale.
 func (s *computedStyle) hasMargin() bool {
-	if s.MarginTop > 0 || s.MarginRight > 0 || s.MarginBottom > 0 || s.MarginLeft > 0 {
-		return true
-	}
 	return hasMeaningfulLength(s.MarginTopLength) ||
 		hasMeaningfulLength(s.MarginRightLength) ||
 		hasMeaningfulLength(s.MarginBottomLength) ||
@@ -575,66 +550,61 @@ func hasMeaningfulLength(l *cssLength) bool {
 	return l.Value != 0
 }
 
-// MarginTopAt resolves the top margin against containerWidth. When the
-// parser stored a *cssLength sibling (post #269 Phase 1) the percent /
-// calc / min / max / clamp tree is resolved against the actual
-// container; otherwise the helper falls back to the legacy eagerly-
-// resolved float64 (which currently returns 0pt for percent-only
-// values — the bug the migration is closing).
+// MarginTopAt resolves the top margin against containerWidth. The
+// stored *cssLength carries the unresolved percent / calc / min /
+// max / clamp tree from the parser; resolution against the actual
+// containing block happens here. A nil sibling means the side was
+// not declared and the helper returns 0.
 //
 // containerWidth is the width of the containing block, in points.
-// Consumers that don't know the container yet (page-time defaults,
-// margin collapse pre-flow, etc.) pass 0 and accept the
-// percent-resolves-to-zero behaviour for now; the legacy float64 was
-// already doing that silently.
+// Consumers that don't know the container yet (e.g. probe paths
+// pre-flow) may pass 0 and accept that percent declarations resolve
+// to 0pt.
 func (s *computedStyle) MarginTopAt(containerWidth float64) float64 {
-	return resolveBoxSide(s.MarginTopLength, s.MarginTop, containerWidth, s.FontSize)
+	return resolveBoxSide(s.MarginTopLength, containerWidth, s.FontSize)
 }
 
 // MarginRightAt — see MarginTopAt.
 func (s *computedStyle) MarginRightAt(containerWidth float64) float64 {
-	return resolveBoxSide(s.MarginRightLength, s.MarginRight, containerWidth, s.FontSize)
+	return resolveBoxSide(s.MarginRightLength, containerWidth, s.FontSize)
 }
 
 // MarginBottomAt — see MarginTopAt.
 func (s *computedStyle) MarginBottomAt(containerWidth float64) float64 {
-	return resolveBoxSide(s.MarginBottomLength, s.MarginBottom, containerWidth, s.FontSize)
+	return resolveBoxSide(s.MarginBottomLength, containerWidth, s.FontSize)
 }
 
 // MarginLeftAt — see MarginTopAt.
 func (s *computedStyle) MarginLeftAt(containerWidth float64) float64 {
-	return resolveBoxSide(s.MarginLeftLength, s.MarginLeft, containerWidth, s.FontSize)
+	return resolveBoxSide(s.MarginLeftLength, containerWidth, s.FontSize)
 }
 
 // PaddingTopAt — see MarginTopAt. Same contract for padding.
 func (s *computedStyle) PaddingTopAt(containerWidth float64) float64 {
-	return resolveBoxSide(s.PaddingTopLength, s.PaddingTop, containerWidth, s.FontSize)
+	return resolveBoxSide(s.PaddingTopLength, containerWidth, s.FontSize)
 }
 
 // PaddingRightAt — see MarginTopAt.
 func (s *computedStyle) PaddingRightAt(containerWidth float64) float64 {
-	return resolveBoxSide(s.PaddingRightLength, s.PaddingRight, containerWidth, s.FontSize)
+	return resolveBoxSide(s.PaddingRightLength, containerWidth, s.FontSize)
 }
 
 // PaddingBottomAt — see MarginTopAt.
 func (s *computedStyle) PaddingBottomAt(containerWidth float64) float64 {
-	return resolveBoxSide(s.PaddingBottomLength, s.PaddingBottom, containerWidth, s.FontSize)
+	return resolveBoxSide(s.PaddingBottomLength, containerWidth, s.FontSize)
 }
 
 // PaddingLeftAt — see MarginTopAt.
 func (s *computedStyle) PaddingLeftAt(containerWidth float64) float64 {
-	return resolveBoxSide(s.PaddingLeftLength, s.PaddingLeft, containerWidth, s.FontSize)
+	return resolveBoxSide(s.PaddingLeftLength, containerWidth, s.FontSize)
 }
 
-// resolveBoxSide picks the right resolution path for a margin/padding
-// side. When the parser stored a *cssLength (Phase 1+) we resolve it
-// against the supplied container; otherwise we fall back to the
-// legacy eager-resolved value, which preserves the historical
-// percent-becomes-zero behaviour for code paths that haven't yet
-// migrated.
-func resolveBoxSide(length *cssLength, legacy, containerWidth, fontSize float64) float64 {
-	if length != nil {
-		return length.toPoints(containerWidth, fontSize)
+// resolveBoxSide resolves a margin / padding side against the
+// supplied containing-block width. A nil length means the side was
+// not declared and resolves to 0.
+func resolveBoxSide(length *cssLength, containerWidth, fontSize float64) float64 {
+	if length == nil {
+		return 0
 	}
-	return legacy
+	return length.toPoints(containerWidth, fontSize)
 }


### PR DESCRIPTION
## Summary

Final phase of the lazy margin/padding migration started in #309 (Phase 1) and #310 (Phase 2). Removes the eight legacy float64 fields from `computedStyle` and collapses the parser, helpers, and consumers onto a single `*cssLength`-based read/write path.

Three setter paths converge on the new storage:

- **CSS Apply registry** (`html/css_props.go`). The 10 margin/padding entries (4 padding sides + 3 margin sides + margin shorthand + padding shorthand + margin-bottom) drop the parallel float64 writes. `parseBoxSideBoth` is replaced by a new `parseBoxSideLength` returning only the `*cssLength`; `parseMarginShorthandLengths` is rewired to use it.
- **Heading / tag default setters** (`html/converter_style.go`). Every `style.MarginTop = N` in `applyTagDefaults` becomes `style.MarginTopLength = &cssLength{Value: N, Unit: "pt"}`. Covers h1-h6, p, pre, hr, ul/ol, blockquote, dl, dd, figure, fieldset.
- **Flex-child consumer** (`html/converter_flex.go`). Was reading `childStyle.MarginTop` directly (the one Phase 2 site that bypassed the helper). Now goes through `MarginTopAt(c.containerWidth)` since the child's containing block is the flex content box.

`resolveBoxSide` loses its `legacy float64` parameter. `hasMargin` / `hasPadding` drop the legacy OR-branch. `parseBoxSide` and `parseMarginShorthand` stay on `properties.go` for the remaining float64-only callers (border-width, outline-width, column-gap, row-gap, page.go's `pc.MarginTop`).

## What does NOT change

- `html/page.go` is untouched. `pc.MarginTop` lives on `PageConfig`, a different type from `computedStyle`. Page-level margins are out of scope.
- `parseBoxSide` and `parseMarginShorthand` (the float64 returners) remain. Border-width and outline-width still need them.

## Determinism pin

`TestHeadingDefaultMarginsSurviveMigration` asserts the documented top/bottom margin values for each heading level (16.08, 14.94, 14.04, 16.02, 16.60, 18.62). A subtle helper bug, a wrong Unit string, or a Top/Bottom transposition would fail this test loudly rather than silently shifting heading metrics by fractions of a point.

## Test plan

- [x] `go test ./...` clean
- [x] `gofmt -s -l .` clean
- [x] `golangci-lint run ./html/...` introduces no new issues (6 pre-existing staticcheck warnings unchanged)
- [x] `TestHeadingDefaultMarginsSurviveMigration` passes; verified it fails on a deliberate wrong value
- [x] No remaining `style.MarginTop` / `style.PaddingTop` legacy reads or writes in `html/` (only in doc comments explaining migration history)
- [x] `go run ./examples/html-to-pdf` still produces a 2-page PDF of plausible size (11052 bytes)