### PR TITLE
html: reset depth between calc operator scan passes

### DIFF
--- a/html/calc_position_test.go
+++ b/html/calc_position_test.go
@@ -234,6 +234,28 @@ func TestPercentFractionAcceptsNestedCalc(t *testing.T) {
 	}
 }
 
+// TestPercentFractionAcceptsRightSideParenCalc is the mirror of
+// TestPercentFractionAcceptsNestedCalc with the parenthesised sub-tree
+// on the left of the operator: calc((50% - 10%) * 2). This form used
+// to fail to parse because parseCalcExpr did not reset its paren-depth
+// counter between the +/- scan and the * / / scan, hiding the top-level
+// '*'. The fix lets parseLength produce a percent-only tree and the
+// helper must reduce it to 0.8.
+func TestPercentFractionAcceptsRightSideParenCalc(t *testing.T) {
+	const input = "calc((50% - 10%) * 2)"
+	l := parseLength(input)
+	if l == nil {
+		t.Fatalf("parseLength(%q) returned nil", input)
+	}
+	got, ok := percentFraction(l)
+	if !ok {
+		t.Fatalf("percentFraction(%q): ok=false, want ok=true", input)
+	}
+	if math.Abs(got-0.8) > 1e-9 {
+		t.Errorf("percentFraction(%q) = %v, want 0.8", input, got)
+	}
+}
+
 // TestPercentFractionRejectsBareNumberAsPx pins the bare-number-as-px
 // convention from parsePlainLength: parseLength("1.5") returns a
 // cssLength tagged with Unit "px", not "num". percentFraction must

--- a/html/calc_test.go
+++ b/html/calc_test.go
@@ -134,3 +134,76 @@ func TestCalcComplexExpression(t *testing.T) {
 		t.Errorf("calc(100%% - 40px - 40px) at 500pt = %.1f, want 440", got)
 	}
 }
+
+// TestCalcParenLeftOperandTimes pins the right-side parenthesised form
+// that exposed the depth-reset bug in parseCalcExpr: the +/- scan walks
+// past every '(' and ')' but its lower bound is i > 0, so an opening
+// paren at s[0] is never decremented. The leftover depth was carried
+// into the '*' / '/' scan and hid the top-level operator. Without the
+// fix this test returns nil.
+func TestCalcParenLeftOperandTimes(t *testing.T) {
+	l := parseLength("calc((50% - 10%) * 2)")
+	if l == nil || l.calc == nil {
+		t.Fatal("expected calc")
+	}
+	// (50% - 10%) of 100pt = 40, * 2 = 80
+	got := l.toPoints(100, 12)
+	if math.Abs(got-80) > 0.1 {
+		t.Errorf("calc((50%% - 10%%) * 2) at 100pt = %.1f, want 80", got)
+	}
+}
+
+// TestCalcParenLeftOperandAddPx covers the same shape with px leaves to
+// confirm the fix is not percent-specific.
+func TestCalcParenLeftOperandAddPx(t *testing.T) {
+	l := parseLength("calc((10px + 5px) * 2)")
+	if l == nil || l.calc == nil {
+		t.Fatal("expected calc")
+	}
+	// (10px + 5px) = 15px = 11.25pt, * 2 = 22.5pt (30px equivalent).
+	got := l.toPoints(0, 12)
+	if math.Abs(got-22.5) > 0.1 {
+		t.Errorf("calc((10px + 5px) * 2) = %.1f, want 22.5", got)
+	}
+}
+
+// TestCalcParenLeftOperandDivide pins the '/' branch of the same scan.
+func TestCalcParenLeftOperandDivide(t *testing.T) {
+	l := parseLength("calc((100% - 20%) / 4)")
+	if l == nil || l.calc == nil {
+		t.Fatal("expected calc")
+	}
+	// (100% - 20%) of 100pt = 80, / 4 = 20.
+	got := l.toPoints(100, 12)
+	if math.Abs(got-20) > 0.1 {
+		t.Errorf("calc((100%% - 20%%) / 4) at 100pt = %.1f, want 20", got)
+	}
+}
+
+// TestCalcParenRightOperandTimes is the mirrored form previously used as
+// a workaround. It must still parse correctly after the fix — regression
+// guard against breaking the form that did work.
+func TestCalcParenRightOperandTimes(t *testing.T) {
+	l := parseLength("calc(2 * (50% - 10%))")
+	if l == nil || l.calc == nil {
+		t.Fatal("expected calc")
+	}
+	got := l.toPoints(100, 12)
+	if math.Abs(got-80) > 0.1 {
+		t.Errorf("calc(2 * (50%% - 10%%)) at 100pt = %.1f, want 80", got)
+	}
+}
+
+// TestCalcDoubleParenLeftOperand pins a deeper nesting on the left side.
+// parseCalcExpr's recursive call on the left operand must strip both
+// paren layers and still produce a percent-only subtree.
+func TestCalcDoubleParenLeftOperand(t *testing.T) {
+	l := parseLength("calc(((50% - 10%)) * 2)")
+	if l == nil || l.calc == nil {
+		t.Fatal("expected calc")
+	}
+	got := l.toPoints(100, 12)
+	if math.Abs(got-80) > 0.1 {
+		t.Errorf("calc(((50%% - 10%%)) * 2) at 100pt = %.1f, want 80", got)
+	}
+}

