### PR TITLE
layout/html: embed default font in @page margin boxes for PDF/A (#328)

### DIFF
--- a/content/stream.go
+++ b/content/stream.go
@@ -612,6 +612,15 @@ func encodeTextStringUTF16BE(s string) string {
 	return b.String()
 }
 
+// BeginArtifact writes the BDC operator opening an /Artifact marked-content
+// sequence. Artifacts are page elements that are not part of the document's
+// logical content — pagination headers/footers, backgrounds, and layout
+// decorations — and are excluded from the structure tree (ISO 32000-2
+// §14.8.2.2, PDF/UA ISO 14289-1 §7.1). Pair every call with EndMarkedContent.
+func (s *Stream) BeginArtifact() {
+	s.writeln("/Artifact BDC")
+}
+
 // MarkedPoint writes the MP operator: designate a marked-content point.
 // tag is the marked-content tag (structure type).
 func (s *Stream) MarkedPoint(tag string) {

--- a/document/html.go
+++ b/document/html.go
@@ -94,14 +94,14 @@ func (d *Document) AddHTMLWithContext(ctx context.Context, htmlStr string, opts 
 		if len(pc.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
 			}
 			d.SetMarginBoxes(boxes)
 		}
 		if pc.First != nil && len(pc.First.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.First.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
 			}
 			d.SetFirstMarginBoxes(boxes)
 		}

--- a/document/issue328_test.go
+++ b/document/issue328_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	foliohtml "github.com/carlos7ags/folio/html"
+)
+
+// TestIssue328MarginBoxPdfAUsesEmbeddedFont reproduces issue #328: a document
+// with an @font-face body font and an @page margin box (running footer with
+// counter(page) / counter(pages)) rendered as PDF/A. Before the fix the
+// margin box was drawn with the non-embedded standard Helvetica, so PDF/A
+// validation failed with "non-embedded standard font Helvetica". After the
+// fix the margin box is drawn with the document's embedded body font, so
+// WriteTo (which validates PDF/A inline) succeeds.
+func TestIssue328MarginBoxPdfAUsesEmbeddedFont(t *testing.T) {
+	fontPath, err := filepath.Abs("../font/testdata/synthetic_cjk.ttf")
+	if err != nil {
+		t.Fatalf("resolve fixture path: %v", err)
+	}
+
+	// Body text uses codepoints the synthetic fixture covers; the margin-box
+	// content ("Page N of M") is ASCII and falls back to .notdef in this
+	// font, which is still embedded and therefore PDF/A-valid.
+	htmlStr := fmt.Sprintf(`<!DOCTYPE html>
+<html><head><style>
+@font-face { font-family: 'CJK'; src: url('%s'); }
+body { font-family: 'CJK'; font-size: 14px; }
+@page { @bottom-center { content: "Page " counter(page) " of " counter(pages); } }
+</style></head><body><p>中华人民共和国是一个历史悠久的文明古国。</p></body></html>`, fontPath)
+
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "Issue 328"
+	doc.SetPdfA(PdfAConfig{Level: PdfA3B})
+	if err := doc.AddHTML(htmlStr, &foliohtml.Options{StrictAssets: true}); err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo (PDF/A validation) failed; margin box must use the "+
+			"embedded body font, not Helvetica: %v", err)
+	}
+	if err := doc.ValidatePdfA(); err != nil {
+		t.Fatalf("ValidatePdfA returned error: %v", err)
+	}
+
+	// Sanity: the standard Helvetica name must not appear as a font resource
+	// (it would if the margin box still used the standard-font path).
+	if strings.Contains(buf.String(), "/BaseFont /Helvetica") {
+		t.Error("output references non-embedded /BaseFont /Helvetica; margin box font was not embedded")
+	}
+}
+
+// TestIssue328MarginBoxFallsBackToHelveticaWithoutEmbeddedFont confirms a
+// document with NO embedded fonts keeps the previous Helvetica behaviour for
+// margin boxes (such a document is not PDF/A, so non-embedded is acceptable).
+func TestIssue328MarginBoxFallsBackToHelveticaWithoutEmbeddedFont(t *testing.T) {
+	htmlStr := `<!DOCTYPE html>
+<html><head><style>
+@page { @bottom-center { content: "Page " counter(page); } }
+</style></head><body><p>Hello world.</p></body></html>`
+
+	doc := NewDocument(PageSizeLetter)
+	if err := doc.AddHTML(htmlStr, nil); err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	// Margin box should still render via the standard Helvetica path.
+	if !strings.Contains(buf.String(), "Helvetica") {
+		t.Error("expected Helvetica fallback for margin box in non-embedded document")
+	}
+}

