### PR TITLE
html, layout: lazy-resolve background-position at draw time (closes #266)

### DIFF
--- a/html/bg_position_lazy_test.go
+++ b/html/bg_position_lazy_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"math"
+	"testing"
+)
+
+// Tests in this file cover the lazy-resolution behaviour added to close
+// the background-position half of issue #266. parseBgPosition now
+// returns layout.ResolvableLength values that resolve at draw time
+// against (container - image) on each axis. Plain lengths and
+// mixed-unit calc — the long-standing gaps — are now valid inputs.
+// The gradient-stops half of the parent issue is tracked separately in
+// issue #318 and is not exercised here.
+
+// TestBgPositionPlainLength pins the plain-length axis path. 100px and
+// 50px must resolve to their points-equivalent (px to pt is 0.75 in
+// the codebase: 100px = 75pt, 50px = 37.5pt) on both axes regardless
+// of the container dimension. Plain lengths are raw offsets; the
+// container argument is unused at the leaf.
+func TestBgPositionPlainLength(t *testing.T) {
+	pos := parseBgPosition("100px 50px")
+	for _, container := range []float64{50, 200, 1000} {
+		gotX := pos[0].Resolve(container, 0)
+		gotY := pos[1].Resolve(container, 0)
+		if math.Abs(gotX-75) > 1e-9 || math.Abs(gotY-37.5) > 1e-9 {
+			t.Errorf("Resolve(container=%v) = [%v, %v], want [75, 37.5]",
+				container, gotX, gotY)
+		}
+	}
+}
+
+// TestBgPositionPlainLengthEm exercises em-relative plain lengths.
+// fontSize=16 feeds the em multiplier directly: 2em = 32pt, 1em = 16pt.
+func TestBgPositionPlainLengthEm(t *testing.T) {
+	pos := parseBgPosition("2em 1em")
+	gotX := pos[0].Resolve(100, 16)
+	gotY := pos[1].Resolve(100, 16)
+	if math.Abs(gotX-32) > 1e-9 || math.Abs(gotY-16) > 1e-9 {
+		t.Errorf("Resolve = [%v, %v], want [32, 16]", gotX, gotY)
+	}
+}
+
+// TestBgPositionMixedUnitCalcX pins the mixed-unit calc path closed by
+// the migration. calc(50% + 10px) against a (container - image) box of
+// 100pt resolves to 50%*100 + 10px*0.75 = 50 + 7.5 = 57.5pt. The y
+// axis stays plain percent.
+func TestBgPositionMixedUnitCalcX(t *testing.T) {
+	pos := parseBgPosition("calc(50% + 10px) 50%")
+	gotX := pos[0].Resolve(100, 0)
+	gotY := pos[1].Resolve(100, 0)
+	if math.Abs(gotX-57.5) > 1e-9 || math.Abs(gotY-50) > 1e-9 {
+		t.Errorf("Resolve = [%v, %v], want [57.5, 50]", gotX, gotY)
+	}
+}
+
+// TestBgPositionPercentY pins plain percent on both axes with
+// dissimilar container sizes for x and y. 50% of a 100pt (container-
+// image) x box = 50; 25% of a 50pt (container - image) y box = 12.5.
+func TestBgPositionPercentY(t *testing.T) {
+	pos := parseBgPosition("50% 25%")
+	gotX := pos[0].Resolve(100, 0)
+	gotY := pos[1].Resolve(50, 0)
+	if math.Abs(gotX-50) > 1e-9 || math.Abs(gotY-12.5) > 1e-9 {
+		t.Errorf("Resolve = [%v, %v], want [50, 12.5]", gotX, gotY)
+	}
+}
+
+// TestBgPositionKeywordPlusCalc pins the keyword + calc compose path
+// after the lazy migration. "left" maps to the percent constant 0%, so
+// it resolves to 0 regardless of container. calc(30%) resolves
+// against the y container.
+func TestBgPositionKeywordPlusCalc(t *testing.T) {
+	pos := parseBgPosition("left calc(30%)")
+	gotX := pos[0].Resolve(123, 0)
+	gotY := pos[1].Resolve(100, 0)
+	if math.Abs(gotX-0) > 1e-9 || math.Abs(gotY-30) > 1e-9 {
+		t.Errorf("Resolve = [%v, %v], want [0, 30]", gotX, gotY)
+	}
+}
+
+// TestBgPositionSingleAxisLength pins the single-axis default for a
+// plain length input. "100px" targets the x axis (it is not "top" or
+// "bottom"); the y axis defaults to the bgPosHalf percent constant
+// (50%). Resolution against a 100pt y (container - image) yields 50.
+func TestBgPositionSingleAxisLength(t *testing.T) {
+	pos := parseBgPosition("100px")
+	gotX := pos[0].Resolve(200, 0)
+	gotY := pos[1].Resolve(100, 0)
+	if math.Abs(gotX-75) > 1e-9 || math.Abs(gotY-50) > 1e-9 {
+		t.Errorf("Resolve = [%v, %v], want [75, 50]", gotX, gotY)
+	}
+}
+
+// TestBgPositionUnitlessNumberAsPx pins the folio convention from
+// parsePlainLength: a bare number with no unit is tagged with Unit
+// "px". Resolution applies the px-to-pt 0.75 factor. The single-axis
+// fallback applies as above: y defaults to bgPosHalf.
+func TestBgPositionUnitlessNumberAsPx(t *testing.T) {
+	pos := parseBgPosition("100")
+	gotX := pos[0].Resolve(200, 0)
+	gotY := pos[1].Resolve(100, 0)
+	if math.Abs(gotX-75) > 1e-9 || math.Abs(gotY-50) > 1e-9 {
+		t.Errorf("Resolve = [%v, %v], want [75, 50]", gotX, gotY)
+	}
+}
+
+// TestBgPositionInvalidFallsBack confirms the parser preserves its
+// "unrecognised input -> default" semantics after the migration. A
+// garbage token drops both axes to the bgPosZero constant, which
+// resolves to 0 regardless of the container dimension.
+func TestBgPositionInvalidFallsBack(t *testing.T) {
+	pos := parseBgPosition("garbage")
+	gotX := pos[0].Resolve(200, 0)
+	gotY := pos[1].Resolve(100, 0)
+	if gotX != 0 || gotY != 0 {
+		t.Errorf("Resolve = [%v, %v], want [0, 0]", gotX, gotY)
+	}
+}

