### PR TITLE
html: recognize calc()/min()/max()/clamp() in gradient stops and bg-position (closes #265, #266)

### DIFF
--- a/html/calc_position_test.go
+++ b/html/calc_position_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"math"
+	"testing"
+)
+
+// TestPercentFractionAcceptsPercentOnlyTrees covers the restricted-calc
+// branch shared by parseGradientStops and parseBgPosition: any
+// calc/min/max/clamp tree whose leaves are all percent or dimensionless
+// must reduce to a [0..1] fraction without needing a resolution context.
+func TestPercentFractionAcceptsPercentOnlyTrees(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"50%", 0.5},
+		{"0%", 0.0},
+		{"100%", 1.0},
+		{"calc(50% - 10%)", 0.4},
+		{"calc(50% + 30%)", 0.8},
+		{"calc(50% * 2)", 1.0},
+		{"calc(60% / 2)", 0.3},
+		{"min(40%, 60%)", 0.4},
+		{"max(0%, 30%)", 0.3},
+		{"clamp(10%, 50%, 90%)", 0.5},
+		{"clamp(10%, 5%, 90%)", 0.1},  // preferred below min -> clamp up
+		{"clamp(10%, 95%, 90%)", 0.9}, // preferred above max -> clamp down
+	}
+	for _, tt := range tests {
+		l := parseLength(tt.input)
+		if l == nil {
+			t.Errorf("parseLength(%q) returned nil", tt.input)
+			continue
+		}
+		got, ok := percentFraction(l)
+		if !ok {
+			t.Errorf("percentFraction(%q): ok=false, want ok=true", tt.input)
+			continue
+		}
+		if math.Abs(got-tt.want) > 1e-9 {
+			t.Errorf("percentFraction(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+// TestPercentFractionRejectsMixedUnit confirms that any leaf carrying a
+// length unit poisons the whole tree — the position parsers cannot
+// reduce mixed-unit calc to a fraction without the resolution dimension
+// (gradient line length or background box), so the helper must reject.
+func TestPercentFractionRejectsMixedUnit(t *testing.T) {
+	tests := []string{
+		"calc(50% + 10px)",
+		"calc(50% - 10px)",
+		"calc(1em + 50%)",
+		"calc(50% + 1pt)",
+		"min(50%, 10px)",
+		"max(10px, 50%)",
+		"clamp(10%, 50%, 100px)",
+	}
+	for _, in := range tests {
+		l := parseLength(in)
+		if l == nil {
+			t.Errorf("parseLength(%q) returned nil", in)
+			continue
+		}
+		got, ok := percentFraction(l)
+		if ok {
+			t.Errorf("percentFraction(%q) = (%v, true), want (_, false)", in, got)
+		}
+	}
+}
+
+// TestPercentFractionRejectsPureLength confirms a plain length without
+// percent is also rejected — it's a valid cssLength but not a fraction.
+func TestPercentFractionRejectsPureLength(t *testing.T) {
+	tests := []string{"10px", "2em", "12pt", "1rem", "calc(10px + 5px)"}
+	for _, in := range tests {
+		l := parseLength(in)
+		if l == nil {
+			t.Errorf("parseLength(%q) returned nil", in)
+			continue
+		}
+		got, ok := percentFraction(l)
+		if ok {
+			t.Errorf("percentFraction(%q) = (%v, true), want (_, false)", in, got)
+		}
+	}
+}
+
+// TestParseGradientStopsWithCalcPosition drives parseGradientStops with
+// the parts list produced by parseLinearGradient for
+// "linear-gradient(red, blue calc(50% - 10%), green)". The middle stop
+// must land at 0.4 with a non-zero blue color, not be dropped or fall
+// through to the black default.
+func TestParseGradientStopsWithCalcPosition(t *testing.T) {
+	parts := []string{"red", "blue calc(50% - 10%)", "green"}
+	stops := parseGradientStops(parts)
+	if len(stops) != 3 {
+		t.Fatalf("got %d stops, want 3", len(stops))
+	}
+	if math.Abs(stops[1].Position-0.4) > 1e-9 {
+		t.Errorf("middle stop position = %v, want 0.4", stops[1].Position)
+	}
+	// Blue is sRGB (0, 0, 1). Confirm parseColor ran on "blue" only.
+	if stops[1].Color.R != 0 || stops[1].Color.G != 0 || stops[1].Color.B == 0 {
+		t.Errorf("middle stop color = %+v, want blue (R=0 G=0 B=1)", stops[1].Color)
+	}
+}
+
+// TestParseGradientStopsPlainPercentStillWorks guards the
+// fast-path: literal "<num>%" positions must keep working after the
+// tokenizer swap.
+func TestParseGradientStopsPlainPercentStillWorks(t *testing.T) {
+	parts := []string{"#ff0000 0%", "#0000ff 100%"}
+	stops := parseGradientStops(parts)
+	if len(stops) != 2 {
+		t.Fatalf("got %d stops, want 2", len(stops))
+	}
+	if stops[0].Position != 0 || stops[1].Position != 1 {
+		t.Errorf("positions = [%v, %v], want [0, 1]",
+			stops[0].Position, stops[1].Position)
+	}
+}
+
+// TestParseGradientStopsMixedUnitCalcFallsBack confirms the documented
+// limitation: mixed-unit calc cannot be reduced to a fraction without
+// the gradient line length, so the whole field is treated as a color.
+// parseColor then fails on "blue calc(50% + 10px)" and the stop's color
+// is left zero. This matches "rejected, not resolved" — the renderer's
+// existing behaviour for unparseable stops.
+func TestParseGradientStopsMixedUnitCalcFallsBack(t *testing.T) {
+	parts := []string{"blue calc(50% + 10px)"}
+	stops := parseGradientStops(parts)
+	if len(stops) != 1 {
+		t.Fatalf("got %d stops, want 1", len(stops))
+	}
+	if stops[0].Position != 0 {
+		t.Errorf("position = %v, want 0 (default for unparseable)",
+			stops[0].Position)
+	}
+}
+
+// TestParseBgPositionWithCalc covers the percent-only calc path and the
+// single-axis fallback. Mixed-unit calc must fall back to the existing
+// "unparseable axis -> default" behaviour.
+func TestParseBgPositionWithCalc(t *testing.T) {
+	tests := []struct {
+		input string
+		wantX float64
+		wantY float64
+	}{
+		{"calc(50% - 10%) 50%", 0.4, 0.5},
+		{"calc(30%)", 0.3, 0.5},
+		{"min(40%, 60%) 50%", 0.4, 0.5},
+		{"clamp(10%, 50%, 90%) 25%", 0.5, 0.25},
+		// Mixed-unit calc on x: x falls back to 0 (existing
+		// behaviour for unparseable), y still resolves.
+		{"calc(50% + 10px) 50%", 0, 0.5},
+	}
+	for _, tt := range tests {
+		pos := parseBgPosition(tt.input)
+		if math.Abs(pos[0]-tt.wantX) > 1e-9 || math.Abs(pos[1]-tt.wantY) > 1e-9 {
+			t.Errorf("parseBgPosition(%q) = [%v, %v], want [%v, %v]",
+				tt.input, pos[0], pos[1], tt.wantX, tt.wantY)
+		}
+	}
+}

--- a/html/converter_helpers.go
+++ b/html/converter_helpers.go
@@ -623,7 +623,16 @@ func parseGradientDirection(dir string) float64 {
 	}
 }
 
-// parseGradientStops parses a slice of "color [position]" strings into GradientStops.
+// parseGradientStops parses a slice of "color [position]" strings into
+// GradientStops.
+//
+// Calc support level is "restricted calc": a position token may be a
+// plain percent ("50%") or a calc/min/max/clamp tree whose leaves are
+// all percent or dimensionless (e.g. calc(50% - 10%), min(40%, 60%)).
+// Mixed-unit calc such as calc(50% + 10px) is currently rejected —
+// reducing it to a fraction requires the gradient line length, which is
+// not known until render time. Lazy resolution against the gradient
+// line is the deferred fix (option (c) in issue #265).
 func parseGradientStops(parts []string) []layout.GradientStop {
 	var stops []layout.GradientStop
 	for _, p := range parts {
@@ -632,17 +641,39 @@ func parseGradientStops(parts []string) []layout.GradientStop {
 			continue
 		}
 
-		// Try to split into color + position.
-		// The position is the last token if it ends with %.
+		// Split on whitespace at paren depth 0 so calc/min/max/clamp
+		// values stay a single token (e.g. "calc(50% - 10%)" with its
+		// internal spaces is one token, not three).
 		stop := layout.GradientStop{}
-		tokens := strings.Fields(p)
+		tokens := splitTopLevelFields(p)
 
 		if len(tokens) >= 2 {
 			last := tokens[len(tokens)-1]
+			positionMatched := false
+
+			// Plain "<num>%" first — keeps the fast path for the
+			// common case and avoids parseLength's calc dispatch.
 			if strings.HasSuffix(last, "%") {
 				if v, err := strconv.ParseFloat(strings.TrimSuffix(last, "%"), 64); err == nil {
 					stop.Position = v / 100
+					positionMatched = true
 				}
+			}
+
+			// Calc/min/max/clamp: parse the token and accept only
+			// percent-only trees. Mixed-unit trees fall through and
+			// the whole field is treated as a color, matching the
+			// pre-calc behaviour.
+			if !positionMatched {
+				if l := parseLength(last); l != nil {
+					if frac, ok := percentFraction(l); ok {
+						stop.Position = frac
+						positionMatched = true
+					}
+				}
+			}
+
+			if positionMatched {
 				colorStr := strings.Join(tokens[:len(tokens)-1], " ")
 				if clr, ok := parseColor(colorStr); ok {
 					stop.Color = clr
@@ -667,13 +698,25 @@ func parseGradientStops(parts []string) []layout.GradientStop {
 
 // parseBgPosition converts CSS background-position keywords to [x, y]
 // fractions in [0, 1].
+//
+// Calc support level is "restricted calc": each axis may be a plain
+// percent, a keyword (left/center/right/top/bottom), or a
+// calc/min/max/clamp tree whose leaves are all percent or dimensionless
+// (e.g. calc(50% - 10%) -> 0.4). Mixed-unit calc such as
+// calc(50% + 10px) is currently rejected and the axis falls back to its
+// default (0 for x, 0.5 for y in single-axis cases). Reducing
+// mixed-unit calc to a fraction requires the background box dimensions,
+// which are not known until render time. Lazy resolution against those
+// dimensions is the deferred fix (option (c) in issue #266).
 func parseBgPosition(val string) [2]float64 {
 	val = strings.TrimSpace(strings.ToLower(val))
 	if val == "" {
 		return [2]float64{0, 0}
 	}
 
-	parts := strings.Fields(val)
+	// splitTopLevelFields keeps calc()/min()/max()/clamp() values as a
+	// single token even when they contain internal whitespace.
+	parts := splitTopLevelFields(val)
 
 	toFrac := func(s string) (float64, bool) {
 		switch s {
@@ -691,6 +734,13 @@ func parseBgPosition(val string) [2]float64 {
 		if strings.HasSuffix(s, "%") {
 			if v, err := strconv.ParseFloat(strings.TrimSuffix(s, "%"), 64); err == nil {
 				return v / 100, true
+			}
+		}
+		// Calc/min/max/clamp: accept only percent-only trees. Mixed-unit
+		// trees fall back to the default (caller decides).
+		if l := parseLength(s); l != nil {
+			if frac, ok := percentFraction(l); ok {
+				return frac, true
 			}
 		}
 		return 0, false

--- a/html/properties.go
+++ b/html/properties.go
@@ -566,6 +566,75 @@ func parseCalcLeaf(s string) *cssLength {
 	return nil
 }
 
+// percentFraction returns the [0..1] fraction value of a percent-only
+// cssLength tree. Examples: 50% -> 0.5, calc(50% - 10%) -> 0.4,
+// calc(50% * 2) -> 1.0, min(40%, 60%) -> 0.4.
+//
+// Returns (0, false) when the tree contains any leaf with a length unit
+// (px, em, pt, rem, mm, cm, in) — mixed-dimension calc cannot be reduced
+// to a fraction without knowing the resolution context (gradient line
+// length or background box dimensions), which the position parsers do
+// not have at parse time. True lazy resolution against those dimensions
+// is deferred future work; see issues #265 and #266.
+//
+// Dimensionless leaves (Unit "num") are accepted so multipliers and
+// divisors inside calc work, e.g. calc(50% * 2) and calc(60% / 2).
+func percentFraction(l *cssLength) (float64, bool) {
+	if l == nil {
+		return 0, false
+	}
+	if !isPercentOnly(l) {
+		return 0, false
+	}
+	// Resolve with relativeTo=100 so that a leaf "50%" evaluates to 50,
+	// then divide by 100 to get the fraction. fontSize is irrelevant for
+	// percent / num leaves and is passed as 0.
+	return l.toPoints(100, 0) / 100, true
+}
+
+// isPercentOnly reports whether every leaf in the cssLength tree is
+// either a percent ("%") or a dimensionless number ("num"). Used by
+// percentFraction to gate length-aware reduction in contexts where the
+// resolution dimension is unknown.
+func isPercentOnly(l *cssLength) bool {
+	if l == nil {
+		return false
+	}
+	if l.calc != nil {
+		return calcExprIsPercentOnly(l.calc)
+	}
+	if len(l.minArgs) > 0 {
+		for _, a := range l.minArgs {
+			if !isPercentOnly(a) {
+				return false
+			}
+		}
+		return true
+	}
+	if len(l.maxArgs) > 0 {
+		for _, a := range l.maxArgs {
+			if !isPercentOnly(a) {
+				return false
+			}
+		}
+		return true
+	}
+	return l.Unit == "%" || l.Unit == "num"
+}
+
+func calcExprIsPercentOnly(e *calcExpr) bool {
+	if e == nil {
+		return false
+	}
+	if e.leaf != nil {
+		return isPercentOnly(e.leaf)
+	}
+	if e.left == nil || e.right == nil {
+		return false
+	}
+	return calcExprIsPercentOnly(e.left) && calcExprIsPercentOnly(e.right)
+}
+
 // parseFontSize parses a CSS font-size into points.
 // Handles absolute keywords, lengths, and percentages.
 func parseFontSize(value string, parentSize float64) float64 {


### PR DESCRIPTION
## Summary

Closes #265 and #266. Both bugs are narrow CSS-parsing holdouts from the calc-tokenization series (#236-#263): `parseGradientStops` detected positions by literal `%` suffix only, and `parseBgPosition`'s `toFrac` helper only recognised keywords and plain `<num>%`. Functional values like `calc(50% - 10%)`, `min(40%, 60%)`, or `clamp(10%, 50%, 90%)` were misclassified as colour (dropping the stop) or rejected (axis falling back to 0). Both call sites were also still tokenising with `strings.Fields`, which splits a calc on its internal whitespace.

This PR takes the "restricted calc" option from the issue bodies: percent-only calc trees are reduced to a fraction at parse time; mixed-unit calc is rejected.

## What's covered

- Plain percent: `50%` (unchanged fast path)
- Percent-only `calc`: `calc(50% - 10%)`, `calc(50% + 30%)`, `calc(50% * 2)`, `calc(60% / 2)`
- Percent-only `min` / `max` / `clamp`: `min(40%, 60%)`, `max(0%, 30%)`, `clamp(10%, 50%, 90%)`
- Dimensionless leaves inside calc (so multipliers and divisors work)

## What's deferred

Mixed-unit calc such as `calc(50% + 10px)` is rejected, not resolved. Reducing it to a fraction requires the resolution dimension — the gradient line length or the background box — which the parsers do not have at parse time. The deferred path is option (c) from the issue bodies: store the position as a deferred type (akin to `layout.UnitValue` from #236) and resolve at render time when dimensions are known. That requires structural changes to `layout.GradientStop` and `layout.BackgroundImage` plus consumer updates in the render path, so it's left as follow-up.

Both `parseGradientStops` and `parseBgPosition` carry doc comments stating the calc support level and pointing at the deferred lazy-resolution path.

## Implementation

- New helper `percentFraction(*cssLength) (float64, bool)` in `html/properties.go`. Walks the `calc` / `minArgs` / `maxArgs` tree and accepts only leaves with `Unit == "%"` or `Unit == "num"`. On accept, calls `l.toPoints(100, 0)` and divides by 100. Matches the existing `dependsOnPercent` / `isDimensionless` walker shape.
- `parseGradientStops` switches from `strings.Fields` to `splitTopLevelFields`, keeps the literal `<num>%` fast path, and falls through to `parseLength` + `percentFraction` for functional positions.
- `parseBgPosition` switches from `strings.Fields` to `splitTopLevelFields` and `toFrac` is extended with the same calc fallback. Single-axis cases continue to default the missing axis to 0.5.

## Test plan

- [x] `TestPercentFractionAcceptsPercentOnlyTrees` — table over plain `50%`, `calc(50% - 10%)`, `calc(50% * 2)`, `min(40%, 60%)`, `max(0%, 30%)`, `clamp(10%, 50%, 90%)` plus clamp edge cases.
- [x] `TestPercentFractionRejectsMixedUnit` — `calc(50% + 10px)`, `calc(1em + 50%)`, `min(50%, 10px)`, etc. all return `(0, false)`.
- [x] `TestPercentFractionRejectsPureLength` — plain `10px`, `2em`, `12pt`, `1rem`, `calc(10px + 5px)` all return `(0, false)`.
- [x] `TestParseGradientStopsWithCalcPosition` — `linear-gradient(red, blue calc(50% - 10%), green)` produces a blue stop at 0.4.
- [x] `TestParseGradientStopsPlainPercentStillWorks` — guards the literal `<num>%` fast path after the tokenizer swap.
- [x] `TestParseGradientStopsMixedUnitCalcFallsBack` — documents the limitation: `blue calc(50% + 10px)` falls back to position 0.
- [x] `TestParseBgPositionWithCalc` — percent-only calc, single-axis case, mixed-unit fallback.
- [x] Existing `TestParseLinearGradient`, `TestParseRadialGradient`, `TestParseBgPosition` all still pass.
- [x] `go test ./...` clean.
- [x] `gofmt -s -l .` clean.
- [x] `golangci-lint run ./html/...` — only the 6 pre-existing staticcheck warnings in unrelated test files remain.