### PR TITLE
layout/html: render position:fixed on every page (#327)

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -134,6 +134,7 @@ func renderHTML(_ js.Value, args []js.Value) any {
 			RightAligned: abs.RightAligned,
 			ZIndex:       abs.ZIndex,
 			PageIndex:    -1,
+			Fixed:        abs.Fixed,
 		})
 	}
 

--- a/document/document.go
+++ b/document/document.go
@@ -62,6 +62,7 @@ type absoluteElement struct {
 	pageIndex    int // -1 = last page
 	rightAligned bool
 	zIndex       int
+	fixed        bool // render on every page (position: fixed)
 }
 
 // Document is the top-level API for building a PDF.
@@ -284,6 +285,7 @@ func (d *Document) AddAbsoluteWithOpts(e layout.Element, x, y, width float64, op
 	d.absolutes = append(d.absolutes, absoluteElement{
 		elem: e, x: x, y: y, width: width,
 		pageIndex: opts.PageIndex, rightAligned: opts.RightAligned, zIndex: opts.ZIndex,
+		fixed: opts.Fixed,
 	})
 }
 
@@ -378,6 +380,7 @@ func (d *Document) buildAllPages(ctx context.Context) (all []*Page, structTags [
 				RightAligned: a.rightAligned,
 				ZIndex:       a.zIndex,
 				PageIndex:    a.pageIndex,
+				Fixed:        a.fixed,
 			})
 		}
 		results, rerr := r.RenderContext(ctx)

--- a/document/html.go
+++ b/document/html.go
@@ -120,6 +120,7 @@ func (d *Document) AddHTMLWithContext(ctx context.Context, htmlStr string, opts 
 			pageIndex:    -1,
 			rightAligned: abs.RightAligned,
 			zIndex:       abs.ZIndex,
+			fixed:        abs.Fixed,
 		})
 	}
 

--- a/document/layout_test.go
+++ b/document/layout_test.go
@@ -6,6 +6,7 @@ package document
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -283,6 +284,73 @@ func TestDocumentHeaderFooterMultiPage(t *testing.T) {
 		if !strings.Contains(text, expected) {
 			t.Errorf("missing %q in PDF", expected)
 		}
+	}
+}
+
+func TestDocumentHTMLFixedMastheadEveryPage(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+
+	// Body content spanning several pages plus a position:fixed masthead.
+	var body strings.Builder
+	body.WriteString(`<div style="position: fixed; top: 0; left: 0">MASTHEADMARK</div>`)
+	for range 150 {
+		body.WriteString("<p>Body line of text that fills the page nicely.</p>")
+	}
+	if err := doc.AddHTML(body.String(), nil); err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	// Count leaf page objects in the PDF.
+	pageRe := regexp.MustCompile(`/Type\s*/Page[^s]`)
+	numPages := len(pageRe.FindAll(buf.Bytes(), -1))
+	if numPages < 3 {
+		t.Fatalf("expected the body to span at least 3 pages, got %d", numPages)
+	}
+
+	// The fixed masthead must be drawn once per page.
+	cs := decompressedContentStreams(t, buf.Bytes())
+	occurrences := strings.Count(cs, "MASTHEADMARK")
+	if occurrences != numPages {
+		t.Errorf("fixed masthead should appear on every page: got %d occurrences across %d pages", occurrences, numPages)
+	}
+}
+
+func TestDocumentAddAbsoluteWithOptsFixedEveryPage(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+
+	// Flow content spanning several pages.
+	for range 150 {
+		doc.Add(layout.NewParagraph("Body line of text that fills the page nicely.", font.Helvetica, 12))
+	}
+
+	// A position:fixed absolute element added via the opts path (the WASM /
+	// C-ABI ingestion route). This must render on every page, not just the last.
+	doc.AddAbsoluteWithOpts(
+		layout.NewParagraph("FIXEDOPTSMARK", font.Helvetica, 12),
+		72, 720, 200,
+		layout.AbsoluteOpts{Fixed: true},
+	)
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	pageRe := regexp.MustCompile(`/Type\s*/Page[^s]`)
+	numPages := len(pageRe.FindAll(buf.Bytes(), -1))
+	if numPages < 3 {
+		t.Fatalf("expected the body to span at least 3 pages, got %d", numPages)
+	}
+
+	cs := decompressedContentStreams(t, buf.Bytes())
+	occurrences := strings.Count(cs, "FIXEDOPTSMARK")
+	if occurrences != numPages {
+		t.Errorf("fixed absolute (via AddAbsoluteWithOpts) should appear on every page: got %d occurrences across %d pages", occurrences, numPages)
 	}
 }
 

