### PR TITLE
html/layout: percentage border-radius with elliptical corners (#329)

### DIFF
--- a/content/stream.go
+++ b/content/stream.go
@@ -682,72 +682,99 @@ func (s *Stream) RoundedRect(x, y, w, h, r float64) {
 	s.ClosePath()
 }
 
-// RoundedRectPerCorner draws a rounded rectangle with different radii per corner.
-// The radii are rTL (top-left), rTR (top-right), rBR (bottom-right), rBL (bottom-left).
+// RoundedRectPerCorner draws a rounded rectangle with different (circular)
+// radii per corner. The radii are rTL (top-left), rTR (top-right),
+// rBR (bottom-right), rBL (bottom-left).
 // In PDF coordinates y increases upward, so (x, y) is the bottom-left of the rect.
 //
 // Radii are proportionally reduced so that no edge is over-subscribed by its
 // two adjacent corners (the CSS border-radius algorithm, CSS Backgrounds and
 // Borders Module Level 3 §5.5). Negative radii are treated as 0.
+//
+// This is a circular special case of RoundedRectPerCornerXY: it delegates with
+// rx == ry per corner so there is a single drawing implementation.
 func (s *Stream) RoundedRectPerCorner(x, y, w, h, rTL, rTR, rBR, rBL float64) {
-	if rTL < 0 {
-		rTL = 0
-	}
-	if rTR < 0 {
-		rTR = 0
-	}
-	if rBR < 0 {
-		rBR = 0
-	}
-	if rBL < 0 {
-		rBL = 0
+	s.RoundedRectPerCornerXY(x, y, w, h,
+		[4]float64{rTL, rTR, rBR, rBL},
+		[4]float64{rTL, rTR, rBR, rBL})
+}
+
+// RoundedRectPerCornerXY draws a rounded rectangle with independent horizontal
+// (rx) and vertical (ry) radii per corner, producing elliptical corners. The
+// arrays are indexed [TL, TR, BR, BL]. A corner with rx == ry is circular.
+// In PDF coordinates y increases upward, so (x, y) is the bottom-left of the rect.
+//
+// Radii are proportionally reduced so that no edge is over-subscribed by its
+// two adjacent corners (the generalized CSS border-radius algorithm, CSS
+// Backgrounds and Borders Module Level 3 §5.5): the horizontal radii constrain
+// the top/bottom edges against w, and the vertical radii constrain the
+// left/right edges against h. A single reduction factor f scales every rx and
+// ry. Negative radii are treated as 0.
+func (s *Stream) RoundedRectPerCornerXY(x, y, w, h float64, rx, ry [4]float64) {
+	const (
+		tl = 0
+		tr = 1
+		br = 2
+		bl = 3
+	)
+	for i := range rx {
+		if rx[i] < 0 {
+			rx[i] = 0
+		}
+		if ry[i] < 0 {
+			ry[i] = 0
+		}
 	}
 	f := 1.0
-	if s := rTL + rTR; s > 0 {
-		f = min(f, w/s)
+	if sum := rx[tl] + rx[tr]; sum > 0 { // top edge
+		f = min(f, w/sum)
 	}
-	if s := rTR + rBR; s > 0 {
-		f = min(f, h/s)
+	if sum := rx[bl] + rx[br]; sum > 0 { // bottom edge
+		f = min(f, w/sum)
 	}
-	if s := rBL + rBR; s > 0 {
-		f = min(f, w/s)
+	if sum := ry[tl] + ry[bl]; sum > 0 { // left edge
+		f = min(f, h/sum)
 	}
-	if s := rTL + rBL; s > 0 {
-		f = min(f, h/s)
+	if sum := ry[tr] + ry[br]; sum > 0 { // right edge
+		f = min(f, h/sum)
 	}
 	if f < 1 {
-		rTL *= f
-		rTR *= f
-		rBR *= f
-		rBL *= f
+		for i := range rx {
+			rx[i] *= f
+			ry[i] *= f
+		}
 	}
 	const k = 0.5522847498
 
-	// Start at bottom-left, just past the BL corner radius.
-	s.MoveTo(x+rBL, y)
-	// Bottom edge → bottom-right corner
-	s.LineTo(x+w-rBR, y)
-	if rBR > 0 {
-		kr := rBR * k
-		s.CurveTo(x+w-rBR+kr, y, x+w, y+rBR-kr, x+w, y+rBR)
+	// Start at bottom-left, just past the BL corner radius (x extent).
+	s.MoveTo(x+rx[bl], y)
+	// Bottom edge → bottom-right corner.
+	s.LineTo(x+w-rx[br], y)
+	if rx[br] > 0 || ry[br] > 0 {
+		krx := rx[br] * k
+		kry := ry[br] * k
+		s.CurveTo(x+w-rx[br]+krx, y, x+w, y+ry[br]-kry, x+w, y+ry[br])
 	}
-	// Right edge → top-right corner
-	s.LineTo(x+w, y+h-rTR)
-	if rTR > 0 {
-		kr := rTR * k
-		s.CurveTo(x+w, y+h-rTR+kr, x+w-rTR+kr, y+h, x+w-rTR, y+h)
+	// Right edge → top-right corner.
+	s.LineTo(x+w, y+h-ry[tr])
+	if rx[tr] > 0 || ry[tr] > 0 {
+		krx := rx[tr] * k
+		kry := ry[tr] * k
+		s.CurveTo(x+w, y+h-ry[tr]+kry, x+w-rx[tr]+krx, y+h, x+w-rx[tr], y+h)
 	}
-	// Top edge → top-left corner
-	s.LineTo(x+rTL, y+h)
-	if rTL > 0 {
-		kr := rTL * k
-		s.CurveTo(x+rTL-kr, y+h, x, y+h-rTL+kr, x, y+h-rTL)
+	// Top edge → top-left corner.
+	s.LineTo(x+rx[tl], y+h)
+	if rx[tl] > 0 || ry[tl] > 0 {
+		krx := rx[tl] * k
+		kry := ry[tl] * k
+		s.CurveTo(x+rx[tl]-krx, y+h, x, y+h-ry[tl]+kry, x, y+h-ry[tl])
 	}
-	// Left edge → bottom-left corner
-	s.LineTo(x, y+rBL)
-	if rBL > 0 {
-		kr := rBL * k
-		s.CurveTo(x, y+rBL-kr, x+rBL-kr, y, x+rBL, y)
+	// Left edge → bottom-left corner.
+	s.LineTo(x, y+ry[bl])
+	if rx[bl] > 0 || ry[bl] > 0 {
+		krx := rx[bl] * k
+		kry := ry[bl] * k
+		s.CurveTo(x, y+ry[bl]-kry, x+rx[bl]-krx, y, x+rx[bl], y)
 	}
 	s.ClosePath()
 }

--- a/content/stream_test.go
+++ b/content/stream_test.go
@@ -1130,6 +1130,96 @@ func TestRoundedRectPerCornerNegativeRadius(t *testing.T) {
 	}
 }
 
+// --- RoundedRectPerCornerXY (elliptical corners) tests ---
+
+// A square box with equal rx==ry per corner must produce exactly the same
+// path as the circular RoundedRectPerCorner — RoundedRectPerCorner delegates
+// to the XY version, so this also guards against a behavior change for
+// existing callers.
+func TestRoundedRectPerCornerXYCircleMatchesCircular(t *testing.T) {
+	// 28x28 box, 50%-equivalent radius = 14 on every corner.
+	circ := NewStream()
+	circ.RoundedRectPerCorner(0, 0, 28, 28, 14, 14, 14, 14)
+	xy := NewStream()
+	xy.RoundedRectPerCornerXY(0, 0, 28, 28,
+		[4]float64{14, 14, 14, 14}, [4]float64{14, 14, 14, 14})
+	if string(circ.Bytes()) != string(xy.Bytes()) {
+		t.Errorf("circular and XY paths differ:\ncircular=%q\nxy=%q",
+			circ.Bytes(), xy.Bytes())
+	}
+}
+
+// An elliptical corner (rx != ry) must place its control points at distinct
+// x and y extents — the curve reaches rx horizontally and ry vertically.
+func TestRoundedRectPerCornerXYElliptical(t *testing.T) {
+	// 100x40 box, 50% radius → rx=50, ry=20 on every corner (a pill).
+	s := NewStream()
+	rx := [4]float64{50, 50, 50, 50}
+	ry := [4]float64{20, 20, 20, 20}
+	s.RoundedRectPerCornerXY(0, 0, 100, 40, rx, ry)
+	got := string(s.Bytes())
+	// Start point is at x = rx[BL] = 50 (horizontal extent), y = 0.
+	if !strings.HasPrefix(got, "50 0 m") {
+		t.Errorf("expected elliptical path to start with %q, got %q", "50 0 m", got)
+	}
+	// Four curves, one per corner.
+	if strings.Count(got, " c") != 4 {
+		t.Errorf("expected 4 curve operators, got %d in %q", strings.Count(got, " c"), got)
+	}
+	// The vertical extent (ry=20) and horizontal extent (rx=50) differ, so the
+	// path must mention both 20 and 50 — confirming the corners are not
+	// circular. A circular rendering would collapse to a single radius.
+	if !strings.Contains(got, "20") || !strings.Contains(got, "50") {
+		t.Errorf("expected distinct x/y extents (20 and 50) in %q", got)
+	}
+}
+
+// The generalized clamp must reduce over-subscribed radii using w for the
+// horizontal (rx) sums and h for the vertical (ry) sums, scaling both axes by
+// the same factor.
+func TestRoundedRectPerCornerXYClamp(t *testing.T) {
+	// w=20, h=100, all rx=30 → top sum=60, f_top=20/60=1/3.
+	// all ry=10 → left sum=20, f_left=100/20=5. f=min(1, 1/3, ...)=1/3.
+	// rx scales to 10 (start x = rx[BL] = 10), ry scales to 10/3≈3.333.
+	s := NewStream()
+	s.RoundedRectPerCornerXY(0, 0, 20, 100,
+		[4]float64{30, 30, 30, 30}, [4]float64{10, 10, 10, 10})
+	got := string(s.Bytes())
+	if !strings.HasPrefix(got, "10 0 m") {
+		t.Errorf("expected clamped path to start with %q, got %q", "10 0 m", got)
+	}
+	// ry must be scaled by the SAME factor f=1/3: ry 10 → 3.333333. Guard the
+	// vertical axis explicitly so a bug that scales only rx (leaving ry=10)
+	// cannot pass. The right edge runs to y = h-ry = 100-3.333333 = 96.666667
+	// (an unscaled ry would emit 90), and the bottom-right corner curve ends at
+	// y = ry = 3.333333 with control y = ry-ry*k = 1.492384. Assert the whole
+	// BR curve operator as an exact line so the match is not a loose substring.
+	const brCurve = "15.522847 0 20 1.492384 20 3.333333 c"
+	if !strings.Contains(got, "\n"+brCurve+"\n") &&
+		!strings.HasSuffix(got, "\n"+brCurve) {
+		t.Errorf("expected BR corner curve %q (proving ry scaled by f=1/3) in %q",
+			brCurve, got)
+	}
+	if !strings.Contains(got, "\n20 96.666667 l\n") {
+		t.Errorf("expected right edge %q (ry scaled to 3.333333, not 10) in %q",
+			"20 96.666667 l", got)
+	}
+}
+
+// Negative radii on either axis are treated as 0.
+func TestRoundedRectPerCornerXYNegative(t *testing.T) {
+	s := NewStream()
+	s.RoundedRectPerCornerXY(0, 0, 100, 50,
+		[4]float64{-5, 0, 0, 0}, [4]float64{-5, 0, 0, 0})
+	got := string(s.Bytes())
+	if !strings.HasPrefix(got, "0 0 m") {
+		t.Errorf("expected path to start with %q, got %q", "0 0 m", got)
+	}
+	if strings.Contains(got, " c") {
+		t.Errorf("expected no curves with zero/negative radii, got %q", got)
+	}
+}
+
 // --- ISO 32000 operator tests (Part B) ---
 
 func TestMoveTextWithLeading(t *testing.T) {

--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -159,7 +159,7 @@ func (c *converter) convertBlock(n *html.Node, style computedStyle) []layout.Ele
 	// If no box-model properties, skip the Div wrapper.
 	hasWidthConstraints := style.Width != nil || style.MaxWidth != nil || style.MinWidth != nil
 	hasHeightConstraints := style.Height != nil || style.MinHeight != nil || style.MaxHeight != nil || style.AspectRatio > 0
-	hasVisualEffects := style.BorderRadius > 0 || style.BorderRadiusTL > 0 || style.BorderRadiusTR > 0 || style.BorderRadiusBR > 0 || style.BorderRadiusBL > 0 || (style.Opacity > 0 && style.Opacity < 1) || style.Overflow == "hidden"
+	hasVisualEffects := style.BorderRadius > 0 || style.BorderRadiusTL > 0 || style.BorderRadiusTR > 0 || style.BorderRadiusBR > 0 || style.BorderRadiusBL > 0 || style.BorderRadiusTLPct > 0 || style.BorderRadiusTRPct > 0 || style.BorderRadiusBRPct > 0 || style.BorderRadiusBLPct > 0 || (style.Opacity > 0 && style.Opacity < 1) || style.Overflow == "hidden"
 	hasBoxShadow := len(style.BoxShadows) > 0
 	hasOutline := style.OutlineWidth > 0
 	hasTransform := style.Transform != "" && strings.ToLower(strings.TrimSpace(style.Transform)) != "none"
@@ -290,6 +290,15 @@ func applyDivStyles(div *layout.Div, style computedStyle, containerWidth float64
 		div.SetBorderRadiusPerCorner(style.BorderRadiusTL, style.BorderRadiusTR, style.BorderRadiusBR, style.BorderRadiusBL)
 	} else if style.BorderRadius > 0 {
 		div.SetBorderRadius(style.BorderRadius)
+	}
+	// Percentage radii resolve against the box width/height at draw time
+	// (elliptical corners); pass them through even when no absolute radius
+	// is set so a percentage-only border-radius still rounds.
+	if style.BorderRadiusTLPct > 0 || style.BorderRadiusTRPct > 0 || style.BorderRadiusBRPct > 0 || style.BorderRadiusBLPct > 0 {
+		div.SetBorderRadiusPercent([4]float64{
+			style.BorderRadiusTLPct, style.BorderRadiusTRPct,
+			style.BorderRadiusBRPct, style.BorderRadiusBLPct,
+		})
 	}
 	if style.Clear != "" && style.Clear != "none" {
 		div.SetClear(style.Clear)

--- a/html/css_props.go
+++ b/html/css_props.go
@@ -545,28 +545,28 @@ var cssProperties = []cssProperty{
 		Name: "border-top-left-radius", Category: "Borders",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.BorderRadiusTL = parseLengthPt(value, s.FontSize)
+			s.BorderRadiusTL, s.BorderRadiusTLPct = parseRadiusComponent(value, s.FontSize)
 		},
 	},
 	{
 		Name: "border-top-right-radius", Category: "Borders",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.BorderRadiusTR = parseLengthPt(value, s.FontSize)
+			s.BorderRadiusTR, s.BorderRadiusTRPct = parseRadiusComponent(value, s.FontSize)
 		},
 	},
 	{
 		Name: "border-bottom-right-radius", Category: "Borders",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.BorderRadiusBR = parseLengthPt(value, s.FontSize)
+			s.BorderRadiusBR, s.BorderRadiusBRPct = parseRadiusComponent(value, s.FontSize)
 		},
 	},
 	{
 		Name: "border-bottom-left-radius", Category: "Borders",
 		Values: []string{"<length>", "<percentage>"},
 		Apply: func(s *computedStyle, value string) {
-			s.BorderRadiusBL = parseLengthPt(value, s.FontSize)
+			s.BorderRadiusBL, s.BorderRadiusBLPct = parseRadiusComponent(value, s.FontSize)
 		},
 	},
 
@@ -1265,41 +1265,52 @@ var cssProperties = []cssProperty{
 		Values: []string{"<length>", "<percentage>", "<1-4 of these>"},
 		Notes:  "splitTopLevelFields preserves calc()/min()/max()/clamp() as single tokens.",
 		Apply: func(s *computedStyle, value string) {
+			// The `border-radius: <h> / <v>` slash syntax (independent
+			// horizontal/vertical radii) is deferred follow-up work; only the
+			// leading (horizontal) set is consumed here, and a single value per
+			// corner drives both axes. parseRadiusComponent preserves
+			// percentages so they resolve against the box at layout time.
+			if slash := indexByteAtTopLevel(value, '/'); slash >= 0 {
+				value = strings.TrimSpace(value[:slash])
+			}
 			parts := splitTopLevelFields(value)
+			var (
+				tlA, tlP float64
+				trA, trP float64
+				brA, brP float64
+				blA, blP float64
+			)
 			switch len(parts) {
 			case 1:
-				if l := parseLength(parts[0]); l != nil {
-					v := l.toPoints(0, s.FontSize)
-					s.BorderRadius = v
-					s.BorderRadiusTL = v
-					s.BorderRadiusTR = v
-					s.BorderRadiusBR = v
-					s.BorderRadiusBL = v
-				}
+				tlA, tlP = parseRadiusComponent(parts[0], s.FontSize)
+				trA, trP = tlA, tlP
+				brA, brP = tlA, tlP
+				blA, blP = tlA, tlP
 			case 2:
-				tl := parseLengthPt(parts[0], s.FontSize)
-				br := parseLengthPt(parts[1], s.FontSize)
-				s.BorderRadiusTL = tl
-				s.BorderRadiusBR = tl
-				s.BorderRadiusTR = br
-				s.BorderRadiusBL = br
-				s.BorderRadius = tl
+				// parts[0] -> TL & BR (diagonal), parts[1] -> TR & BL.
+				tlA, tlP = parseRadiusComponent(parts[0], s.FontSize)
+				trA, trP = parseRadiusComponent(parts[1], s.FontSize)
+				brA, brP = tlA, tlP
+				blA, blP = trA, trP
 			case 3:
-				tl := parseLengthPt(parts[0], s.FontSize)
-				tr := parseLengthPt(parts[1], s.FontSize)
-				bl := parseLengthPt(parts[2], s.FontSize)
-				s.BorderRadiusTL = tl
-				s.BorderRadiusTR = tr
-				s.BorderRadiusBR = bl
-				s.BorderRadiusBL = tr
-				s.BorderRadius = tl
+				// parts[0] -> TL, parts[1] -> TR & BL, parts[2] -> BR.
+				tlA, tlP = parseRadiusComponent(parts[0], s.FontSize)
+				trA, trP = parseRadiusComponent(parts[1], s.FontSize)
+				brA, brP = parseRadiusComponent(parts[2], s.FontSize)
+				blA, blP = trA, trP
 			case 4:
-				s.BorderRadiusTL = parseLengthPt(parts[0], s.FontSize)
-				s.BorderRadiusTR = parseLengthPt(parts[1], s.FontSize)
-				s.BorderRadiusBR = parseLengthPt(parts[2], s.FontSize)
-				s.BorderRadiusBL = parseLengthPt(parts[3], s.FontSize)
-				s.BorderRadius = s.BorderRadiusTL
+				tlA, tlP = parseRadiusComponent(parts[0], s.FontSize)
+				trA, trP = parseRadiusComponent(parts[1], s.FontSize)
+				brA, brP = parseRadiusComponent(parts[2], s.FontSize)
+				blA, blP = parseRadiusComponent(parts[3], s.FontSize)
+			default:
+				return
 			}
+			s.BorderRadiusTL, s.BorderRadiusTLPct = tlA, tlP
+			s.BorderRadiusTR, s.BorderRadiusTRPct = trA, trP
+			s.BorderRadiusBR, s.BorderRadiusBRPct = brA, brP
+			s.BorderRadiusBL, s.BorderRadiusBLPct = blA, blP
+			s.BorderRadius = tlA
 		},
 	},
 	{

--- a/html/css_props_test.go
+++ b/html/css_props_test.go
@@ -616,6 +616,47 @@ func TestCSSPropertyParitySnapshot(t *testing.T) {
 			},
 		},
 		{
+			// border-radius: 50% — percentage must be preserved as a
+			// fraction on every corner (abs stays 0), so it can resolve
+			// against the box at layout time instead of collapsing to 0.
+			name:     "border-radius/percent-shorthand",
+			property: "border-radius", value: "50%", fontSize: 12,
+			expectField: func(s *computedStyle) bool {
+				return s.BorderRadiusTLPct == 0.5 && s.BorderRadiusTRPct == 0.5 &&
+					s.BorderRadiusBRPct == 0.5 && s.BorderRadiusBLPct == 0.5 &&
+					s.BorderRadiusTL == 0 && s.BorderRadiusTR == 0 &&
+					s.BorderRadiusBR == 0 && s.BorderRadiusBL == 0
+			},
+		},
+		{
+			// Per-corner percentage longhand.
+			name:     "border-top-left-radius/percent",
+			property: "border-top-left-radius", value: "25%", fontSize: 12,
+			expectField: func(s *computedStyle) bool {
+				return s.BorderRadiusTLPct == 0.25 && s.BorderRadiusTL == 0
+			},
+		},
+		{
+			// A length corner must leave the percentage fraction at 0 and
+			// resolve to points as before.
+			name:     "border-top-left-radius/length",
+			property: "border-top-left-radius", value: "14pt", fontSize: 12,
+			expectField: func(s *computedStyle) bool {
+				return s.BorderRadiusTLPct == 0 && s.BorderRadiusTL == parseLengthPt("14pt", 12)
+			},
+		},
+		{
+			// Mixed shorthand: percentage and length per corner.
+			name:     "border-radius/mixed-four",
+			property: "border-radius", value: "50% 4px 25% 8px", fontSize: 12,
+			expectField: func(s *computedStyle) bool {
+				return s.BorderRadiusTLPct == 0.5 && s.BorderRadiusTL == 0 &&
+					s.BorderRadiusTRPct == 0 && s.BorderRadiusTR == parseLengthPt("4px", 12) &&
+					s.BorderRadiusBRPct == 0.25 && s.BorderRadiusBR == 0 &&
+					s.BorderRadiusBLPct == 0 && s.BorderRadiusBL == parseLengthPt("8px", 12)
+			},
+		},
+		{
 			// font shorthand sets style, weight, size, line-height, family.
 			// "16px" parses to 12pt (CSS 1px = 0.75pt).
 			name:     "font/full-shorthand",

--- a/html/features_test.go
+++ b/html/features_test.go
@@ -2332,3 +2332,58 @@ func TestBaselineShiftThenVerticalAlign(t *testing.T) {
 		}
 	}
 }
+
+// --- border-radius percentage (issue #329) ---
+
+// findDivWithRadius walks the element tree and returns the first *layout.Div
+// that has a non-zero border-radius (absolute or percentage). Returns nil if
+// none is found.
+func findDivWithRadius(elems []layout.Element) *layout.Div {
+	for _, e := range elems {
+		if d, ok := e.(*layout.Div); ok {
+			pct := d.BorderRadiusPercent()
+			if pct[0] > 0 || pct[1] > 0 || pct[2] > 0 || pct[3] > 0 {
+				return d
+			}
+			if c := findDivWithRadius(d.Children()); c != nil {
+				return c
+			}
+		}
+	}
+	return nil
+}
+
+// border-radius: 50% on a 28x28 box must reach the layout Div as a 0.5
+// fraction per corner (not collapse to 0 the way the pre-fix eager parse did).
+func TestBorderRadiusPercentReachesDiv(t *testing.T) {
+	src := `<div style="width:28px;height:28px;background:#130048;border-radius:50%"></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := findDivWithRadius(elems)
+	if d == nil {
+		t.Fatal("expected a Div carrying a percentage border-radius")
+	}
+	pct := d.BorderRadiusPercent()
+	for i, p := range pct {
+		if p != 0.5 {
+			t.Errorf("corner %d: border-radius percent = %v, want 0.5", i, p)
+		}
+	}
+}
+
+// A length border-radius must NOT set any percentage fraction — the control
+// case that distinguishes the percentage path from the absolute path.
+func TestBorderRadiusLengthHasNoPercent(t *testing.T) {
+	src := `<div style="width:28px;height:28px;background:#130048;border-radius:14pt"></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// findDivWithRadius only matches percentage corners; a length-only radius
+	// must therefore not be found.
+	if d := findDivWithRadius(elems); d != nil {
+		t.Errorf("length border-radius should not carry a percentage fraction, got %v", d.BorderRadiusPercent())
+	}
+}

--- a/html/properties.go
+++ b/html/properties.go
@@ -345,6 +345,25 @@ func parseLengthPt(val string, fontSize float64) float64 {
 	return 0
 }
 
+// parseRadiusComponent parses a single border-radius corner component and
+// splits it into an absolute point length and a percentage fraction. A
+// percentage value (e.g. "50%") returns (0, 0.5) so the caller can resolve it
+// against the box width/height at layout time; any other length returns its
+// resolved points and a 0 fraction. Invalid input returns (0, 0).
+//
+// Note: the CSS `border-radius: <h> / <v>` slash syntax (independent horizontal
+// and vertical radii) is not handled here — that is deferred follow-up work.
+func parseRadiusComponent(val string, fontSize float64) (abs float64, pct float64) {
+	l := parseLength(val)
+	if l == nil {
+		return 0, 0
+	}
+	if l.Unit == "%" {
+		return 0, l.Value / 100
+	}
+	return l.toPoints(0, fontSize), 0
+}
+
 // hslToRGB converts HSL values (each 0-1) to RGB values (each 0-1).
 func hslToRGB(h, s, l float64) (r, g, b float64) {
 	if s == 0 {

--- a/html/style.go
+++ b/html/style.go
@@ -171,8 +171,15 @@ type computedStyle struct {
 	BorderRadiusTR float64 // per-corner: top-right
 	BorderRadiusBR float64 // per-corner: bottom-right
 	BorderRadiusBL float64 // per-corner: bottom-left
-	Opacity        float64 // 0..1 (0 = default, meaning "not set")
-	Overflow       string  // "visible", "hidden"
+	// Per-corner percentage radii (fraction 0..1; 0 = not a percentage).
+	// CSS resolves a percentage radius against the box width (horizontal axis)
+	// and height (vertical axis) at layout time, yielding elliptical corners.
+	BorderRadiusTLPct float64
+	BorderRadiusTRPct float64
+	BorderRadiusBRPct float64
+	BorderRadiusBLPct float64
+	Opacity           float64 // 0..1 (0 = default, meaning "not set")
+	Overflow          string  // "visible", "hidden"
 
 	// Box shadow (multiple shadows supported, drawn bottom-to-top)
 	BoxShadows []boxShadow

--- a/layout/div.go
+++ b/layout/div.go
@@ -79,16 +79,21 @@ type Div struct {
 	hCenter       bool       // true = horizontally center within parent (margin: auto)
 	hRight        bool       // true = right-align within parent (margin-left: auto)
 	borderRadius  [4]float64 // corner radii [TL, TR, BR, BL] (points, 0 = sharp)
-	opacity       float64    // 0..1 (0 = default/opaque, meaning "not set")
-	overflow      string     // "visible" (default), "hidden"
-	boxShadows    []BoxShadow
-	outlineWidth  float64
-	outlineStyle  string
-	outlineColor  Color
-	outlineOffset float64
-	bgImage       *BackgroundImage
-	clear         string // CSS clear: "left", "right", "both"
-	structTag     string // custom structure tag for PDF/UA (empty = default "Div")
+	// Per-corner percentage radii (fraction 0..1; 0 = not a percentage).
+	// A percentage resolves its horizontal radius against the box width and
+	// its vertical radius against the box height at draw time, producing
+	// elliptical corners (CSS Backgrounds & Borders L3 §5.1).
+	borderRadiusPct [4]float64
+	opacity         float64 // 0..1 (0 = default/opaque, meaning "not set")
+	overflow        string  // "visible" (default), "hidden"
+	boxShadows      []BoxShadow
+	outlineWidth    float64
+	outlineStyle    string
+	outlineColor    Color
+	outlineOffset   float64
+	bgImage         *BackgroundImage
+	clear           string // CSS clear: "left", "right", "both"
+	structTag       string // custom structure tag for PDF/UA (empty = default "Div")
 
 	// CSS position:relative offsets (visual only, don't affect layout flow).
 	relOffsetX float64
@@ -345,9 +350,47 @@ func (d *Div) SetBorderRadiusPerCorner(tl, tr, br, bl float64) *Div {
 	return d
 }
 
-// hasRadius returns true if any corner has a non-zero radius.
+// SetBorderRadiusPercent sets per-corner percentage radii as fractions
+// (0..1), indexed [TL, TR, BR, BL]; 0 means the corner is not a percentage.
+// A percentage corner resolves rx against the box width and ry against the
+// box height at draw time, yielding elliptical corners (e.g. 0.5 on a square
+// box draws a circle; on a rectangle it draws a pill). It composes with
+// SetBorderRadius / SetBorderRadiusPerCorner: a corner with a non-zero
+// percentage overrides the absolute radius for that corner.
+func (d *Div) SetBorderRadiusPercent(pct [4]float64) *Div {
+	d.borderRadiusPct = pct
+	return d
+}
+
+// BorderRadiusPercent returns the per-corner percentage radii as fractions
+// (0..1), indexed [TL, TR, BR, BL]. A zero entry means the corner is driven
+// by an absolute radius (or is sharp). Exposed for introspection and tests.
+func (d *Div) BorderRadiusPercent() [4]float64 {
+	return d.borderRadiusPct
+}
+
+// hasRadius returns true if any corner has a non-zero radius, whether
+// absolute or percentage.
 func (d *Div) hasRadius() bool {
-	return d.borderRadius[0] > 0 || d.borderRadius[1] > 0 || d.borderRadius[2] > 0 || d.borderRadius[3] > 0
+	return d.borderRadius[0] > 0 || d.borderRadius[1] > 0 || d.borderRadius[2] > 0 || d.borderRadius[3] > 0 ||
+		d.borderRadiusPct[0] > 0 || d.borderRadiusPct[1] > 0 || d.borderRadiusPct[2] > 0 || d.borderRadiusPct[3] > 0
+}
+
+// resolvedRadii returns the per-corner horizontal (rx) and vertical (ry)
+// radii in points for a box of the given width and height. A percentage
+// corner resolves rx = pct*w and ry = pct*h (elliptical); an absolute
+// corner has rx == ry. Indexed [TL, TR, BR, BL].
+func (d *Div) resolvedRadii(w, h float64) (rx, ry [4]float64) {
+	for i := 0; i < 4; i++ {
+		if d.borderRadiusPct[i] > 0 {
+			rx[i] = d.borderRadiusPct[i] * w
+			ry[i] = d.borderRadiusPct[i] * h
+		} else {
+			rx[i] = d.borderRadius[i]
+			ry[i] = d.borderRadius[i]
+		}
+	}
+	return rx, ry
 }
 
 // SetOpacity sets the opacity for the entire Div (0 = transparent, 1 = opaque).
@@ -679,8 +722,11 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 		Tag: d.resolveTag(),
 		Draw: func(ctx DrawContext, absX, absTopY float64) {
 			bottomY := absTopY - capturedTotalH
-			r := capturedDiv.borderRadius
 			hasR := capturedDiv.hasRadius()
+			// Resolve per-corner rx/ry against the final box size: percentage
+			// corners become elliptical (rx=pct*w, ry=pct*h), absolute corners
+			// stay circular (rx==ry).
+			rx, ry := capturedDiv.resolvedRadii(capturedOuterW, capturedTotalH)
 
 			// Apply CSS transform if set.
 			if len(capturedDiv.transforms) > 0 {
@@ -714,7 +760,7 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 			if capturedDiv.overflow == "hidden" {
 				ctx.Stream.SaveState()
 				if hasR {
-					ctx.Stream.RoundedRectPerCorner(absX, bottomY, capturedOuterW, capturedTotalH, r[0], r[1], r[2], r[3])
+					ctx.Stream.RoundedRectPerCornerXY(absX, bottomY, capturedOuterW, capturedTotalH, rx, ry)
 				} else {
 					ctx.Stream.Rectangle(absX, bottomY, capturedOuterW, capturedTotalH)
 				}
@@ -726,7 +772,7 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 				ctx.Stream.SaveState()
 				setFillColor(ctx.Stream, *capturedDiv.background)
 				if hasR {
-					ctx.Stream.RoundedRectPerCorner(absX, bottomY, capturedOuterW, capturedTotalH, r[0], r[1], r[2], r[3])
+					ctx.Stream.RoundedRectPerCornerXY(absX, bottomY, capturedOuterW, capturedTotalH, rx, ry)
 				} else {
 					ctx.Stream.Rectangle(absX, bottomY, capturedOuterW, capturedTotalH)
 				}
@@ -735,12 +781,15 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 			}
 
 			// Draw background image after background color, before borders.
+			// The bgimage rounded clip is single-radius (rx[0]); elliptical /
+			// per-corner clipping for background images is a separate
+			// enhancement and is not expanded here.
 			if capturedDiv.bgImage != nil && capturedDiv.bgImage.Image != nil {
-				drawBackgroundImage(ctx, capturedDiv.bgImage, absX, bottomY, capturedOuterW, capturedTotalH, r[0])
+				drawBackgroundImage(ctx, capturedDiv.bgImage, absX, bottomY, capturedOuterW, capturedTotalH, rx[0])
 			}
 
 			if hasR {
-				drawRoundedBorders(ctx.Stream, capturedDiv.borders, absX, bottomY, capturedOuterW, capturedTotalH, r)
+				drawRoundedBorders(ctx.Stream, capturedDiv.borders, absX, bottomY, capturedOuterW, capturedTotalH, rx, ry)
 			} else {
 				drawCellBorders(ctx.Stream, capturedDiv.borders, absX, bottomY, capturedOuterW, capturedTotalH)
 			}

--- a/layout/div_test.go
+++ b/layout/div_test.go
@@ -108,6 +108,61 @@ func TestDivUniformBorderRadius(t *testing.T) {
 	}
 }
 
+// resolvedRadii must turn a percentage corner into rx=pct*w (horizontal)
+// and ry=pct*h (vertical), and leave absolute corners circular (rx==ry).
+func TestDivResolvedRadiiPercent(t *testing.T) {
+	// 50% on a 28x28 box → circle (rx=ry=14).
+	d := NewDiv().SetBorderRadiusPercent([4]float64{0.5, 0.5, 0.5, 0.5})
+	rx, ry := d.resolvedRadii(28, 28)
+	for i := 0; i < 4; i++ {
+		if rx[i] != 14 || ry[i] != 14 {
+			t.Fatalf("corner %d: expected rx=ry=14 on 28x28, got rx=%v ry=%v", i, rx[i], ry[i])
+		}
+	}
+
+	// 50% on a 100x40 box → elliptical (rx=50, ry=20).
+	rx, ry = d.resolvedRadii(100, 40)
+	for i := 0; i < 4; i++ {
+		if rx[i] != 50 || ry[i] != 20 {
+			t.Fatalf("corner %d: expected rx=50 ry=20 on 100x40, got rx=%v ry=%v", i, rx[i], ry[i])
+		}
+		if rx[i] == ry[i] {
+			t.Fatalf("corner %d: expected elliptical (rx!=ry), got rx==ry==%v", i, rx[i])
+		}
+	}
+}
+
+// An absolute radius equal to half the box (14pt on 28x28) must resolve to
+// the same circle as the 50% percentage case — the length control for the
+// percentage fix.
+func TestDivResolvedRadiiAbsoluteCircle(t *testing.T) {
+	d := NewDiv().SetBorderRadiusPerCorner(14, 14, 14, 14)
+	rx, ry := d.resolvedRadii(28, 28)
+	for i := 0; i < 4; i++ {
+		if rx[i] != 14 || ry[i] != 14 {
+			t.Fatalf("corner %d: expected rx=ry=14, got rx=%v ry=%v", i, rx[i], ry[i])
+		}
+	}
+}
+
+// A percentage-only border-radius (no absolute radius set) must still report
+// hasRadius and render without panicking.
+func TestDivPercentBorderRadiusRenders(t *testing.T) {
+	d := NewDiv().
+		SetBorderRadiusPercent([4]float64{0.5, 0.5, 0.5, 0.5}).
+		SetBackground(RGB(0.9, 0.9, 0.95)).
+		SetPadding(10).
+		Add(NewParagraph("circle", font.Helvetica, 12))
+	if !d.hasRadius() {
+		t.Fatal("expected hasRadius() true for percentage-only border-radius")
+	}
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.Add(d)
+	if pages := r.Render(); len(pages) == 0 {
+		t.Fatal("expected at least 1 page")
+	}
+}
+
 func TestDivAspectRatio(t *testing.T) {
 	// 2:1 ratio on a 400pt wide area → height should be 200pt.
 	d := NewDiv().

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -989,16 +989,19 @@ func drawOutline(ctx DrawContext, width float64, style string, color Color, offs
 	ctx.Stream.RestoreState()
 }
 
-// drawRoundedBorders draws borders with per-corner rounded corners.
-// Falls back to straight borders when border styles differ per side.
-func drawRoundedBorders(stream *content.Stream, borders CellBorders, x, y, w, h float64, r [4]float64) {
+// drawRoundedBorders draws borders with per-corner rounded corners, using
+// independent horizontal (rx) and vertical (ry) radii per corner so that
+// percentage-driven elliptical corners stroke correctly. The arrays are
+// indexed [TL, TR, BR, BL]. Falls back to straight borders when border styles
+// differ per side.
+func drawRoundedBorders(stream *content.Stream, borders CellBorders, x, y, w, h float64, rx, ry [4]float64) {
 	// If all borders are the same, draw a single rounded rect stroke.
 	if borders.Top.Width > 0 && borders.Top == borders.Right &&
 		borders.Top == borders.Bottom && borders.Top == borders.Left {
 		stream.SaveState()
 		setStrokeColor(stream, borders.Top.Color)
 		stream.SetLineWidth(borders.Top.Width)
-		stream.RoundedRectPerCorner(x, y, w, h, r[0], r[1], r[2], r[3])
+		stream.RoundedRectPerCornerXY(x, y, w, h, rx, ry)
 		stream.Stroke()
 		stream.RestoreState()
 		return


### PR DESCRIPTION
Part 1 of #329.

`border-radius: <percentage>` (e.g. `border-radius: 50%`) rendered square
corners, while the equivalent fixed length rendered the expected circle.

## Cause
All border-radius corners are parsed via `parseLengthPt`, which resolves
against `relativeTo = 0`, so `50%` collapsed to `0` at parse time and was
never deferred to layout where the box size is known.

## Fix
- Preserve the percentage as a per-corner fraction in the computed style
  (longhand + 1–4 value shorthand) and carry it onto the box.
- Resolve it at layout time against the border box, per CSS: horizontal
  radius = pct·width, vertical = pct·height — so `50%` is a circle on a
  square box and an ellipse (pill) on a rectangle. A single length stays
  circular.
- New drawing primitive `RoundedRectPerCornerXY` supports per-corner
  elliptical radii with a generalized CSS Backgrounds & Borders L3 §5.5
  proportional clamp. The existing `RoundedRectPerCorner` delegates to it
  and is byte-identical for the circular case, so current callers are
  unchanged.

## Scope / follow-ups
- Slash syntax (`border-radius: 10px / 20px`) is deferred.
- The background-image rounded clip remains single-radius (unchanged).
- Pre-existing: a rounded box that splits across pages drops its radius on
  the continuation fragment (the absolute radius was already dropped; not
  introduced here) — worth a separate tracking issue.

## Tests
New content-stream tests assert the elliptical Bézier output and that the
§5.5 clamp scales both axes; layout tests assert `50%` → rx≈ry≈14 on a
28×28 box and rx=50/ry=20 on a 100×40 box; html tests confirm the
percentage reaches the box (fail-before / pass-after).