### PR TITLE
html/layout: keep border-radius on text-bearing boxes (#329)

### DIFF
--- a/html/border_radius_text_box_test.go
+++ b/html/border_radius_text_box_test.go
@@ -1,0 +1,354 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"testing"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// Regression tests for issue #329 (part 2): border-radius was dropped when a
+// block box directly contained a text run. The block's wrapping Div draws the
+// background rounded, but the synthesized child Paragraph re-drew the same
+// background as a plain (square) rectangle on top, squaring off the corners.
+// The fix clears the redundant block-level background on the child Paragraph
+// when the wrapping Div owns the fill.
+
+// findFirstDiv returns the first *layout.Div found by a shallow walk of elems
+// (top level only). Returns nil if none.
+func findFirstDiv(elems []layout.Element) *layout.Div {
+	for _, e := range elems {
+		if d, ok := e.(*layout.Div); ok {
+			return d
+		}
+	}
+	return nil
+}
+
+// firstChildParagraph returns the first direct child *layout.Paragraph of d.
+func firstChildParagraph(d *layout.Div) *layout.Paragraph {
+	for _, c := range d.Children() {
+		if p, ok := c.(*layout.Paragraph); ok {
+			return p
+		}
+	}
+	return nil
+}
+
+// TestBorderRadiusBoxWithTextChildClearsParagraphBackground reproduces the
+// issue: a fixed-radius box containing a direct text run must keep its rounded
+// fill on the Div and must NOT re-draw the same fill via the child Paragraph.
+func TestBorderRadiusBoxWithTextChildClearsParagraphBackground(t *testing.T) {
+	src := `<div style="background:#4F46E5;width:28pt;height:28pt;border-radius:14pt">4</div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	div := findFirstDiv(elems)
+	if div == nil {
+		t.Fatal("expected a wrapping Div carrying the box background")
+	}
+	if div.Background() == nil {
+		t.Fatal("Div should carry the block background")
+	}
+	r := div.BorderRadii()
+	if r[0] == 0 || r[1] == 0 || r[2] == 0 || r[3] == 0 {
+		t.Errorf("Div should carry border-radius on all corners, got %v", r)
+	}
+	p := firstChildParagraph(div)
+	if p == nil {
+		t.Fatal("expected a child Paragraph for the text run")
+	}
+	// This is the assertion that FAILS on pre-fix code: the child Paragraph
+	// re-drew the same background as a square rectangle.
+	if p.Background() != nil {
+		t.Errorf("child Paragraph background should be cleared (Div owns the fill), got %+v", *p.Background())
+	}
+}
+
+// TestBorderRadiusEmptyBoxUnaffected is a regression guard: an empty box with a
+// radius still produces a Div with the background and radius (no Paragraph).
+func TestBorderRadiusEmptyBoxUnaffected(t *testing.T) {
+	src := `<div style="background:#4F46E5;width:28pt;height:28pt;border-radius:14pt"></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	div := findFirstDiv(elems)
+	if div == nil {
+		t.Fatal("expected a Div for the empty box with visual properties")
+	}
+	if div.Background() == nil {
+		t.Error("Div should carry the block background")
+	}
+	if div.BorderRadii()[0] == 0 {
+		t.Error("Div should carry border-radius")
+	}
+}
+
+// TestBorderRadiusElementOnlyChildUnaffected is a regression guard: a box whose
+// only child is an element (not direct text) keeps Div background + radius, and
+// any inner element-level Div keeps its own background.
+func TestBorderRadiusElementOnlyChildUnaffected(t *testing.T) {
+	src := `<div style="background:#4F46E5;width:28pt;height:28pt;border-radius:14pt"><span>4</span></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	div := findFirstDiv(elems)
+	if div == nil {
+		t.Fatal("expected a wrapping Div")
+	}
+	if div.Background() == nil {
+		t.Error("Div should carry the block background")
+	}
+	if div.BorderRadii()[0] == 0 {
+		t.Error("Div should carry border-radius")
+	}
+	// The inline <span> produces an anonymous paragraph child whose
+	// block-level background (inherited from the block) must be cleared too.
+	if p := firstChildParagraph(div); p != nil && p.Background() != nil {
+		t.Errorf("child Paragraph background should be cleared, got %+v", *p.Background())
+	}
+}
+
+// TestBorderRadiusBoxPreservesInlineSpanHighlight ensures the per-RUN
+// BackgroundColor of an inline <span> highlight is NOT cleared by the fix.
+// The block-level Paragraph background is cleared, but the run highlight on the
+// word "world" must survive.
+func TestBorderRadiusBoxPreservesInlineSpanHighlight(t *testing.T) {
+	src := `<div style="background:#4F46E5;border-radius:14pt">hello <span style="background:yellow">world</span></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	div := findFirstDiv(elems)
+	if div == nil {
+		t.Fatal("expected a wrapping Div")
+	}
+	p := firstChildParagraph(div)
+	if p == nil {
+		t.Fatal("expected a child Paragraph")
+	}
+	// Block-level background cleared (Div owns the indigo fill).
+	if p.Background() != nil {
+		t.Errorf("block-level Paragraph background should be cleared, got %+v", *p.Background())
+	}
+	// Per-run highlight on "world" must be preserved.
+	foundHighlight := false
+	for _, run := range p.Runs() {
+		if run.BackgroundColor != nil {
+			foundHighlight = true
+		}
+	}
+	if !foundHighlight {
+		t.Error("inline <span> highlight (per-run BackgroundColor) must be preserved")
+	}
+}
+
+// findFirstFlex returns the first *layout.Flex found by a shallow walk of elems.
+func findFirstFlex(elems []layout.Element) *layout.Flex {
+	for _, e := range elems {
+		if f, ok := e.(*layout.Flex); ok {
+			return f
+		}
+	}
+	return nil
+}
+
+// flexItemDiv extracts the *layout.Div carried by a flex item, whether the item
+// holds the Div directly or wraps it in a FlexItem.
+func flexItemDiv(elem layout.Element) *layout.Div {
+	if d, ok := elem.(*layout.Div); ok {
+		return d
+	}
+	return nil
+}
+
+// TestBorderRadiusFlexItemWithText covers the flex `flex:0 0 auto` text case
+// from the issue: a rounded flex item containing a direct text run inside a real
+// `display:flex` parent. Each direct child of the flex container is converted
+// via convertNode → convertBlock (the child <div> is display:block), so the same
+// fix applies. We assert the flex item's Div keeps its rounded fill while the
+// child Paragraph's block-level background is cleared.
+func TestBorderRadiusFlexItemWithText(t *testing.T) {
+	src := `<div style="display:flex"><div style="flex:0 0 auto;background:#4F46E5;width:28pt;height:28pt;border-radius:14pt">4</div></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flex := findFirstFlex(elems)
+	if flex == nil {
+		t.Fatal("expected a layout.Flex for the display:flex parent")
+	}
+	items := flex.Items()
+	if len(items) != 1 {
+		t.Fatalf("expected exactly one flex item, got %d", len(items))
+	}
+	div := flexItemDiv(items[0].Element())
+	if div == nil {
+		t.Fatal("expected the flex item to wrap a rounded Div")
+	}
+	if div.Background() == nil {
+		t.Error("flex item Div should carry the background")
+	}
+	if div.BorderRadii()[0] == 0 {
+		t.Error("flex item Div should carry border-radius")
+	}
+	if p := firstChildParagraph(div); p != nil && p.Background() != nil {
+		t.Errorf("flex item child Paragraph background should be cleared, got %+v", *p.Background())
+	}
+}
+
+// TestBorderRadiusBoxIndependentParagraphBackgroundKept verifies that a child
+// paragraph carrying a DIFFERENT background from the wrapping Div is left alone
+// (the clearing is gated on the background matching the Div's fill).
+func TestBorderRadiusBoxIndependentParagraphBackgroundKept(t *testing.T) {
+	src := `<div style="background:#4F46E5;border-radius:14pt"><p style="background:#FF0000">hi</p></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	div := findFirstDiv(elems)
+	if div == nil {
+		t.Fatal("expected a wrapping Div")
+	}
+	// The inner <p style="background:#FF0000"> itself forces its own Div
+	// wrapper (needsWrapper), so the outer Div's direct child is that inner
+	// Div, not a Paragraph. The outer clearing must not touch it: the outer
+	// Div has only Div children, so nothing is cleared. Verify the inner Div
+	// still carries its red background.
+	var innerDiv *layout.Div
+	for _, c := range div.Children() {
+		if d, ok := c.(*layout.Div); ok {
+			innerDiv = d
+		}
+	}
+	if innerDiv == nil {
+		t.Fatal("expected inner Div for the styled <p>")
+	}
+	if innerDiv.Background() == nil {
+		t.Error("inner Div should keep its independent red background")
+	}
+}
+
+// findFirstTable returns the first *layout.Table found by a shallow walk of
+// elems, looking one level into any wrapping Div (a <table> with margins is
+// wrapped in a Div). Returns nil if none.
+func findFirstTable(elems []layout.Element) *layout.Table {
+	for _, e := range elems {
+		switch v := e.(type) {
+		case *layout.Table:
+			return v
+		case *layout.Div:
+			for _, c := range v.Children() {
+				if t, ok := c.(*layout.Table); ok {
+					return t
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// firstCell returns the first cell of the first row of a table, or nil.
+func firstCell(tbl *layout.Table) *layout.Cell {
+	rows := tbl.Rows()
+	if len(rows) == 0 {
+		return nil
+	}
+	cells := rows[0].Cells()
+	if len(cells) == 0 {
+		return nil
+	}
+	return cells[0]
+}
+
+// cellContentParagraph returns the cell's direct content as a *layout.Paragraph,
+// either when the content is a Paragraph directly or the first child Paragraph
+// of a wrapping Div. Returns nil if no content Paragraph is present.
+func cellContentParagraph(cell *layout.Cell) *layout.Paragraph {
+	switch v := cell.Content().(type) {
+	case *layout.Paragraph:
+		return v
+	case *layout.Div:
+		return firstChildParagraph(v)
+	}
+	return nil
+}
+
+// TestBorderRadiusTableCellWithText reproduces the BLOCKER (B1): a <td> with a
+// background + border-radius + direct text must keep the background AND radius
+// on the *cell* (which draws the rounded fill), while the cell's content
+// Paragraph must NOT carry the same background (which would re-draw a square
+// rectangle on top, squaring the corners). Pre-fix the content Paragraph
+// carried a non-nil background; this test fails before the B1 fix.
+func TestBorderRadiusTableCellWithText(t *testing.T) {
+	src := `<table><tr><td style="background:#4F46E5;border-radius:14pt">x</td></tr></table>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tbl := findFirstTable(elems)
+	if tbl == nil {
+		t.Fatal("expected a layout.Table")
+	}
+	cell := firstCell(tbl)
+	if cell == nil {
+		t.Fatal("expected a cell in the first row")
+	}
+	if cell.Background() == nil {
+		t.Fatal("cell should carry the block background")
+	}
+	r := cell.BorderRadii()
+	if r[0] == 0 || r[1] == 0 || r[2] == 0 || r[3] == 0 {
+		t.Errorf("cell should carry border-radius on all corners, got %v", r)
+	}
+	p := cellContentParagraph(cell)
+	if p == nil {
+		t.Fatal("expected a content Paragraph for the cell text")
+	}
+	// The assertion that FAILS on pre-fix code: the content Paragraph re-drew
+	// the same background as a square rectangle.
+	if p.Background() != nil {
+		t.Errorf("cell content Paragraph background should be cleared (cell owns the fill), got %+v", *p.Background())
+	}
+}
+
+// TestBorderRadiusCSSTableCellWithText is the display:table variant of the
+// BLOCKER (B1): a display:table-cell with background + border-radius + direct
+// text must keep background + radius on the cell and clear the content
+// Paragraph's redundant background.
+func TestBorderRadiusCSSTableCellWithText(t *testing.T) {
+	src := `<div style="display:table"><div style="display:table-row">` +
+		`<div style="display:table-cell;background:#4F46E5;border-radius:14pt">x</div>` +
+		`</div></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tbl := findFirstTable(elems)
+	if tbl == nil {
+		t.Fatal("expected a layout.Table for display:table")
+	}
+	cell := firstCell(tbl)
+	if cell == nil {
+		t.Fatal("expected a cell in the first row")
+	}
+	if cell.Background() == nil {
+		t.Fatal("cell should carry the block background")
+	}
+	r := cell.BorderRadii()
+	if r[0] == 0 || r[1] == 0 || r[2] == 0 || r[3] == 0 {
+		t.Errorf("cell should carry border-radius on all corners, got %v", r)
+	}
+	p := cellContentParagraph(cell)
+	if p == nil {
+		t.Fatal("expected a content Paragraph for the cell text")
+	}
+	if p.Background() != nil {
+		t.Errorf("cell content Paragraph background should be cleared, got %+v", *p.Background())
+	}
+}

--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -182,12 +182,61 @@ func (c *converter) convertBlock(n *html.Node, style computedStyle) []layout.Ele
 	}
 	applyDivStyles(div, style, c.containerWidth)
 
+	// The Div now owns and draws the box background (honoring border-radius).
+	// Clear any redundant block-level background on direct child paragraphs to
+	// avoid a square-cornered overdraw on top of the rounded fill (issue #329).
+	if style.BackgroundColor != nil {
+		clearMatchingParagraphBackgrounds(div.Children(), *style.BackgroundColor)
+	}
+
 	// Apply background image if set.
 	if bgImg := c.resolveBackgroundImage(style); bgImg != nil {
 		div.SetBackgroundImage(bgImg)
 	}
 
 	return []layout.Element{div}
+}
+
+// clearMatchingParagraphBackgrounds removes the block-level background from any
+// direct *layout.Paragraph in elems whose paragraph background equals bg.
+//
+// When a block (or paragraph, or table cell) with a background is converted,
+// the enclosing container (a wrapping Div, or a layout.Cell) owns and draws the
+// box fill — honoring border-radius. If a synthesized or inner child Paragraph
+// also carries the same block-level background, it re-draws that fill as a
+// plain (square-cornered) rectangle on top, squaring off any rounded corners
+// (issue #329). Since the container already paints the fill, the child's copy
+// is redundant; clearing it removes the overdraw.
+//
+// Only the paragraph-level background is cleared. Per-run/word BackgroundColor
+// (inline <span> highlights) lives on the TextRuns, not on p.background, and is
+// left untouched.
+func clearMatchingParagraphBackgrounds(elems []layout.Element, bg layout.Color) {
+	for _, e := range elems {
+		if p, ok := e.(*layout.Paragraph); ok {
+			if pbg := p.Background(); pbg != nil && *pbg == bg {
+				p.ClearBackground()
+			}
+		}
+	}
+}
+
+// clearCellParagraphBackground clears the redundant block-level background on a
+// table cell's direct content when the cell owns and draws the rounded fill.
+//
+// A layout.Cell holds a single content Element: either the cell's only child
+// directly (a Paragraph for "<td>text</td>") or a wrapping Div for multi-child
+// cells. In both shapes the cell itself paints the background (honoring
+// border-radius), so a Paragraph carrying the same fill would re-draw it as a
+// square rectangle, squaring off the corners — the same overdraw as the Div
+// case (issue #329). Mirrors the Div gating: matching color only.
+func clearCellParagraphBackground(cell *layout.Cell, bg layout.Color) {
+	switch content := cell.Content().(type) {
+	case *layout.Paragraph:
+		clearMatchingParagraphBackgrounds([]layout.Element{content}, bg)
+	case *layout.Div:
+		clearMatchingParagraphBackgrounds(content.Children(), bg)
+	}
 }
 
 // containsAreaBreak reports whether any element in the slice is an AreaBreak.
@@ -216,6 +265,9 @@ func (c *converter) splitOnAreaBreaks(children []layout.Element, style computedS
 			div.Add(child)
 		}
 		applyDivStyles(div, style, c.containerWidth)
+		if style.BackgroundColor != nil {
+			clearMatchingParagraphBackgrounds(div.Children(), *style.BackgroundColor)
+		}
 		if bgImg := c.resolveBackgroundImage(style); bgImg != nil {
 			div.SetBackgroundImage(bgImg)
 		}

--- a/html/converter_paragraph.go
+++ b/html/converter_paragraph.go
@@ -51,6 +51,12 @@ func (c *converter) convertParagraph(n *html.Node, style computedStyle) []layout
 			div.Add(e)
 		}
 		applyDivStyles(div, style, c.containerWidth)
+		// The Div now owns and draws the box background (honoring
+		// border-radius); clear the redundant paragraph-level background on
+		// the wrapped children to avoid a square-cornered overdraw (issue #329).
+		if style.BackgroundColor != nil {
+			clearMatchingParagraphBackgrounds(div.Children(), *style.BackgroundColor)
+		}
 		return []layout.Element{div}
 	}
 

--- a/html/converter_table.go
+++ b/html/converter_table.go
@@ -187,6 +187,10 @@ func (c *converter) convertCSSTable(n *html.Node, style computedStyle) []layout.
 				}
 				if cellStyle.BackgroundColor != nil {
 					layoutCell.SetBackground(*cellStyle.BackgroundColor)
+					// The cell owns and draws the rounded box fill; clear the
+					// same block-level background on its content Paragraph(s)
+					// to avoid a square-cornered overdraw (issue #329).
+					clearCellParagraphBackground(layoutCell, *cellStyle.BackgroundColor)
 				}
 				if cellStyle.hasBorder() {
 					layoutCell.SetBorders(buildCellBorders(cellStyle))
@@ -385,10 +389,15 @@ func (c *converter) convertTableRowKind(n *html.Node, tbl *layout.Table, parentS
 		}
 
 		// Background color: cell CSS > row CSS.
+		// The cell now owns and draws the box fill (honoring border-radius);
+		// clear the same block-level background on the cell's content
+		// Paragraph(s) to avoid a square-cornered overdraw (issue #329).
 		if cellStyle.BackgroundColor != nil {
 			cell.SetBackground(*cellStyle.BackgroundColor)
+			clearCellParagraphBackground(cell, *cellStyle.BackgroundColor)
 		} else if rowStyle.BackgroundColor != nil {
 			cell.SetBackground(*rowStyle.BackgroundColor)
+			clearCellParagraphBackground(cell, *rowStyle.BackgroundColor)
 		}
 
 		// Cell borders: prefer per-cell CSS borders, fall back to table border,

--- a/layout/div.go
+++ b/layout/div.go
@@ -189,6 +189,17 @@ func (d *Div) SetBackground(c Color) *Div {
 	return d
 }
 
+// Background returns a copy of the Div's background fill color, or nil if the
+// Div has no background. A copy is returned so callers cannot mutate the Div's
+// internal fill through the pointer. Provided for testing.
+func (d *Div) Background() *Color {
+	if d.background == nil {
+		return nil
+	}
+	c := *d.background
+	return &c
+}
+
 // SetSpaceBefore sets extra vertical space before the Div.
 func (d *Div) SetSpaceBefore(pts float64) *Div {
 	d.spaceBefore = pts
@@ -368,6 +379,11 @@ func (d *Div) SetBorderRadiusPercent(pct [4]float64) *Div {
 func (d *Div) BorderRadiusPercent() [4]float64 {
 	return d.borderRadiusPct
 }
+
+// BorderRadii returns the per-corner radii in CSS order
+// (top-left, top-right, bottom-right, bottom-left), in points. A value of 0
+// means the corner is sharp. Provided for testing.
+func (d *Div) BorderRadii() [4]float64 { return d.borderRadius }
 
 // hasRadius returns true if any corner has a non-zero radius, whether
 // absolute or percentage.

--- a/layout/flex.go
+++ b/layout/flex.go
@@ -72,6 +72,10 @@ func NewFlexItem(elem Element) *FlexItem {
 	return &FlexItem{element: elem, shrink: 1}
 }
 
+// Element returns the layout element wrapped by this flex item.
+// Provided for testing.
+func (fi *FlexItem) Element() Element { return fi.element }
+
 // SetGrow sets the flex-grow factor.
 func (fi *FlexItem) SetGrow(v float64) *FlexItem { fi.grow = v; return fi }
 
@@ -132,6 +136,10 @@ func (f *Flex) AddItem(item *FlexItem) *Flex {
 	f.items = append(f.items, item)
 	return f
 }
+
+// Items returns the flex container's items in layout order.
+// Provided for testing.
+func (f *Flex) Items() []*FlexItem { return f.items }
 
 // SetDirection sets the main axis direction.
 func (f *Flex) SetDirection(d FlexDirection) *Flex { f.direction = d; return f }

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -172,6 +172,26 @@ func (p *Paragraph) SetBackground(c Color) *Paragraph {
 	return p
 }
 
+// Background returns a copy of the paragraph's background fill color, or nil
+// if the paragraph has no block-level background. A copy is returned so callers
+// cannot mutate the paragraph's internal fill through the pointer. Provided for
+// testing and for callers that own the box fill (e.g. a wrapping Div) and need
+// to detect and clear a redundant paragraph-level background.
+func (p *Paragraph) Background() *Color {
+	if p.background == nil {
+		return nil
+	}
+	c := *p.background
+	return &c
+}
+
+// ClearBackground removes the paragraph's block-level background fill.
+// Per-run/word BackgroundColor (inline <span> highlights) is unaffected.
+func (p *Paragraph) ClearBackground() *Paragraph {
+	p.background = nil
+	return p
+}
+
 // SetFirstLineIndent sets the indentation for the first line (in points).
 // This corresponds to the CSS text-indent property.
 func (p *Paragraph) SetFirstLineIndent(pts float64) *Paragraph {

--- a/layout/table.go
+++ b/layout/table.go
@@ -195,6 +195,28 @@ func (c *Cell) SetBackground(color Color) *Cell {
 	return c
 }
 
+// Content returns the cell's rich content Element, or nil if the cell holds
+// plain text instead. When the cell owns and draws the box fill (background +
+// border-radius), callers use this to detect and clear a redundant
+// block-level background on the content element (see issue #329).
+func (c *Cell) Content() Element { return c.content }
+
+// Background returns a copy of the cell's background fill color, or nil if the
+// cell has no background. A copy is returned so callers cannot mutate the
+// cell's internal fill through the pointer. Provided for testing.
+func (c *Cell) Background() *Color {
+	if c.bgColor == nil {
+		return nil
+	}
+	col := *c.bgColor
+	return &col
+}
+
+// BorderRadii returns the cell's per-corner radii in CSS order
+// (top-left, top-right, bottom-right, bottom-left), in points. A value of 0
+// means the corner is sharp. Provided for testing.
+func (c *Cell) BorderRadii() [4]float64 { return c.borderRadius }
+
 // SetColspan sets the number of columns this cell spans.
 func (c *Cell) SetColspan(n int) *Cell {
 	if n < 1 {
@@ -286,6 +308,13 @@ type Table struct {
 func NewTable() *Table {
 	return &Table{}
 }
+
+// Rows returns the table's rows in order (header, body, and footer rows are
+// all stored in this single slice). Provided for testing.
+func (t *Table) Rows() []*Row { return t.rows }
+
+// Cells returns the row's cells in order. Provided for testing.
+func (r *Row) Cells() []*Cell { return r.cells }
 
 // SetColumnWidths sets explicit column widths in points.
 // If not set, columns are distributed equally within the available width.


### PR DESCRIPTION
Part 2 of #329.

`border-radius` was dropped as soon as a box directly contained a text run
(even with a fixed length). Empty boxes, element-only boxes, and inline-block
flex items kept their corners; a direct text child squared them.

## Cause
A block with direct text synthesizes a child `Paragraph` that inherits the
block `background`. The wrapping box draws that background **rounded**, then
the child Paragraph re-draws the **same** background as a **plain rectangle**
on top, squaring the corners. The block background was effectively painted
twice; the overdraw was only visible when a radius was present.

## Fix
A background always forces a box wrapper that owns the rounded fill, so the
inner Paragraph's block-level background is redundant. Clear it on the
wrapper's direct child paragraphs when the wrapper carries the matching
background:
- Div wrappers — `convertBlock`, `splitOnAreaBreaks`, `convertParagraph`.
- Table cells — `convertTableCell` and `convertCSSTable`, which had the
  identical double-paint (`drawBackgroundRounded` under a square Paragraph
  fill).

Inline `<span>` highlights live on `TextRun.BackgroundColor` (per run), not
the paragraph-level background, so they are preserved. The clear is gated on
an exact color match with the wrapper's own fill, so an independently styled
child is never affected. Read-only `Background()` getters return a copy to
avoid exposing the internal color pointer.

## Tests
Fail-before / pass-after coverage for a text-bearing rounded `<div>`, a
`<td>` cell, and a `display:table-cell` cell; regression guards for empty
boxes, element-only children, a genuine `display:flex` item, preserved
inline `<span>` highlights, and an independently-backgrounded child.