### PR TITLE
html/layout: display:inline-block shrinks to fit and flows inline (#330)

### DIFF
--- a/html/converter_paragraph.go
+++ b/html/converter_paragraph.go
@@ -356,10 +356,18 @@ func (c *converter) convertInlineElement(n *html.Node, style computedStyle) layo
 // layout.Element suitable for inline placement within a paragraph.
 func (c *converter) convertInlineBlockElement(n *html.Node, style computedStyle) layout.Element {
 	elems := c.convertBlock(n, style)
-	if len(elems) > 0 {
-		return elems[0]
+	if len(elems) == 0 {
+		return nil
 	}
-	return nil
+	el := elems[0]
+	// Enable shrink-to-fit (CSS fit-content) so the inline-block sizes to its
+	// content and flows inline, instead of filling the whole paragraph width.
+	// An explicit CSS width still wins (SetShrinkToFit only applies when no
+	// explicit width is set, handled in Div.PlanLayout).
+	if div, ok := el.(*layout.Div); ok {
+		div.SetShrinkToFit(true)
+	}
+	return el
 }
 
 // collectListItemRuns collects styled TextRuns from a <li> element,

--- a/html/features_test.go
+++ b/html/features_test.go
@@ -1570,6 +1570,151 @@ func TestInlineBlockDivInParagraph(t *testing.T) {
 	}
 }
 
+func TestInlineBlockShrinkToFitFlowsInline(t *testing.T) {
+	// Issue #330: two display:inline-block spans (no explicit width) should
+	// shrink to fit their content and flow on the same line, rather than each
+	// becoming a full-width block on its own line.
+	src := `<p><span style="display:inline-block; background:#eee;">One</span> <span style="display:inline-block; background:#eee;">Two</span></p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	p, ok := elems[0].(*layout.Paragraph)
+	if !ok {
+		t.Fatalf("expected *layout.Paragraph, got %T", elems[0])
+	}
+
+	const areaWidth = 400.0
+	lines := p.Layout(areaWidth)
+
+	// Collect the inline-block words across all lines.
+	var inlineWords []layout.Word
+	for _, line := range lines {
+		for _, w := range line.Words {
+			if w.InlineBlock != nil {
+				inlineWords = append(inlineWords, w)
+			}
+		}
+	}
+	if len(inlineWords) != 2 {
+		t.Fatalf("expected 2 inline-block words, got %d", len(inlineWords))
+	}
+
+	// Both inline-blocks should land on a single line (shrink-to-fit), so the
+	// paragraph should not have split them onto separate lines.
+	if len(lines) != 1 {
+		t.Errorf("expected inline-blocks to flow on a single line, got %d lines", len(lines))
+	}
+
+	// Each inline-block must be far narrower than the full area width: a
+	// full-width regression would make each one ~areaWidth.
+	for i, w := range inlineWords {
+		if w.InlineWidth >= areaWidth {
+			t.Errorf("inline-block %d width = %.1f, should shrink below area width %.0f", i, w.InlineWidth, areaWidth)
+		}
+		if w.InlineWidth <= 0 {
+			t.Errorf("inline-block %d width = %.1f, should be positive", i, w.InlineWidth)
+		}
+	}
+}
+
+func TestInlineBlockNoWrapperFlowsInline(t *testing.T) {
+	// Issue #330: a display:inline-block span with NO background/padding/border
+	// converts to a Paragraph (not a Div) and is inlined as an InlineElement.
+	// It must still flow inline on one line and hug its content (the inline
+	// element width is well below the full area width).
+	src := `<p>Before <span style="display:inline-block">chip</span> after</p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	p, ok := elems[0].(*layout.Paragraph)
+	if !ok {
+		t.Fatalf("expected *layout.Paragraph, got %T", elems[0])
+	}
+
+	const areaWidth = 400.0
+	lines := p.Layout(areaWidth)
+	if len(lines) != 1 {
+		t.Errorf("expected content to flow on a single line, got %d lines", len(lines))
+	}
+
+	var inlineWords []layout.Word
+	for _, line := range lines {
+		for _, w := range line.Words {
+			if w.InlineBlock != nil {
+				inlineWords = append(inlineWords, w)
+			}
+		}
+	}
+	if len(inlineWords) != 1 {
+		t.Fatalf("expected 1 inline-block word, got %d", len(inlineWords))
+	}
+	w := inlineWords[0]
+	if w.InlineWidth <= 0 {
+		t.Errorf("inline-block width = %.1f, should be positive", w.InlineWidth)
+	}
+	// "chip" is short; it must hug its content well below the 400pt area.
+	if w.InlineWidth >= areaWidth/2 {
+		t.Errorf("inline-block width = %.1f, should hug content (< %.0f)", w.InlineWidth, areaWidth/2)
+	}
+}
+
+func TestInlineBlockChipsWrapAcrossLines(t *testing.T) {
+	// Issue #330: several inline-block chips (with background, so each is a
+	// shrink-to-fit Div) whose combined width exceeds the area must wrap onto
+	// multiple lines, and each chip's width must stay below the area width.
+	src := `<p>` +
+		`<span style="display:inline-block; background:#eee;">Chip One</span> ` +
+		`<span style="display:inline-block; background:#eee;">Chip Two</span> ` +
+		`<span style="display:inline-block; background:#eee;">Chip Three</span> ` +
+		`<span style="display:inline-block; background:#eee;">Chip Four</span>` +
+		`</p>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	p, ok := elems[0].(*layout.Paragraph)
+	if !ok {
+		t.Fatalf("expected *layout.Paragraph, got %T", elems[0])
+	}
+
+	// Narrow area forces wrapping across multiple lines.
+	const areaWidth = 120.0
+	lines := p.Layout(areaWidth)
+	if len(lines) < 2 {
+		t.Errorf("expected chips to wrap onto multiple lines at width %.0f, got %d", areaWidth, len(lines))
+	}
+
+	chipCount := 0
+	for _, line := range lines {
+		for _, w := range line.Words {
+			if w.InlineBlock == nil {
+				continue
+			}
+			chipCount++
+			if w.InlineWidth >= areaWidth {
+				t.Errorf("chip width = %.1f, should be < area width %.0f", w.InlineWidth, areaWidth)
+			}
+			if w.InlineWidth <= 0 {
+				t.Errorf("chip width = %.1f, should be positive", w.InlineWidth)
+			}
+		}
+	}
+	if chipCount != 4 {
+		t.Errorf("expected 4 inline-block chips, got %d", chipCount)
+	}
+}
+
 func TestInlineBlockStandalone(t *testing.T) {
 	// A standalone display:inline-block (not inside a paragraph)
 	// should still render as a block element at the top level.

--- a/layout/div.go
+++ b/layout/div.go
@@ -104,6 +104,11 @@ type Div struct {
 	// the entire Div to the next page rather than splitting it.
 	keepTogether bool
 
+	// shrinkToFit makes the Div size to its content (CSS fit-content)
+	// when no explicit width is set, instead of filling the available
+	// area width. Used for display:inline-block atomic boxes.
+	shrinkToFit bool
+
 	// Overlay children: absolutely positioned elements within this
 	// containing block. They are laid out independently and placed at
 	// fixed offsets (overlayX, overlayY) from the Div's top-left,
@@ -371,6 +376,14 @@ func (d *Div) KeepTogether() bool {
 	return d.keepTogether
 }
 
+// SetShrinkToFit enables shrink-to-fit (CSS fit-content) sizing. When enabled
+// and no explicit width is set, the Div sizes to its content's max-content
+// width (clamped to the available area) instead of filling the area width.
+func (d *Div) SetShrinkToFit(v bool) *Div {
+	d.shrinkToFit = v
+	return d
+}
+
 // SetTag sets a custom PDF structure tag for accessibility (PDF/UA).
 // Common tags: "Sect", "Art", "BlockQuote", "Caption", "Part".
 // If empty, the default "Div" tag is used.
@@ -518,6 +531,25 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 		effectiveWidth = area.Width * d.widthPct
 	} else if d.width > 0 {
 		effectiveWidth = d.width
+	} else if d.shrinkToFit {
+		// CSS fit-content: size to the content's max-content width, but
+		// never exceed the available area. MaxWidth() already includes
+		// horizontal padding, so it yields an outer width consistent with
+		// effectiveWidth. Explicit min/max-width clamping below still runs.
+		fitContent := d.MaxWidth()
+		// Circular-dependency fallback: MaxWidth() deliberately treats
+		// percentage/calc-width children as non-intrinsic (they depend on
+		// the very width we are trying to compute), so it returns only this
+		// box's own horizontal padding when there is no intrinsic content
+		// width. Shrinking to that would collapse the box to an invisible
+		// sliver. When the fit-content width is no wider than our own
+		// horizontal padding, fall back to filling the available area.
+		if fitContent <= d.padding.Left+d.padding.Right {
+			fitContent = area.Width
+		} else if fitContent > area.Width {
+			fitContent = area.Width
+		}
+		effectiveWidth = fitContent
 	}
 
 	// Resolve max-width.
@@ -768,12 +800,13 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 
 	// Create overflow Div with remaining children.
 	overflowDiv := &Div{
-		elements:   overflowElements,
-		padding:    d.padding,
-		borders:    d.borders,
-		background: d.background,
-		bgImage:    d.bgImage,
-		spaceAfter: d.spaceAfter,
+		elements:    overflowElements,
+		padding:     d.padding,
+		borders:     d.borders,
+		background:  d.background,
+		bgImage:     d.bgImage,
+		spaceAfter:  d.spaceAfter,
+		shrinkToFit: d.shrinkToFit,
 	}
 	return LayoutPlan{
 		Status: LayoutPartial, Consumed: consumed, Blocks: blocks, Overflow: overflowDiv,

--- a/layout/div_test.go
+++ b/layout/div_test.go
@@ -298,6 +298,139 @@ func TestDivMaxWidthAndMaxHeight(t *testing.T) {
 	}
 }
 
+// --- Shrink-to-fit (CSS fit-content) tests for issue #330 ---
+
+func divBlockWidth(plan LayoutPlan) float64 {
+	if len(plan.Blocks) == 0 {
+		return 0
+	}
+	return plan.Blocks[0].Width
+}
+
+func TestDivShrinkToFitSizesToContent(t *testing.T) {
+	d := NewDiv().
+		SetShrinkToFit(true).
+		Add(NewParagraph("Hi", font.Helvetica, 12))
+
+	contentMax := d.MaxWidth()
+	plan := d.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	got := divBlockWidth(plan)
+
+	// Width should hug the content, not fill the 400pt area.
+	if got >= 400 {
+		t.Errorf("shrinkToFit width should be < area width 400, got %f", got)
+	}
+	if got != contentMax {
+		t.Errorf("shrinkToFit width = %f, want content max-width %f", got, contentMax)
+	}
+}
+
+func TestDivShrinkToFitClampedToArea(t *testing.T) {
+	// Content wider than the available area must clamp to area.Width.
+	d := NewDiv().
+		SetShrinkToFit(true).
+		Add(NewParagraph("This is a very long single word: supercalifragilisticexpialidocious", font.Helvetica, 12))
+
+	area := 100.0
+	plan := d.PlanLayout(LayoutArea{Width: area, Height: 1000})
+	got := divBlockWidth(plan)
+	if got > area {
+		t.Errorf("shrinkToFit width should clamp to area %f, got %f", area, got)
+	}
+}
+
+func TestDivNonShrinkToFitFillsArea(t *testing.T) {
+	// Regression guard: without shrinkToFit, the Div fills the area width.
+	d := NewDiv().
+		Add(NewParagraph("Hi", font.Helvetica, 12))
+
+	plan := d.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	got := divBlockWidth(plan)
+	if got != 400 {
+		t.Errorf("non-shrinkToFit width should fill area = 400, got %f", got)
+	}
+}
+
+func TestDivShrinkToFitExplicitWidthWins(t *testing.T) {
+	// An explicit width overrides shrink-to-fit.
+	d := NewDiv().
+		SetShrinkToFit(true).
+		SetWidthUnit(Pt(250)).
+		Add(NewParagraph("Hi", font.Helvetica, 12))
+
+	plan := d.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	got := divBlockWidth(plan)
+	if got != 250 {
+		t.Errorf("explicit width 250 should win over shrinkToFit, got %f", got)
+	}
+}
+
+func TestDivShrinkToFitMinWidthClamps(t *testing.T) {
+	// min-width forces a larger width than the content's fit-content size.
+	d := NewDiv().
+		SetShrinkToFit(true).
+		SetMinWidthUnit(Pt(200)).
+		Add(NewParagraph("Hi", font.Helvetica, 12))
+
+	plan := d.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	got := divBlockWidth(plan)
+	if got != 200 {
+		t.Errorf("min-width 200 should clamp shrinkToFit width, got %f", got)
+	}
+}
+
+func TestDivShrinkToFitMaxWidthClamps(t *testing.T) {
+	// max-width caps fit-content below the content's natural max-content width.
+	d := NewDiv().
+		SetShrinkToFit(true).
+		SetMaxWidthUnit(Pt(20)).
+		Add(NewParagraph("Hello world content", font.Helvetica, 12))
+
+	plan := d.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	got := divBlockWidth(plan)
+	if got != 20 {
+		t.Errorf("max-width 20 should clamp shrinkToFit width, got %f", got)
+	}
+}
+
+func TestDivShrinkToFitPercentChildDoesNotCollapse(t *testing.T) {
+	// Issue #330, Change 1: a shrink-to-fit Div whose only child is a
+	// percentage-width box with no intrinsic content is non-intrinsic —
+	// MaxWidth() returns only the box's own padding (here 0). Without the
+	// fallback guard the box would collapse to ~0 width (invisible). It must
+	// instead fall back to area.Width.
+	child := NewDiv().SetWidthUnit(Pct(50))
+	d := NewDiv().SetShrinkToFit(true).Add(child)
+
+	// Sanity: MaxWidth must be ~0 (only padding), confirming the collapse
+	// condition the guard protects against.
+	if mw := d.MaxWidth(); mw > 0.5 {
+		t.Fatalf("test precondition: expected ~0 MaxWidth for percentage child, got %f", mw)
+	}
+
+	const area = 400.0
+	plan := d.PlanLayout(LayoutArea{Width: area, Height: 1000})
+	got := divBlockWidth(plan)
+	if got < area-0.5 {
+		t.Errorf("percentage-child shrinkToFit width = %f, want fallback to area %f (must not collapse)", got, area)
+	}
+}
+
+func TestDivShrinkToFitPercentChildWithPaddingDoesNotCollapse(t *testing.T) {
+	// Same as above but the shrink-to-fit box has its own padding. The
+	// fit-content width equals only that padding (no intrinsic content), so
+	// the guard (fitContent <= padding.Left+padding.Right) must trigger.
+	child := NewDiv().SetWidthUnit(Pct(50))
+	d := NewDiv().SetShrinkToFit(true).SetPadding(10).Add(child)
+
+	const area = 400.0
+	plan := d.PlanLayout(LayoutArea{Width: area, Height: 1000})
+	got := divBlockWidth(plan)
+	if got < area-0.5 {
+		t.Errorf("percentage-child (with padding) shrinkToFit width = %f, want fallback to area %f", got, area)
+	}
+}
+
 func TestDivBackgroundOnlyNoBorders(t *testing.T) {
 	d := NewDiv().
 		SetBackground(RGB(0.95, 0.95, 1)).

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -1033,6 +1033,18 @@ func (p *Paragraph) MinWidth() float64 {
 func (p *Paragraph) MaxWidth() float64 {
 	total := 0.0
 	for _, run := range p.runs {
+		// Inline elements (e.g. a nested inline-block) participate in the
+		// same line as adjacent text. Treat them like a non-breaking word
+		// that contributes its own max-content width plus the same
+		// inter-run space the text branch adds below, so a fit-content
+		// parent measures wide enough to contain the nested chip.
+		if run.InlineElement != nil {
+			total += inlineElementMaxWidth(run.InlineElement)
+			// Add a space after the inline element (mirrors the per-run
+			// trailing space added for text runs).
+			total += inlineRunSpace(p.runs, run)
+			continue
+		}
 		measurer := runMeasurer(run)
 		words := splitWords(run.Text)
 		spaceW := measurer.MeasureString(" ", run.FontSize)
@@ -1052,6 +1064,49 @@ func (p *Paragraph) MaxWidth() float64 {
 		}
 	}
 	return total
+}
+
+// inlineElementMaxWidth reports the max-content width of an inline element
+// run. It prefers the element's own Measurable.MaxWidth(); otherwise it
+// falls back to measuring via PlanLayout at a large width and reading the
+// first block's width (mirroring how measureInlineElement extracts width).
+func inlineElementMaxWidth(el Element) float64 {
+	if m, ok := el.(Measurable); ok {
+		return m.MaxWidth()
+	}
+	plan := el.PlanLayout(LayoutArea{Width: 1e6, Height: 1e6})
+	if plan.Status != LayoutNothing && len(plan.Blocks) > 0 {
+		return plan.Blocks[0].Width
+	}
+	return 0
+}
+
+// inlineRunSpace returns the inter-run trailing space to add after an inline
+// element run, consistent with the per-run space the text branch of MaxWidth
+// adds. It derives the space width from a measurer; inline element runs carry
+// no font, so a fallback FontSize is used when none is present.
+func inlineRunSpace(runs []TextRun, run TextRun) float64 {
+	// An inline-element run typically has no font; derive the space width
+	// from the run's own font metrics when available, otherwise fall back
+	// to a neighboring text run's measurer.
+	if run.Font != nil || run.Embedded != nil {
+		return runMeasurer(run).MeasureString(" ", runFontSize(run))
+	}
+	for _, r := range runs {
+		if r.InlineElement == nil && (r.Font != nil || r.Embedded != nil) {
+			return runMeasurer(r).MeasureString(" ", r.FontSize)
+		}
+	}
+	return 0
+}
+
+// runFontSize returns a non-zero font size for measuring, defaulting to a
+// reasonable value when the run carries none.
+func runFontSize(run TextRun) float64 {
+	if run.FontSize > 0 {
+		return run.FontSize
+	}
+	return 12
 }
 
 // MeasureLines reports how many wrapped lines this paragraph produces at

--- a/layout/paragraph_test.go
+++ b/layout/paragraph_test.go
@@ -609,6 +609,45 @@ func TestParagraphInlineElementLayout(t *testing.T) {
 	}
 }
 
+func TestParagraphMaxWidthIncludesInlineElement(t *testing.T) {
+	// Issue #330, Change 2: Paragraph.MaxWidth must include the intrinsic
+	// width of inline-element runs (previously they were skipped, so a
+	// nested inline-block under-measured and got clipped). fixedElement does
+	// not implement Measurable, exercising the PlanLayout fallback path.
+	el := &fixedElement{width: 80, height: 16}
+
+	textOnly := NewParagraph("Hello", font.Helvetica, 12)
+	base := textOnly.MaxWidth()
+
+	withInline := NewStyledParagraph(
+		NewRun("Hello", font.Helvetica, 12),
+		RunInline(el),
+	)
+	got := withInline.MaxWidth()
+
+	// The inline element contributes its 80pt width, so the paragraph's
+	// max-content width must grow by at least that amount.
+	if got < base+80 {
+		t.Errorf("MaxWidth = %.1f, want >= base(%.1f)+80 to include inline element", got, base)
+	}
+}
+
+func TestParagraphMaxWidthInlineElementMeasurable(t *testing.T) {
+	// When the inline element implements Measurable, MaxWidth should use its
+	// MaxWidth() directly. A nested shrink-to-fit Div is Measurable.
+	inner := NewDiv().SetShrinkToFit(true).Add(NewParagraph("Chip", font.Helvetica, 12))
+	innerMax := inner.MaxWidth()
+	if innerMax <= 0 {
+		t.Fatalf("expected positive inner MaxWidth, got %f", innerMax)
+	}
+
+	p := NewStyledParagraph(RunInline(inner))
+	got := p.MaxWidth()
+	if got < innerMax {
+		t.Errorf("paragraph MaxWidth = %.1f, want >= inner MaxWidth %.1f", got, innerMax)
+	}
+}
+
 func TestParagraphInlineElementPlanLayout(t *testing.T) {
 	el := &fixedElement{width: 20, height: 16}
 	p := NewStyledParagraph(


### PR DESCRIPTION
Fixes #330.

display:inline-block elements without an explicit width rendered as
full-width blocks each on their own line, instead of shrink-to-fit inline
atomic boxes that flow with surrounding text.

## Cause
The inline-block Div had no explicit width, so Div.PlanLayout defaulted
its width to the full available area, and that width propagated to the
inline word — pushing following content onto the next line.

## Fix
- Div gains a shrinkToFit flag. When set with no explicit width,
  PlanLayout sizes to CSS fit-content: min(max-content, available).
  Explicit width, min-width and max-width are still honored.
- Guard against the percentage/calc circular-dependency: when content
  has no intrinsic width, fall back to the available width rather than
  collapsing to ~0.
- Paragraph.MaxWidth counts inline-element children so a nested
  inline-block measures correctly.
- The inline-block converter path enables the flag; plain block layout
  is unchanged.

## Tests
13 new tests. The issue's two-chips-on-one-line scenario
(TestInlineBlockShrinkToFitFlowsInline) fails on the prior code
(2 lines, each chip 400pt wide) and passes with the fix. Coverage
includes multi-chip wrapping, the no-wrapper path, percentage-child
fallback, and min/max-width clamping.