--- a/html/converter.go
+++ b/html/converter.go
@@ -320,7 +320,17 @@ type DocMetadata struct {
 type MarginBoxContent struct {
 	Content  string     // resolved content string (after evaluating counter(), string literals, etc.)
 	FontSize float64    // font size in points (0 = use default 9pt)
-	Color    [3]float64 // RGB color (0-1 each; all zero = default gray)
+	Color    [3]float64 // RGB color (0-1 each)
+	// HasColor is true only when a `color` declaration was present in the
+	// margin-box rule. It lets the renderer distinguish an explicit
+	// `color: black` from an unset color (which defaults to gray).
+	HasColor bool
+	// Embedded is the document's default body font, stamped during
+	// conversion so the renderer can draw the margin box with an embedded
+	// (PDF/A-safe) font instead of the non-embedded standard Helvetica.
+	// Nil when the document uses no embedded fonts. Font-family declared
+	// inside the margin box itself is not yet honoured (follow-up).
+	Embedded *font.EmbeddedFont
 }
 
 // PageMargins holds the margin values and margin-box content for a
@@ -354,8 +364,13 @@ type PageConfig struct {
 	MarginBoxes map[string]MarginBoxContent // e.g. "top-center" → content
 }
 
-// convertMarginBoxes converts html.MarginBoxContent to layout.MarginBox.
-func convertMarginBoxes(src map[string]MarginBoxContent) map[string]layout.MarginBox {
+// convertMarginBoxes converts html.MarginBoxContent to layout.MarginBox,
+// stamping the document's default body font (emb) onto each box so the
+// renderer draws running headers/footers with an embedded, PDF/A-safe font
+// instead of the non-embedded standard Helvetica (issue #328). emb may be
+// nil when the document has no embedded fonts; the renderer then falls back
+// to Helvetica, which is acceptable because such a document is not PDF/A.
+func convertMarginBoxes(src map[string]MarginBoxContent, emb *font.EmbeddedFont) map[string]layout.MarginBox {
 	if len(src) == 0 {
 		return nil
 	}
@@ -365,9 +380,62 @@ func convertMarginBoxes(src map[string]MarginBoxContent) map[string]layout.Margi
 			Content:  mbc.Content,
 			FontSize: mbc.FontSize,
 			Color:    mbc.Color,
+			HasColor: mbc.HasColor,
+			Embedded: emb,
 		}
 	}
 	return out
+}
+
+// stampMarginBoxFont writes emb onto the Embedded field of every
+// MarginBoxContent in src. It is used so the document.AddHTML path, which
+// reconstructs layout.MarginBox from PageConfig rather than from the
+// already-converted ConvertResult.MarginBoxes, embeds the same body font.
+func stampMarginBoxFont(src map[string]MarginBoxContent, emb *font.EmbeddedFont) {
+	for name, mbc := range src {
+		mbc.Embedded = emb
+		src[name] = mbc
+	}
+}
+
+// defaultMarginBoxFont returns the embedded font that body text resolves to,
+// for use as the default font of @page margin boxes. It computes the <body>
+// element's cascaded style (so an author's `body { font-family: 'X' }` with a
+// matching @font-face is honoured) and resolves that style to an embedded
+// font. Returns nil when the document uses no embedded fonts (pure
+// standard-font document), in which case the renderer keeps the Helvetica
+// fallback. Font-family declared inside the margin box itself is not parsed
+// yet (deferred follow-up); the body font is the default per CSS GCPM.
+func (c *converter) defaultMarginBoxFont(doc *html.Node, root computedStyle) *font.EmbeddedFont {
+	if len(c.embeddedFonts) == 0 {
+		return nil
+	}
+	style := root
+	if body := findBodyNode(doc); body != nil {
+		style = c.computeElementStyle(body, root)
+	}
+	_, emb := c.resolveFontPair(style)
+	return emb
+}
+
+// findBodyNode returns the first <body> element in the parsed tree, or nil.
+func findBodyNode(doc *html.Node) *html.Node {
+	var walk func(*html.Node) *html.Node
+	walk = func(n *html.Node) *html.Node {
+		if n == nil {
+			return nil
+		}
+		if n.Type == html.ElementNode && n.DataAtom == atom.Body {
+			return n
+		}
+		for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
+			if found := walk(ch); found != nil {
+				return found
+			}
+		}
+		return nil
+	}
+	return walk(doc)
 }
 
 // AbsoluteItem represents an element removed from normal flow via
@@ -447,11 +515,18 @@ func ConvertFullWithContext(ctx context.Context, htmlStr string, opts *Options) 
 	result.PageConfig = pageConfig
 
 	// Build ready-to-use margin box maps so callers can pass them
-	// directly to doc.SetMarginBoxes without type conversion.
+	// directly to doc.SetMarginBoxes without type conversion. The
+	// document's default body font is stamped onto each box (issue #328)
+	// and also onto the MarginBoxContent values in pageConfig so the
+	// document.AddHTML path (which rebuilds layout.MarginBox from
+	// pageConfig) embeds the same font.
 	if pageConfig != nil {
-		result.MarginBoxes = convertMarginBoxes(pageConfig.MarginBoxes)
+		marginFont := c.defaultMarginBoxFont(doc, style)
+		stampMarginBoxFont(pageConfig.MarginBoxes, marginFont)
+		result.MarginBoxes = convertMarginBoxes(pageConfig.MarginBoxes, marginFont)
 		if pageConfig.First != nil {
-			result.FirstMarginBoxes = convertMarginBoxes(pageConfig.First.MarginBoxes)
+			stampMarginBoxFont(pageConfig.First.MarginBoxes, marginFont)
+			result.FirstMarginBoxes = convertMarginBoxes(pageConfig.First.MarginBoxes, marginFont)
 		}
 	}
 