--- a/html/properties.go
+++ b/html/properties.go
@@ -501,6 +501,12 @@ func parseCalcExpr(s string) *calcExpr {
 	}
 
 	// Try * and / (higher precedence).
+	// Reset depth: the +/- scan above walks past every ')' and '(' in the
+	// string, and the loop bound i > 0 skips index 0, so an opening paren
+	// at s[0] is never matched and leaves depth at a stale non-zero value.
+	// Without this reset, expressions like "(50% - 10%) * 2" hide their
+	// top-level '*' behind a phantom paren depth and fail to parse.
+	depth = 0
 	for i := len(s) - 1; i > 0; i-- {
 		ch := s[i]
 		switch ch {


### PR DESCRIPTION
## Summary

`parseCalcExpr` in `html/properties.go` scans its input twice — once for top-level `+` / `-` (lowest precedence) and then for `*` / `/`. Both loops are bounded `i > 0`, so an opening paren at `s[0]` is never visited, and its matching `)` at the end of the string leaves the shared `depth` counter at `+1` when the first pass finishes. The second pass then sees every position as nested and skips the top-level operator, returning `nil`.

Concrete reproducer: `calc((50% - 10%) * 2)` failed to parse; the mirrored `calc(2 * (50% - 10%))` worked only because its top-level operator appears before any paren.

## Fix

One-line reset of `depth = 0` between the two scan passes, mirroring the pattern already used by `resolveAngleCalc` in `converter_style_parsers.go`. The doc comment above the reset explains the asymmetry.

## Regression tests

`html/calc_test.go`:
- `TestCalcParenLeftOperandTimes` — `calc((50% - 10%) * 2)` at 100pt should resolve to 80.
- `TestCalcParenLeftOperandAddPx` — `calc((10px + 5px) * 2)` should resolve to 22.5pt (30px).
- `TestCalcParenLeftOperandDivide` — `calc((100% - 20%) / 4)` at 100pt should resolve to 20.
- `TestCalcParenRightOperandTimes` — the mirrored `calc(2 * (50% - 10%))` form must still parse (regression guard).
- `TestCalcDoubleParenLeftOperand` — `calc(((50% - 10%)) * 2)` exercises the nested-paren branch.

`html/calc_position_test.go`:
- `TestPercentFractionAcceptsRightSideParenCalc` — once the parser produces a correct tree, `calcExprIsPercentOnly` / `isPercentOnly` walk into it, and `percentFraction(parseLength("calc((50% - 10%) * 2)"))` returns `(0.8, true)`. Mirrors the existing `TestPercentFractionAcceptsNestedCalc`.

## Verification

- `go test ./html/...` passes.
- `go test ./...` passes.
- `gofmt -s -l .` clean.
- `golangci-lint run ./html/...` shows the same six pre-existing SA5011 baseline warnings, no new findings.