### PR TITLE
all: standardize error message prefixes

### DIFF
--- a/core/encrypt.go
+++ b/core/encrypt.go
@@ -87,7 +87,7 @@ func NewEncryptor(rev EncryptionRevision, userPassword, ownerPassword string, pe
 
 	fileID, err := randomBytes(16)
 	if err != nil {
-		return nil, fmt.Errorf("encrypt: generate file ID: %w", err)
+		return nil, fmt.Errorf("core: encrypt: generate file ID: %w", err)
 	}
 
 	p := permBits(perms)
@@ -100,7 +100,7 @@ func NewEncryptor(rev EncryptionRevision, userPassword, ownerPassword string, pe
 	case RevisionAES256:
 		return newEncryptorR6(userPassword, ownerPassword, p, fileID)
 	default:
-		return nil, fmt.Errorf("encrypt: unsupported revision %d", rev)
+		return nil, fmt.Errorf("core: encrypt: unsupported revision %d", rev)
 	}
 }
 
@@ -143,7 +143,7 @@ func (e *Encryptor) walkEncrypt(obj PdfObject, objNum, genNum int) error {
 	case *PdfString:
 		enc, err := e.EncryptBytes(objNum, genNum, []byte(o.value))
 		if err != nil {
-			return fmt.Errorf("encrypt string (obj %d): %w", objNum, err)
+			return fmt.Errorf("core: encrypt string (obj %d): %w", objNum, err)
 		}
 		o.value = string(enc)
 		o.encoding = StringHexadecimal // binary data must be hex-encoded
@@ -171,7 +171,7 @@ func (e *Encryptor) walkEncrypt(obj PdfObject, objNum, genNum int) error {
 		if o.compress {
 			compressed, err := DeflateStreamData(data)
 			if err != nil {
-				return fmt.Errorf("compress stream (obj %d): %w", objNum, err)
+				return fmt.Errorf("core: compress stream (obj %d): %w", objNum, err)
 			}
 			data = compressed
 			o.Dict.Set("Filter", NewPdfName("FlateDecode"))
@@ -179,7 +179,7 @@ func (e *Encryptor) walkEncrypt(obj PdfObject, objNum, genNum int) error {
 		}
 		enc, err := e.EncryptBytes(objNum, genNum, data)
 		if err != nil {
-			return fmt.Errorf("encrypt stream (obj %d): %w", objNum, err)
+			return fmt.Errorf("core: encrypt stream (obj %d): %w", objNum, err)
 		}
 		o.Data = enc
 	}
@@ -513,7 +513,7 @@ func buildPermsBlock(p int32) ([]byte, error) {
 	buf[9], buf[10], buf[11] = 'a', 'd', 'b'
 	// Bytes 12-15: random.
 	if _, err := rand.Read(buf[12:16]); err != nil {
-		return nil, fmt.Errorf("encrypt: random bytes for perms block: %w", err)
+		return nil, fmt.Errorf("core: encrypt: random bytes for perms block: %w", err)
 	}
 	return buf, nil
 }

--- a/core/objstm.go
+++ b/core/objstm.go
@@ -62,7 +62,7 @@ type ObjStmPlacement struct {
 // builder-owned keys.
 func BuildObjStm(entries []ObjStmEntry) (*PdfStream, error) {
 	if len(entries) == 0 {
-		return nil, fmt.Errorf("objstm: no entries")
+		return nil, fmt.Errorf("core: objstm: no entries")
 	}
 
 	seen := make(map[int]struct{}, len(entries))
@@ -71,18 +71,18 @@ func BuildObjStm(entries []ObjStmEntry) (*PdfStream, error) {
 
 	for i, e := range entries {
 		if e.Object == nil {
-			return nil, fmt.Errorf("objstm: entry %d: nil object", i)
+			return nil, fmt.Errorf("core: objstm: entry %d: nil object", i)
 		}
 		if e.ObjectNumber <= 0 {
-			return nil, fmt.Errorf("objstm: entry %d: object number must be positive, got %d", i, e.ObjectNumber)
+			return nil, fmt.Errorf("core: objstm: entry %d: object number must be positive, got %d", i, e.ObjectNumber)
 		}
 		if _, dup := seen[e.ObjectNumber]; dup {
-			return nil, fmt.Errorf("objstm: duplicate object number %d", e.ObjectNumber)
+			return nil, fmt.Errorf("core: objstm: duplicate object number %d", e.ObjectNumber)
 		}
 		seen[e.ObjectNumber] = struct{}{}
 
 		if e.Object.Type() == ObjectTypeStream {
-			return nil, fmt.Errorf("objstm: entry %d (object %d): stream objects cannot be compressed", i, e.ObjectNumber)
+			return nil, fmt.Errorf("core: objstm: entry %d (object %d): stream objects cannot be compressed", i, e.ObjectNumber)
 		}
 
 		if i > 0 {
@@ -94,7 +94,7 @@ func BuildObjStm(entries []ObjStmEntry) (*PdfStream, error) {
 		}
 		offsets[i] = bodies.Len()
 		if _, err := e.Object.WriteTo(&bodies); err != nil {
-			return nil, fmt.Errorf("objstm: entry %d (object %d): serialize body: %w", i, e.ObjectNumber, err)
+			return nil, fmt.Errorf("core: objstm: entry %d (object %d): serialize body: %w", i, e.ObjectNumber, err)
 		}
 	}
 

--- a/core/stream.go
+++ b/core/stream.go
@@ -63,7 +63,7 @@ func (s *PdfStream) WriteTo(w io.Writer) (int64, error) {
 	if s.compress {
 		compressed, err := DeflateStreamData(s.Data)
 		if err != nil {
-			return 0, fmt.Errorf("flate compress: %w", err)
+			return 0, fmt.Errorf("core: flate compress: %w", err)
 		}
 		streamData = compressed
 		s.Dict.Set("Filter", NewPdfName("FlateDecode"))
@@ -119,12 +119,12 @@ func DeflateStreamData(data []byte) ([]byte, error) {
 func InflateStreamData(data []byte) ([]byte, error) {
 	r, err := zlib.NewReader(bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("inflate: %w", err)
+		return nil, fmt.Errorf("core: inflate: %w", err)
 	}
 	defer func() { _ = r.Close() }()
 	out, err := io.ReadAll(r)
 	if err != nil {
-		return nil, fmt.Errorf("inflate: %w", err)
+		return nil, fmt.Errorf("core: inflate: %w", err)
 	}
 	return out, nil
 }

--- a/core/xref_entry.go
+++ b/core/xref_entry.go
@@ -46,16 +46,16 @@ type XRefStreamEntry struct {
 func EncodeXRefStreamEntry(dst []byte, e XRefStreamEntry, widths [3]int) error {
 	total := widths[0] + widths[1] + widths[2]
 	if len(dst) != total {
-		return fmt.Errorf("xref entry: dst length %d, want %d", len(dst), total)
+		return fmt.Errorf("core: xref entry: dst length %d, want %d", len(dst), total)
 	}
 	if err := putUintBE(dst[:widths[0]], uint64(e.Type)); err != nil {
-		return fmt.Errorf("xref entry field 1: %w", err)
+		return fmt.Errorf("core: xref entry field 1: %w", err)
 	}
 	if err := putUintBE(dst[widths[0]:widths[0]+widths[1]], e.Field2); err != nil {
-		return fmt.Errorf("xref entry field 2: %w", err)
+		return fmt.Errorf("core: xref entry field 2: %w", err)
 	}
 	if err := putUintBE(dst[widths[0]+widths[1]:], e.Field3); err != nil {
-		return fmt.Errorf("xref entry field 3: %w", err)
+		return fmt.Errorf("core: xref entry field 3: %w", err)
 	}
 	return nil
 }
@@ -68,14 +68,14 @@ func EncodeXRefStreamEntry(dst []byte, e XRefStreamEntry, widths [3]int) error {
 func putUintBE(dst []byte, v uint64) error {
 	if len(dst) == 0 {
 		if v != 0 {
-			return fmt.Errorf("value %d does not fit in 0 bytes", v)
+			return fmt.Errorf("core: value %d does not fit in 0 bytes", v)
 		}
 		return nil
 	}
 	if len(dst) < 8 {
 		limit := uint64(1) << (uint(len(dst)) * 8)
 		if v >= limit {
-			return fmt.Errorf("value %d does not fit in %d bytes", v, len(dst))
+			return fmt.Errorf("core: value %d does not fit in %d bytes", v, len(dst))
 		}
 	}
 	for i := len(dst) - 1; i >= 0; i-- {

--- a/core/xref_stream_builder.go
+++ b/core/xref_stream_builder.go
@@ -35,20 +35,20 @@ type XRefStreamSubsection struct {
 // is deferred until the rest of the optimizer is in place.
 func BuildXRefStream(subsections []XRefStreamSubsection, size int, extras *PdfDictionary) (*PdfStream, error) {
 	if len(subsections) == 0 {
-		return nil, fmt.Errorf("xref stream: at least one subsection required")
+		return nil, fmt.Errorf("core: xref stream: at least one subsection required")
 	}
 	if size <= 0 {
-		return nil, fmt.Errorf("xref stream: size must be positive, got %d", size)
+		return nil, fmt.Errorf("core: xref stream: size must be positive, got %d", size)
 	}
 
 	var maxField2, maxField3 uint64
 	totalEntries := 0
 	for _, sub := range subsections {
 		if sub.First < 0 {
-			return nil, fmt.Errorf("xref stream: subsection First must be non-negative, got %d", sub.First)
+			return nil, fmt.Errorf("core: xref stream: subsection First must be non-negative, got %d", sub.First)
 		}
 		if sub.First+len(sub.Entries) > size {
-			return nil, fmt.Errorf("xref stream: subsection [%d,%d) extends past size %d",
+			return nil, fmt.Errorf("core: xref stream: subsection [%d,%d) extends past size %d",
 				sub.First, sub.First+len(sub.Entries), size)
 		}
 		totalEntries += len(sub.Entries)

--- a/document/document.go
+++ b/document/document.go
@@ -309,7 +309,7 @@ func (d *Document) PageCount() int {
 // Returns an error if the index is out of range.
 func (d *Document) Page(index int) (*Page, error) {
 	if index < 0 || index >= len(d.pages) {
-		return nil, fmt.Errorf("page index %d out of range [0, %d)", index, len(d.pages))
+		return nil, fmt.Errorf("document: page index %d out of range [0, %d)", index, len(d.pages))
 	}
 	return d.pages[index], nil
 }
@@ -318,7 +318,7 @@ func (d *Document) Page(index int) (*Page, error) {
 // Returns an error if the index is out of range.
 func (d *Document) RemovePage(index int) error {
 	if index < 0 || index >= len(d.pages) {
-		return fmt.Errorf("page index %d out of range [0, %d)", index, len(d.pages))
+		return fmt.Errorf("document: page index %d out of range [0, %d)", index, len(d.pages))
 	}
 	d.pages = slices.Delete(d.pages, index, index+1)
 	return nil

--- a/document/page.go
+++ b/document/page.go
@@ -292,10 +292,10 @@ func buildImportCmd(name string, opts *ImportPageOpts) string {
 // Panics if f is nil or size is negative.
 func (p *Page) AddText(text string, f *font.Standard, size, x, y float64) {
 	if f == nil {
-		panic("folio: AddText called with nil font")
+		panic("document.AddText: nil font")
 	}
 	if size < 0 {
-		panic("folio: AddText called with negative font size")
+		panic("document.AddText: negative font size")
 	}
 	resName := p.standardFontResource(f)
 	p.ensureStream()
@@ -311,10 +311,10 @@ func (p *Page) AddText(text string, f *font.Standard, size, x, y float64) {
 // Panics if ef is nil or size is negative.
 func (p *Page) AddTextEmbedded(text string, ef *font.EmbeddedFont, size, x, y float64) {
 	if ef == nil {
-		panic("folio: AddTextEmbedded called with nil font")
+		panic("document.AddTextEmbedded: nil font")
 	}
 	if size < 0 {
-		panic("folio: AddTextEmbedded called with negative font size")
+		panic("document.AddTextEmbedded: negative font size")
 	}
 	resName := p.embeddedFontResource(ef)
 	encoded := ef.EncodeString(text)
@@ -370,10 +370,10 @@ func (p *Page) AddRectFilled(x, y, w, h float64, color [3]float64) {
 // Panics if img is nil or width/height is negative.
 func (p *Page) AddImage(img *folioimage.Image, x, y, width, height float64) {
 	if img == nil {
-		panic("folio: AddImage called with nil image")
+		panic("document.AddImage: nil image")
 	}
 	if width < 0 || height < 0 {
-		panic("folio: AddImage called with negative dimensions")
+		panic("document.AddImage: negative dimensions")
 	}
 	if width == 0 && height == 0 {
 		width = float64(img.Width())

--- a/document/pdfa.go
+++ b/document/pdfa.go
@@ -241,14 +241,14 @@ func (d *Document) validatePdfA(allPages []*Page) error {
 
 	// PDF/A forbids encryption.
 	if d.encryption != nil {
-		return fmt.Errorf("pdfa: encryption is not allowed in PDF/A documents")
+		return fmt.Errorf("document: pdfa: encryption is not allowed in PDF/A documents")
 	}
 
 	// All fonts on all pages must be embedded (no bare standard fonts).
 	for i, page := range allPages {
 		for _, fr := range page.fonts {
 			if fr.standard != nil && fr.embedded == nil {
-				return fmt.Errorf("pdfa: page %d uses non-embedded standard font %q; PDF/A requires all fonts to be embedded",
+				return fmt.Errorf("document: pdfa: page %d uses non-embedded standard font %q; PDF/A requires all fonts to be embedded",
 					i, fr.standard.Name())
 			}
 		}
@@ -258,7 +258,7 @@ func (d *Document) validatePdfA(allPages []*Page) error {
 	if isPdfA1(d.pdfA.Level) {
 		for i, page := range allPages {
 			if len(page.extGStates) > 0 {
-				return fmt.Errorf("pdfa: page %d uses transparency (ExtGState); PDF/A-1 forbids transparency", i)
+				return fmt.Errorf("document: pdfa: page %d uses transparency (ExtGState); PDF/A-1 forbids transparency", i)
 			}
 		}
 	}
@@ -267,12 +267,12 @@ func (d *Document) validatePdfA(allPages []*Page) error {
 	// allow them: PDF/A-3 (ISO 19005-3 §6.4) and PDF/A-4f / PDF/A-4e
 	// (ISO 19005-4 §6.8). Plain PDF/A-4 forbids them.
 	if len(d.attachments) > 0 && !allowsAttachments(d.pdfA.Level) {
-		return fmt.Errorf("pdfa: file attachments are only permitted in PDF/A-3 (a/b) or PDF/A-4f / PDF/A-4e; current level does not allow them")
+		return fmt.Errorf("document: pdfa: file attachments are only permitted in PDF/A-3 (a/b) or PDF/A-4f / PDF/A-4e; current level does not allow them")
 	}
 
 	// Title is required.
 	if d.Info.Title == "" {
-		return fmt.Errorf("pdfa: document Title is required for PDF/A conformance")
+		return fmt.Errorf("document: pdfa: document Title is required for PDF/A conformance")
 	}
 
 	// Level A (accessibility-conformance) requires a declared natural
@@ -280,7 +280,7 @@ func (d *Document) validatePdfA(allPages []*Page) error {
 	// Folio satisfies this via the catalog /Lang entry, populated from
 	// Info.Language. Per-structure Lang is not yet exposed.
 	if isLevelA(d.pdfA.Level) && d.Info.Language == "" {
-		return fmt.Errorf("pdfa: Info.Language is required for Level A (accessibility-conformance) variants; set Info.Language to a BCP 47 / RFC 3066 tag (e.g. \"en-US\")")
+		return fmt.Errorf("document: pdfa: Info.Language is required for Level A (accessibility-conformance) variants; set Info.Language to a BCP 47 / RFC 3066 tag (e.g. \"en-US\")")
 	}
 
 	return nil

--- a/document/writer.go
+++ b/document/writer.go
@@ -73,7 +73,7 @@ func (w *Writer) SetFileID(id []byte) {
 func (w *Writer) GenerateFileID() error {
 	id := make([]byte, 16)
 	if _, err := rand.Read(id); err != nil {
-		return fmt.Errorf("writer: generate file ID: %w", err)
+		return fmt.Errorf("document: writer: generate file ID: %w", err)
 	}
 	w.fileID = id
 	return nil

--- a/document/writer_objstm.go
+++ b/document/writer_objstm.go
@@ -66,7 +66,7 @@ func (w *Writer) writeXRefStreamWithObjStms(cw *countingWriter, opts WriteOption
 	// the encryption walk; this is defense in depth in case a future
 	// caller bypasses WriteToWithOptions.
 	if w.encryptor != nil {
-		return fmt.Errorf("writer: object streams are not supported with encryption in phase 1")
+		return fmt.Errorf("document: writer: object streams are not supported with encryption in phase 1")
 	}
 
 	capacity := opts.ObjectStreamCapacity
@@ -102,7 +102,7 @@ func (w *Writer) writeXRefStreamWithObjStms(cw *countingWriter, opts WriteOption
 		}
 		stream, err := core.BuildObjStm(entries)
 		if err != nil {
-			return fmt.Errorf("build object stream: %w", err)
+			return fmt.Errorf("document: build object stream: %w", err)
 		}
 
 		thisObjStmNum := nextObjNum
@@ -193,7 +193,7 @@ func (w *Writer) writeXRefStreamWithObjStms(cw *countingWriter, opts WriteOption
 		}
 		off, ok := inlineOffsets[i]
 		if !ok {
-			return fmt.Errorf("writer: object %d is neither inline nor compressed", i)
+			return fmt.Errorf("document: writer: object %d is neither inline nor compressed", i)
 		}
 		entries[i] = core.XRefStreamEntry{
 			Type:   core.XRefEntryInUse,
@@ -215,7 +215,7 @@ func (w *Writer) writeXRefStreamWithObjStms(cw *countingWriter, opts WriteOption
 	subsections := []core.XRefStreamSubsection{{First: 0, Entries: entries}}
 	stream, err := core.BuildXRefStream(subsections, size, extras)
 	if err != nil {
-		return fmt.Errorf("build xref stream: %w", err)
+		return fmt.Errorf("document: build xref stream: %w", err)
 	}
 
 	if _, err := fmt.Fprintf(cw, "%d 0 obj\n", xrefStreamObjNum); err != nil {

--- a/document/writer_objstm.go
+++ b/document/writer_objstm.go
@@ -102,7 +102,7 @@ func (w *Writer) writeXRefStreamWithObjStms(cw *countingWriter, opts WriteOption
 		}
 		stream, err := core.BuildObjStm(entries)
 		if err != nil {
-			return fmt.Errorf("document: build object stream: %w", err)
+			return fmt.Errorf("document: writer: build object stream: %w", err)
 		}
 
 		thisObjStmNum := nextObjNum

--- a/document/writer_xref_stream.go
+++ b/document/writer_xref_stream.go
@@ -133,7 +133,7 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 		// §7.5.8.3: type-2 xref entries (compressed objects) require an
 		// xref stream to express. Refuse the contradictory combination
 		// instead of silently upgrading.
-		return 0, fmt.Errorf("writer: UseObjectStreams requires UseXRefStream")
+		return 0, fmt.Errorf("document: writer: UseObjectStreams requires UseXRefStream")
 	}
 	if opts.UseObjectStreams && w.encryptor != nil {
 		// Refuse before the encryption walk runs. EncryptObject mutates
@@ -142,7 +142,7 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 		// would double-encrypt. Phase 1 does not support per-objstm
 		// encryption (§7.6.1 requires the entire object stream to be
 		// encrypted as a unit, not the individual entries).
-		return 0, fmt.Errorf("writer: object streams are not supported with encryption in phase 1")
+		return 0, fmt.Errorf("document: writer: object streams are not supported with encryption in phase 1")
 	}
 	if opts.OrphanSweep && w.encryptor != nil {
 		// Same defense as the objstm refusal above: refuse before the
@@ -151,7 +151,7 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 		// object on its number (§7.6.3.3); a sweep that renumbers
 		// objects in an encrypted document would silently invalidate
 		// the keys for every renumbered entry.
-		return 0, fmt.Errorf("writer: orphan sweep is not supported on encrypted documents")
+		return 0, fmt.Errorf("document: writer: orphan sweep is not supported on encrypted documents")
 	}
 	if opts.RecompressStreams && w.encryptor != nil {
 		// Same defense as the sweep refusal above: rewriting payload
@@ -159,17 +159,17 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 		// (encrypted ciphertext decrypts only against the bytes that
 		// were encrypted). Refuse before any mutation so a retry
 		// without RecompressStreams is unaffected.
-		return 0, fmt.Errorf("writer: stream recompression is not supported on encrypted documents")
+		return 0, fmt.Errorf("document: writer: stream recompression is not supported on encrypted documents")
 	}
 	if opts.DeduplicateObjects && w.encryptor != nil {
 		// Same defense: dedup renumbers survivors, which would
 		// invalidate per-object encryption keys (§7.6.3.3).
-		return 0, fmt.Errorf("writer: object deduplication is not supported on encrypted documents")
+		return 0, fmt.Errorf("document: writer: object deduplication is not supported on encrypted documents")
 	}
 	if opts.CleanContentStreams && w.encryptor != nil {
 		// Same defense as RecompressStreams: rewriting payload bytes
 		// interacts badly with the encryption walk.
-		return 0, fmt.Errorf("writer: content stream cleanup is not supported on encrypted documents")
+		return 0, fmt.Errorf("document: writer: content stream cleanup is not supported on encrypted documents")
 	}
 	// Order: sweep → cleanup → dedup → recompress → encrypt → serialize.
 	// - Sweep first so later passes do not waste effort on orphans.
@@ -198,7 +198,7 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 	if w.encryptor != nil {
 		for _, obj := range w.objects {
 			if err := w.encryptor.EncryptObject(obj.Object, obj.ObjectNumber, obj.GenerationNumber); err != nil {
-				return 0, fmt.Errorf("encrypt object %d: %w", obj.ObjectNumber, err)
+				return 0, fmt.Errorf("document: encrypt object %d: %w", obj.ObjectNumber, err)
 			}
 		}
 	}
@@ -318,7 +318,7 @@ func (w *Writer) writeXRefStreamTrailer(cw *countingWriter, offsets []int64) err
 	subsections := []core.XRefStreamSubsection{{First: 0, Entries: entries}}
 	stream, err := core.BuildXRefStream(subsections, size, extras)
 	if err != nil {
-		return fmt.Errorf("build xref stream: %w", err)
+		return fmt.Errorf("document: build xref stream: %w", err)
 	}
 
 	if _, err := fmt.Fprintf(cw, "%d 0 obj\n", xrefStreamObjNum); err != nil {

--- a/font/cff_parse.go
+++ b/font/cff_parse.go
@@ -106,7 +106,7 @@ func (idx *cffIndex) Object(i int) []byte {
 // represented as an empty INDEX in CID-keyed fonts.
 func parseCFFIndex(raw []byte, pos int) (*cffIndex, error) {
 	if pos < 0 || pos+2 > len(raw) {
-		return nil, fmt.Errorf("cff: INDEX header truncated at offset %d: %w", pos, ErrTruncated)
+		return nil, fmt.Errorf("font: cff: INDEX header truncated at offset %d: %w", pos, ErrTruncated)
 	}
 	count := int(binary.BigEndian.Uint16(raw[pos : pos+2]))
 	if count == 0 {
@@ -117,34 +117,34 @@ func parseCFFIndex(raw []byte, pos int) (*cffIndex, error) {
 		}, nil
 	}
 	if pos+3 > len(raw) {
-		return nil, fmt.Errorf("cff: INDEX offSize truncated at offset %d: %w", pos, ErrTruncated)
+		return nil, fmt.Errorf("font: cff: INDEX offSize truncated at offset %d: %w", pos, ErrTruncated)
 	}
 	offSize := int(raw[pos+2])
 	if offSize < 1 || offSize > 4 {
-		return nil, fmt.Errorf("cff: INDEX offSize %d out of range: %w", offSize, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: INDEX offSize %d out of range: %w", offSize, ErrCorruptTable)
 	}
 	offBase := pos + 3
 	offBytes := (count + 1) * offSize
 	if offBase+offBytes > len(raw) {
-		return nil, fmt.Errorf("cff: INDEX offset table truncated: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: cff: INDEX offset table truncated: %w", ErrTruncated)
 	}
 	offsets := make([]int, count+1)
 	for i := range count + 1 {
 		offsets[i] = readOffset(raw[offBase+i*offSize:], offSize)
 	}
 	if offsets[0] != 1 {
-		return nil, fmt.Errorf("cff: INDEX first offset %d != 1: %w", offsets[0], ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: INDEX first offset %d != 1: %w", offsets[0], ErrCorruptTable)
 	}
 	for i := range count {
 		if offsets[i+1] < offsets[i] {
-			return nil, fmt.Errorf("cff: INDEX offsets non-monotonic at %d: %w", i, ErrCorruptTable)
+			return nil, fmt.Errorf("font: cff: INDEX offsets non-monotonic at %d: %w", i, ErrCorruptTable)
 		}
 	}
 	objectsBase := offBase + offBytes
 	payloadSize := offsets[count] - 1
 	end := objectsBase + payloadSize
 	if end > len(raw) || end < objectsBase {
-		return nil, fmt.Errorf("cff: INDEX payload truncated: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: cff: INDEX payload truncated: %w", ErrTruncated)
 	}
 	return &cffIndex{
 		rawStart:    pos,
@@ -277,7 +277,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			var op, opSize int
 			if bv == cffOpEscape {
 				if pos+1 >= len(b) {
-					return nil, fmt.Errorf("cff: DICT 2-byte operator truncated: %w", ErrTruncated)
+					return nil, fmt.Errorf("font: cff: DICT 2-byte operator truncated: %w", ErrTruncated)
 				}
 				op = cffOpEscape<<8 | int(b[pos+1])
 				opSize = 2
@@ -300,7 +300,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			operandStart = pos
 		case bv == 28:
 			if pos+3 > len(b) {
-				return nil, fmt.Errorf("cff: DICT shortint truncated: %w", ErrTruncated)
+				return nil, fmt.Errorf("font: cff: DICT shortint truncated: %w", ErrTruncated)
 			}
 			v := int64(int16(binary.BigEndian.Uint16(b[pos+1 : pos+3])))
 			operands = append(operands, v)
@@ -308,7 +308,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			spans = append(spans, [2]int{opStart, pos})
 		case bv == 29:
 			if pos+5 > len(b) {
-				return nil, fmt.Errorf("cff: DICT longint truncated: %w", ErrTruncated)
+				return nil, fmt.Errorf("font: cff: DICT longint truncated: %w", ErrTruncated)
 			}
 			v := int64(int32(binary.BigEndian.Uint32(b[pos+1 : pos+5])))
 			operands = append(operands, v)
@@ -327,7 +327,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 				}
 			}
 			if !ended {
-				return nil, fmt.Errorf("cff: DICT BCD real unterminated: %w", ErrTruncated)
+				return nil, fmt.Errorf("font: cff: DICT BCD real unterminated: %w", ErrTruncated)
 			}
 			// Reserve a zero-valued slot in intOperands; the original
 			// bytes live in operandSpans for Phase 3 to copy verbatim.
@@ -340,7 +340,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			spans = append(spans, [2]int{opStart, pos})
 		case bv >= 247 && bv <= 250:
 			if pos+1 >= len(b) {
-				return nil, fmt.Errorf("cff: DICT 2-byte int truncated: %w", ErrTruncated)
+				return nil, fmt.Errorf("font: cff: DICT 2-byte int truncated: %w", ErrTruncated)
 			}
 			v := int64(bv-247)*256 + int64(b[pos+1]) + 108
 			operands = append(operands, v)
@@ -348,7 +348,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			spans = append(spans, [2]int{opStart, pos})
 		case bv >= 251 && bv <= 254:
 			if pos+1 >= len(b) {
-				return nil, fmt.Errorf("cff: DICT 2-byte int truncated: %w", ErrTruncated)
+				return nil, fmt.Errorf("font: cff: DICT 2-byte int truncated: %w", ErrTruncated)
 			}
 			v := -int64(bv-251)*256 - int64(b[pos+1]) - 108
 			operands = append(operands, v)
@@ -356,7 +356,7 @@ func parseCFFDict(b []byte) (cffDict, error) {
 			spans = append(spans, [2]int{opStart, pos})
 		default:
 			// 22..27, 31, 255 are reserved/invalid in DICT streams.
-			return nil, fmt.Errorf("cff: DICT reserved byte 0x%02X at offset %d: %w", bv, pos, ErrCorruptTable)
+			return nil, fmt.Errorf("font: cff: DICT reserved byte 0x%02X at offset %d: %w", bv, pos, ErrCorruptTable)
 		}
 	}
 	// Operands not followed by an operator are spec-illegal but we
@@ -387,35 +387,35 @@ func dictInt(d cffDict, op int) (int64, bool) {
 // returns an error wrapping one of the package sentinels.
 func parseCFF(raw []byte) (*cffFont, error) {
 	if len(raw) < 4 {
-		return nil, fmt.Errorf("cff: header truncated: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: cff: header truncated: %w", ErrTruncated)
 	}
 	if raw[0] != 1 {
-		return nil, fmt.Errorf("cff: unsupported major %d: %w", raw[0], ErrUnknownFormat)
+		return nil, fmt.Errorf("font: cff: unsupported major %d: %w", raw[0], ErrUnknownFormat)
 	}
 	hdrSize := int(raw[2])
 	if hdrSize < 4 || hdrSize > len(raw) {
-		return nil, fmt.Errorf("cff: bad hdrSize %d: %w", hdrSize, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: bad hdrSize %d: %w", hdrSize, ErrCorruptTable)
 	}
 
 	pos := hdrSize
 	nameIdx, err := parseCFFIndex(raw, pos)
 	if err != nil {
-		return nil, fmt.Errorf("cff: name index: %w", err)
+		return nil, fmt.Errorf("font: cff: name index: %w", err)
 	}
 	pos = nameIdx.rawEnd
 
 	topDictIdx, err := parseCFFIndex(raw, pos)
 	if err != nil {
-		return nil, fmt.Errorf("cff: top dict index: %w", err)
+		return nil, fmt.Errorf("font: cff: top dict index: %w", err)
 	}
 	if topDictIdx.count != 1 {
-		return nil, fmt.Errorf("cff: top dict count %d != 1 (font collection unsupported): %w", topDictIdx.count, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: top dict count %d != 1 (font collection unsupported): %w", topDictIdx.count, ErrCorruptTable)
 	}
 	pos = topDictIdx.rawEnd
 
 	topDict, err := parseCFFDict(topDictIdx.Object(0))
 	if err != nil {
-		return nil, fmt.Errorf("cff: top dict: %w", err)
+		return nil, fmt.Errorf("font: cff: top dict: %w", err)
 	}
 
 	// Require ROS so callers can rely on CID-keyed semantics. Charset
@@ -423,31 +423,31 @@ func parseCFF(raw []byte) (*cffFont, error) {
 	// keyed CFFs (TN #5176 §18); enforce them explicitly.
 	rosEntry, ok := topDict.get(cffOp2ROS)
 	if !ok || len(rosEntry.intOperands) < 3 {
-		return nil, fmt.Errorf("cff: missing or malformed ROS operator: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: missing or malformed ROS operator: %w", ErrCorruptTable)
 	}
 
 	stringIdx, err := parseCFFIndex(raw, pos)
 	if err != nil {
-		return nil, fmt.Errorf("cff: string index: %w", err)
+		return nil, fmt.Errorf("font: cff: string index: %w", err)
 	}
 	pos = stringIdx.rawEnd
 
 	gsubrIdx, err := parseCFFIndex(raw, pos)
 	if err != nil {
-		return nil, fmt.Errorf("cff: gsubr index: %w", err)
+		return nil, fmt.Errorf("font: cff: gsubr index: %w", err)
 	}
 
 	charStringsOff, ok := dictInt(topDict, cffOpCharStrings)
 	if !ok {
-		return nil, fmt.Errorf("cff: missing CharStrings operator: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: missing CharStrings operator: %w", ErrCorruptTable)
 	}
 	fdArrayOff, ok := dictInt(topDict, cffOp2FDArray)
 	if !ok {
-		return nil, fmt.Errorf("cff: missing FDArray operator: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: missing FDArray operator: %w", ErrCorruptTable)
 	}
 	fdSelectOff, ok := dictInt(topDict, cffOp2FDSelect)
 	if !ok {
-		return nil, fmt.Errorf("cff: missing FDSelect operator: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: missing FDSelect operator: %w", ErrCorruptTable)
 	}
 	// CID-keyed CFFs must declare a custom charset explicitly
 	// (TN #5176 §18). The implicit-default values 0 (ISOAdobe), 1
@@ -457,10 +457,10 @@ func parseCFF(raw []byte) (*cffFont, error) {
 	// charset format byte, yielding nonsense. Reject early.
 	charsetOff, ok := dictInt(topDict, cffOpCharset)
 	if !ok {
-		return nil, fmt.Errorf("cff: CID-keyed font missing charset operator: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: CID-keyed font missing charset operator: %w", ErrCorruptTable)
 	}
 	if charsetOff < 3 {
-		return nil, fmt.Errorf("cff: CID-keyed font using predefined charset %d (reserved for non-CID CFF): %w", charsetOff, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: CID-keyed font using predefined charset %d (reserved for non-CID CFF): %w", charsetOff, ErrCorruptTable)
 	}
 	cidCountVal, _ := dictInt(topDict, cffOp2CIDCount)
 	cidCount := int(cidCountVal)
@@ -471,35 +471,35 @@ func parseCFF(raw []byte) (*cffFont, error) {
 
 	charStringsIdx, err := parseCFFIndex(raw, int(charStringsOff))
 	if err != nil {
-		return nil, fmt.Errorf("cff: charstrings index: %w", err)
+		return nil, fmt.Errorf("font: cff: charstrings index: %w", err)
 	}
 	numGlyphs := charStringsIdx.count
 	if numGlyphs == 0 {
-		return nil, fmt.Errorf("cff: charstrings index empty: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: charstrings index empty: %w", ErrCorruptTable)
 	}
 
 	fdArrayIdx, err := parseCFFIndex(raw, int(fdArrayOff))
 	if err != nil {
-		return nil, fmt.Errorf("cff: fdarray index: %w", err)
+		return nil, fmt.Errorf("font: cff: fdarray index: %w", err)
 	}
 	if fdArrayIdx.count == 0 {
-		return nil, fmt.Errorf("cff: empty FDArray INDEX: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: empty FDArray INDEX: %w", ErrCorruptTable)
 	}
 
 	charsetSize, err := computeCharsetSize(raw, int(charsetOff), numGlyphs)
 	if err != nil {
-		return nil, fmt.Errorf("cff: charset: %w", err)
+		return nil, fmt.Errorf("font: cff: charset: %w", err)
 	}
 	fdSelectSize, err := computeFDSelectSize(raw, int(fdSelectOff), numGlyphs)
 	if err != nil {
-		return nil, fmt.Errorf("cff: fdselect: %w", err)
+		return nil, fmt.Errorf("font: cff: fdselect: %w", err)
 	}
 
 	fds := make([]*cffFD, fdArrayIdx.count)
 	for i := range fdArrayIdx.count {
 		fd, err := parseCFFFD(raw, fdArrayIdx, i)
 		if err != nil {
-			return nil, fmt.Errorf("cff: fd[%d]: %w", i, err)
+			return nil, fmt.Errorf("font: cff: fd[%d]: %w", i, err)
 		}
 		fds[i] = fd
 	}
@@ -534,35 +534,35 @@ func parseCFF(raw []byte) (*cffFont, error) {
 func parseCFFFD(raw []byte, fdArrayIdx *cffIndex, i int) (*cffFD, error) {
 	fontDictBytes := fdArrayIdx.Object(i)
 	if fontDictBytes == nil {
-		return nil, fmt.Errorf("cff: fd %d missing: %w", i, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: fd %d missing: %w", i, ErrCorruptTable)
 	}
 	fontDict, err := parseCFFDict(fontDictBytes)
 	if err != nil {
-		return nil, fmt.Errorf("cff: fd %d font dict: %w", i, err)
+		return nil, fmt.Errorf("font: cff: fd %d font dict: %w", i, err)
 	}
 	privEntry, ok := fontDict.get(cffOpPrivate)
 	if !ok || len(privEntry.intOperands) != 2 {
-		return nil, fmt.Errorf("cff: fd %d Private operator missing or malformed: %w", i, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: fd %d Private operator missing or malformed: %w", i, ErrCorruptTable)
 	}
 	privSize := int(privEntry.intOperands[0])
 	privOff := int(privEntry.intOperands[1])
 	if privSize < 0 || privOff < 0 || privOff+privSize > len(raw) {
-		return nil, fmt.Errorf("cff: fd %d Private range [%d:%d] out of raw bounds: %w", i, privOff, privOff+privSize, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cff: fd %d Private range [%d:%d] out of raw bounds: %w", i, privOff, privOff+privSize, ErrCorruptTable)
 	}
 	privBytes := raw[privOff : privOff+privSize]
 	privDict, err := parseCFFDict(privBytes)
 	if err != nil {
-		return nil, fmt.Errorf("cff: fd %d private dict: %w", i, err)
+		return nil, fmt.Errorf("font: cff: fd %d private dict: %w", i, err)
 	}
 	var localSubrs *cffIndex
 	if subrsEntry, ok := privDict.get(cffOpSubrs); ok {
 		if len(subrsEntry.intOperands) != 1 {
-			return nil, fmt.Errorf("cff: fd %d Subrs operand count %d: %w", i, len(subrsEntry.intOperands), ErrCorruptTable)
+			return nil, fmt.Errorf("font: cff: fd %d Subrs operand count %d: %w", i, len(subrsEntry.intOperands), ErrCorruptTable)
 		}
 		subrsRel := int(subrsEntry.intOperands[0])
 		localSubrs, err = parseCFFIndex(raw, privOff+subrsRel)
 		if err != nil {
-			return nil, fmt.Errorf("cff: fd %d local subr index: %w", i, err)
+			return nil, fmt.Errorf("font: cff: fd %d local subr index: %w", i, err)
 		}
 	}
 	return &cffFD{
@@ -587,10 +587,10 @@ func parseCFFFD(raw []byte, fdArrayIdx *cffIndex, i int) (*cffFD, error) {
 // reaches numGlyphs-1 (charset omits GID 0 — .notdef is implicit).
 func computeCharsetSize(raw []byte, off, numGlyphs int) (int, error) {
 	if off < 0 || off >= len(raw) {
-		return 0, fmt.Errorf("cff: charset offset out of range: %w", ErrCorruptTable)
+		return 0, fmt.Errorf("font: cff: charset offset out of range: %w", ErrCorruptTable)
 	}
 	if numGlyphs < 1 {
-		return 0, fmt.Errorf("cff: numGlyphs %d invalid: %w", numGlyphs, ErrCorruptTable)
+		return 0, fmt.Errorf("font: cff: numGlyphs %d invalid: %w", numGlyphs, ErrCorruptTable)
 	}
 	format := raw[off]
 	remaining := numGlyphs - 1 // glyphs to cover, excluding GID 0
@@ -598,39 +598,39 @@ func computeCharsetSize(raw []byte, off, numGlyphs int) (int, error) {
 	case 0:
 		size := 1 + remaining*2
 		if off+size > len(raw) {
-			return 0, fmt.Errorf("cff: charset format 0 truncated: %w", ErrTruncated)
+			return 0, fmt.Errorf("font: cff: charset format 0 truncated: %w", ErrTruncated)
 		}
 		return size, nil
 	case 1:
 		pos := off + 1
 		for remaining > 0 {
 			if pos+3 > len(raw) {
-				return 0, fmt.Errorf("cff: charset format 1 truncated: %w", ErrTruncated)
+				return 0, fmt.Errorf("font: cff: charset format 1 truncated: %w", ErrTruncated)
 			}
 			nLeft := int(raw[pos+2])
 			remaining -= nLeft + 1
 			pos += 3
 		}
 		if remaining < 0 {
-			return 0, fmt.Errorf("cff: charset format 1 over-covers glyphs by %d: %w", -remaining, ErrCorruptTable)
+			return 0, fmt.Errorf("font: cff: charset format 1 over-covers glyphs by %d: %w", -remaining, ErrCorruptTable)
 		}
 		return pos - off, nil
 	case 2:
 		pos := off + 1
 		for remaining > 0 {
 			if pos+4 > len(raw) {
-				return 0, fmt.Errorf("cff: charset format 2 truncated: %w", ErrTruncated)
+				return 0, fmt.Errorf("font: cff: charset format 2 truncated: %w", ErrTruncated)
 			}
 			nLeft := int(binary.BigEndian.Uint16(raw[pos+2 : pos+4]))
 			remaining -= nLeft + 1
 			pos += 4
 		}
 		if remaining < 0 {
-			return 0, fmt.Errorf("cff: charset format 2 over-covers glyphs by %d: %w", -remaining, ErrCorruptTable)
+			return 0, fmt.Errorf("font: cff: charset format 2 over-covers glyphs by %d: %w", -remaining, ErrCorruptTable)
 		}
 		return pos - off, nil
 	default:
-		return 0, fmt.Errorf("cff: charset format %d unknown: %w", format, ErrCorruptTable)
+		return 0, fmt.Errorf("font: cff: charset format %d unknown: %w", format, ErrCorruptTable)
 	}
 }
 
@@ -641,24 +641,24 @@ func computeCharsetSize(raw []byte, off, numGlyphs int) (int, error) {
 //   - 3: fmt(1) + nRanges(uint16) + nRanges*(first uint16 + fd uint8) + sentinel uint16
 func computeFDSelectSize(raw []byte, off, numGlyphs int) (int, error) {
 	if off < 0 || off >= len(raw) {
-		return 0, fmt.Errorf("cff: fdselect offset out of range: %w", ErrCorruptTable)
+		return 0, fmt.Errorf("font: cff: fdselect offset out of range: %w", ErrCorruptTable)
 	}
 	format := raw[off]
 	switch format {
 	case 0:
 		size := 1 + numGlyphs
 		if off+size > len(raw) {
-			return 0, fmt.Errorf("cff: fdselect format 0 truncated: %w", ErrTruncated)
+			return 0, fmt.Errorf("font: cff: fdselect format 0 truncated: %w", ErrTruncated)
 		}
 		return size, nil
 	case 3:
 		if off+3 > len(raw) {
-			return 0, fmt.Errorf("cff: fdselect format 3 header truncated: %w", ErrTruncated)
+			return 0, fmt.Errorf("font: cff: fdselect format 3 header truncated: %w", ErrTruncated)
 		}
 		nRanges := int(binary.BigEndian.Uint16(raw[off+1 : off+3]))
 		size := 1 + 2 + nRanges*3 + 2
 		if off+size > len(raw) {
-			return 0, fmt.Errorf("cff: fdselect format 3 body truncated: %w", ErrTruncated)
+			return 0, fmt.Errorf("font: cff: fdselect format 3 body truncated: %w", ErrTruncated)
 		}
 		// Per TN #5176 §19, the trailing sentinel uint16 must equal
 		// numGlyphs — it terminates the implied range that begins at
@@ -668,10 +668,10 @@ func computeFDSelectSize(raw []byte, off, numGlyphs int) (int, error) {
 		// assignment, so reject up-front.
 		sentinel := int(binary.BigEndian.Uint16(raw[off+size-2 : off+size]))
 		if sentinel != numGlyphs {
-			return 0, fmt.Errorf("cff: fdselect format 3 sentinel %d != numGlyphs %d: %w", sentinel, numGlyphs, ErrCorruptTable)
+			return 0, fmt.Errorf("font: cff: fdselect format 3 sentinel %d != numGlyphs %d: %w", sentinel, numGlyphs, ErrCorruptTable)
 		}
 		return size, nil
 	default:
-		return 0, fmt.Errorf("cff: fdselect format %d unknown: %w", format, ErrCorruptTable)
+		return 0, fmt.Errorf("font: cff: fdselect format %d unknown: %w", format, ErrCorruptTable)
 	}
 }

--- a/font/cff_subset.go
+++ b/font/cff_subset.go
@@ -31,7 +31,7 @@ import (
 func SubsetCFF(cffBytes []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 	src, err := parseCFF(cffBytes)
 	if err != nil {
-		return nil, fmt.Errorf("subset cff: %w", err)
+		return nil, fmt.Errorf("font: subset cff: %w", err)
 	}
 
 	keepGlyph := make([]bool, src.numGlyphs)
@@ -54,7 +54,7 @@ func SubsetCFF(cffBytes []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 		}
 		fd, err := src.fdForGlyph(gid)
 		if err != nil {
-			return nil, fmt.Errorf("subset cff: gid %d: %w", gid, err)
+			return nil, fmt.Errorf("font: subset cff: gid %d: %w", gid, err)
 		}
 		walker.Trace(src.charStringsIndex.Object(gid), fd)
 	}
@@ -227,7 +227,7 @@ func SubsetCFF(cffBytes []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 		out = append(out, b.localSubrsData...)
 	}
 	if len(out) != finalSize {
-		return nil, fmt.Errorf("subset cff: assembled %d bytes, expected %d: %w", len(out), finalSize, ErrCorruptTable)
+		return nil, fmt.Errorf("font: subset cff: assembled %d bytes, expected %d: %w", len(out), finalSize, ErrCorruptTable)
 	}
 	return out, nil
 }
@@ -238,7 +238,7 @@ func SubsetCFF(cffBytes []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 // format is unknown.
 func (cff *cffFont) fdForGlyph(gid int) (int, error) {
 	if gid < 0 || gid >= cff.numGlyphs {
-		return 0, fmt.Errorf("cff: gid %d out of range [0,%d): %w", gid, cff.numGlyphs, ErrCorruptTable)
+		return 0, fmt.Errorf("font: cff: gid %d out of range [0,%d): %w", gid, cff.numGlyphs, ErrCorruptTable)
 	}
 	off := cff.fdSelectOffset
 	switch cff.raw[off] {
@@ -262,9 +262,9 @@ func (cff *cffFont) fdForGlyph(gid int) (int, error) {
 				return fd, nil
 			}
 		}
-		return 0, fmt.Errorf("cff: gid %d not covered by fdselect format 3: %w", gid, ErrCorruptTable)
+		return 0, fmt.Errorf("font: cff: gid %d not covered by fdselect format 3: %w", gid, ErrCorruptTable)
 	}
-	return 0, fmt.Errorf("cff: fdselect format %d unsupported: %w", cff.raw[off], ErrCorruptTable)
+	return 0, fmt.Errorf("font: cff: fdselect format %d unsupported: %w", cff.raw[off], ErrCorruptTable)
 }
 
 // writeCFFIndex serializes a list of object payloads as a CFF INDEX

--- a/font/cmap.go
+++ b/font/cmap.go
@@ -44,12 +44,12 @@ type cmapTable map[rune]uint16
 func parseCmapTable(data []byte) (cmapTable, error) {
 	dataLen := uint64(len(data))
 	if dataLen < 4 {
-		return nil, fmt.Errorf("cmap: header truncated (%d < 4): %w", dataLen, ErrTruncated)
+		return nil, fmt.Errorf("font: cmap: header truncated (%d < 4): %w", dataLen, ErrTruncated)
 	}
 	numTables := uint64(binary.BigEndian.Uint16(data[2:4]))
 	recordsEnd := 4 + numTables*8
 	if recordsEnd > dataLen {
-		return nil, fmt.Errorf("cmap: encoding records truncated (need %d, have %d): %w", recordsEnd, dataLen, ErrTruncated)
+		return nil, fmt.Errorf("font: cmap: encoding records truncated (need %d, have %d): %w", recordsEnd, dataLen, ErrTruncated)
 	}
 
 	type pick struct {
@@ -80,7 +80,7 @@ func parseCmapTable(data []byte) (cmapTable, error) {
 		}
 	}
 	if best.score == 0 {
-		return nil, fmt.Errorf("cmap: no supported Unicode subtable: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: cmap: no supported Unicode subtable: %w", ErrCorruptTable)
 	}
 	var (
 		out cmapTable
@@ -92,7 +92,7 @@ func parseCmapTable(data []byte) (cmapTable, error) {
 	case 12:
 		out, err = parseCmapFormat12(data, best.offset)
 	default:
-		return nil, fmt.Errorf("cmap: subtable format %d not implemented: %w", best.format, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cmap: subtable format %d not implemented: %w", best.format, ErrCorruptTable)
 	}
 	if err != nil {
 		return nil, err
@@ -197,15 +197,15 @@ func scoreSubtable(platformID, encodingID, format uint16) int {
 func parseCmapFormat4(data []byte, subOff uint64) (cmapTable, error) {
 	dataLen := uint64(len(data))
 	if subOff+14 > dataLen {
-		return nil, fmt.Errorf("cmap fmt4: header truncated: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: cmap fmt4: header truncated: %w", ErrTruncated)
 	}
 	length := uint64(binary.BigEndian.Uint16(data[subOff+2 : subOff+4]))
 	if subOff+length > dataLen {
-		return nil, fmt.Errorf("cmap fmt4: declared length %d exceeds table: %w", length, ErrTruncated)
+		return nil, fmt.Errorf("font: cmap fmt4: declared length %d exceeds table: %w", length, ErrTruncated)
 	}
 	segCountX2 := uint64(binary.BigEndian.Uint16(data[subOff+6 : subOff+8]))
 	if segCountX2%2 != 0 || segCountX2 == 0 {
-		return nil, fmt.Errorf("cmap fmt4: invalid segCountX2 %d: %w", segCountX2, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cmap fmt4: invalid segCountX2 %d: %w", segCountX2, ErrCorruptTable)
 	}
 	segCount := segCountX2 / 2
 
@@ -216,7 +216,7 @@ func parseCmapFormat4(data []byte, subOff uint64) (cmapTable, error) {
 	glyphArrOff := rangeOff + segCountX2
 
 	if glyphArrOff > subOff+length {
-		return nil, fmt.Errorf("cmap fmt4: arrays exceed declared length: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: cmap fmt4: arrays exceed declared length: %w", ErrTruncated)
 	}
 
 	out := make(cmapTable)
@@ -295,19 +295,19 @@ func parseCmapFormat4(data []byte, subOff uint64) (cmapTable, error) {
 func parseCmapFormat12(data []byte, subOff uint64) (cmapTable, error) {
 	dataLen := uint64(len(data))
 	if subOff+16 > dataLen {
-		return nil, fmt.Errorf("cmap fmt12: header truncated: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: cmap fmt12: header truncated: %w", ErrTruncated)
 	}
 	length := uint64(binary.BigEndian.Uint32(data[subOff+4 : subOff+8]))
 	if length < 16 {
-		return nil, fmt.Errorf("cmap fmt12: declared length %d < header size: %w", length, ErrCorruptTable)
+		return nil, fmt.Errorf("font: cmap fmt12: declared length %d < header size: %w", length, ErrCorruptTable)
 	}
 	if subOff+length > dataLen {
-		return nil, fmt.Errorf("cmap fmt12: declared length %d exceeds table: %w", length, ErrTruncated)
+		return nil, fmt.Errorf("font: cmap fmt12: declared length %d exceeds table: %w", length, ErrTruncated)
 	}
 	numGroups := uint64(binary.BigEndian.Uint32(data[subOff+12 : subOff+16]))
 	groupsEnd := subOff + 16 + numGroups*12
 	if groupsEnd > subOff+length {
-		return nil, fmt.Errorf("cmap fmt12: groups (%d) exceed declared length: %w", numGroups, ErrTruncated)
+		return nil, fmt.Errorf("font: cmap fmt12: groups (%d) exceed declared length: %w", numGroups, ErrTruncated)
 	}
 
 	out := make(cmapTable)

--- a/font/head.go
+++ b/font/head.go
@@ -45,14 +45,14 @@ type head struct {
 // The minimum length is 54 bytes.
 func parseHead(data []byte) (head, error) {
 	if uint64(len(data)) < 54 {
-		return head{}, fmt.Errorf("head: table truncated (%d < 54 bytes): %w", len(data), ErrTruncated)
+		return head{}, fmt.Errorf("font: head: table truncated (%d < 54 bytes): %w", len(data), ErrTruncated)
 	}
 	if magic := binary.BigEndian.Uint32(data[12:16]); magic != 0x5F0F3CF5 {
-		return head{}, fmt.Errorf("head: magicNumber 0x%08X != 0x5F0F3CF5: %w", magic, ErrCorruptTable)
+		return head{}, fmt.Errorf("font: head: magicNumber 0x%08X != 0x5F0F3CF5: %w", magic, ErrCorruptTable)
 	}
 	upem := binary.BigEndian.Uint16(data[18:20])
 	if upem == 0 {
-		return head{}, fmt.Errorf("head: unitsPerEm is zero: %w", ErrCorruptTable)
+		return head{}, fmt.Errorf("font: head: unitsPerEm is zero: %w", ErrCorruptTable)
 	}
 	return head{
 		unitsPerEm:       upem,

--- a/font/hhea.go
+++ b/font/hhea.go
@@ -41,7 +41,7 @@ type hhea struct {
 // Minimum length is 36 bytes.
 func parseHhea(data []byte) (hhea, error) {
 	if uint64(len(data)) < 36 {
-		return hhea{}, fmt.Errorf("hhea: table truncated (%d < 36 bytes): %w", len(data), ErrTruncated)
+		return hhea{}, fmt.Errorf("font: hhea: table truncated (%d < 36 bytes): %w", len(data), ErrTruncated)
 	}
 	return hhea{
 		ascender:         int16(binary.BigEndian.Uint16(data[4:6])),

--- a/font/hmtx.go
+++ b/font/hmtx.go
@@ -25,15 +25,15 @@ import (
 // numberOfHMetrics is required to be at least 1 by the spec.
 func parseHmtx(data []byte, numberOfHMetrics, numGlyphs int) ([]uint16, []int16, error) {
 	if numberOfHMetrics <= 0 {
-		return nil, nil, fmt.Errorf("hmtx: numberOfHMetrics must be >= 1, got %d: %w", numberOfHMetrics, ErrCorruptTable)
+		return nil, nil, fmt.Errorf("font: hmtx: numberOfHMetrics must be >= 1, got %d: %w", numberOfHMetrics, ErrCorruptTable)
 	}
 	if numGlyphs < numberOfHMetrics {
-		return nil, nil, fmt.Errorf("hmtx: numGlyphs %d < numberOfHMetrics %d: %w", numGlyphs, numberOfHMetrics, ErrCorruptTable)
+		return nil, nil, fmt.Errorf("font: hmtx: numGlyphs %d < numberOfHMetrics %d: %w", numGlyphs, numberOfHMetrics, ErrCorruptTable)
 	}
 	tail := numGlyphs - numberOfHMetrics
 	need := uint64(numberOfHMetrics)*4 + uint64(tail)*2
 	if uint64(len(data)) < need {
-		return nil, nil, fmt.Errorf("hmtx: table truncated (have %d, need %d): %w", len(data), need, ErrTruncated)
+		return nil, nil, fmt.Errorf("font: hmtx: table truncated (have %d, need %d): %w", len(data), need, ErrTruncated)
 	}
 
 	advances := make([]uint16, numGlyphs)

--- a/font/load.go
+++ b/font/load.go
@@ -60,21 +60,21 @@ func ParseFont(data []byte) (Face, error) {
 // can match failure modes with errors.Is.
 func ParseFontForLanguage(data []byte, lang string) (Face, error) {
 	if len(data) < 4 {
-		return nil, fmt.Errorf("font data too short to determine format: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: data too short to determine format: %w", ErrTruncated)
 	}
 	sig := binary.BigEndian.Uint32(data[0:4])
 	switch sig {
 	case woffMagic:
 		ttfData, err := decodeWOFF(data)
 		if err != nil {
-			return nil, fmt.Errorf("decode WOFF: %w", err)
+			return nil, fmt.Errorf("font: decode WOFF: %w", err)
 		}
 		return ParseTTF(ttfData)
 	case ttcMagic:
 		idx := max(pickFaceForLanguage(data, lang), 0)
 		ttfData, err := extractTTCFont(data, idx)
 		if err != nil {
-			return nil, fmt.Errorf("decode TTC: %w", err)
+			return nil, fmt.Errorf("font: decode TTC: %w", err)
 		}
 		return ParseTTF(ttfData)
 	// When adding a magic to this switch, also extend
@@ -85,7 +85,7 @@ func ParseFontForLanguage(data []byte, lang string) (Face, error) {
 		0x74727565: // "true" (legacy Apple TrueType)
 		return ParseTTF(data)
 	}
-	return nil, fmt.Errorf("unknown font magic 0x%08X: %w", sig, ErrUnknownFormat)
+	return nil, fmt.Errorf("font: unknown font magic 0x%08X: %w", sig, ErrUnknownFormat)
 }
 
 // LoadFont reads and parses a font file from disk, auto-detecting the format.
@@ -111,7 +111,7 @@ func LoadFont(path string) (Face, error) {
 func LoadFontForLanguage(path, lang string) (Face, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read font file: %w", err)
+		return nil, fmt.Errorf("font: read font file: %w", err)
 	}
 	return ParseFontForLanguage(data, lang)
 }

--- a/font/maxp.go
+++ b/font/maxp.go
@@ -27,11 +27,11 @@ type maxp struct {
 // Minimum length is 6 bytes.
 func parseMaxp(data []byte) (maxp, error) {
 	if uint64(len(data)) < 6 {
-		return maxp{}, fmt.Errorf("maxp: table truncated (%d < 6 bytes): %w", len(data), ErrTruncated)
+		return maxp{}, fmt.Errorf("font: maxp: table truncated (%d < 6 bytes): %w", len(data), ErrTruncated)
 	}
 	n := binary.BigEndian.Uint16(data[4:6])
 	if n == 0 {
-		return maxp{}, fmt.Errorf("maxp: numGlyphs is zero: %w", ErrCorruptTable)
+		return maxp{}, fmt.Errorf("font: maxp: numGlyphs is zero: %w", ErrCorruptTable)
 	}
 	return maxp{numGlyphs: n}, nil
 }

--- a/font/name.go
+++ b/font/name.go
@@ -55,16 +55,16 @@ type nameRecords struct {
 func parseName(data []byte) (nameRecords, error) {
 	dataLen := uint64(len(data))
 	if dataLen < 6 {
-		return nameRecords{}, fmt.Errorf("name: header truncated (%d < 6): %w", dataLen, ErrTruncated)
+		return nameRecords{}, fmt.Errorf("font: name: header truncated (%d < 6): %w", dataLen, ErrTruncated)
 	}
 	count := uint64(binary.BigEndian.Uint16(data[2:4]))
 	stringOff := uint64(binary.BigEndian.Uint16(data[4:6]))
 	recordsEnd := 6 + count*12
 	if recordsEnd > dataLen {
-		return nameRecords{}, fmt.Errorf("name: record array truncated (need %d, have %d): %w", recordsEnd, dataLen, ErrTruncated)
+		return nameRecords{}, fmt.Errorf("font: name: record array truncated (need %d, have %d): %w", recordsEnd, dataLen, ErrTruncated)
 	}
 	if stringOff > dataLen {
-		return nameRecords{}, fmt.Errorf("name: stringOffset %d beyond table length %d: %w", stringOff, dataLen, ErrCorruptTable)
+		return nameRecords{}, fmt.Errorf("font: name: stringOffset %d beyond table length %d: %w", stringOff, dataLen, ErrCorruptTable)
 	}
 
 	type candidate struct {

--- a/font/os2.go
+++ b/font/os2.go
@@ -71,7 +71,7 @@ func (o *os2) useTypoMetrics() bool {
 // Version 0 is 78 bytes; versions 1 and up extend the trailing fields.
 func parseOS2(data []byte) (*os2, error) {
 	if uint64(len(data)) < 78 {
-		return nil, fmt.Errorf("OS/2: table truncated (%d < 78 bytes): %w", len(data), ErrTruncated)
+		return nil, fmt.Errorf("font: OS/2: table truncated (%d < 78 bytes): %w", len(data), ErrTruncated)
 	}
 	o := &os2{
 		version:        binary.BigEndian.Uint16(data[0:2]),

--- a/font/subset.go
+++ b/font/subset.go
@@ -35,33 +35,33 @@ func Subset(raw []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 	// Read numGlyphs from maxp.
 	maxpData, ok := tables["maxp"]
 	if !ok {
-		return nil, fmt.Errorf("subset: missing maxp table: %w", ErrMissingTable)
+		return nil, fmt.Errorf("font: subset: missing maxp table: %w", ErrMissingTable)
 	}
 	if len(maxpData) < 6 {
-		return nil, fmt.Errorf("subset: maxp table too short: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: subset: maxp table too short: %w", ErrTruncated)
 	}
 	numGlyphs := int(binary.BigEndian.Uint16(maxpData[4:6]))
 
 	// Read head to get loca format.
 	headData, ok := tables["head"]
 	if !ok {
-		return nil, fmt.Errorf("subset: missing head table: %w", ErrMissingTable)
+		return nil, fmt.Errorf("font: subset: missing head table: %w", ErrMissingTable)
 	}
 	if len(headData) < 54 {
-		return nil, fmt.Errorf("subset: head table too short: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: subset: head table too short: %w", ErrTruncated)
 	}
 	locaFormat := int16(binary.BigEndian.Uint16(headData[50:52]))
 
 	// Read loca table.
 	locaData, ok := tables["loca"]
 	if !ok {
-		return nil, fmt.Errorf("subset: missing loca table: %w", ErrMissingTable)
+		return nil, fmt.Errorf("font: subset: missing loca table: %w", ErrMissingTable)
 	}
 
 	// Read glyf table.
 	glyfData, ok := tables["glyf"]
 	if !ok {
-		return nil, fmt.Errorf("subset: missing glyf table: %w", ErrMissingTable)
+		return nil, fmt.Errorf("font: subset: missing glyf table: %w", ErrMissingTable)
 	}
 
 	// Parse loca to get glyph offsets.
@@ -79,11 +79,11 @@ func Subset(raw []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 	// Rebuild hmtx (zero unused entries).
 	hheaData, ok := tables["hhea"]
 	if !ok {
-		return nil, fmt.Errorf("subset: missing hhea table: %w", ErrMissingTable)
+		return nil, fmt.Errorf("font: subset: missing hhea table: %w", ErrMissingTable)
 	}
 	hmtxData, ok := tables["hmtx"]
 	if !ok {
-		return nil, fmt.Errorf("subset: missing hmtx table: %w", ErrMissingTable)
+		return nil, fmt.Errorf("font: subset: missing hmtx table: %w", ErrMissingTable)
 	}
 	numHMetrics := int(binary.BigEndian.Uint16(hheaData[34:36]))
 	newHmtx := rebuildHmtx(hmtxData, glyphSet, numGlyphs, numHMetrics)
@@ -133,12 +133,12 @@ func Subset(raw []byte, usedGlyphs map[uint16]rune) ([]byte, error) {
 // parseTTFTables extracts table data from a raw TTF file.
 func parseTTFTables(raw []byte) (map[string][]byte, error) {
 	if len(raw) < 12 {
-		return nil, fmt.Errorf("subset: file too short for TTF header: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: subset: file too short for TTF header: %w", ErrTruncated)
 	}
 
 	numTables := int(binary.BigEndian.Uint16(raw[4:6]))
 	if len(raw) < 12+numTables*16 {
-		return nil, fmt.Errorf("subset: file too short for table directory: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: subset: file too short for table directory: %w", ErrTruncated)
 	}
 
 	tables := make(map[string][]byte, numTables)
@@ -148,7 +148,7 @@ func parseTTFTables(raw []byte) (map[string][]byte, error) {
 		tblOffset := int(binary.BigEndian.Uint32(raw[offset+8 : offset+12]))
 		tblLength := int(binary.BigEndian.Uint32(raw[offset+12 : offset+16]))
 		if tblOffset+tblLength > len(raw) {
-			return nil, fmt.Errorf("subset: table %q extends beyond file: %w", tag, ErrTruncated)
+			return nil, fmt.Errorf("font: subset: table %q extends beyond file: %w", tag, ErrTruncated)
 		}
 		tables[tag] = raw[tblOffset : tblOffset+tblLength]
 	}
@@ -163,7 +163,7 @@ func parseLoca(data []byte, format int16, numGlyphs int) ([]uint32, error) {
 		// Short format: uint16, multiply by 2.
 		need := (numGlyphs + 1) * 2
 		if len(data) < need {
-			return nil, fmt.Errorf("subset: loca table too short (short format): %w", ErrTruncated)
+			return nil, fmt.Errorf("font: subset: loca table too short (short format): %w", ErrTruncated)
 		}
 		for i := range numGlyphs + 1 {
 			offsets[i] = uint32(binary.BigEndian.Uint16(data[i*2:])) * 2
@@ -172,7 +172,7 @@ func parseLoca(data []byte, format int16, numGlyphs int) ([]uint32, error) {
 		// Long format: uint32.
 		need := (numGlyphs + 1) * 4
 		if len(data) < need {
-			return nil, fmt.Errorf("subset: loca table too short (long format): %w", ErrTruncated)
+			return nil, fmt.Errorf("font: subset: loca table too short (long format): %w", ErrTruncated)
 		}
 		for i := range numGlyphs + 1 {
 			offsets[i] = binary.BigEndian.Uint32(data[i*4:])

--- a/font/truetype.go
+++ b/font/truetype.go
@@ -56,7 +56,7 @@ type sfntFace struct {
 func ParseTTF(data []byte) (Face, error) {
 	pf, err := parseAllTables(data)
 	if err != nil {
-		return nil, fmt.Errorf("parse font: %w", err)
+		return nil, fmt.Errorf("font: parse font: %w", err)
 	}
 	return &sfntFace{
 		pf:      pf,
@@ -68,7 +68,7 @@ func ParseTTF(data []byte) (Face, error) {
 func LoadTTF(path string) (Face, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read font file: %w", err)
+		return nil, fmt.Errorf("font: read font file: %w", err)
 	}
 	return ParseTTF(data)
 }

--- a/font/ttc.go
+++ b/font/ttc.go
@@ -38,25 +38,25 @@ const ttcMagic = 0x74746366 // "ttcf"
 func extractTTCFont(data []byte, index int) ([]byte, error) {
 	dataLen := uint64(len(data))
 	if dataLen < 12 {
-		return nil, fmt.Errorf("ttc: header too short: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: ttc: header too short: %w", ErrTruncated)
 	}
 	if binary.BigEndian.Uint32(data[0:4]) != ttcMagic {
-		return nil, fmt.Errorf("ttc: missing ttcf magic: %w", ErrUnknownFormat)
+		return nil, fmt.Errorf("font: ttc: missing ttcf magic: %w", ErrUnknownFormat)
 	}
 	numFonts := uint64(binary.BigEndian.Uint32(data[8:12]))
 	if numFonts < 1 {
-		return nil, fmt.Errorf("ttc: empty collection: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: ttc: empty collection: %w", ErrCorruptTable)
 	}
 	if index < 0 || uint64(index) >= numFonts {
-		return nil, fmt.Errorf("ttc: font index %d out of range [0,%d): %w", index, numFonts, ErrCorruptTable)
+		return nil, fmt.Errorf("font: ttc: font index %d out of range [0,%d): %w", index, numFonts, ErrCorruptTable)
 	}
 	if dataLen < 12+numFonts*4 {
-		return nil, fmt.Errorf("ttc: offset table truncated: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: ttc: offset table truncated: %w", ErrTruncated)
 	}
 
 	fontOffset := uint64(binary.BigEndian.Uint32(data[12+index*4:]))
 	if fontOffset+12 > dataLen {
-		return nil, fmt.Errorf("ttc: font %d offset out of range: %w", index, ErrTruncated)
+		return nil, fmt.Errorf("font: ttc: font %d offset out of range: %w", index, ErrTruncated)
 	}
 
 	// Offset Table (12 bytes): sfntVersion[4], numTables[2], searchRange[2],
@@ -64,7 +64,7 @@ func extractTTCFont(data []byte, index int) ([]byte, error) {
 	numTables := uint64(binary.BigEndian.Uint16(data[fontOffset+4:]))
 	dirSize := numTables * 16
 	if fontOffset+12+dirSize > dataLen {
-		return nil, fmt.Errorf("ttc: font %d directory truncated: %w", index, ErrTruncated)
+		return nil, fmt.Errorf("font: ttc: font %d directory truncated: %w", index, ErrTruncated)
 	}
 
 	// Snapshot each (tag, checksum, srcOffset, length) and accumulate the
@@ -85,7 +85,7 @@ func extractTTCFont(data []byte, index int) ([]byte, error) {
 		e.srcOff = uint64(binary.BigEndian.Uint32(data[base+8:]))
 		e.length = uint64(binary.BigEndian.Uint32(data[base+12:]))
 		if e.srcOff+e.length > dataLen {
-			return nil, fmt.Errorf("ttc: table %s extends beyond data: %w", string(e.tag[:]), ErrTruncated)
+			return nil, fmt.Errorf("font: ttc: table %s extends beyond data: %w", string(e.tag[:]), ErrTruncated)
 		}
 		entries[i] = e
 		// Tables in TTF are 4-byte aligned in the file.
@@ -95,7 +95,7 @@ func extractTTCFont(data []byte, index int) ([]byte, error) {
 	headerSize := 12 + dirSize
 	totalSize := headerSize + payload
 	if totalSize > uint64(^uint(0)>>1) {
-		return nil, fmt.Errorf("ttc: extracted size %d exceeds platform int range: %w", totalSize, ErrCorruptTable)
+		return nil, fmt.Errorf("font: ttc: extracted size %d exceeds platform int range: %w", totalSize, ErrCorruptTable)
 	}
 	out := make([]byte, totalSize)
 

--- a/font/woff.go
+++ b/font/woff.go
@@ -44,26 +44,26 @@ type woffTableEntry struct {
 // decodeWOFF decodes a WOFF1 font file into raw TTF/OTF bytes.
 func decodeWOFF(data []byte) ([]byte, error) {
 	if len(data) < woffHeaderSize {
-		return nil, fmt.Errorf("woff: data too short for header: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: woff: data too short for header: %w", ErrTruncated)
 	}
 
 	// Parse header.
 	var hdr woffHeader
 	hdr.signature = binary.BigEndian.Uint32(data[0:4])
 	if hdr.signature != woffMagic {
-		return nil, fmt.Errorf("woff: invalid signature 0x%08X: %w", hdr.signature, ErrUnknownFormat)
+		return nil, fmt.Errorf("font: woff: invalid signature 0x%08X: %w", hdr.signature, ErrUnknownFormat)
 	}
 	hdr.flavor = binary.BigEndian.Uint32(data[4:8])
 	hdr.numTables = binary.BigEndian.Uint16(data[12:14])
 
 	if hdr.numTables == 0 {
-		return nil, fmt.Errorf("woff: no tables: %w", ErrCorruptTable)
+		return nil, fmt.Errorf("font: woff: no tables: %w", ErrCorruptTable)
 	}
 
 	// Parse table directory.
 	dirEnd := woffHeaderSize + int(hdr.numTables)*woffTableDirEntrySize
 	if len(data) < dirEnd {
-		return nil, fmt.Errorf("woff: data too short for table directory: %w", ErrTruncated)
+		return nil, fmt.Errorf("font: woff: data too short for table directory: %w", ErrTruncated)
 	}
 
 	entries := make([]woffTableEntry, hdr.numTables)
@@ -82,7 +82,7 @@ func decodeWOFF(data []byte) ([]byte, error) {
 	tables := make([][]byte, len(entries))
 	for i, e := range entries {
 		if int(e.offset)+int(e.compLength) > len(data) {
-			return nil, fmt.Errorf("woff: table %d extends beyond file: %w", i, ErrTruncated)
+			return nil, fmt.Errorf("font: woff: table %d extends beyond file: %w", i, ErrTruncated)
 		}
 		tableData := data[e.offset : e.offset+e.compLength]
 
@@ -90,15 +90,15 @@ func decodeWOFF(data []byte) ([]byte, error) {
 			// zlib-compressed table.
 			r, err := zlib.NewReader(bytes.NewReader(tableData))
 			if err != nil {
-				return nil, fmt.Errorf("woff: zlib init for table %d: %v: %w", i, err, ErrCorruptTable)
+				return nil, fmt.Errorf("font: woff: zlib init for table %d: %v: %w", i, err, ErrCorruptTable)
 			}
 			decompressed, err := io.ReadAll(r)
 			_ = r.Close()
 			if err != nil {
-				return nil, fmt.Errorf("woff: zlib decompress table %d: %v: %w", i, err, ErrCorruptTable)
+				return nil, fmt.Errorf("font: woff: zlib decompress table %d: %v: %w", i, err, ErrCorruptTable)
 			}
 			if uint32(len(decompressed)) != e.origLength {
-				return nil, fmt.Errorf("woff: table %d decompressed size mismatch: got %d, want %d: %w", i, len(decompressed), e.origLength, ErrCorruptTable)
+				return nil, fmt.Errorf("font: woff: table %d decompressed size mismatch: got %d, want %d: %w", i, len(decompressed), e.origLength, ErrCorruptTable)
 			}
 			tables[i] = decompressed
 		} else {

--- a/html/converter.go
+++ b/html/converter.go
@@ -114,7 +114,7 @@ func (o *Options) defaults() Options {
 
 // errNoBaseFS is returned by readAsset when a relative or root-anchored path is
 // requested but the caller did not configure Options.BaseFS.
-var errNoBaseFS = errors.New("no BaseFS configured for local asset resolution")
+var errNoBaseFS = errors.New("html: no BaseFS configured for local asset resolution")
 
 // readAsset resolves p through baseFS. Path normalisation:
 //   - Backslashes are converted to forward slashes (fs.FS convention).
@@ -144,17 +144,17 @@ func readAsset(baseFS fs.FS, p string) ([]byte, error) {
 // the same on macOS / Linux).
 func normaliseFSPath(p string) (string, error) {
 	if p == "" {
-		return "", fmt.Errorf("empty path")
+		return "", fmt.Errorf("html: empty path")
 	}
 	fsPath := strings.ReplaceAll(p, `\`, "/")
 	fsPath = strings.TrimPrefix(fsPath, "./")
 	fsPath = strings.TrimPrefix(fsPath, "/")
 	if fsPath == "" {
-		return "", fmt.Errorf("empty path after normalisation: %q", p)
+		return "", fmt.Errorf("html: empty path after normalisation: %q", p)
 	}
 	fsPath = path.Clean(fsPath)
 	if !fs.ValidPath(fsPath) {
-		return "", fmt.Errorf("invalid path for BaseFS: %q", p)
+		return "", fmt.Errorf("html: invalid path for BaseFS: %q", p)
 	}
 	return fsPath, nil
 }
@@ -559,7 +559,7 @@ func formatAssetError(category string, err error, attrs []any) error {
 // Options.Logger but are not added to the joined return-error — the
 // caller already received the signal they wired URLPolicy to produce.
 // Use with errors.Is to test the cause.
-var ErrURLPolicyDenied = errors.New("folio/html: URL fetch blocked by URLPolicy")
+var ErrURLPolicyDenied = errors.New("html: URL fetch blocked by URLPolicy")
 
 // containingBlock tracks a positioned ancestor for absolute positioning resolution.
 type containingBlock struct {
@@ -690,18 +690,18 @@ func decodeFontDataURI(uri string) (font.Face, error) {
 	rest := strings.TrimPrefix(uri, "data:")
 	commaIdx := strings.IndexByte(rest, ',')
 	if commaIdx < 0 {
-		return nil, fmt.Errorf("invalid data URI: no comma")
+		return nil, fmt.Errorf("html: invalid data URI: no comma")
 	}
 	meta := rest[:commaIdx]
 	encoded := rest[commaIdx+1:]
 
 	if !strings.Contains(meta, ";base64") {
-		return nil, fmt.Errorf("font data URI must be base64-encoded")
+		return nil, fmt.Errorf("html: font data URI must be base64-encoded")
 	}
 
 	data, err := base64Decode(encoded)
 	if err != nil {
-		return nil, fmt.Errorf("font data URI base64: %w", err)
+		return nil, fmt.Errorf("html: font data URI base64: %w", err)
 	}
 
 	return font.ParseTTF(data)

--- a/html/converter_image.go
+++ b/html/converter_image.go
@@ -154,7 +154,7 @@ func decodeDataURI(uri string) (*folioimage.Image, error) {
 	// Split at comma: metadata,data
 	commaIdx := strings.IndexByte(rest, ',')
 	if commaIdx < 0 {
-		return nil, fmt.Errorf("invalid data URI: no comma")
+		return nil, fmt.Errorf("html: invalid data URI: no comma")
 	}
 	meta := rest[:commaIdx]
 	encoded := rest[commaIdx+1:]
@@ -165,7 +165,7 @@ func decodeDataURI(uri string) (*folioimage.Image, error) {
 		var err error
 		data, err = base64Decode(encoded)
 		if err != nil {
-			return nil, fmt.Errorf("data URI base64: %w", err)
+			return nil, fmt.Errorf("html: data URI base64: %w", err)
 		}
 	} else {
 		data = []byte(encoded)
@@ -269,7 +269,7 @@ func (c *converter) convertImgSVG(src, alt string, style computedStyle) []layout
 		rest := strings.TrimPrefix(src, "data:")
 		commaIdx := strings.IndexByte(rest, ',')
 		if commaIdx < 0 {
-			err = fmt.Errorf("invalid data URI: no comma")
+			err = fmt.Errorf("html: invalid data URI: no comma")
 		} else {
 			meta := rest[:commaIdx]
 			encoded := rest[commaIdx+1:]

--- a/html/fetch_image.go
+++ b/html/fetch_image.go
@@ -18,11 +18,11 @@ import (
 func httpGetBytes(client *http.Client, url string, maxBytes int64) ([]byte, error) {
 	resp, err := client.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("fetch %s: %w", url, err)
+		return nil, fmt.Errorf("html: fetch %s: %w", url, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("fetch %s: HTTP %d", url, resp.StatusCode)
+		return nil, fmt.Errorf("html: fetch %s: HTTP %d", url, resp.StatusCode)
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, maxBytes))
 }

--- a/html/fetch_image_wasm.go
+++ b/html/fetch_image_wasm.go
@@ -16,5 +16,5 @@ import (
 // Use base64 data URIs (`<img src="data:image/png;base64,...">`) for inline
 // assets in browser builds.
 func httpGetBytes(_ *http.Client, url string, _ int64) ([]byte, error) {
-	return nil, fmt.Errorf("HTTP fetch not supported in WASM: %s", url)
+	return nil, fmt.Errorf("html: HTTP fetch not supported in WASM: %s", url)
 }

--- a/image/gif.go
+++ b/image/gif.go
@@ -16,14 +16,14 @@ import (
 func NewGIF(data []byte) (*Image, error) {
 	img, err := gif.Decode(bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("gif: %w", err)
+		return nil, fmt.Errorf("image: gif: %w", err)
 	}
 
 	bounds := img.Bounds()
 	w := bounds.Dx()
 	h := bounds.Dy()
 	if err := checkDimensions(w, h); err != nil {
-		return nil, fmt.Errorf("gif: %w", err)
+		return nil, fmt.Errorf("image: gif: %w", err)
 	}
 
 	// GIF returns *goimage.Paletted; buildRGBMaybeAlpha's generic path

--- a/image/jpeg.go
+++ b/image/jpeg.go
@@ -35,10 +35,10 @@ const maxJPEGSegments = 10000
 func NewJPEG(data []byte) (*Image, error) {
 	w, h, ncomp, hasAdobe, err := parseJPEGHeader(data)
 	if err != nil {
-		return nil, fmt.Errorf("jpeg: %w", err)
+		return nil, fmt.Errorf("image: jpeg: %w", err)
 	}
 	if err := checkDimensions(w, h); err != nil {
-		return nil, fmt.Errorf("jpeg: %w", err)
+		return nil, fmt.Errorf("image: jpeg: %w", err)
 	}
 
 	var cs string
@@ -50,7 +50,7 @@ func NewJPEG(data []byte) (*Image, error) {
 	case 4:
 		cs = "DeviceCMYK"
 	default:
-		return nil, fmt.Errorf("jpeg: unsupported component count %d", ncomp)
+		return nil, fmt.Errorf("image: jpeg: unsupported component count %d", ncomp)
 	}
 
 	return &Image{
@@ -87,18 +87,18 @@ func LoadJPEG(path string) (*Image, error) {
 // the inverted-CMYK convention and emit a PDF /Decode array accordingly.
 func parseJPEGHeader(data []byte) (width, height, numComponents int, hasAdobe bool, err error) {
 	if len(data) < 2 || binary.BigEndian.Uint16(data[0:2]) != markerSOI {
-		return 0, 0, 0, false, fmt.Errorf("not a JPEG file")
+		return 0, 0, 0, false, fmt.Errorf("image: not a JPEG file")
 	}
 
 	pos := 2
 	for segments := 0; pos < len(data)-1; segments++ {
 		if segments > maxJPEGSegments {
-			return 0, 0, 0, false, fmt.Errorf("too many segments (>%d)", maxJPEGSegments)
+			return 0, 0, 0, false, fmt.Errorf("image: too many segments (>%d)", maxJPEGSegments)
 		}
 
 		// Find marker (0xFF followed by non-zero byte).
 		if data[pos] != 0xFF {
-			return 0, 0, 0, false, fmt.Errorf("expected marker at offset %d", pos)
+			return 0, 0, 0, false, fmt.Errorf("image: expected marker at offset %d", pos)
 		}
 
 		// Skip padding 0xFF bytes.
@@ -117,7 +117,7 @@ func parseJPEGHeader(data []byte) (width, height, numComponents int, hasAdobe bo
 			// SOF layout: length(2) + precision(1) + height(2) + width(2) + ncomp(1)
 			// The ncomp byte lives at data[pos+7], so we need pos+8 ≤ len(data).
 			if pos+8 > len(data) {
-				return 0, 0, 0, false, fmt.Errorf("truncated SOF segment")
+				return 0, 0, 0, false, fmt.Errorf("image: truncated SOF segment")
 			}
 			height = int(binary.BigEndian.Uint16(data[pos+3 : pos+5]))
 			width = int(binary.BigEndian.Uint16(data[pos+5 : pos+7]))
@@ -137,7 +137,7 @@ func parseJPEGHeader(data []byte) (width, height, numComponents int, hasAdobe bo
 		}
 		segLen := int(binary.BigEndian.Uint16(data[pos : pos+2]))
 		if segLen < 2 {
-			return 0, 0, 0, false, fmt.Errorf("invalid segment length %d at offset %d", segLen, pos)
+			return 0, 0, 0, false, fmt.Errorf("image: invalid segment length %d at offset %d", segLen, pos)
 		}
 
 		// APP14 Adobe marker: 2-byte length, then "Adobe" + 7-byte body.
@@ -154,5 +154,5 @@ func parseJPEGHeader(data []byte) (width, height, numComponents int, hasAdobe bo
 		pos += segLen
 	}
 
-	return 0, 0, 0, false, fmt.Errorf("no SOF marker found")
+	return 0, 0, 0, false, fmt.Errorf("image: no SOF marker found")
 }

--- a/image/png.go
+++ b/image/png.go
@@ -18,14 +18,14 @@ import (
 func NewPNG(data []byte) (*Image, error) {
 	img, err := png.Decode(bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("png: %w", err)
+		return nil, fmt.Errorf("image: png: %w", err)
 	}
 
 	bounds := img.Bounds()
 	w := bounds.Dx()
 	h := bounds.Dy()
 	if err := checkDimensions(w, h); err != nil {
-		return nil, fmt.Errorf("png: %w", err)
+		return nil, fmt.Errorf("image: png: %w", err)
 	}
 
 	if isGrayscale(img) {

--- a/image/tiff.go
+++ b/image/tiff.go
@@ -18,14 +18,14 @@ import (
 func NewTIFF(data []byte) (*Image, error) {
 	img, err := tiff.Decode(bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("tiff: %w", err)
+		return nil, fmt.Errorf("image: tiff: %w", err)
 	}
 
 	bounds := img.Bounds()
 	w := bounds.Dx()
 	h := bounds.Dy()
 	if err := checkDimensions(w, h); err != nil {
-		return nil, fmt.Errorf("tiff: %w", err)
+		return nil, fmt.Errorf("image: tiff: %w", err)
 	}
 
 	if isGrayscale(img) {

--- a/image/webp.go
+++ b/image/webp.go
@@ -16,14 +16,14 @@ import (
 func NewWebP(data []byte) (*Image, error) {
 	img, err := webp.Decode(bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("webp: %w", err)
+		return nil, fmt.Errorf("image: webp: %w", err)
 	}
 
 	bounds := img.Bounds()
 	w := bounds.Dx()
 	h := bounds.Dy()
 	if err := checkDimensions(w, h); err != nil {
-		return nil, fmt.Errorf("webp: %w", err)
+		return nil, fmt.Errorf("image: webp: %w", err)
 	}
 
 	// buildRGBMaybeAlpha walks the decoded image once: RGB bytes go

--- a/internal/gen-css-docs/main.go
+++ b/internal/gen-css-docs/main.go
@@ -58,5 +58,5 @@ func findRepoRoot() (string, error) {
 		}
 		dir = parent
 	}
-	return "", fmt.Errorf("go.mod not found in any parent of cwd")
+	return "", fmt.Errorf("gen-css-docs: go.mod not found in any parent of cwd")
 }

--- a/reader/flatten.go
+++ b/reader/flatten.go
@@ -23,7 +23,7 @@ func (m *Modifier) FlattenForms() error {
 			continue
 		}
 		if err := m.flattenPage(pageDict, i); err != nil {
-			return fmt.Errorf("flatten page %d: %w", i, err)
+			return fmt.Errorf("reader: flatten page %d: %w", i, err)
 		}
 	}
 

--- a/reader/import.go
+++ b/reader/import.go
@@ -45,17 +45,17 @@ type PageImport struct {
 func ExtractPageImport(r *PdfReader, pageIndex int) (*PageImport, error) {
 	page, err := r.Page(pageIndex)
 	if err != nil {
-		return nil, fmt.Errorf("import: page %d: %w", pageIndex, err)
+		return nil, fmt.Errorf("reader: import: page %d: %w", pageIndex, err)
 	}
 
 	data, err := page.ContentStream()
 	if err != nil {
-		return nil, fmt.Errorf("import: content stream: %w", err)
+		return nil, fmt.Errorf("reader: import: content stream: %w", err)
 	}
 
 	resources, err := page.Resources()
 	if err != nil {
-		return nil, fmt.Errorf("import: resources: %w", err)
+		return nil, fmt.Errorf("reader: import: resources: %w", err)
 	}
 
 	// Deep-copy resources, resolving all indirect references so the
@@ -64,7 +64,7 @@ func ExtractPageImport(r *PdfReader, pageIndex int) (*PageImport, error) {
 	// that are meaningless outside the source PDF.
 	resolvedRes, err := resolveDeep(resources, r.resolver)
 	if err != nil {
-		return nil, fmt.Errorf("import: resolve resources: %w", err)
+		return nil, fmt.Errorf("reader: import: resolve resources: %w", err)
 	}
 	resDict, _ := resolvedRes.(*core.PdfDictionary)
 

--- a/reader/merge.go
+++ b/reader/merge.go
@@ -35,7 +35,7 @@ func MergeFiles(paths ...string) (*Modifier, error) {
 	for _, path := range paths {
 		r, err := Load(path)
 		if err != nil {
-			return nil, fmt.Errorf("merge: %w", err)
+			return nil, fmt.Errorf("reader: merge: %w", err)
 		}
 		readers = append(readers, r)
 	}
@@ -85,18 +85,18 @@ func (m *Modifier) appendReader(r *PdfReader) error {
 	for i := range r.PageCount() {
 		page, err := r.Page(i)
 		if err != nil {
-			return fmt.Errorf("merge page %d: %w", i, err)
+			return fmt.Errorf("reader: merge page %d: %w", i, err)
 		}
 
 		// Deep-copy the page dictionary.
 		copied, err := copier.CopyObject(page.pageDict)
 		if err != nil {
-			return fmt.Errorf("merge page %d: %w", i, err)
+			return fmt.Errorf("reader: merge page %d: %w", i, err)
 		}
 
 		copiedDict, ok := copied.(*core.PdfDictionary)
 		if !ok {
-			return fmt.Errorf("merge page %d: copied object is not a dictionary", i)
+			return fmt.Errorf("reader: merge page %d: copied object is not a dictionary", i)
 		}
 
 		// Remove /Parent from source, set our own.
@@ -193,7 +193,7 @@ func (m *Modifier) PageCount() int {
 // RemovePage removes the page at the given 0-based index.
 func (m *Modifier) RemovePage(index int) error {
 	if index < 0 || index >= m.pageCount {
-		return fmt.Errorf("page index %d out of range [0, %d)", index, m.pageCount)
+		return fmt.Errorf("reader: page index %d out of range [0, %d)", index, m.pageCount)
 	}
 	m.kids.RemoveAt(index)
 	m.pageDicts = append(m.pageDicts[:index], m.pageDicts[index+1:]...)
@@ -205,13 +205,13 @@ func (m *Modifier) RemovePage(index int) error {
 // Degrees must be a multiple of 90 (0, 90, 180, 270).
 func (m *Modifier) RotatePage(index int, degrees int) error {
 	if index < 0 || index >= m.pageCount {
-		return fmt.Errorf("page index %d out of range [0, %d)", index, m.pageCount)
+		return fmt.Errorf("reader: page index %d out of range [0, %d)", index, m.pageCount)
 	}
 	if degrees%90 != 0 {
-		return fmt.Errorf("rotation must be a multiple of 90, got %d", degrees)
+		return fmt.Errorf("reader: rotation must be a multiple of 90, got %d", degrees)
 	}
 	if m.pageDicts[index] == nil {
-		return fmt.Errorf("page %d has no accessible dictionary", index)
+		return fmt.Errorf("reader: page %d has no accessible dictionary", index)
 	}
 	m.pageDicts[index].Set("Rotate", core.NewPdfInteger(degrees))
 	return nil
@@ -221,15 +221,15 @@ func (m *Modifier) RotatePage(index int, degrees int) error {
 // order must be a permutation of [0, pageCount).
 func (m *Modifier) ReorderPages(order []int) error {
 	if len(order) != m.pageCount {
-		return fmt.Errorf("order length %d does not match page count %d", len(order), m.pageCount)
+		return fmt.Errorf("reader: order length %d does not match page count %d", len(order), m.pageCount)
 	}
 	seen := make(map[int]bool, m.pageCount)
 	for _, idx := range order {
 		if idx < 0 || idx >= m.pageCount {
-			return fmt.Errorf("invalid page index %d in order", idx)
+			return fmt.Errorf("reader: invalid page index %d in order", idx)
 		}
 		if seen[idx] {
-			return fmt.Errorf("duplicate page index %d in order", idx)
+			return fmt.Errorf("reader: duplicate page index %d in order", idx)
 		}
 		seen[idx] = true
 	}
@@ -247,10 +247,10 @@ func (m *Modifier) ReorderPages(order []int) error {
 // CropPage sets the CropBox on the page at the given index.
 func (m *Modifier) CropPage(index int, rect [4]float64) error {
 	if index < 0 || index >= m.pageCount {
-		return fmt.Errorf("page index %d out of range [0, %d)", index, m.pageCount)
+		return fmt.Errorf("reader: page index %d out of range [0, %d)", index, m.pageCount)
 	}
 	if m.pageDicts[index] == nil {
-		return fmt.Errorf("page %d has no accessible dictionary", index)
+		return fmt.Errorf("reader: page %d has no accessible dictionary", index)
 	}
 	m.pageDicts[index].Set("CropBox", core.NewPdfArray(
 		core.NewPdfReal(rect[0]), core.NewPdfReal(rect[1]),

--- a/reader/redact.go
+++ b/reader/redact.go
@@ -80,7 +80,7 @@ func RedactRegions(r *PdfReader, marks []RedactionMark, opts *RedactOptions) (*M
 	// Create a writable copy of the input PDF.
 	m, err := Merge(r)
 	if err != nil {
-		return nil, fmt.Errorf("redact: copy PDF: %w", err)
+		return nil, fmt.Errorf("reader: redact: copy PDF: %w", err)
 	}
 
 	// Group marks by page.
@@ -98,11 +98,11 @@ func RedactRegions(r *PdfReader, marks []RedactionMark, opts *RedactOptions) (*M
 		// Get the page's content stream and font cache.
 		page, err := r.Page(pageIdx)
 		if err != nil {
-			return nil, fmt.Errorf("redact: page %d: %w", pageIdx, err)
+			return nil, fmt.Errorf("reader: redact: page %d: %w", pageIdx, err)
 		}
 		data, err := page.ContentStream()
 		if err != nil {
-			return nil, fmt.Errorf("redact: page %d content: %w", pageIdx, err)
+			return nil, fmt.Errorf("reader: redact: page %d content: %w", pageIdx, err)
 		}
 		resources, _ := page.Resources()
 		fonts := buildFontCache(resources, r.resolver)
@@ -142,7 +142,7 @@ func RedactText(r *PdfReader, targets []string, opts *RedactOptions) (*Modifier,
 	for pageIdx := range r.PageCount() {
 		marks, err := findTextMarks(r, pageIdx, targets)
 		if err != nil {
-			return nil, fmt.Errorf("redact: scan page %d: %w", pageIdx, err)
+			return nil, fmt.Errorf("reader: redact: scan page %d: %w", pageIdx, err)
 		}
 		allMarks = append(allMarks, marks...)
 	}
@@ -161,7 +161,7 @@ func RedactPattern(r *PdfReader, pattern *regexp.Regexp, opts *RedactOptions) (*
 	for pageIdx := range r.PageCount() {
 		marks, err := findPatternMarks(r, pageIdx, pattern)
 		if err != nil {
-			return nil, fmt.Errorf("redact: scan page %d: %w", pageIdx, err)
+			return nil, fmt.Errorf("reader: redact: scan page %d: %w", pageIdx, err)
 		}
 		allMarks = append(allMarks, marks...)
 	}

--- a/reader/redact_apply.go
+++ b/reader/redact_apply.go
@@ -60,7 +60,7 @@ func buildRedactionOverlay(rects []Box, opts *RedactOptions) *core.PdfStream {
 // content and adds the redaction overlay.
 func applyRedaction(m *Modifier, pageIdx int, rewritten []byte, overlay *core.PdfStream, opts *RedactOptions) error {
 	if pageIdx < 0 || pageIdx >= len(m.pageDicts) {
-		return fmt.Errorf("redact: page index %d out of range", pageIdx)
+		return fmt.Errorf("reader: redact: page index %d out of range", pageIdx)
 	}
 	pageDict := m.pageDicts[pageIdx]
 

--- a/reader/resolver.go
+++ b/reader/resolver.go
@@ -580,13 +580,13 @@ func extractFilters(obj core.PdfObject) []string {
 func inflateFlateDecode(data []byte, maxBytes int64) ([]byte, error) {
 	r, err := zlib.NewReader(bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("FlateDecode: %w", err)
+		return nil, fmt.Errorf("reader: FlateDecode: %w", err)
 	}
 	defer func() { _ = r.Close() }()
 
 	result, err := limitedReadAll(r, maxBytes)
 	if err != nil {
-		return nil, fmt.Errorf("FlateDecode: %w", err)
+		return nil, fmt.Errorf("reader: FlateDecode: %w", err)
 	}
 	return result, nil
 }

--- a/reader/xref.go
+++ b/reader/xref.go
@@ -446,38 +446,38 @@ func parseOneXrefSection(tok *Tokenizer, table *xrefTable, data []byte) (*core.P
 func parseXrefEntry(line string) (xrefEntry, error) {
 	line = strings.TrimRight(line, "\r\n ")
 	if len(line) < 18 {
-		return xrefEntry{}, fmt.Errorf("xref entry too short (%d chars): %q", len(line), line)
+		return xrefEntry{}, fmt.Errorf("reader: xref entry too short (%d chars): %q", len(line), line)
 	}
 
 	// Bounds are guaranteed by the len(line) >= 18 check above, but we
 	// validate explicitly to guard against future changes and make the
 	// invariant clear to readers.
 	if len(line) < 10 {
-		return xrefEntry{}, fmt.Errorf("xref entry too short for offset field: %q", line)
+		return xrefEntry{}, fmt.Errorf("reader: xref entry too short for offset field: %q", line)
 	}
 	offsetStr := strings.TrimSpace(line[0:10])
 	if len(line) < 16 {
-		return xrefEntry{}, fmt.Errorf("xref entry too short for generation field: %q", line)
+		return xrefEntry{}, fmt.Errorf("reader: xref entry too short for generation field: %q", line)
 	}
 	genStr := strings.TrimSpace(line[11:16])
 	if len(line) < 18 {
-		return xrefEntry{}, fmt.Errorf("xref entry too short for type field: %q", line)
+		return xrefEntry{}, fmt.Errorf("reader: xref entry too short for type field: %q", line)
 	}
 	typeChar := line[17]
 
 	offset, err := strconv.ParseInt(offsetStr, 10, 64)
 	if err != nil {
-		return xrefEntry{}, fmt.Errorf("invalid offset %q", offsetStr)
+		return xrefEntry{}, fmt.Errorf("reader: invalid offset %q", offsetStr)
 	}
 	if offset < 0 {
-		return xrefEntry{}, fmt.Errorf("negative offset %d", offset)
+		return xrefEntry{}, fmt.Errorf("reader: negative offset %d", offset)
 	}
 	gen, err := strconv.Atoi(genStr)
 	if err != nil {
-		return xrefEntry{}, fmt.Errorf("invalid generation %q", genStr)
+		return xrefEntry{}, fmt.Errorf("reader: invalid generation %q", genStr)
 	}
 	if gen < 0 {
-		return xrefEntry{}, fmt.Errorf("negative generation %d", gen)
+		return xrefEntry{}, fmt.Errorf("reader: negative generation %d", gen)
 	}
 
 	return xrefEntry{

--- a/sign/ocsp.go
+++ b/sign/ocsp.go
@@ -150,10 +150,10 @@ func validateOCSPResponse(data []byte) error {
 	var resp ocspResponse
 	_, err := asn1.Unmarshal(data, &resp)
 	if err != nil {
-		return fmt.Errorf("unmarshal: %w", err)
+		return fmt.Errorf("sign: unmarshal: %w", err)
 	}
 	if resp.ResponseStatus != 0 {
-		return fmt.Errorf("OCSP response status %d (not successful)", resp.ResponseStatus)
+		return fmt.Errorf("sign: OCSP response status %d (not successful)", resp.ResponseStatus)
 	}
 	return nil
 }

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -330,7 +330,7 @@ func locatePlaceholders(pdf []byte, sigDictObjNum int) (signaturePlaceholder, er
 	objHeader := fmt.Sprintf("%d 0 obj", sigDictObjNum)
 	objStart := bytes.Index(pdf, []byte(objHeader))
 	if objStart < 0 {
-		return ph, fmt.Errorf("could not find signature object %d", sigDictObjNum)
+		return ph, fmt.Errorf("sign: could not find signature object %d", sigDictObjNum)
 	}
 
 	searchArea := pdf[objStart:]
@@ -338,14 +338,14 @@ func locatePlaceholders(pdf []byte, sigDictObjNum int) (signaturePlaceholder, er
 	brMarker := []byte("/ByteRange ")
 	brIdx := bytes.Index(searchArea, brMarker)
 	if brIdx < 0 {
-		return ph, errors.New("could not find /ByteRange placeholder")
+		return ph, errors.New("sign: could not find /ByteRange placeholder")
 	}
 	ph.ByteRangeOffset = objStart + brIdx + len(brMarker)
 
 	contentsMarker := []byte("/Contents <")
 	cIdx := bytes.Index(searchArea, contentsMarker)
 	if cIdx < 0 {
-		return ph, errors.New("could not find /Contents placeholder")
+		return ph, errors.New("sign: could not find /Contents placeholder")
 	}
 	ph.ContentsOffset = objStart + cIdx + len("/Contents ")
 	ph.ContentsLen = len(contentsPlaceholder)

--- a/sign/tsa.go
+++ b/sign/tsa.go
@@ -100,7 +100,7 @@ func buildTimestampReq(digest []byte, hashFunc crypto.Hash) ([]byte, error) {
 	case crypto.SHA512:
 		hashOID = oidSHA512
 	default:
-		return nil, fmt.Errorf("unsupported hash function: %v", hashFunc)
+		return nil, fmt.Errorf("sign: unsupported hash function: %v", hashFunc)
 	}
 
 	req := timeStampReq{

--- a/svg/path.go
+++ b/svg/path.go
@@ -446,14 +446,14 @@ func consumeArgs(tokens []pathToken, pos, argCount int) ([]float64, int, error) 
 	args := make([]float64, argCount)
 	for j := range argCount {
 		if pos >= len(tokens) {
-			return nil, pos, fmt.Errorf("expected %d args, got %d", argCount, j)
+			return nil, pos, fmt.Errorf("svg: expected %d args, got %d", argCount, j)
 		}
 		if tokens[pos].isCommand {
-			return nil, pos, fmt.Errorf("expected number, got command %q", tokens[pos].value)
+			return nil, pos, fmt.Errorf("svg: expected number, got command %q", tokens[pos].value)
 		}
 		v, err := parseFloat(tokens[pos].value)
 		if err != nil {
-			return nil, pos, fmt.Errorf("invalid number %q: %w", tokens[pos].value, err)
+			return nil, pos, fmt.Errorf("svg: invalid number %q: %w", tokens[pos].value, err)
 		}
 		args[j] = v
 		pos++

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -381,13 +381,13 @@ func defaultFuncs() htmltpl.FuncMap {
 		// as a template execution failure.
 		"dict": func(pairs ...any) (map[string]any, error) {
 			if len(pairs)%2 != 0 {
-				return nil, fmt.Errorf("dict: odd number of arguments (%d)", len(pairs))
+				return nil, fmt.Errorf("tmpl: dict: odd number of arguments (%d)", len(pairs))
 			}
 			m := make(map[string]any, len(pairs)/2)
 			for i := 0; i+1 < len(pairs); i += 2 {
 				k, ok := pairs[i].(string)
 				if !ok {
-					return nil, fmt.Errorf("dict: key at position %d is %T, want string", i, pairs[i])
+					return nil, fmt.Errorf("tmpl: dict: key at position %d is %T, want string", i, pairs[i])
 				}
 				m[k] = pairs[i+1]
 			}


### PR DESCRIPTION
## Summary

- Apply a single convention to error/panic messages across all library packages: `<pkg>:` for top-level errors, `<pkg>: <subdomain>:` for sub-feature errors inside `font/`, `reader/`, `document/`, `image/`, `tmpl/`, and `<pkg>.<Func>:` for panics naming a public constructor or method.
- Adds the package prefix to ~130 previously unprefixed internal-helper errors that relied on caller wrapping. Wrappers preserve `%w` and the chain stays intact.
- Renames the message of `html.ErrURLPolicyDenied` from `"folio/html: URL fetch blocked by URLPolicy"` to `"html: URL fetch blocked by URLPolicy"`. The exported var name is unchanged; callers using `errors.Is` are unaffected. Callers that string-match the message will see the new prefix.

## Scope

- 47 files touched across `font/`, `reader/`, `core/`, `document/`, `image/`, `html/`, `svg/`, `sign/`, `tmpl/`, `internal/gen-css-docs/`.
- `cmd/folio/` and `examples/*` keep their verb-style prefixes (`usage:`, `open:`, `parse cert:`) — they are CLIs, not library APIs.
- 6 `panic("folio: ...")` sites in `document/page.go` changed to `document.AddText:` / `document.AddTextEmbedded:` / `document.AddImage:` to match the existing `layout.NewParagraph:` / `core.PdfDictionary.Set:` style.
- `html` continues to use a `folio/html:` prefix for slog log lines; only error message strings switch to `html:`. The split is intentional — log strings flow through user-supplied loggers and benefit from the longer disambiguating prefix.

## Non-goals

- No behavior change. Identifiers, function signatures, and error types are unchanged.
- No tests needed updating: existing assertions use `errors.Is` or substring matches against the kernel of the message, not the prefix.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all 27 testable packages green)
- [ ] Reviewer spot-check on a few packages for prefix routing