--- a/html/calc_position_test.go
+++ b/html/calc_position_test.go
@@ -157,27 +157,39 @@ func TestParseGradientStopsMixedUnitCalcFallsBack(t *testing.T) {
 }
 
 // TestParseBgPositionWithCalc covers the percent-only calc path and the
-// single-axis fallback. Mixed-unit calc must fall back to the existing
-// "unparseable axis -> default" behaviour.
+// single-axis fallback. The lazy-resolution migration changes the
+// mixed-unit row: x now resolves to (container - image) * 0.5 + 10px's
+// point value at draw time, rather than dropping to 0 at parse time.
+// The percent-only rows are unchanged in intent; this test resolves
+// each axis against a 100pt "(container - image)" surrogate so the
+// recovered fraction matches the pre-migration expectations.
+//
+// Migrated from the [2]float64 return shape. The mixed-unit row is
+// rewritten to assert the new resolved-point semantics (60pt with the
+// codebase's px-to-pt convention of 0.75: 100*0.5 + 10*0.75 = 57.5).
 func TestParseBgPositionWithCalc(t *testing.T) {
 	tests := []struct {
-		input string
-		wantX float64
-		wantY float64
+		input         string
+		wantX         float64
+		wantY         float64
+		containerSize float64
+		fontSize      float64
 	}{
-		{"calc(50% - 10%) 50%", 0.4, 0.5},
-		{"calc(30%)", 0.3, 0.5},
-		{"min(40%, 60%) 50%", 0.4, 0.5},
-		{"clamp(10%, 50%, 90%) 25%", 0.5, 0.25},
-		// Mixed-unit calc on x: x falls back to 0 (existing
-		// behaviour for unparseable), y still resolves.
-		{"calc(50% + 10px) 50%", 0, 0.5},
+		{"calc(50% - 10%) 50%", 40, 50, 100, 0},
+		{"calc(30%)", 30, 50, 100, 0},
+		{"min(40%, 60%) 50%", 40, 50, 100, 0},
+		{"clamp(10%, 50%, 90%) 25%", 50, 25, 100, 0},
+		// Mixed-unit calc on x: now resolves lazily. 50% of 100 + 10px
+		// in points = 50 + 7.5 = 57.5. Y is plain 50% = 50.
+		{"calc(50% + 10px) 50%", 57.5, 50, 100, 0},
 	}
 	for _, tt := range tests {
 		pos := parseBgPosition(tt.input)
-		if math.Abs(pos[0]-tt.wantX) > 1e-9 || math.Abs(pos[1]-tt.wantY) > 1e-9 {
-			t.Errorf("parseBgPosition(%q) = [%v, %v], want [%v, %v]",
-				tt.input, pos[0], pos[1], tt.wantX, tt.wantY)
+		gotX := pos[0].Resolve(tt.containerSize, tt.fontSize)
+		gotY := pos[1].Resolve(tt.containerSize, tt.fontSize)
+		if math.Abs(gotX-tt.wantX) > 1e-9 || math.Abs(gotY-tt.wantY) > 1e-9 {
+			t.Errorf("parseBgPosition(%q).Resolve(%v, %v) = [%v, %v], want [%v, %v]",
+				tt.input, tt.containerSize, tt.fontSize, gotX, gotY, tt.wantX, tt.wantY)
 		}
 	}
 }
@@ -332,18 +344,24 @@ func TestParseGradientStopsLengthPositionDrops(t *testing.T) {
 // parseBgPosition with a calc value. The existing TestParseBgPositionWithCalc
 // only covers calc on the x axis; this test pairs a plain percent x
 // with a single-leaf calc y so the calc dispatch runs on parts[1].
+// Migrated to the resolved-points shape: a 100pt container makes the
+// recovered fractions match the pre-migration expectations.
 func TestParseBgPositionSingleAxisY(t *testing.T) {
 	pos := parseBgPosition("50% calc(30%)")
-	if math.Abs(pos[0]-0.5) > 1e-9 || math.Abs(pos[1]-0.3) > 1e-9 {
+	gotX := pos[0].Resolve(100, 0) / 100
+	gotY := pos[1].Resolve(100, 0) / 100
+	if math.Abs(gotX-0.5) > 1e-9 || math.Abs(gotY-0.3) > 1e-9 {
 		t.Errorf("parseBgPosition(%q) = [%v, %v], want [0.5, 0.3]",
-			"50% calc(30%)", pos[0], pos[1])
+			"50% calc(30%)", gotX, gotY)
 	}
 }
 
 // TestParseBgPositionKeywordPlusCalc pins the keyword + calc interplay
-// on both axes. The keyword resolves through toFrac's switch, the calc
-// resolves through the percent-only calc path, and the two compose
-// positionally.
+// on both axes. The keyword resolves through parseAxis's switch to a
+// percent constant (bgPosZero / bgPosHalf / bgPosFull), the calc
+// resolves through parseLength, and the two compose positionally.
+// Migrated from the [2]float64 return shape; a 100pt container surrogate
+// recovers the original fractions.
 func TestParseBgPositionKeywordPlusCalc(t *testing.T) {
 	tests := []struct {
 		input string
@@ -356,35 +374,42 @@ func TestParseBgPositionKeywordPlusCalc(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			pos := parseBgPosition(tt.input)
-			if math.Abs(pos[0]-tt.wantX) > 1e-9 || math.Abs(pos[1]-tt.wantY) > 1e-9 {
+			gotX := pos[0].Resolve(100, 0) / 100
+			gotY := pos[1].Resolve(100, 0) / 100
+			if math.Abs(gotX-tt.wantX) > 1e-9 || math.Abs(gotY-tt.wantY) > 1e-9 {
 				t.Errorf("parseBgPosition(%q) = [%v, %v], want [%v, %v]",
-					tt.input, pos[0], pos[1], tt.wantX, tt.wantY)
+					tt.input, gotX, gotY, tt.wantX, tt.wantY)
 			}
 		})
 	}
 }
 
-// TestParseBgPositionBothAxesMixedUnit exercises mixed-unit rejection
-// on both axes simultaneously. Each axis independently fails the
-// percent-only check and falls back to 0; neither axis "rescues" the
-// other.
+// TestParseBgPositionBothAxesMixedUnit exercises mixed-unit calc on
+// both axes simultaneously. After the lazy-resolution migration both
+// axes resolve at draw time: 50% of a 100pt (container - image) box
+// plus / minus 10px (= 7.5pt). Migrated from the
+// "both axes fall back to 0" assertion that captured the old behaviour.
 func TestParseBgPositionBothAxesMixedUnit(t *testing.T) {
 	pos := parseBgPosition("calc(50% + 10px) calc(50% - 10px)")
-	if pos[0] != 0 || pos[1] != 0 {
-		t.Errorf("parseBgPosition(%q) = [%v, %v], want [0, 0]",
-			"calc(50% + 10px) calc(50% - 10px)", pos[0], pos[1])
+	gotX := pos[0].Resolve(100, 0)
+	gotY := pos[1].Resolve(100, 0)
+	if math.Abs(gotX-57.5) > 1e-9 || math.Abs(gotY-42.5) > 1e-9 {
+		t.Errorf("parseBgPosition(%q).Resolve(100, 0) = [%v, %v], want [57.5, 42.5]",
+			"calc(50% + 10px) calc(50% - 10px)", gotX, gotY)
 	}
 }
 
-// TestParseBgPositionLengthDrops pins the documented plain-length spec
-// gap on background-position. The x-axis "100px" is rejected as
-// unparseable and falls back to 0; the y-axis "50%" still resolves to
-// 0.5. Resolving plain lengths requires the background box dimensions
-// (see issue #266).
+// TestParseBgPositionLengthDrops formerly pinned the plain-length spec
+// gap. The gap is closed by lazy resolution: the x-axis "100px" now
+// resolves to 75pt (px-to-pt 0.75) at draw time and the y-axis "50%"
+// resolves to half of (container - image). The test name is kept for
+// git-blame continuity but the assertion now confirms the closure.
 func TestParseBgPositionLengthDrops(t *testing.T) {
 	pos := parseBgPosition("100px 50%")
-	if math.Abs(pos[0]-0) > 1e-9 || math.Abs(pos[1]-0.5) > 1e-9 {
-		t.Errorf("parseBgPosition(%q) = [%v, %v], want [0, 0.5]",
-			"100px 50%", pos[0], pos[1])
+	gotX := pos[0].Resolve(200, 0)
+	gotY := pos[1].Resolve(100, 0)
+	if math.Abs(gotX-75) > 1e-9 || math.Abs(gotY-50) > 1e-9 {
+		t.Errorf("parseBgPosition(%q) = [%v, %v], want [75, 50]",
+			"100px 50%", gotX, gotY)
 	}
 }

--- a/html/converter_helpers.go
+++ b/html/converter_helpers.go
@@ -699,83 +699,91 @@ func parseGradientStops(parts []string) []layout.GradientStop {
 	return stops
 }
 
-// parseBgPosition converts CSS background-position keywords to [x, y]
-// fractions in [0, 1].
+// bgPosZero / bgPosHalf / bgPosFull are the percent constants that back
+// the background-position keywords (left/top -> 0%, center -> 50%,
+// right/bottom -> 100%). Storing them as cssLength preserves the percent
+// semantics at draw time: 100% on a 200pt container with a 100pt image
+// resolves to (200-100) * 1.0 = 100, which places the image's right
+// edge against the container's right edge, matching the CSS "100% 100%"
+// spec.
+var (
+	bgPosZero = &cssLength{Value: 0, Unit: "%"}
+	bgPosHalf = &cssLength{Value: 50, Unit: "%"}
+	bgPosFull = &cssLength{Value: 100, Unit: "%"}
+)
+
+// parseBgPosition parses the CSS background-position value into a pair
+// of layout.ResolvableLength values. Resolution against the background
+// box (and any em/rem inputs against font-size) happens lazily at draw
+// time so plain lengths and mixed-unit calc — e.g. "100px 50%" or
+// "calc(50% + 10px)" — produce the correct offset without needing the
+// box dimensions at parse time.
 //
-// Calc support level is "restricted calc": each axis may be a plain
-// percent, a keyword (left/center/right/top/bottom), or a
-// calc/min/max/clamp tree whose leaves are all percent or dimensionless
-// (e.g. calc(50% - 10%) -> 0.4). Mixed-unit calc such as
-// calc(50% + 10px) is currently rejected and the axis falls back to its
-// default (0 for x, 0.5 for y in single-axis cases). The same gap
-// applies to plain length axis values such as "100px 50%" or "1em 1em":
-// the length axis falls back to its default rather than being resolved
-// against the background box. Reducing mixed-unit calc or plain
-// lengths to a fraction requires the background box dimensions, which
-// are not known until render time. Lazy resolution against those
-// dimensions is the deferred fix (option (c) in issue #266).
-func parseBgPosition(val string) [2]float64 {
+// Each axis may be a keyword (left/center/right/top/bottom), a plain
+// percent, a plain length, or a calc/min/max/clamp tree. Single-axis
+// inputs default the missing axis to center. An unrecognised token
+// drops both axes to their default (matching the prior fraction return
+// of [0, 0] / [center, center] in the single-keyword case).
+//
+// The same lazy-resolution refactor is tracked for gradient stops in
+// issue #318; gradient stops still parse to fractions because the
+// gradient line length lives behind a different rendering boundary.
+func parseBgPosition(val string) [2]layout.ResolvableLength {
 	val = strings.TrimSpace(strings.ToLower(val))
+	def := [2]layout.ResolvableLength{bgPosZero, bgPosZero}
 	if val == "" {
-		return [2]float64{0, 0}
+		return def
 	}
 
 	// splitTopLevelFields keeps calc()/min()/max()/clamp() values as a
 	// single token even when they contain internal whitespace.
 	parts := splitTopLevelFields(val)
 
-	toFrac := func(s string) (float64, bool) {
+	// parseAxis maps a single axis token to a *cssLength. Keywords map
+	// to the bgPosZero/Half/Full percent constants; everything else is
+	// routed through parseLength which already understands plain
+	// lengths, percents, and the calc/min/max/clamp family.
+	parseAxis := func(s string) (*cssLength, bool) {
 		switch s {
-		case "left":
-			return 0, true
+		case "left", "top":
+			return bgPosZero, true
 		case "center":
-			return 0.5, true
-		case "right":
-			return 1, true
-		case "top":
-			return 0, true
-		case "bottom":
-			return 1, true
+			return bgPosHalf, true
+		case "right", "bottom":
+			return bgPosFull, true
 		}
-		if strings.HasSuffix(s, "%") {
-			if v, err := strconv.ParseFloat(strings.TrimSuffix(s, "%"), 64); err == nil {
-				return v / 100, true
-			}
-		}
-		// Calc/min/max/clamp: accept only percent-only trees. Mixed-unit
-		// trees fall back to the default (caller decides).
 		if l := parseLength(s); l != nil {
-			if frac, ok := percentFraction(l); ok {
-				return frac, true
-			}
+			return l, true
 		}
-		return 0, false
+		return nil, false
 	}
 
 	if len(parts) == 1 {
 		if parts[0] == "center" {
-			return [2]float64{0.5, 0.5}
+			return [2]layout.ResolvableLength{bgPosHalf, bgPosHalf}
 		}
-		if f, ok := toFrac(parts[0]); ok {
-			// Single keyword: "left" = 0, 0.5; "top" = 0.5, 0
+		if l, ok := parseAxis(parts[0]); ok {
+			// Single keyword/value: "top"/"bottom" target the y-axis
+			// (x defaults to center); everything else targets x
+			// (y defaults to center).
 			switch parts[0] {
 			case "top", "bottom":
-				return [2]float64{0.5, f}
+				return [2]layout.ResolvableLength{bgPosHalf, l}
 			default:
-				return [2]float64{f, 0.5}
+				return [2]layout.ResolvableLength{l, bgPosHalf}
 			}
 		}
-		return [2]float64{0, 0}
+		return def
 	}
 
-	x, y := 0.0, 0.0
-	if f, ok := toFrac(parts[0]); ok {
-		x = f
+	x, y := layout.ResolvableLength(bgPosZero), layout.ResolvableLength(bgPosZero)
+	if l, ok := parseAxis(parts[0]); ok {
+		x = l
 	}
-	if f, ok := toFrac(parts[1]); ok {
-		y = f
+	if l, ok := parseAxis(parts[1]); ok {
+		y = l
 	}
-	return [2]float64{x, y}
+	return [2]layout.ResolvableLength{x, y}
 }
 
 // resolveBackgroundImage resolves a background-image CSS value into a layout.BackgroundImage.
@@ -841,6 +849,7 @@ func (c *converter) resolveBackgroundImage(style computedStyle) *layout.Backgrou
 		Image:    img,
 		Size:     size,
 		Position: parseBgPosition(style.BackgroundPosition),
+		FontSize: style.FontSize,
 		Repeat:   repeat,
 	}
 

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -8290,6 +8290,14 @@ func TestParseRadialGradient(t *testing.T) {
 	}
 }
 
+// TestParseBgPosition was migrated from the original [2]float64 fraction
+// assertion to the new [2]layout.ResolvableLength shape. The expected
+// fractions are recovered by Resolve(100, 0) on each axis — percent
+// leaves multiply Value/100 by 100, so a 50% axis resolves to 50 and
+// the test reads back the original 0.5 fraction by dividing by 100.
+// Plain-length axes (none of the inputs below use them) would not
+// round-trip through this helper; the dedicated bg_position_lazy_test
+// covers those cases.
 func TestParseBgPosition(t *testing.T) {
 	tests := []struct {
 		input string
@@ -8305,9 +8313,11 @@ func TestParseBgPosition(t *testing.T) {
 	}
 	for _, tt := range tests {
 		pos := parseBgPosition(tt.input)
-		if pos[0] != tt.wantX || pos[1] != tt.wantY {
+		gotX := pos[0].Resolve(100, 0) / 100
+		gotY := pos[1].Resolve(100, 0) / 100
+		if math.Abs(gotX-tt.wantX) > 1e-9 || math.Abs(gotY-tt.wantY) > 1e-9 {
 			t.Errorf("parseBgPosition(%q) = [%v, %v], want [%v, %v]",
-				tt.input, pos[0], pos[1], tt.wantX, tt.wantY)
+				tt.input, gotX, gotY, tt.wantX, tt.wantY)
 		}
 	}
 }

--- a/html/style.go
+++ b/html/style.go
@@ -389,6 +389,15 @@ func (e *calcExpr) resolve(relativeTo, fontSize float64) float64 {
 	return 0
 }
 
+// Resolve satisfies layout.ResolvableLength so cssLength values can feed
+// background-position lazy resolution at draw time. It is a thin alias
+// for toPoints; container maps to the percent-resolution dimension and
+// fontSize feeds em / rem leaves. See layout.ResolvableLength for the
+// background-position semantic (container is (box - image) on each axis).
+func (l *cssLength) Resolve(container, fontSize float64) float64 {
+	return l.toPoints(container, fontSize)
+}
+
 // toPoints converts a CSS length to PDF points.
 // relativeTo is used for percentage values.
 func (l *cssLength) toPoints(relativeTo, fontSize float64) float64 {

--- a/layout/div.go
+++ b/layout/div.go
@@ -5,14 +5,29 @@ package layout
 
 import folioimage "github.com/carlos7ags/folio/image"
 
+// ResolvableLength is a length that resolves lazily against a container
+// dimension at draw time. Defined in layout (rather than imported from
+// html) so the layout package stays free of html-parsing concerns; the
+// html package's cssLength satisfies this interface. Used by
+// BackgroundImage.Position so that plain lengths and mixed-unit calc on
+// background-position can be resolved against the background box, which
+// is only known at draw time. See issue #266.
+type ResolvableLength interface {
+	// Resolve returns the length in PDF points. Percent leaves evaluate
+	// against container; em / rem leaves against fontSize. Plain length
+	// leaves (px, pt, mm, in, cm) ignore both arguments.
+	Resolve(container, fontSize float64) float64
+}
+
 // BackgroundImage describes a background image for a Div container.
 type BackgroundImage struct {
-	Image    *folioimage.Image // the image to draw
-	Size     string            // "auto", "cover", "contain"
-	SizeW    float64           // explicit width (0 = auto)
-	SizeH    float64           // explicit height (0 = auto)
-	Position [2]float64        // x%, y% (0-1 each)
-	Repeat   string            // "no-repeat", "repeat", "repeat-x", "repeat-y"
+	Image    *folioimage.Image   // the image to draw
+	Size     string              // "auto", "cover", "contain"
+	SizeW    float64             // explicit width (0 = auto)
+	SizeH    float64             // explicit height (0 = auto)
+	Position [2]ResolvableLength // x, y; resolved against the background box at draw time
+	FontSize float64             // font-size in points, for em/rem resolution of Position
+	Repeat   string              // "no-repeat", "repeat", "repeat-x", "repeat-y"
 }
 
 // Padding defines the padding on each side of a container.

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -1007,6 +1007,29 @@ func drawRoundedBorders(stream *content.Stream, borders CellBorders, x, y, w, h 
 	drawCellBorders(stream, borders, x, y, w, h)
 }
 
+// resolveBgPositionAxis resolves a single axis of background-position to
+// a point offset from the container's leading edge. containerSize is the
+// background box dimension on this axis; imageSize is the rendered
+// image dimension on the same axis. fontSize feeds em/rem resolution.
+//
+// Per CSS background-position semantics, percent values measure against
+// (container - image): "50%" centres the image. Plain lengths are raw
+// offsets from the container edge. Mixed-unit calc such as
+// calc(50% - 10px) splits the difference — percent leaves resolve
+// against (container - image) and length leaves contribute their raw
+// point value. The ResolvableLength contract (percent leaf reads the
+// container argument; length leaf ignores it) makes this fall out
+// naturally by passing (container - image) as the resolution dimension.
+//
+// A nil position (e.g. a parser fallback) maps to 0, matching the
+// previous fraction-default behaviour.
+func resolveBgPositionAxis(l ResolvableLength, containerSize, imageSize, fontSize float64) float64 {
+	if l == nil {
+		return 0
+	}
+	return l.Resolve(containerSize-imageSize, fontSize)
+}
+
 // drawBackgroundImage draws a background image into a container area.
 // (x, y) is bottom-left corner, w and h are the container dimensions.
 func drawBackgroundImage(ctx DrawContext, bg *BackgroundImage, x, y, w, h, radius float64) {
@@ -1089,13 +1112,28 @@ func drawBackgroundImage(ctx DrawContext, bg *BackgroundImage, x, y, w, h, radiu
 	}
 
 	// Compute initial position based on background-position.
-	posX := bg.Position[0] // 0-1
-	posY := bg.Position[1] // 0-1
+	//
+	// CSS background-position semantics treat percent and length values
+	// differently. A percent like "50%" centres the corresponding image
+	// edge fraction over the same container edge fraction, which works
+	// out to (container - image) * percent. A plain length like "50px"
+	// is a raw offset from the container's left/top edge. For calc that
+	// mixes both — e.g. calc(50% - 10px) — CSS computes the percent
+	// against (container - image) and adds the length on top. The
+	// resolver here passes (w - drawW) / (h - drawH) as the container
+	// dimension so percent leaves naturally pick up the right factor;
+	// plain-length leaves return their raw point value because they
+	// don't read the container argument.
+	posX := resolveBgPositionAxis(bg.Position[0], w, drawW, bg.FontSize)
+	posY := resolveBgPositionAxis(bg.Position[1], h, drawH, bg.FontSize)
 
 	// Origin position: the offset of the image's top-left within the container.
 	// PDF y-axis: y is bottom-left; image placed from bottom-left.
-	startX := x + posX*(w-drawW)
-	startY := y + (1-posY)*(h-drawH) // posY=0 → top → y + (h - drawH)
+	startX := x + posX
+	// posY is the distance from the container's top edge to the image's
+	// top edge. In PDF coords (y bottom-left), that means subtracting
+	// posY + drawH from the container's top.
+	startY := y + h - drawH - posY
 
 	switch repeat {
 	case "no-repeat":


### PR DESCRIPTION
## Summary

Closes the background-position half of #266. The gradient-stops half remains tracked in #318.

`parseBgPosition` now returns `[2]layout.ResolvableLength` instead of `[2]float64`. Resolution against the background box (and `em` / `rem` against font-size) happens lazily at draw time, so the plain-length and mixed-unit calc gaps documented in #312 / #314 are closed.

- `background-position: 100px 50px` now resolves to the literal points instead of dropping to 0.
- `background-position: calc(50% + 10px) 50%` now resolves correctly against `(container - image)`.
- `background-position: 2em 1em` resolves against the originating element's font-size.

## Design notes

- A new `layout.ResolvableLength` interface carries the percent / fontSize contract across the html / layout boundary. `cssLength` satisfies it via a thin `Resolve` method that delegates to the existing `toPoints`. The interface lives in `layout` so the layout package doesn't import html.
- `drawBackgroundImage` passes `(container - image)` on each axis when resolving percent leaves. This matches CSS background-position semantics: a percent value measures against `(container - image)` (so `50% 50%` centres the image), a plain length is a raw offset from the container edge, and mixed-unit calc splits the difference naturally because percent leaves consult the container argument while length leaves don't. There is a one-line comment at the call site explaining the `(container - image)` factor.
- `BackgroundImage` gains a `FontSize float64` field so `em` / `rem` leaves resolve against the element's font size. The converter populates it from the computed style.

## Test plan

- [x] `go test ./html/...` passes (including the migrated `TestParseBgPosition*` cases and the new `html/bg_position_lazy_test.go` coverage).
- [x] `go test ./layout/...` passes.
- [x] `go test ./...` full suite passes.
- [x] `gofmt -s -l .` clean.
- [x] `golangci-lint run ./html/... ./layout/...` clean (0 issues).
- [x] `go vet ./...` clean.
- [x] `examples/html-to-pdf` renders without regression (default-position gradient still places top-left as before).

## Migration of existing tests

The previously-failing-gap pins `TestParseBgPositionBothAxesMixedUnit` and `TestParseBgPositionLengthDrops` are migrated in-place — same test names, new assertions that confirm the gap is closed. Other tests that asserted the `[2]float64` shape now read `pos[axis].Resolve(container, fontSize)`. Each migrated test carries a one-line block comment so the diff is easy to review.