--- a/export/cabi_html.go
+++ b/export/cabi_html.go
@@ -119,6 +119,7 @@ func htmlToDocument(htmlStr string, pageWidth, pageHeight float64) (*document.Do
 			RightAligned: abs.RightAligned,
 			ZIndex:       abs.ZIndex,
 			PageIndex:    -1,
+			Fixed:        abs.Fixed,
 		})
 	}
 

--- a/html/converter.go
+++ b/html/converter.go
@@ -1503,10 +1503,16 @@ func (c *converter) convertElement(n *html.Node, parentStyle computedStyle) []la
 		} else if style.Right != nil {
 			dx = -style.Right.toPoints(c.containerWidth, style.FontSize)
 		}
+		// Per CSS, top/bottom percentages on a relatively positioned box
+		// resolve against the height of its containing block. We don't track
+		// the containing block height through normal flow here, so we
+		// approximate with the page height (the nearest available basis),
+		// mirroring how left/right use c.containerWidth. Absolute lengths
+		// (px/pt/em) are unaffected since they ignore the percentage basis.
 		if style.Top != nil {
-			dy = style.Top.toPoints(0, style.FontSize)
+			dy = style.Top.toPoints(c.opts.PageHeight, style.FontSize)
 		} else if style.Bottom != nil {
-			dy = -style.Bottom.toPoints(0, style.FontSize)
+			dy = -style.Bottom.toPoints(c.opts.PageHeight, style.FontSize)
 		}
 		if dx != 0 || dy != 0 {
 			var result []layout.Element

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -6019,6 +6019,60 @@ func TestConvertPositionFixed(t *testing.T) {
 	}
 }
 