--- a/html/marginbox_color_test.go
+++ b/html/marginbox_color_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import "testing"
+
+// TestMarginBoxHasColorExplicit verifies that an explicit `color` declaration
+// on a margin box sets HasColor=true and carries the parsed color through to
+// the converted layout.MarginBox (issue #328 adjacent color bug).
+func TestMarginBoxHasColorExplicit(t *testing.T) {
+	src := `<!DOCTYPE html><html><head><style>
+@page { @bottom-center { content: "Page " counter(page); color: black; } }
+</style></head><body><p>Hi</p></body></html>`
+
+	result, err := ConvertFull(src, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box, ok := result.MarginBoxes["bottom-center"]
+	if !ok {
+		t.Fatalf("no bottom-center margin box; got %v", result.MarginBoxes)
+	}
+	if !box.HasColor {
+		t.Error("HasColor = false, want true for explicit color: black")
+	}
+	if box.Color != [3]float64{0, 0, 0} {
+		t.Errorf("Color = %v, want black {0,0,0}", box.Color)
+	}
+}
+
+// TestMarginBoxHasColorUnset verifies HasColor stays false when no color
+// declaration is present, so the renderer applies its default gray.
+func TestMarginBoxHasColorUnset(t *testing.T) {
+	src := `<!DOCTYPE html><html><head><style>
+@page { @bottom-center { content: "Page " counter(page); } }
+</style></head><body><p>Hi</p></body></html>`
+
+	result, err := ConvertFull(src, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box, ok := result.MarginBoxes["bottom-center"]
+	if !ok {
+		t.Fatalf("no bottom-center margin box; got %v", result.MarginBoxes)
+	}
+	if box.HasColor {
+		t.Error("HasColor = true, want false when no color declared")
+	}
+}
+
+// TestMarginBoxNonBlackColor verifies a distinct (non-black) color is parsed
+// and carried with HasColor=true.
+func TestMarginBoxNonBlackColor(t *testing.T) {
+	src := `<!DOCTYPE html><html><head><style>
+@page { @top-right { content: counter(page); color: #ff0000; } }
+</style></head><body><p>Hi</p></body></html>`
+
+	result, err := ConvertFull(src, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box, ok := result.MarginBoxes["top-right"]
+	if !ok {
+		t.Fatalf("no top-right margin box; got %v", result.MarginBoxes)
+	}
+	if !box.HasColor {
+		t.Error("HasColor = false, want true for explicit color")
+	}
+	if box.Color[0] != 1 || box.Color[1] != 0 || box.Color[2] != 0 {
+		t.Errorf("Color = %v, want red {1,0,0}", box.Color)
+	}
+}

--- a/html/marginbox_font_issue328_test.go
+++ b/html/marginbox_font_issue328_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// These tests exercise issue #328 through the production HTML →
+// font-resolution path (ConvertFull → ConvertResult.MarginBoxes), which
+// is exactly how document.AddHTML obtains the margin-box body font.
+//
+// Fixture limitation: the only embeddable font checked into the repo is
+// font/testdata/synthetic_cjk.ttf, which covers a few CJK ideographs and
+// NOTHING in ASCII. Its cmap maps every ASCII codepoint to GID 0
+// (.notdef), so a real-world margin box of page-number digits ("Page 1")
+// encodes to an all-zero GID stream and renders INVISIBLE — even though
+// the font is embedded and the PDF passes PDF/A. To prove the margin box
+// draws REAL glyphs (the regression the review asked to guard) we use
+// margin-box content the fixture actually covers (CJK runes), so the
+// resolved EmbeddedFont produces a provably non-.notdef GID stream. The
+// ASCII case is pinned negatively below to document the fixture gap.
+
+// marginFontHTML builds a document whose body uses the synthetic CJK
+// @font-face and whose @page declares margin boxes with the given
+// bottom-center / top-right content.
+func marginFontHTML(fontPath, bottomCenter, topRight string) string {
+	return `<!DOCTYPE html><html><head><style>
+@font-face { font-family: 'Synth'; src: url('` + fontPath + `'); }
+body { font-family: 'Synth'; font-size: 14px; }
+@page { @bottom-center { content: "` + bottomCenter + `"; } @top-right { content: "` + topRight + `"; } }
+</style></head><body><p>中华人民共和国</p></body></html>`
+}
+
+func resolveCJKFixture(t *testing.T) string {
+	t.Helper()
+	abs, err := filepath.Abs("../font/testdata/synthetic_cjk.ttf")
+	if err != nil {
+		t.Fatalf("resolve fixture path: %v", err)
+	}
+	return abs
+}
+
+// bodyRunEmbedded returns the embedded font of the first paragraph run
+// in the conversion result, or fails the test.
+func bodyRunEmbedded(t *testing.T, elems []layout.Element) *font.EmbeddedFont {
+	t.Helper()
+	for _, e := range elems {
+		p, ok := e.(*layout.Paragraph)
+		if !ok {
+			continue
+		}
+		runs := p.Runs()
+		if len(runs) == 0 {
+			t.Fatal("body paragraph has no runs")
+		}
+		if runs[0].Embedded == nil {
+			t.Fatal("body paragraph run has no embedded font; @font-face body font not resolved")
+		}
+		return runs[0].Embedded
+	}
+	t.Fatal("no body Paragraph found in elements")
+	return nil
+}
+
+// TestIssue328MarginBoxResolvedFontEncodesRealGlyphs is the core
+// regression guard: the margin box's PRODUCTION-resolved EmbeddedFont
+// must encode its (covered) content to a non-.notdef GID stream via the
+// same EncodeString API drawWordEmbedded uses. A regression that routed
+// the margin box to .notdef — or that failed to subset the drawn glyphs
+// — would yield an all-zero stream and fail here.
+func TestIssue328MarginBoxResolvedFontEncodesRealGlyphs(t *testing.T) {
+	fontPath := resolveCJKFixture(t)
+	// 中华国 are codepoints the fixture covers → GIDs 1, 2, 7.
+	const content = "中华国"
+
+	result, err := ConvertFull(marginFontHTML(fontPath, content, content), &Options{StrictAssets: true})
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+
+	box, ok := result.MarginBoxes["bottom-center"]
+	if !ok {
+		t.Fatal("bottom-center margin box missing from conversion result")
+	}
+	if box.Embedded == nil {
+		t.Fatal("margin box has no embedded font; body font was not inherited (issue #328)")
+	}
+
+	gids := box.Embedded.EncodeString(box.Content)
+	if len(gids) == 0 {
+		t.Fatal("EncodeString returned no bytes for margin-box content")
+	}
+	if allZero(gids) {
+		t.Fatalf("margin-box content %q encoded to an all-.notdef GID stream % X; "+
+			"covered glyphs were routed to .notdef (invisible text)", box.Content, gids)
+	}
+}
+
+// TestIssue328MarginBoxAsciiIsNotdefInCJKFixture pins the fixture
+// limitation that motivates the CJK-content choice above: ASCII
+// page-number text resolves to ALL .notdef in the CJK-only font. This is
+// why the positive guard cannot use "Page 1" — and it proves the
+// all-zero failure mode the positive guard detects is real.
+func TestIssue328MarginBoxAsciiIsNotdefInCJKFixture(t *testing.T) {
+	fontPath := resolveCJKFixture(t)
+
+	result, err := ConvertFull(marginFontHTML(fontPath, "Page 1", "Page 1"), &Options{StrictAssets: true})
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box := result.MarginBoxes["bottom-center"]
+	if box.Embedded == nil {
+		t.Fatal("margin box has no embedded font")
+	}
+	gids := box.Embedded.EncodeString(box.Content)
+	if !allZero(gids) {
+		t.Fatalf("expected ASCII to map entirely to .notdef in the CJK-only fixture, "+
+			"got % X; if this changes, the positive guard could use ASCII directly", gids)
+	}
+}
+
+// TestIssue328MarginBoxInheritsBodyFontInstance proves the core of the
+// feature: the margin box does not just have SOME embedded font, it
+// shares the SAME *font.EmbeddedFont instance as the document body text.
+// Inheritance is what makes the glyphs subset together and keeps the
+// running footer PDF/A-valid. A regression that gave the margin box a
+// fresh/independent font (or Helvetica) would break this identity.
+func TestIssue328MarginBoxInheritsBodyFontInstance(t *testing.T) {
+	fontPath := resolveCJKFixture(t)
+	result, err := ConvertFull(marginFontHTML(fontPath, "中", "中"), &Options{StrictAssets: true})
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+
+	bodyFont := bodyRunEmbedded(t, result.Elements)
+
+	for name, box := range result.MarginBoxes {
+		if box.Embedded == nil {
+			t.Errorf("margin box %q has no embedded font", name)
+			continue
+		}
+		if box.Embedded != bodyFont {
+			t.Errorf("margin box %q embedded font is a different instance than the body "+
+				"text font; the body font was not inherited (issue #328)", name)
+		}
+	}
+}
+
+// TestIssue328FirstPageMarginBoxCarriesEmbeddedFont covers the
+// reviewer's extra: @page :first margin boxes must also carry the
+// embedded body font (the first page is where a title-page footer lands).
+func TestIssue328FirstPageMarginBoxCarriesEmbeddedFont(t *testing.T) {
+	fontPath := resolveCJKFixture(t)
+	htmlStr := `<!DOCTYPE html><html><head><style>
+@font-face { font-family: 'Synth'; src: url('` + fontPath + `'); }
+body { font-family: 'Synth'; font-size: 14px; }
+@page :first { @bottom-center { content: "中"; } }
+</style></head><body><p>中华人民共和国</p></body></html>`
+
+	result, err := ConvertFull(htmlStr, &Options{StrictAssets: true})
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	if len(result.FirstMarginBoxes) == 0 {
+		t.Fatal("no first-page margin boxes parsed from @page :first")
+	}
+	bodyFont := bodyRunEmbedded(t, result.Elements)
+	for name, box := range result.FirstMarginBoxes {
+		if box.Embedded == nil {
+			t.Errorf("first-page margin box %q has no embedded font", name)
+			continue
+		}
+		if box.Embedded != bodyFont {
+			t.Errorf("first-page margin box %q does not share the body font instance", name)
+		}
+		// And the inherited font must encode the covered content to real
+		// glyphs, not .notdef.
+		if allZero(box.Embedded.EncodeString(box.Content)) {
+			t.Errorf("first-page margin box %q encoded covered content to all .notdef", name)
+		}
+	}
+}
+
+// TestIssue328MarginBoxEmbeddedMeasureNonZero is the reviewer's
+// right-align width extra: the embedded font must measure covered
+// margin-box content to a positive width so right/center alignment math
+// in drawMarginBoxes places the box correctly. A zero width would jam a
+// right-aligned footer against the right margin regardless of length.
+func TestIssue328MarginBoxEmbeddedMeasureNonZero(t *testing.T) {
+	fontPath := resolveCJKFixture(t)
+	result, err := ConvertFull(marginFontHTML(fontPath, "中", "中华国"), &Options{StrictAssets: true})
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box := result.MarginBoxes["top-right"]
+	if box.Embedded == nil {
+		t.Fatal("top-right margin box has no embedded font")
+	}
+	const fontSize = 9.0
+	w := box.Embedded.MeasureString(box.Content, fontSize)
+	if w <= 0 {
+		t.Fatalf("embedded MeasureString(%q) = %v; want > 0 for right-align placement", box.Content, w)
+	}
+	// A longer covered string must measure wider than a shorter one, so
+	// right-edge placement (x = pageWidth - margin - width) actually
+	// tracks content length.
+	short := box.Embedded.MeasureString("中", fontSize)
+	if w <= short {
+		t.Fatalf("MeasureString(%q)=%v not greater than MeasureString(\"中\")=%v; "+
+			"width does not scale with content length", box.Content, w, short)
+	}
+}
+
+// allZero reports whether every byte in b is zero — i.e. an Identity-H
+// GID stream that is entirely .notdef (GID 0).
+func allZero(b []byte) bool {
+	for _, c := range b {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/html/page.go
+++ b/html/page.go
@@ -153,6 +153,7 @@ func parseMarginBoxDecls(decls []cssDecl, defaultFontSize float64) MarginBoxCont
 		case "color":
 			if c, ok := parseColor(val); ok {
 				mbc.Color = [3]float64{c.R, c.G, c.B}
+				mbc.HasColor = true
 			}
 		}
 	}

--- a/layout/marginbox_embedded_glyph_issue328_test.go
+++ b/layout/marginbox_embedded_glyph_issue328_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// The only embeddable font fixture checked into the repo is
+// font/testdata/synthetic_cjk.ttf, which covers a handful of CJK
+// ideographs and nothing else. Its cmap maps every ASCII codepoint to
+// GID 0 (.notdef), so a margin box containing ASCII page numbers
+// ("Page 1") would encode to an all-zero GID stream and render INVISIBLE
+// even though the font is embedded and PDF/A-valid. These tests
+// therefore drive the margin-box draw path with content the fixture
+// actually covers (CJK runes → non-zero GIDs) so the GID stream is
+// provably non-.notdef. The matching ASCII-coverage guard lives in the
+// html package, where the production font-resolution path is exercised
+// end to end with whatever glyphs the body font supplies.
+
+// loadSyntheticCJKEmbedded loads the synthetic CJK fixture as an
+// EmbeddedFont for use as a margin-box body font.
+func loadSyntheticCJKEmbedded(t *testing.T) *font.EmbeddedFont {
+	t.Helper()
+	path, err := filepath.Abs("../font/testdata/synthetic_cjk.ttf")
+	if err != nil {
+		t.Fatalf("resolve fixture path: %v", err)
+	}
+	face, err := font.LoadFont(path)
+	if err != nil {
+		t.Fatalf("load fixture face: %v", err)
+	}
+	return font.NewEmbeddedFont(face)
+}
+
+// hexTjRe captures the GID bytes of an "<HEX> Tj" operator emitted by
+// the embedded (Identity-H) text path.
+var hexTjRe = regexp.MustCompile(`<([0-9A-Fa-f]+)> Tj`)
+
+// renderEmbeddedMarginBox renders a single page with one bottom-center
+// margin box drawn with the supplied embedded font and returns the
+// page content stream.
+func renderEmbeddedMarginBox(t *testing.T, content string, emb *font.EmbeddedFont) string {
+	t.Helper()
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.Add(NewParagraph("Body", font.Helvetica, 12))
+	r.SetMarginBoxes(map[string]MarginBox{
+		"bottom-center": {Content: content, FontSize: 9, Embedded: emb},
+	})
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("expected at least one page")
+	}
+	return string(pages[0].Stream.Bytes())
+}
+
+// TestMarginBoxEmbeddedDrawsRealGlyphs is the regression guard demanded
+// by the issue #328 review: a margin box whose Embedded font covers the
+// drawn characters must emit a NON-zero GID stream. A regression that
+// routed margin-box text to .notdef (GID 0) — or that failed to encode
+// the characters at all — would produce an all-zero hex stream and fail
+// here.
+//
+// The drawn content uses CJK runes the synthetic fixture covers (its
+// cmap assigns the first checked-in codepoint, 中, to GID 1, etc.), so
+// the expected GID stream is provably non-zero. ASCII page numbers
+// CANNOT be used with this fixture because it has no Latin coverage; see
+// the package comment and the companion html-package test.
+func TestMarginBoxEmbeddedDrawsRealGlyphs(t *testing.T) {
+	emb := loadSyntheticCJKEmbedded(t)
+	// 中华国 are the 1st, 2nd and 7th codepoints in the fixture's
+	// codepoint list, so they map to GIDs 1, 2 and 7 respectively.
+	const content = "中华国"
+
+	stream := renderEmbeddedMarginBox(t, content, emb)
+
+	// The margin box must use the embedded Identity-H hex path, not the
+	// standard-font ShowText path.
+	m := hexTjRe.FindStringSubmatch(stream)
+	if m == nil {
+		t.Fatalf("no <HEX> Tj embedded-text operator in margin-box stream; "+
+			"margin box did not draw via the embedded font:\n%s", stream)
+	}
+	hex := m[1]
+
+	// Each GID is two bytes (four hex chars). An all-zero stream means
+	// every glyph resolved to .notdef — exactly the invisible-text
+	// regression this test exists to catch.
+	if hex == "" || strings.Trim(hex, "0") == "" {
+		t.Fatalf("margin-box embedded GID stream is all .notdef (GID 0): <%s>; "+
+			"covered characters were routed to .notdef", hex)
+	}
+
+	// Cross-check against the font's own encoder: the rendered hex must
+	// equal EncodeString of the same content, and that encoding must be
+	// non-zero. EncodeString is the exact API the production draw path
+	// uses (font.EmbeddedFont.EncodeString via drawWordEmbedded).
+	wantHex := strings.ToUpper(hexOf(emb.EncodeString(content)))
+	if strings.ToUpper(hex) != wantHex {
+		t.Fatalf("margin-box GID stream %q does not match EncodeString(%q)=%q",
+			hex, content, wantHex)
+	}
+}
+
+// TestMarginBoxEmbeddedNotdefWouldFailGuard documents (and proves) that
+// the GID-non-zero assertion in TestMarginBoxEmbeddedDrawsRealGlyphs
+// genuinely fails when text is routed to .notdef. It feeds the SAME
+// embedded font ASCII content, which the CJK-only fixture maps entirely
+// to GID 0, and asserts the resulting stream IS all-zero — i.e. the
+// failure mode the regression guard detects is real for this font.
+func TestMarginBoxEmbeddedNotdefWouldFailGuard(t *testing.T) {
+	emb := loadSyntheticCJKEmbedded(t)
+	// ASCII has no coverage in the CJK fixture → every rune is .notdef.
+	stream := renderEmbeddedMarginBox(t, "Page 1", emb)
+
+	m := hexTjRe.FindStringSubmatch(stream)
+	if m == nil {
+		t.Fatalf("expected an embedded <HEX> Tj operator even for .notdef text:\n%s", stream)
+	}
+	if strings.Trim(m[1], "0") != "" {
+		t.Fatalf("expected ASCII to map entirely to .notdef (all-zero GIDs) in the "+
+			"CJK-only fixture, got non-zero <%s>; the GID-non-zero guard would not "+
+			"distinguish real glyphs from .notdef if this changed", m[1])
+	}
+	// The non-zero guard from the sibling test, applied to this stream,
+	// MUST trip — proving that test would catch a .notdef regression.
+	allNotdef := strings.Trim(m[1], "0") == ""
+	if !allNotdef {
+		t.Fatal("inconsistent: .notdef stream not detected as all-zero")
+	}
+}
+
+// hexOf renders bytes as an uppercase hex string the way ShowTextHex
+// does (without the surrounding <> Tj).
+func hexOf(b []byte) string {
+	const digits = "0123456789ABCDEF"
+	out := make([]byte, 0, len(b)*2)
+	for _, c := range b {
+		out = append(out, digits[c>>4], digits[c&0x0F])
+	}
+	return string(out)
+}

--- a/layout/marginbox_issue328_test.go
+++ b/layout/marginbox_issue328_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// renderWithMarginBox renders a single page with one bottom-center margin box
+// and returns the page content stream as a string.
+func renderWithMarginBox(t *testing.T, box MarginBox, tagged bool) string {
+	t.Helper()
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.SetTagged(tagged)
+	r.Add(NewParagraph("Body", font.Helvetica, 12))
+	r.SetMarginBoxes(map[string]MarginBox{"bottom-center": box})
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("expected at least one page")
+	}
+	return string(pages[0].Stream.Bytes())
+}
+
+// TestMarginBoxExplicitBlackColorHonored verifies issue #328's adjacent color
+// bug: an explicit color (HasColor=true) must be emitted verbatim, including
+// pure black {0,0,0}, rather than being mistaken for unset and forced to gray.
+func TestMarginBoxExplicitBlackColorHonored(t *testing.T) {
+	content := renderWithMarginBox(t, MarginBox{
+		Content:  "Page 1",
+		FontSize: 9,
+		Color:    [3]float64{0, 0, 0},
+		HasColor: true,
+	}, false)
+
+	// Pure black fill: "0 0 0 rg". The default-gray "0.4 0.4 0.4 rg" must not
+	// appear for this box.
+	if !strings.Contains(content, "0 0 0 rg") {
+		t.Errorf("expected explicit black fill color (0 0 0 rg) in output; got:\n%s", content)
+	}
+	if strings.Contains(content, "0.4 0.4 0.4 rg") {
+		t.Error("explicit black color was overridden by the default gray")
+	}
+}
+
+// TestMarginBoxDefaultGrayWhenNoColor verifies the default gray applies when
+// the CSS did not set a color (HasColor=false).
+func TestMarginBoxDefaultGrayWhenNoColor(t *testing.T) {
+	content := renderWithMarginBox(t, MarginBox{
+		Content:  "Page 1",
+		FontSize: 9,
+		HasColor: false,
+	}, false)
+
+	if !strings.Contains(content, "0.4 0.4 0.4 rg") {
+		t.Errorf("expected default gray fill (0.4 0.4 0.4 rg); got:\n%s", content)
+	}
+}
+
+// TestMarginBoxTaggedWrappedAsArtifact verifies that in tagged mode the
+// margin-box drawing is wrapped in an /Artifact marked-content sequence, so a
+// running header/footer stays out of the structure tree (PDF/UA).
+func TestMarginBoxTaggedWrappedAsArtifact(t *testing.T) {
+	content := renderWithMarginBox(t, MarginBox{
+		Content:  "Page 1",
+		FontSize: 9,
+	}, true)
+
+	if !strings.Contains(content, "/Artifact BDC") {
+		t.Errorf("expected /Artifact BDC wrapper in tagged output; got:\n%s", content)
+	}
+	// The artifact sequence must enclose the text and be closed with EMC.
+	artIdx := strings.Index(content, "/Artifact BDC")
+	emcIdx := strings.Index(content[artIdx:], "EMC")
+	tjIdx := strings.Index(content[artIdx:], "Tj")
+	if emcIdx < 0 || tjIdx < 0 || tjIdx > emcIdx {
+		t.Errorf("expected Tj before EMC inside the /Artifact sequence; got:\n%s", content[artIdx:])
+	}
+}
+
+// TestMarginBoxUntaggedNoArtifact verifies that when not tagged, no artifact
+// wrapper is emitted (avoids polluting untagged streams).
+func TestMarginBoxUntaggedNoArtifact(t *testing.T) {
+	content := renderWithMarginBox(t, MarginBox{
+		Content:  "Page 1",
+		FontSize: 9,
+	}, false)
+
+	if strings.Contains(content, "/Artifact BDC") {
+		t.Error("did not expect /Artifact wrapper in untagged output")
+	}
+}

--- a/layout/renderer.go
+++ b/layout/renderer.go
@@ -129,7 +129,18 @@ type Renderer struct {
 type MarginBox struct {
 	Content  string     // template string with placeholders
 	FontSize float64    // font size in points (0 = default 9pt)
-	Color    [3]float64 // RGB color (0-1 each; all zero = default gray)
+	Color    [3]float64 // RGB color (0-1 each)
+	// HasColor is true only when the source CSS explicitly set a `color`
+	// declaration. It distinguishes an explicit `color: black` ({0,0,0})
+	// from an unset color: when false the renderer applies the default
+	// gray; when true it honours Color verbatim (including pure black).
+	HasColor bool
+	// Embedded is the document's default body font, used to draw the
+	// margin-box text. When non-nil the renderer emits the text with this
+	// embedded font (Identity-H GID encoding), so the glyphs are subset
+	// and embedded — required for PDF/A. When nil the renderer falls back
+	// to the built-in standard Helvetica (acceptable for non-PDF/A docs).
+	Embedded *font.EmbeddedFont
 }
 
 // MarginBoxSet holds margin boxes for a page variant.
@@ -214,6 +225,7 @@ func (r *Renderer) drawMarginBoxes(ctx *DrawContext, pageIdx int, margins Margin
 	contentWidth := r.pageWidth - margins.Left - margins.Right
 
 	for name, box := range boxes {
+		box := box
 		text := box.Content
 		if text == "" {
 			continue
@@ -234,14 +246,29 @@ func (r *Renderer) drawMarginBoxes(ctx *DrawContext, pageIdx int, margins Margin
 			fontSize = 9.0
 		}
 
-		// Use box-specific color, or default to gray.
+		// Use box-specific color when the CSS explicitly set one (HasColor),
+		// otherwise default to gray. The HasColor flag is required so an
+		// explicit `color: black` ({0,0,0}) is honoured rather than being
+		// mistaken for "unset" and forced to gray.
 		textColor := Color{R: 0.4, G: 0.4, B: 0.4}
-		if box.Color != [3]float64{0, 0, 0} {
+		if box.HasColor {
 			textColor = Color{R: box.Color[0], G: box.Color[1], B: box.Color[2]}
 		}
 
-		resName := registerFont(ctx.Page, Word{Font: f, FontSize: fontSize})
-		textWidth := f.MeasureString(text, fontSize)
+		// Choose the drawing word: an embedded font (PDF/A-safe, Identity-H
+		// GID encoding) when one was stamped on the box, otherwise the
+		// built-in standard Helvetica. Width is measured with the same font
+		// so alignment math is consistent.
+		word := Word{FontSize: fontSize, OriginalText: text, Text: text}
+		var textWidth float64
+		if box.Embedded != nil {
+			word.Embedded = box.Embedded
+			textWidth = box.Embedded.MeasureString(text, fontSize)
+		} else {
+			word.Font = f
+			textWidth = f.MeasureString(text, fontSize)
+		}
+		resName := registerFont(ctx.Page, word)
 
 		var x, y float64
 		switch name {
@@ -267,12 +294,28 @@ func (r *Renderer) drawMarginBoxes(ctx *DrawContext, pageIdx int, margins Margin
 			continue
 		}
 
+		// Running headers/footers are pagination artifacts, not document
+		// content. In a tagged PDF they must be marked as /Artifact so they
+		// stay out of the structure tree (PDF/UA, ISO 14289-1 §7.1).
+		if r.tagged {
+			ctx.Stream.BeginArtifact()
+		}
 		setFillColor(ctx.Stream, textColor)
 		ctx.Stream.BeginText()
 		ctx.Stream.SetFont(resName, fontSize)
 		ctx.Stream.MoveText(x, y)
-		ctx.Stream.ShowText(text)
+		if box.Embedded != nil {
+			// Embedded fonts require Identity-H GID encoding; route through
+			// the shared embedded-word drawer so glyph subsetting is recorded
+			// via EncodeString. Raw ShowText is only valid for standard fonts.
+			drawWordEmbedded(ctx.Stream, word)
+		} else {
+			ctx.Stream.ShowText(text)
+		}
 		ctx.Stream.EndText()
+		if r.tagged {
+			ctx.Stream.EndMarkedContent()
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #328.

@page margin boxes (running headers/footers, e.g. `@bottom-center { content: "Page " counter(page) " of " counter(pages) }`) were drawn with a hard-coded non-embedded Helvetica, so any PDF/A document with a margin box failed validation even though the body used an embedded `@font-face` font.

## Fix
- Carry the document's default embedded body font onto each margin box and draw margin-box text through the embedded glyph path (Identity-H, subsetted) when present; fall back to standard Helvetica only when the document has no embedded font.
- Honor an explicit `color` on a margin box (a new HasColor flag distinguishes `color: black` from unset; previously pure black became the default gray).
- Tag margin-box content as a PDF/UA `/Artifact` in tagged output.

## Tests
The issue's exact PDF/A repro (`@font-face` body + `@bottom-center counter(page)`, PdfA3B) now validates (fails before). Because the only embeddable test fixture is CJK-only, additional guards drive the embedded draw path with covered glyphs and assert a non-`.notdef` GID stream, and assert the margin box inherits the body's embedded font instance.

Follow-up: `font-family` declared inside a margin box is still not parsed (uses the body default per CSS GCPM).

## Before / after (PDF/A, 13-page render)

**Before** — a document with an embedded `@font-face` body font plus a `@page` page-number footer cannot be produced at all under PDF/A:

```
WriteTo FAILED: document: pdfa: page 0 uses non-embedded standard font "Helvetica";
PDF/A requires all fonts to be embedded
```

**After** — the footer is drawn with the document's embedded font, the file writes, and `ValidatePdfA` passes. Page-number footer renders on every page (page 3 of 13 shown):

![PDF/A page-number footer](https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/334/footer.png)

<details><summary>full page</summary>

![full page](https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/334/page03_full.png)

</details>

_Repro: `@font-face` body font + `@page { @bottom-center { content: "Page " counter(page) " of " counter(pages) } }`, PdfA3B._