+func TestConvertPositionRelativePercentTop(t *testing.T) {
+	// A relative top percentage must resolve against the page height, not 0.
+	// Page height defaults to 792pt, so top:50% should yield a ~396pt offset.
+	htmlStr := `<div style="position: relative; top: 50%"><p>Shifted</p></div>`
+	result, err := ConvertFull(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Elements) == 0 {
+		t.Fatal("expected a relatively positioned element")
+	}
+	div, ok := result.Elements[0].(*layout.Div)
+	if !ok {
+		t.Fatalf("expected *layout.Div, got %T", result.Elements[0])
+	}
+	plan := div.PlanLayout(layout.LayoutArea{Width: 468, Height: 720})
+	if len(plan.Blocks) == 0 {
+		t.Fatal("expected at least one placed block")
+	}
+	gotY := plan.Blocks[0].Y
+	if gotY <= 0 {
+		t.Fatalf("relative top:50%% should produce a non-zero vertical offset, got %v", gotY)
+	}
+	const want = 396.0 // 50% of default 792pt page height
+	if gotY < want-1 || gotY > want+1 {
+		t.Errorf("relative top:50%% offset = %v, want ~%v", gotY, want)
+	}
+}
+
+func TestConvertPositionRelativePercentBottom(t *testing.T) {
+	// A relative bottom percentage shifts the element upward (negative offset).
+	htmlStr := `<div style="position: relative; bottom: 25%"><p>Shifted</p></div>`
+	result, err := ConvertFull(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Elements) == 0 {
+		t.Fatal("expected a relatively positioned element")
+	}
+	div, ok := result.Elements[0].(*layout.Div)
+	if !ok {
+		t.Fatalf("expected *layout.Div, got %T", result.Elements[0])
+	}
+	plan := div.PlanLayout(layout.LayoutArea{Width: 468, Height: 720})
+	if len(plan.Blocks) == 0 {
+		t.Fatal("expected at least one placed block")
+	}
+	gotY := plan.Blocks[0].Y
+	const want = -198.0 // -25% of default 792pt page height
+	if gotY > want+1 || gotY < want-1 {
+		t.Errorf("relative bottom:25%% offset = %v, want ~%v", gotY, want)
+	}
+}
+
 func TestConvertPositionStatic(t *testing.T) {
 	htmlStr := `<div style="position: static"><p>Normal</p></div>`
 	result, err := ConvertFull(htmlStr, nil)

--- a/layout/render_plans.go
+++ b/layout/render_plans.go
@@ -444,6 +444,17 @@ func (r *Renderer) renderAbsolutes(pages []PageResult, defaultWidth float64, tot
 	lastPage := len(pages) - 1
 
 	for _, item := range r.absolutes {
+		// A fixed element (position: fixed) is drawn on every page; its
+		// geometry is page-relative (resolved against page width/height) so it
+		// is laid out and placed identically on each page. Non-fixed elements
+		// resolve to a single page: an explicit pageIndex, or -1 ⇒ last page.
+		if item.fixed {
+			for pageIdx := range pages {
+				r.drawAbsoluteOnPage(pages, item, pageIdx, defaultWidth, totalPages)
+			}
+			continue
+		}
+
 		pageIdx := item.pageIndex
 		if pageIdx < 0 {
 			pageIdx = lastPage
@@ -451,52 +462,58 @@ func (r *Renderer) renderAbsolutes(pages []PageResult, defaultWidth float64, tot
 		if pageIdx < 0 || pageIdx >= len(pages) {
 			continue
 		}
-		page := &pages[pageIdx]
+		r.drawAbsoluteOnPage(pages, item, pageIdx, defaultWidth, totalPages)
+	}
+}
 
-		layoutWidth := item.width
-		if layoutWidth <= 0 {
-			layoutWidth = defaultWidth
+// drawAbsoluteOnPage lays out one absolute item against the given page and
+// draws it, honoring right-alignment and z-index ordering.
+func (r *Renderer) drawAbsoluteOnPage(pages []PageResult, item absoluteItem, pageIdx int, defaultWidth float64, totalPages int) {
+	page := &pages[pageIdx]
+
+	layoutWidth := item.width
+	if layoutWidth <= 0 {
+		layoutWidth = defaultWidth
+	}
+
+	area := LayoutArea{Width: layoutWidth, Height: r.pageHeight}
+	plan := item.elem.PlanLayout(area)
+
+	x := item.x
+	if item.rightAligned {
+		elemWidth := 0.0
+		for _, block := range plan.Blocks {
+			if w := block.X + block.Width; w > elemWidth {
+				elemWidth = w
+			}
 		}
+		x = r.pageWidth - item.x - elemWidth
+	}
 
-		area := LayoutArea{Width: layoutWidth, Height: r.pageHeight}
-		plan := item.elem.PlanLayout(area)
-
-		x := item.x
-		if item.rightAligned {
-			elemWidth := 0.0
-			for _, block := range plan.Blocks {
-				if w := block.X + block.Width; w > elemWidth {
-					elemWidth = w
-				}
-			}
-			x = r.pageWidth - item.x - elemWidth
+	if item.zIndex < 0 {
+		// Render into a temporary stream and prepend to draw behind flow content.
+		bgStream := content.NewStream()
+		bgCtx := DrawContext{
+			Stream:     bgStream,
+			Page:       page,
+			ActualText: r.actualText,
+			PageIdx:    pageIdx,
+			TotalPages: totalPages,
 		}
-
-		if item.zIndex < 0 {
-			// Render into a temporary stream and prepend to draw behind flow content.
-			bgStream := content.NewStream()
-			bgCtx := DrawContext{
-				Stream:     bgStream,
-				Page:       page,
-				ActualText: r.actualText,
-				PageIdx:    pageIdx,
-				TotalPages: totalPages,
-			}
-			for _, block := range plan.Blocks {
-				drawBlock(block, x, item.y, &bgCtx, r.tagged, &r.structTags, pageIdx)
-			}
-			page.Stream.PrependBytes(bgStream.Bytes())
-		} else {
-			ctx := DrawContext{
-				Stream:     page.Stream,
-				Page:       page,
-				ActualText: r.actualText,
-				PageIdx:    pageIdx,
-				TotalPages: totalPages,
-			}
-			for _, block := range plan.Blocks {
-				drawBlock(block, x, item.y, &ctx, r.tagged, &r.structTags, pageIdx)
-			}
+		for _, block := range plan.Blocks {
+			drawBlock(block, x, item.y, &bgCtx, r.tagged, &r.structTags, pageIdx)
+		}
+		page.Stream.PrependBytes(bgStream.Bytes())
+	} else {
+		ctx := DrawContext{
+			Stream:     page.Stream,
+			Page:       page,
+			ActualText: r.actualText,
+			PageIdx:    pageIdx,
+			TotalPages: totalPages,
+		}
+		for _, block := range plan.Blocks {
+			drawBlock(block, x, item.y, &ctx, r.tagged, &r.structTags, pageIdx)
 		}
 	}
 }

--- a/layout/renderer.go
+++ b/layout/renderer.go
@@ -79,6 +79,7 @@ type absoluteItem struct {
 	pageIndex    int     // -1 means "current page at time of rendering"
 	rightAligned bool    // x is a right-edge offset; final X = pageWidth - x - elementWidth
 	zIndex       int     // negative = render behind normal flow content
+	fixed        bool    // position: fixed — draw on every page
 }
 
 // StructTagInfo records a structure tag emitted during rendering.
@@ -408,6 +409,7 @@ type AbsoluteOpts struct {
 	RightAligned bool // x is a right-edge offset
 	ZIndex       int  // negative = render behind normal flow
 	PageIndex    int  // -1 = last page
+	Fixed        bool // position: fixed — draw on every page
 }
 
 // AddAbsolute places an element at the given (x, y) coordinates on the
@@ -426,7 +428,7 @@ func (r *Renderer) AddAbsolute(e Element, x, y, width float64) {
 func (r *Renderer) AddAbsoluteWithOpts(e Element, x, y, width float64, opts AbsoluteOpts) {
 	r.absolutes = append(r.absolutes, absoluteItem{
 		elem: e, x: x, y: y, width: width,
-		pageIndex: opts.PageIndex, rightAligned: opts.RightAligned, zIndex: opts.ZIndex,
+		pageIndex: opts.PageIndex, rightAligned: opts.RightAligned, zIndex: opts.ZIndex, fixed: opts.Fixed,
 	})
 }
 

--- a/layout/renderer_test.go
+++ b/layout/renderer_test.go
@@ -371,6 +371,54 @@ func TestRendererAddAbsoluteOnPage(t *testing.T) {
 	}
 }
 
+func TestRendererAddAbsoluteFixedEveryPage(t *testing.T) {
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+
+	// Fill enough flow content to span at least three pages.
+	for range 120 {
+		r.Add(NewParagraph("Body line of text that fills the page", font.Helvetica, 12))
+	}
+
+	// A fixed masthead must appear on every page.
+	r.AddAbsoluteWithOpts(NewParagraph("MASTHEAD", font.Helvetica, 14), 72, 740, 200, AbsoluteOpts{Fixed: true})
+
+	pages := r.Render()
+	if len(pages) < 3 {
+		t.Fatalf("expected at least 3 pages, got %d", len(pages))
+	}
+	for i := range pages {
+		s := string(pages[i].Stream.Bytes())
+		if !strings.Contains(s, "MASTHEAD") {
+			t.Errorf("fixed element missing from page %d (should render on every page)", i)
+		}
+	}
+}
+
+func TestRendererAddAbsoluteNonFixedLastPageOnly(t *testing.T) {
+	// A non-fixed absolute with pageIndex -1 must remain on the last page only.
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	for range 120 {
+		r.Add(NewParagraph("Body line of text that fills the page", font.Helvetica, 12))
+	}
+	r.AddAbsolute(NewParagraph("ENDMARK", font.Helvetica, 14), 72, 740, 200)
+
+	pages := r.Render()
+	if len(pages) < 3 {
+		t.Fatalf("expected at least 3 pages, got %d", len(pages))
+	}
+	last := len(pages) - 1
+	for i := range pages {
+		s := string(pages[i].Stream.Bytes())
+		has := strings.Contains(s, "ENDMARK")
+		if i == last && !has {
+			t.Errorf("non-fixed absolute should appear on last page %d", i)
+		}
+		if i != last && has {
+			t.Errorf("non-fixed absolute leaked onto non-last page %d", i)
+		}
+	}
+}
+
 func TestRendererAddAbsoluteDefaultWidth(t *testing.T) {
 	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
 	r.Add(NewParagraph("Flow", font.Helvetica, 12))

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -359,11 +359,11 @@ func buildDocumentFromResult(result *foliohtml.ConvertResult, opts *Options) *do
 
 	// Add absolutely positioned elements.
 	for _, abs := range result.Absolutes {
-		if abs.RightAligned {
-			doc.AddAbsoluteRight(abs.Element, abs.X, abs.Y, abs.Width)
-		} else {
-			doc.AddAbsolute(abs.Element, abs.X, abs.Y, abs.Width)
-		}
+		doc.AddAbsoluteWithOpts(abs.Element, abs.X, abs.Y, abs.Width, layout.AbsoluteOpts{
+			RightAligned: abs.RightAligned,
+			PageIndex:    -1,
+			Fixed:        abs.Fixed,
+		})
 	}
 
 	return doc


### PR DESCRIPTION
Part of #327 (the `position: fixed` half).

`position: fixed` (e.g. a masthead) painted on the last page only instead of every page: the parsed Fixed flag was dropped at the document handoff and the element was pinned to a single page.

## Fix
- Thread a `fixed` flag from the converter through Document and the renderer (absoluteElement → AbsoluteOpts → absoluteItem), including `AddAbsoluteWithOpts` and the C-ABI / WASM / tmpl ingestion paths.
- In `renderAbsolutes`, draw a fixed element on every page; non-fixed absolutes are unchanged.
- Fix the related bug where `position: relative` `top`/`bottom` percentages resolved against 0 (now resolved against the page height, mirroring how left/right use the container width).

## Tests
A multi-page document with a fixed masthead asserts it appears on every page (fails before — last page only), at both the HTML and programmatic `AddAbsoluteWithOpts` entry points; plus relative `top`/`bottom` percentage offset tests.

## Before / after (real 17-page render)

**Before** — the `position:fixed` masthead lands on the **last page only**:

| page 1 (no masthead) | page 17 (masthead — only here) |
|---|---|
| ![before p1](https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/335/before_p01.png) | ![before p17](https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/335/before_p17.png) |

**After** — masthead on **every** page:

| page 1 | page 9 (mid-document) |
|---|---|
| ![after p1](https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/335/after_p01.png) | ![after p9](https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/335/after_p09.png) |

_Repro: a 17-page document with `.mast { position:fixed; top:12pt; left:12pt; right:12pt }`._
