### PR TITLE
html/layout: @page :first/:left/:right margin cascade and duplex margin boxes (#327)

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -110,6 +110,12 @@ func renderHTML(_ js.Value, args []js.Value) any {
 	if result.FirstMarginBoxes != nil {
 		doc.SetFirstMarginBoxes(result.FirstMarginBoxes)
 	}
+	if result.LeftMarginBoxes != nil {
+		doc.SetLeftMarginBoxes(result.LeftMarginBoxes)
+	}
+	if result.RightMarginBoxes != nil {
+		doc.SetRightMarginBoxes(result.RightMarginBoxes)
+	}
 
 	// Apply metadata from HTML <title>/<meta> tags
 	if result.Metadata.Title != "" {

--- a/document/document.go
+++ b/document/document.go
@@ -74,7 +74,9 @@ type Document struct {
 	leftMargins      *layout.Margins             // @page :left
 	rightMargins     *layout.Margins             // @page :right
 	marginBoxes      map[string]layout.MarginBox // default margin boxes
-	firstMarginBoxes map[string]layout.MarginBox // first-page margin boxes
+	firstMarginBoxes map[string]layout.MarginBox // first-page margin boxes (@page :first)
+	leftMarginBoxes  map[string]layout.MarginBox // left-page margin boxes (@page :left)
+	rightMarginBoxes map[string]layout.MarginBox // right-page margin boxes (@page :right)
 	elements         []layout.Element
 	absolutes        []absoluteElement
 	Info             Info        // document metadata (Title, Author, etc.)
@@ -175,6 +177,16 @@ func (d *Document) SetMarginBoxes(boxes map[string]layout.MarginBox) {
 // SetFirstMarginBoxes sets margin box content for the first page only.
 func (d *Document) SetFirstMarginBoxes(boxes map[string]layout.MarginBox) {
 	d.firstMarginBoxes = boxes
+}
+
+// SetLeftMarginBoxes sets margin box content for left (even-numbered) pages (@page :left).
+func (d *Document) SetLeftMarginBoxes(boxes map[string]layout.MarginBox) {
+	d.leftMarginBoxes = boxes
+}
+
+// SetRightMarginBoxes sets margin box content for right (odd-numbered) pages (@page :right).
+func (d *Document) SetRightMarginBoxes(boxes map[string]layout.MarginBox) {
+	d.rightMarginBoxes = boxes
 }
 
 // SetHeader sets a decorator that draws on every page (e.g. title, logo).
@@ -367,6 +379,12 @@ func (d *Document) buildAllPages(ctx context.Context) (all []*Page, structTags [
 		}
 		if d.firstMarginBoxes != nil {
 			r.SetFirstMarginBoxes(d.firstMarginBoxes)
+		}
+		if d.leftMarginBoxes != nil {
+			r.SetLeftMarginBoxes(d.leftMarginBoxes)
+		}
+		if d.rightMarginBoxes != nil {
+			r.SetRightMarginBoxes(d.rightMarginBoxes)
 		}
 		if d.tagged {
 			r.SetTagged(true)

--- a/document/html.go
+++ b/document/html.go
@@ -105,6 +105,20 @@ func (d *Document) AddHTMLWithContext(ctx context.Context, htmlStr string, opts 
 			}
 			d.SetFirstMarginBoxes(boxes)
 		}
+		if pc.Left != nil && len(pc.Left.MarginBoxes) > 0 {
+			boxes := make(map[string]layout.MarginBox)
+			for name, mbc := range pc.Left.MarginBoxes {
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
+			}
+			d.SetLeftMarginBoxes(boxes)
+		}
+		if pc.Right != nil && len(pc.Right.MarginBoxes) > 0 {
+			boxes := make(map[string]layout.MarginBox)
+			for name, mbc := range pc.Right.MarginBoxes {
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
+			}
+			d.SetRightMarginBoxes(boxes)
+		}
 	}
 
 	// Add all normal-flow elements.

--- a/document/html_test.go
+++ b/document/html_test.go
@@ -98,6 +98,77 @@ func TestAddHTMLProducesPDF(t *testing.T) {
 	}
 }
 
+// TestAddHTMLFirstMarginsMergeOverBase is the Defect B end-to-end regression
+// through the document entry point: a partial @page :first override inherits the
+// base @page {} margins for sides it does not set.
+func TestAddHTMLFirstMarginsMergeOverBase(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	err := doc.AddHTML(`<html><head><style>
+		@page { margin: 2cm; }
+		@page :first { margin-top: 4cm; }
+	</style></head><body><p>X</p></body></html>`, nil)
+	if err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	if doc.firstMargins == nil {
+		t.Fatal("expected firstMargins to be set")
+	}
+	// 4cm ≈ 113.39pt, 2cm ≈ 56.69pt.
+	const cm2, cm4 = 56.69, 113.39
+	if d := doc.firstMargins.Top - cm4; d > 1 || d < -1 {
+		t.Errorf("firstMargins.Top = %.2f, want ~113.39 (4cm)", doc.firstMargins.Top)
+	}
+	if d := doc.firstMargins.Right - cm2; d > 1 || d < -1 {
+		t.Errorf("firstMargins.Right = %.2f, want ~56.69 (2cm inherited, not 0)", doc.firstMargins.Right)
+	}
+	if d := doc.firstMargins.Bottom - cm2; d > 1 || d < -1 {
+		t.Errorf("firstMargins.Bottom = %.2f, want ~56.69 (2cm inherited, not 0)", doc.firstMargins.Bottom)
+	}
+	if d := doc.firstMargins.Left - cm2; d > 1 || d < -1 {
+		t.Errorf("firstMargins.Left = %.2f, want ~56.69 (2cm inherited, not 0)", doc.firstMargins.Left)
+	}
+}
+
+// TestAddHTMLLeftRightMarginsAndBoxes verifies :left/:right margins and margin
+// boxes are plumbed from HTML through the document to the renderer, and that the
+// resulting multi-page PDF renders without error.
+func TestAddHTMLLeftRightMarginsAndBoxes(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	err := doc.AddHTML(`<html><head><style>
+		@page { margin: 2cm; }
+		@page :left { margin-left: 3cm; @top-left { content: "L"; } }
+		@page :right { margin-right: 3cm; @top-right { content: "R"; } }
+	</style></head><body>
+		<p style="page-break-after: always;">one</p>
+		<p style="page-break-after: always;">two</p>
+		<p>three</p>
+	</body></html>`, nil)
+	if err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	if doc.leftMargins == nil || doc.rightMargins == nil {
+		t.Fatal("expected left and right margins to be set")
+	}
+	if doc.leftMarginBoxes == nil || doc.rightMarginBoxes == nil {
+		t.Fatal("expected left and right margin boxes to be set")
+	}
+	// 3cm ≈ 85.04pt.
+	if d := doc.leftMargins.Left - 85.04; d > 1 || d < -1 {
+		t.Errorf("leftMargins.Left = %.2f, want ~85.04 (3cm)", doc.leftMargins.Left)
+	}
+	if d := doc.rightMargins.Right - 85.04; d > 1 || d < -1 {
+		t.Errorf("rightMargins.Right = %.2f, want ~85.04 (3cm)", doc.rightMargins.Right)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if !strings.HasPrefix(buf.String(), "%PDF-") {
+		t.Error("output does not start with %PDF-")
+	}
+}
+
 func TestAddHTMLTemplate(t *testing.T) {
 	doc := NewDocument(PageSizeLetter)
 

--- a/export/cabi_html.go
+++ b/export/cabi_html.go
@@ -87,12 +87,32 @@ func htmlToDocument(htmlStr string, pageWidth, pageHeight float64) (*document.Do
 
 	doc := document.NewDocument(ps)
 
-	// Apply @page margins.
-	if pc := result.PageConfig; pc != nil && pc.HasMargins {
-		doc.SetMargins(layout.Margins{
-			Top: pc.MarginTop, Right: pc.MarginRight,
-			Bottom: pc.MarginBottom, Left: pc.MarginLeft,
-		})
+	// Apply @page margins (default + :first/:left/:right overrides).
+	if pc := result.PageConfig; pc != nil {
+		if pc.HasMargins {
+			doc.SetMargins(layout.Margins{
+				Top: pc.MarginTop, Right: pc.MarginRight,
+				Bottom: pc.MarginBottom, Left: pc.MarginLeft,
+			})
+		}
+		if pc.First != nil && pc.First.HasMargins {
+			doc.SetFirstMargins(layout.Margins{
+				Top: pc.First.Top, Right: pc.First.Right,
+				Bottom: pc.First.Bottom, Left: pc.First.Left,
+			})
+		}
+		if pc.Left != nil && pc.Left.HasMargins {
+			doc.SetLeftMargins(layout.Margins{
+				Top: pc.Left.Top, Right: pc.Left.Right,
+				Bottom: pc.Left.Bottom, Left: pc.Left.Left,
+			})
+		}
+		if pc.Right != nil && pc.Right.HasMargins {
+			doc.SetRightMargins(layout.Margins{
+				Top: pc.Right.Top, Right: pc.Right.Right,
+				Bottom: pc.Right.Bottom, Left: pc.Right.Left,
+			})
+		}
 	}
 
 	// Apply @page margin boxes (page numbers, headers/footers).
@@ -101,6 +121,12 @@ func htmlToDocument(htmlStr string, pageWidth, pageHeight float64) (*document.Do
 	}
 	if result.FirstMarginBoxes != nil {
 		doc.SetFirstMarginBoxes(result.FirstMarginBoxes)
+	}
+	if result.LeftMarginBoxes != nil {
+		doc.SetLeftMarginBoxes(result.LeftMarginBoxes)
+	}
+	if result.RightMarginBoxes != nil {
+		doc.SetRightMarginBoxes(result.RightMarginBoxes)
 	}
 
 	// Apply metadata.

--- a/html/converter.go
+++ b/html/converter.go
@@ -294,6 +294,14 @@ type ConvertResult struct {
 	// FirstMarginBoxes are margin boxes for @page :first only.
 	// Pass to document.SetFirstMarginBoxes. Nil if not declared.
 	FirstMarginBoxes map[string]layout.MarginBox
+
+	// LeftMarginBoxes are margin boxes for @page :left (even pages, LTR).
+	// Pass to document.SetLeftMarginBoxes. Nil if not declared.
+	LeftMarginBoxes map[string]layout.MarginBox
+
+	// RightMarginBoxes are margin boxes for @page :right (odd pages, LTR).
+	// Pass to document.SetRightMarginBoxes. Nil if not declared.
+	RightMarginBoxes map[string]layout.MarginBox
 }
 
 // DocMetadata holds document metadata extracted from HTML head elements.
@@ -318,9 +326,16 @@ type DocMetadata struct {
 
 // MarginBoxContent holds the parsed content of a CSS margin box (e.g. @top-center).
 type MarginBoxContent struct {
-	Content  string     // resolved content string (after evaluating counter(), string literals, etc.)
-	FontSize float64    // font size in points (0 = use default 9pt)
-	Color    [3]float64 // RGB color (0-1 each)
+	Content string // resolved content string (after evaluating counter(), string literals, etc.)
+	// HasContent is true when a `content` declaration was present in the
+	// margin-box rule, even if it resolved to the empty string (e.g.
+	// `content: ""` or `content: none`). It lets a pseudo-page box
+	// (@page :first { @bottom-center { content: "" } }) be preserved so it
+	// can OVERRIDE — and thereby blank — the inherited default box for that
+	// page/slot, instead of being dropped and falling back to the default.
+	HasContent bool
+	FontSize   float64    // font size in points (0 = use default 9pt)
+	Color      [3]float64 // RGB color (0-1 each)
 	// HasColor is true only when a `color` declaration was present in the
 	// margin-box rule. It lets the renderer distinguish an explicit
 	// `color: black` from an unset color (which defaults to gray).
@@ -527,6 +542,14 @@ func ConvertFullWithContext(ctx context.Context, htmlStr string, opts *Options) 
 		if pageConfig.First != nil {
 			stampMarginBoxFont(pageConfig.First.MarginBoxes, marginFont)
 			result.FirstMarginBoxes = convertMarginBoxes(pageConfig.First.MarginBoxes, marginFont)
+		}
+		if pageConfig.Left != nil {
+			stampMarginBoxFont(pageConfig.Left.MarginBoxes, marginFont)
+			result.LeftMarginBoxes = convertMarginBoxes(pageConfig.Left.MarginBoxes, marginFont)
+		}
+		if pageConfig.Right != nil {
+			stampMarginBoxFont(pageConfig.Right.MarginBoxes, marginFont)
+			result.RightMarginBoxes = convertMarginBoxes(pageConfig.Right.MarginBoxes, marginFont)
 		}
 	}
 

--- a/html/css.go
+++ b/html/css.go
@@ -196,12 +196,34 @@ func (ss *styleSheet) parseCSS(css string, origin string) {
 		}
 		// Parse @page rules (with optional pseudo-selector like :first, :left, :right).
 		if selectorStr == "@page" || strings.HasPrefix(selectorStr, "@page ") || strings.HasPrefix(selectorStr, "@page:") {
-			sel := ""
 			rest := strings.TrimPrefix(selectorStr, "@page")
 			rest = strings.TrimSpace(rest)
-			if strings.HasPrefix(rest, ":") {
-				sel = strings.TrimPrefix(rest, ":")
-				sel = strings.TrimSpace(sel)
+
+			// Determine the page selector. Only a bare `@page {}` (empty
+			// rest) or a recognised pseudo (:first/:left/:right) are honoured.
+			//
+			// A NAMED page (`@page narrow {}`) or an UNSUPPORTED pseudo
+			// (`@page :blank {}`) must NOT pollute the global default @page {}
+			// rule: a named page has rest="narrow" (no leading ':'), and an
+			// unsupported pseudo has sel="blank" with no case in page.go. Both
+			// previously fell through to the default rule (selector ""), which
+			// applied their margins to every page. We now skip them entirely.
+			sel := ""
+			if rest != "" {
+				if !strings.HasPrefix(rest, ":") {
+					// Named page (e.g. "@page narrow") — drop it.
+					continue
+				}
+				// CSS page pseudo names are case-insensitive.
+				sel = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(rest, ":")))
+				switch sel {
+				case "first", "left", "right":
+					// Recognised pseudo — honour it.
+				default:
+					// Unsupported pseudo (e.g. ":blank") — drop it so it
+					// does not become the default rule.
+					continue
+				}
 			}
 
 			// Extract nested margin box rules (e.g. @top-center { ... }) from declStr.

--- a/html/features_test.go
+++ b/html/features_test.go
@@ -179,6 +179,200 @@ func TestPagePseudoSelectors(t *testing.T) {
 	}
 }
 
+// TestPagePseudoSelectorCaseInsensitive verifies that page pseudo names are
+// matched case-insensitively (CSS page pseudo names are case-insensitive), so
+// `@page :First` is honoured exactly like `@page :first`.
+//
+// Fail-before/pass-after: before the fix `sel` was compared against lowercase
+// literals without lowercasing, so `:First` fell into the default case and was
+// dropped — pc.First would be nil and its margins lost.
+func TestPagePseudoSelectorCaseInsensitive(t *testing.T) {
+	html := `<html><head><style>
+		@page { margin: 2cm; }
+		@page :First { margin-top: 4cm; }
+		@page :LEFT { margin-left: 3cm; }
+		@page :Right { margin-right: 3cm; }
+	</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := result.PageConfig
+	if pc == nil {
+		t.Fatal("expected PageConfig")
+	}
+
+	// :First (capitalized) must be honoured.
+	if pc.First == nil {
+		t.Fatal("expected First page margins from @page :First")
+	}
+	// 4cm ≈ 113.39pt
+	if math.Abs(pc.First.Top-113.39) > 1 {
+		t.Errorf("First.Top = %.2f, want ~113.39 (4cm)", pc.First.Top)
+	}
+
+	// :LEFT must be honoured.
+	if pc.Left == nil {
+		t.Fatal("expected Left page margins from @page :LEFT")
+	}
+	if math.Abs(pc.Left.Left-85.04) > 1 {
+		t.Errorf("Left.Left = %.2f, want ~85.04 (3cm)", pc.Left.Left)
+	}
+
+	// :Right must be honoured.
+	if pc.Right == nil {
+		t.Fatal("expected Right page margins from @page :Right")
+	}
+	if math.Abs(pc.Right.Right-85.04) > 1 {
+		t.Errorf("Right.Right = %.2f, want ~85.04 (3cm)", pc.Right.Right)
+	}
+}
+
+// TestPageFirstMarginsMergeOverBase is the Defect B regression: a partial
+// `@page :first { margin-top: 4cm }` over a base `@page { margin: 2cm }` must
+// yield top=4cm AND right/bottom/left=2cm (inherited base), not 0.
+func TestPageFirstMarginsMergeOverBase(t *testing.T) {
+	html := `<html><head><style>
+		@page { margin: 2cm; }
+		@page :first { margin-top: 4cm; }
+	</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := result.PageConfig
+	if pc == nil || pc.First == nil {
+		t.Fatal("expected PageConfig with First margins")
+	}
+	// 4cm ≈ 113.39pt, 2cm ≈ 56.69pt.
+	if math.Abs(pc.First.Top-113.39) > 1 {
+		t.Errorf("First.Top = %.2f, want ~113.39 (4cm)", pc.First.Top)
+	}
+	if math.Abs(pc.First.Right-56.69) > 1 {
+		t.Errorf("First.Right = %.2f, want ~56.69 (2cm inherited from base, not 0)", pc.First.Right)
+	}
+	if math.Abs(pc.First.Bottom-56.69) > 1 {
+		t.Errorf("First.Bottom = %.2f, want ~56.69 (2cm inherited from base, not 0)", pc.First.Bottom)
+	}
+	if math.Abs(pc.First.Left-56.69) > 1 {
+		t.Errorf("First.Left = %.2f, want ~56.69 (2cm inherited from base, not 0)", pc.First.Left)
+	}
+}
+
+// TestPageLeftRightMarginsMergeOverBase verifies :left/:right partial margins
+// also inherit the base @page {} margins for unspecified sides.
+func TestPageLeftRightMarginsMergeOverBase(t *testing.T) {
+	html := `<html><head><style>
+		@page { margin: 2cm; }
+		@page :left { margin-left: 3cm; }
+		@page :right { margin-right: 3cm; }
+	</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := result.PageConfig
+	if pc == nil || pc.Left == nil || pc.Right == nil {
+		t.Fatal("expected PageConfig with Left and Right margins")
+	}
+	// :left margin-left = 3cm (~85.04), other sides inherit 2cm (~56.69).
+	if math.Abs(pc.Left.Left-85.04) > 1 {
+		t.Errorf("Left.Left = %.2f, want ~85.04 (3cm)", pc.Left.Left)
+	}
+	if math.Abs(pc.Left.Top-56.69) > 1 {
+		t.Errorf("Left.Top = %.2f, want ~56.69 (2cm inherited)", pc.Left.Top)
+	}
+	if math.Abs(pc.Left.Right-56.69) > 1 {
+		t.Errorf("Left.Right = %.2f, want ~56.69 (2cm inherited)", pc.Left.Right)
+	}
+	// :right margin-right = 3cm, other sides inherit 2cm.
+	if math.Abs(pc.Right.Right-85.04) > 1 {
+		t.Errorf("Right.Right = %.2f, want ~85.04 (3cm)", pc.Right.Right)
+	}
+	if math.Abs(pc.Right.Left-56.69) > 1 {
+		t.Errorf("Right.Left = %.2f, want ~56.69 (2cm inherited)", pc.Right.Left)
+	}
+}
+
+// TestPagePseudoBeforeBaseStillMerges verifies the seeding works even when the
+// :first rule appears in source BEFORE the base @page {} rule (two-pass fix).
+func TestPagePseudoBeforeBaseStillMerges(t *testing.T) {
+	html := `<html><head><style>
+		@page :first { margin-top: 4cm; }
+		@page { margin: 2cm; }
+	</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := result.PageConfig
+	if pc == nil || pc.First == nil {
+		t.Fatal("expected PageConfig with First margins")
+	}
+	if math.Abs(pc.First.Top-113.39) > 1 {
+		t.Errorf("First.Top = %.2f, want ~113.39 (4cm)", pc.First.Top)
+	}
+	if math.Abs(pc.First.Left-56.69) > 1 {
+		t.Errorf("First.Left = %.2f, want ~56.69 (2cm inherited, source order independent)", pc.First.Left)
+	}
+}
+
+// TestPageNamedDoesNotPolluteDefault is the Defect C regression: a NAMED page
+// (`@page narrow { margin: 5cm }`) must NOT become the global default rule.
+func TestPageNamedDoesNotPolluteDefault(t *testing.T) {
+	html := `<html><head><style>
+		@page { margin: 2cm; }
+		@page narrow { margin: 5cm; }
+	</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := result.PageConfig
+	if pc == nil {
+		t.Fatal("expected PageConfig")
+	}
+	// 2cm ≈ 56.69pt; must NOT be 5cm (~141.73pt) from the named page.
+	if math.Abs(pc.MarginTop-56.69) > 1 {
+		t.Errorf("default MarginTop = %.2f, want ~56.69 (named page must not pollute default)", pc.MarginTop)
+	}
+}
+
+// TestPageNamedAloneNoDefaultMargins verifies a named page on its own does not
+// set any default margins (HasMargins stays false).
+func TestPageNamedAloneNoDefaultMargins(t *testing.T) {
+	html := `<html><head><style>
+		@page narrow { margin: 5cm; }
+	</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.PageConfig != nil && result.PageConfig.HasMargins {
+		t.Errorf("named-only page set default HasMargins=true with MarginTop=%.2f, want no default margins", result.PageConfig.MarginTop)
+	}
+}
+
+// TestPageBlankDoesNotPolluteDefault verifies an unsupported pseudo (:blank)
+// does not become the global default rule.
+func TestPageBlankDoesNotPolluteDefault(t *testing.T) {
+	html := `<html><head><style>
+		@page { margin: 2cm; }
+		@page :blank { margin: 5cm; }
+	</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := result.PageConfig
+	if pc == nil {
+		t.Fatal("expected PageConfig")
+	}
+	if math.Abs(pc.MarginTop-56.69) > 1 {
+		t.Errorf("default MarginTop = %.2f, want ~56.69 (:blank must not pollute default)", pc.MarginTop)
+	}
+}
+
 // --- Body padding renders as Div ---
 
 func TestBodyPaddingRendered(t *testing.T) {
@@ -813,6 +1007,79 @@ func TestPageMarginBoxFirstPage(t *testing.T) {
 		t.Error("expected top-center margin box on :first")
 	} else if mb.Content != "Cover Page" {
 		t.Errorf("content = %q, want %q", mb.Content, "Cover Page")
+	}
+}
+
+// TestPageFirstEmptyMarginBoxPreserved is the parse-side regression guard for
+// the bug where @page :first { @bottom-center { content: "" } } was dropped at
+// parse, so it never reached the renderer and could not blank the first-page
+// footer. An explicitly-declared empty-content box must be preserved (with
+// HasContent set) so the renderer can OVERRIDE the inherited default for that
+// page/slot. The base @page rule keeps dropping empty boxes (nothing to draw,
+// nothing to override).
+//
+// Fail-before/pass-after: before the fix pc.First.MarginBoxes had no
+// bottom-center entry, so the default footer leaked onto page 1.
+func TestPageFirstEmptyMarginBoxPreserved(t *testing.T) {
+	html := `<html><head><style>
+		@page {
+			margin: 36pt;
+			@bottom-center { content: "Page " counter(page); }
+		}
+		@page :first {
+			@bottom-center { content: ""; }
+		}
+	</style></head><body><p>Content</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := result.PageConfig
+	if pc == nil {
+		t.Fatal("expected PageConfig")
+	}
+	// The default base box must still be present and non-empty.
+	if mb, ok := pc.MarginBoxes["bottom-center"]; !ok {
+		t.Error("expected default bottom-center margin box")
+	} else if !strings.Contains(mb.Content, "Page ") {
+		t.Errorf("default bottom-center content = %q, should contain 'Page '", mb.Content)
+	}
+	// The :first empty box must be preserved so it can override the default.
+	if pc.First == nil {
+		t.Fatal("expected First page config")
+	}
+	mb, ok := pc.First.MarginBoxes["bottom-center"]
+	if !ok {
+		t.Fatal("empty :first bottom-center box was dropped; it must be preserved to override the default")
+	}
+	if mb.Content != "" {
+		t.Errorf(":first bottom-center content = %q, want empty", mb.Content)
+	}
+	if !mb.HasContent {
+		t.Error(":first bottom-center HasContent should be true (content was explicitly declared)")
+	}
+}
+
+// TestPageBaseEmptyMarginBoxDropped confirms an empty-content box on the BASE
+// @page rule is still dropped (it has nothing to draw and nothing to override),
+// preserving the pre-existing behaviour for the non-pseudo case.
+func TestPageBaseEmptyMarginBoxDropped(t *testing.T) {
+	html := `<html><head><style>
+		@page {
+			margin: 36pt;
+			@bottom-center { content: ""; }
+		}
+	</style></head><body><p>Content</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := result.PageConfig
+	if pc == nil {
+		t.Fatal("expected PageConfig")
+	}
+	if _, ok := pc.MarginBoxes["bottom-center"]; ok {
+		t.Error("empty base bottom-center box should be dropped, but it was kept")
 	}
 }
 

--- a/html/page.go
+++ b/html/page.go
@@ -22,93 +22,57 @@ var pageSizes = map[string][2]float64{
 
 // parsePageConfig extracts page dimensions and margins from @page rules.
 // Supports pseudo-selectors: @page :first, @page :left, @page :right.
+//
+// Margin cascade: each pseudo target (:first/:left/:right) is seeded from the
+// RESOLVED base @page {} margins BEFORE its own declarations are applied, so a
+// side the pseudo does not specify inherits the base value (CSS cascade). For
+// example, `@page { margin: 2cm } @page :first { margin-top: 4cm }` yields a
+// first page with top=4cm and right/bottom/left=2cm — not 0.
+//
+// Two passes are required because a pseudo rule may appear in source before the
+// base @page {} rule it inherits from: pass 1 resolves the base, pass 2 seeds
+// and applies the pseudos.
 func parsePageConfig(rules []pageRule, defaultFontSize float64) *PageConfig {
 	pc := &PageConfig{}
 	hasAny := false
 
+	// Pass 1: resolve the base @page {} rule (selector == "") — size,
+	// margins, and margin boxes. Named pages and unrecognised pseudos are
+	// already dropped upstream in css.go so they cannot pollute the default.
 	for _, rule := range rules {
-		// Determine which margin target to apply to based on selector.
-		var target *PageMargins
-		switch rule.selector {
-		case "first":
-			if pc.First == nil {
-				pc.First = &PageMargins{}
-			}
-			target = pc.First
-		case "left":
-			if pc.Left == nil {
-				pc.Left = &PageMargins{}
-			}
-			target = pc.Left
-		case "right":
-			if pc.Right == nil {
-				pc.Right = &PageMargins{}
-			}
-			target = pc.Right
+		if rule.selector != "" {
+			continue
 		}
-
 		for _, d := range rule.declarations {
 			prop := strings.TrimSpace(strings.ToLower(d.property))
 			val := strings.TrimSpace(d.value)
-
 			switch prop {
 			case "size":
 				parsePageSize(val, pc, defaultFontSize)
 				hasAny = true
 			case "margin":
 				t, r, b, l := parseMarginShorthand(val, defaultFontSize)
-				if target != nil {
-					target.Top, target.Right, target.Bottom, target.Left = t, r, b, l
-					target.HasMargins = true
-				} else {
-					pc.MarginTop, pc.MarginRight, pc.MarginBottom, pc.MarginLeft = t, r, b, l
-					pc.HasMargins = true
-				}
+				pc.MarginTop, pc.MarginRight, pc.MarginBottom, pc.MarginLeft = t, r, b, l
+				pc.HasMargins = true
 				hasAny = true
 			case "margin-top":
-				v := parseSingleLength(val, defaultFontSize)
-				if target != nil {
-					target.Top = v
-					target.HasMargins = true
-				} else {
-					pc.MarginTop = v
-					pc.HasMargins = true
-				}
+				pc.MarginTop = parseSingleLength(val, defaultFontSize)
+				pc.HasMargins = true
 				hasAny = true
 			case "margin-right":
-				v := parseSingleLength(val, defaultFontSize)
-				if target != nil {
-					target.Right = v
-					target.HasMargins = true
-				} else {
-					pc.MarginRight = v
-					pc.HasMargins = true
-				}
+				pc.MarginRight = parseSingleLength(val, defaultFontSize)
+				pc.HasMargins = true
 				hasAny = true
 			case "margin-bottom":
-				v := parseSingleLength(val, defaultFontSize)
-				if target != nil {
-					target.Bottom = v
-					target.HasMargins = true
-				} else {
-					pc.MarginBottom = v
-					pc.HasMargins = true
-				}
+				pc.MarginBottom = parseSingleLength(val, defaultFontSize)
+				pc.HasMargins = true
 				hasAny = true
 			case "margin-left":
-				v := parseSingleLength(val, defaultFontSize)
-				if target != nil {
-					target.Left = v
-					target.HasMargins = true
-				} else {
-					pc.MarginLeft = v
-					pc.HasMargins = true
-				}
+				pc.MarginLeft = parseSingleLength(val, defaultFontSize)
+				pc.HasMargins = true
 				hasAny = true
 			}
 		}
-
-		// Extract margin box content.
 		if len(rule.marginBoxes) > 0 {
 			hasAny = true
 			for boxName, boxDecls := range rule.marginBoxes {
@@ -116,17 +80,86 @@ func parsePageConfig(rules []pageRule, defaultFontSize float64) *PageConfig {
 				if mbc.Content == "" {
 					continue
 				}
-				if target != nil {
-					if target.MarginBoxes == nil {
-						target.MarginBoxes = make(map[string]MarginBoxContent)
-					}
-					target.MarginBoxes[boxName] = mbc
-				} else {
-					if pc.MarginBoxes == nil {
-						pc.MarginBoxes = make(map[string]MarginBoxContent)
-					}
-					pc.MarginBoxes[boxName] = mbc
+				if pc.MarginBoxes == nil {
+					pc.MarginBoxes = make(map[string]MarginBoxContent)
 				}
+				pc.MarginBoxes[boxName] = mbc
+			}
+		}
+	}
+
+	// Pass 2: pseudo selectors (:first/:left/:right). Each target inherits
+	// the resolved base margins, then overlays its own declarations.
+	for _, rule := range rules {
+		var target *PageMargins
+		switch rule.selector {
+		case "first":
+			if pc.First == nil {
+				pc.First = newSeededMargins(pc)
+			}
+			target = pc.First
+		case "left":
+			if pc.Left == nil {
+				pc.Left = newSeededMargins(pc)
+			}
+			target = pc.Left
+		case "right":
+			if pc.Right == nil {
+				pc.Right = newSeededMargins(pc)
+			}
+			target = pc.Right
+		default:
+			continue
+		}
+
+		for _, d := range rule.declarations {
+			prop := strings.TrimSpace(strings.ToLower(d.property))
+			val := strings.TrimSpace(d.value)
+			switch prop {
+			case "margin":
+				t, r, b, l := parseMarginShorthand(val, defaultFontSize)
+				target.Top, target.Right, target.Bottom, target.Left = t, r, b, l
+				target.HasMargins = true
+				hasAny = true
+			case "margin-top":
+				target.Top = parseSingleLength(val, defaultFontSize)
+				target.HasMargins = true
+				hasAny = true
+			case "margin-right":
+				target.Right = parseSingleLength(val, defaultFontSize)
+				target.HasMargins = true
+				hasAny = true
+			case "margin-bottom":
+				target.Bottom = parseSingleLength(val, defaultFontSize)
+				target.HasMargins = true
+				hasAny = true
+			case "margin-left":
+				target.Left = parseSingleLength(val, defaultFontSize)
+				target.HasMargins = true
+				hasAny = true
+			}
+		}
+
+		// Extract margin box content for this pseudo target.
+		//
+		// Unlike the base @page rule, a pseudo box with empty resolved content
+		// is PRESERVED when the `content` property was explicitly declared
+		// (HasContent). Such a box (e.g. `@page :first { @bottom-center {
+		// content: "" } }`) must enter the pseudo set so the per-slot merge in
+		// the renderer lets it OVERRIDE — and thus blank — the inherited
+		// default box for that page/slot. A box with no content declaration at
+		// all (only font-size/color, say) and empty content is still dropped.
+		if len(rule.marginBoxes) > 0 {
+			hasAny = true
+			for boxName, boxDecls := range rule.marginBoxes {
+				mbc := parseMarginBoxDecls(boxDecls, defaultFontSize)
+				if mbc.Content == "" && !mbc.HasContent {
+					continue
+				}
+				if target.MarginBoxes == nil {
+					target.MarginBoxes = make(map[string]MarginBoxContent)
+				}
+				target.MarginBoxes[boxName] = mbc
 			}
 		}
 	}
@@ -135,6 +168,22 @@ func parsePageConfig(rules []pageRule, defaultFontSize float64) *PageConfig {
 		return nil
 	}
 	return pc
+}
+
+// newSeededMargins creates a PageMargins for a pseudo target (:first/:left/
+// :right) seeded with the resolved base @page {} margins. If the base set any
+// margins, the seeded set is marked HasMargins so unspecified sides inherit the
+// base instead of defaulting to 0 (CSS cascade — Defect B fix).
+func newSeededMargins(pc *PageConfig) *PageMargins {
+	pm := &PageMargins{}
+	if pc.HasMargins {
+		pm.Top = pc.MarginTop
+		pm.Right = pc.MarginRight
+		pm.Bottom = pc.MarginBottom
+		pm.Left = pc.MarginLeft
+		pm.HasMargins = true
+	}
+	return pm
 }
 
 // parseMarginBoxDecls extracts content, font-size, and color from margin box declarations.
@@ -146,6 +195,7 @@ func parseMarginBoxDecls(decls []cssDecl, defaultFontSize float64) MarginBoxCont
 		switch prop {
 		case "content":
 			mbc.Content = parseContentValue(val)
+			mbc.HasContent = true
 		case "font-size":
 			if l := parseCSSLengthWithUnit(val); l != nil {
 				mbc.FontSize = l.toPoints(0, defaultFontSize)

--- a/layout/features_test.go
+++ b/layout/features_test.go
@@ -354,6 +354,68 @@ func TestRendererDefaultMarginsWhenNoVariants(t *testing.T) {
 	}
 }
 
+// TestRendererFirstWinsOverRightOnPage0 verifies the :first set takes
+// precedence over the parity-derived :right set on page 0 (CSS specificity).
+func TestRendererFirstWinsOverRightOnPage0(t *testing.T) {
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.SetFirstMargins(Margins{Top: 100, Right: 72, Bottom: 72, Left: 72})
+	r.SetRightMargins(Margins{Top: 72, Right: 90, Bottom: 72, Left: 50})
+
+	m0 := r.marginsForPage(0)
+	if m0.Top != 100 {
+		t.Errorf("page 0: Top = %.1f, want 100 (:first wins over :right)", m0.Top)
+	}
+	if m0.Right == 90 {
+		t.Errorf("page 0: Right = 90, expected :first set, not :right")
+	}
+}
+
+// TestRendererMarginBoxesForPage verifies parity selection and merge-over-base
+// for margin boxes: page 0 = :first, page 1 = :left, page 2 = :right, with the
+// default boxes filled in for slots the parity set does not define.
+func TestRendererMarginBoxesForPage(t *testing.T) {
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.SetMarginBoxes(map[string]MarginBox{
+		"bottom-center": {Content: "default-footer"},
+	})
+	r.SetFirstMarginBoxes(map[string]MarginBox{
+		"top-center": {Content: "first-header"},
+	})
+	r.SetLeftMarginBoxes(map[string]MarginBox{
+		"top-left": {Content: "left-header"},
+	})
+	r.SetRightMarginBoxes(map[string]MarginBox{
+		"top-right": {Content: "right-header"},
+	})
+
+	// Page 0 → :first, merged over default.
+	b0 := r.marginBoxesForPage(0)
+	if b0["top-center"].Content != "first-header" {
+		t.Errorf("page 0: top-center = %q, want first-header", b0["top-center"].Content)
+	}
+	if b0["bottom-center"].Content != "default-footer" {
+		t.Errorf("page 0: bottom-center = %q, want default-footer (merge over base)", b0["bottom-center"].Content)
+	}
+	if _, ok := b0["top-left"]; ok {
+		t.Error("page 0: should not have left-page box")
+	}
+
+	// Page 1 → :left.
+	b1 := r.marginBoxesForPage(1)
+	if b1["top-left"].Content != "left-header" {
+		t.Errorf("page 1: top-left = %q, want left-header", b1["top-left"].Content)
+	}
+	if b1["bottom-center"].Content != "default-footer" {
+		t.Errorf("page 1: bottom-center = %q, want default-footer", b1["bottom-center"].Content)
+	}
+
+	// Page 2 → :right.
+	b2 := r.marginBoxesForPage(2)
+	if b2["top-right"].Content != "right-header" {
+		t.Errorf("page 2: top-right = %q, want right-header", b2["top-right"].Content)
+	}
+}
+
 // --- Heading SetRuns ---
 
 func TestHeadingSetRuns(t *testing.T) {

--- a/layout/render_plans.go
+++ b/layout/render_plans.go
@@ -133,13 +133,21 @@ func (r *Renderer) renderWithPlans() []PageResult {
 		queue = queue[1:]
 
 		// Handle AreaBreak — always flush and start a new page.
+		//
+		// Unlike startNewPage (which skips empty pages), an explicit break
+		// always advances the page even when the current page has no blocks.
+		// Crucially it must recompute margins/dimensions for the new page via
+		// pageMarginsFor(pageIdx): the per-page margin selection (@page :first
+		// / :left / :right) keys off the cumulative pageIdx, so without this
+		// recalc every break-delimited page would keep page 0's :first margins.
 		if _, ok := elem.(*AreaBreak); ok {
 			flushPage()
 			curBlocks = nil
+			pageIdx++
+			maxWidth, usableHeight, curMargins = pageMarginsFor(pageIdx)
 			remainingHeight = usableHeight
 			curY = 0
 			floats = nil
-			pageIdx++
 			atPageTop = true
 			continue
 		}
@@ -255,8 +263,12 @@ func (r *Renderer) renderWithPlans() []PageResult {
 	}
 
 	// For auto-height pages, compute the actual page height from content.
+	// Auto-height only ever produces page 0, so use the margins resolved for
+	// that page (which may come from @page :first) — matching the margins used
+	// to position the content — rather than the default margin set.
 	if autoHeight && len(curBlocks) > 0 {
-		r.pageHeight = curY + r.margins.Top + r.margins.Bottom
+		m0 := r.marginsForPage(0)
+		r.pageHeight = curY + m0.Top + m0.Bottom
 	}
 
 	// Flush the last page.
@@ -265,7 +277,8 @@ func (r *Renderer) renderWithPlans() []PageResult {
 	} else if len(records) == 0 {
 		// Ensure at least one page.
 		if autoHeight {
-			r.pageHeight = r.margins.Top + r.margins.Bottom
+			m0 := r.marginsForPage(0)
+			r.pageHeight = m0.Top + m0.Bottom
 		}
 		records = append(records, pageRecord{idx: 0, margins: r.marginsForPage(0)})
 	}

--- a/layout/renderer.go
+++ b/layout/renderer.go
@@ -102,7 +102,9 @@ type Renderer struct {
 	leftMargins      *Margins             // @page :left margins for even pages (nil = use default)
 	rightMargins     *Margins             // @page :right margins for odd pages (nil = use default)
 	marginBoxes      map[string]MarginBox // default margin boxes
-	firstMarginBoxes map[string]MarginBox // first-page margin boxes
+	firstMarginBoxes map[string]MarginBox // first-page margin boxes (@page :first)
+	leftMarginBoxes  map[string]MarginBox // left-page margin boxes (@page :left)
+	rightMarginBoxes map[string]MarginBox // right-page margin boxes (@page :right)
 	elements         []Element
 	absolutes        []absoluteItem
 	tagged           bool            // if true, emit BDC/EMC marked content
@@ -159,21 +161,69 @@ func (r *Renderer) SetFirstMarginBoxes(boxes map[string]MarginBox) {
 	r.firstMarginBoxes = boxes
 }
 
+// SetLeftMarginBoxes sets margin boxes for left (even-numbered) pages (@page :left).
+func (r *Renderer) SetLeftMarginBoxes(boxes map[string]MarginBox) {
+	r.leftMarginBoxes = boxes
+}
+
+// SetRightMarginBoxes sets margin boxes for right (odd-numbered) pages (@page :right).
+func (r *Renderer) SetRightMarginBoxes(boxes map[string]MarginBox) {
+	r.rightMarginBoxes = boxes
+}
+
 // marginsForPage returns the margins to use for the given page index (0-based).
-// Priority: :first (page 0) > :left/:right > default.
+//
+// Page parity follows CSS paged media for LEFT-TO-RIGHT documents: page 0 (the
+// first page, page number 1) is a :right page, page 1 (page number 2) is a
+// :left page, then alternating. Right-to-left progression is not modelled.
+//
+// Precedence (highest first): :first (page 0 only) > :left/:right by parity >
+// default. :first wins over :right on page 0 because CSS gives :first higher
+// specificity. Each pseudo set already inherits the base @page {} margins for
+// sides it does not specify (the cascade merge happens in html/page.go), so the
+// returned Margins are fully resolved.
 func (r *Renderer) marginsForPage(pageIdx int) Margins {
 	if pageIdx == 0 && r.firstMargins != nil {
 		return *r.firstMargins
 	}
 	if pageIdx%2 == 0 && r.rightMargins != nil {
-		// Page 0 = first right page (odd page number 1), page 2 = page number 3, etc.
+		// Even index = right page (odd page number: 1, 3, 5, ...).
 		return *r.rightMargins
 	}
 	if pageIdx%2 == 1 && r.leftMargins != nil {
-		// Page 1 = page number 2 (left/even), page 3 = page number 4, etc.
+		// Odd index = left page (even page number: 2, 4, 6, ...).
 		return *r.leftMargins
 	}
 	return r.margins
+}
+
+// marginBoxesForPage selects the margin-box set for the given page index,
+// merged over the default set. Parity and precedence mirror marginsForPage:
+// :first (page 0) > :left/:right by parity > default. A parity-specific or
+// first-page box overrides the same-named default box; sides absent from the
+// parity set fall back to the default. LTR progression is assumed (see
+// marginsForPage).
+func (r *Renderer) marginBoxesForPage(pageIdx int) map[string]MarginBox {
+	var override map[string]MarginBox
+	switch {
+	case pageIdx == 0 && r.firstMarginBoxes != nil:
+		override = r.firstMarginBoxes
+	case pageIdx%2 == 0 && r.rightMarginBoxes != nil:
+		override = r.rightMarginBoxes
+	case pageIdx%2 == 1 && r.leftMarginBoxes != nil:
+		override = r.leftMarginBoxes
+	}
+	if override == nil {
+		return r.marginBoxes
+	}
+	merged := make(map[string]MarginBox, len(r.marginBoxes)+len(override))
+	for k, v := range r.marginBoxes {
+		merged[k] = v
+	}
+	for k, v := range override {
+		merged[k] = v
+	}
+	return merged
 }
 
 // NewRenderer creates a renderer for the given page dimensions and margins.
@@ -205,19 +255,8 @@ func (r *Renderer) SetRightMargins(m Margins) {
 
 // drawMarginBoxes renders margin box content (headers/footers) on the current page.
 func (r *Renderer) drawMarginBoxes(ctx *DrawContext, pageIdx int, margins Margins) {
-	// Select margin boxes for this page.
-	boxes := r.marginBoxes
-	if pageIdx == 0 && r.firstMarginBoxes != nil {
-		// Merge: first-page boxes override defaults.
-		merged := make(map[string]MarginBox)
-		for k, v := range r.marginBoxes {
-			merged[k] = v
-		}
-		for k, v := range r.firstMarginBoxes {
-			merged[k] = v
-		}
-		boxes = merged
-	}
+	// Select margin boxes for this page (parity-aware, merged over defaults).
+	boxes := r.marginBoxesForPage(pageIdx)
 	if len(boxes) == 0 {
 		return
 	}

--- a/layout/renderer_test.go
+++ b/layout/renderer_test.go
@@ -5,6 +5,7 @@ package layout
 
 import (
 	"bytes"
+	"fmt"
 	goimage "image"
 	"image/jpeg"
 	"strings"
@@ -57,6 +58,160 @@ func TestRendererMultipleElements(t *testing.T) {
 	// Should have two fonts registered.
 	if len(pages[0].Fonts) != 2 {
 		t.Errorf("expected 2 fonts, got %d", len(pages[0].Fonts))
+	}
+}
+
+// TestAutoHeightWithFirstMargins verifies that an auto-height page (page
+// height 0) which also has @page :first margins is sized using the :first
+// margins — the same margins used to position its content — rather than the
+// default margin set. Content is positioned at marginsForPage(0).Top from the
+// top, so the computed page height must include that (larger) top margin to
+// avoid clipping.
+//
+// Fail-before/pass-after: before the fix the auto-height height used
+// r.margins.Top (default 10) instead of the :first top (200), so the page was
+// ~190pt too short and the content's top would fall outside the page box.
+func TestAutoHeightWithFirstMargins(t *testing.T) {
+	defaultMargins := Margins{Top: 10, Right: 10, Bottom: 10, Left: 10}
+	r := NewRenderer(612, 0, defaultMargins) // height 0 => auto-height
+	firstTop := 200.0
+	r.SetFirstMargins(Margins{Top: firstTop, Right: 10, Bottom: 10, Left: 10})
+	r.Add(NewParagraph("Hello", font.Helvetica, 12))
+
+	pages := r.Render()
+	if len(pages) != 1 {
+		t.Fatalf("expected 1 page, got %d", len(pages))
+	}
+
+	got := pages[0].PageHeight
+	// The page must be at least as tall as the :first top margin plus the
+	// content. With the default-margin bug the height would be < firstTop.
+	if got < firstTop {
+		t.Errorf("auto-height page too short: got %.1f, want >= %.1f (:first top margin)", got, firstTop)
+	}
+	// Sanity: height should account for the larger :first top, not the
+	// default top (10). It must exceed default top + bottom + content.
+	if got <= defaultMargins.Top+defaultMargins.Bottom {
+		t.Errorf("auto-height page ignored :first top margin: got %.1f", got)
+	}
+}
+
+// firstTextY returns the y-coordinate of the first text-positioning (Td)
+// operator in a content stream. Text is drawn from a bottom-left origin, so a
+// larger top margin pushes content lower and yields a SMALLER y value.
+// Returns -1 if no Td operator is present.
+func firstTextY(t *testing.T, stream string) float64 {
+	t.Helper()
+	for _, line := range strings.Split(stream, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 3 && fields[2] == "Td" {
+			var y float64
+			if _, err := fmt.Sscanf(fields[1], "%g", &y); err == nil {
+				return y
+			}
+		}
+	}
+	return -1
+}
+
+// TestFirstMarginsWithExplicitPageBreaks is the regression guard for the bug
+// where @page :first margins leaked onto EVERY page of a document that uses
+// explicit page breaks (AreaBreak). Natural-overflow pagination correctly
+// increments the cumulative page index, so :first applied only to page 0; the
+// explicit-break path failed to recompute per-page margins after advancing the
+// index, so every break-delimited page kept page 0's (:first) margins.
+//
+// Fail-before/pass-after: before the fix all three pages' first-line Y matched
+// (all used the 144pt :first top). After the fix page 0 sits lower (smaller Y,
+// from the 144pt top) while pages 1 and 2 sit higher (larger Y, from the 36pt
+// base top).
+func TestFirstMarginsWithExplicitPageBreaks(t *testing.T) {
+	base := Margins{Top: 36, Right: 36, Bottom: 36, Left: 36}
+	r := NewRenderer(612, 792, base)
+	first := base
+	first.Top = 144
+	r.SetFirstMargins(first)
+
+	r.Add(NewParagraph("Page one", font.Helvetica, 12))
+	r.Add(NewAreaBreak())
+	r.Add(NewParagraph("Page two", font.Helvetica, 12))
+	r.Add(NewAreaBreak())
+	r.Add(NewParagraph("Page three", font.Helvetica, 12))
+
+	pages := r.Render()
+	if len(pages) != 3 {
+		t.Fatalf("expected 3 pages, got %d", len(pages))
+	}
+
+	y0 := firstTextY(t, string(pages[0].Stream.Bytes()))
+	y1 := firstTextY(t, string(pages[1].Stream.Bytes()))
+	y2 := firstTextY(t, string(pages[2].Stream.Bytes()))
+	for i, y := range []float64{y0, y1, y2} {
+		if y < 0 {
+			t.Fatalf("page %d has no text", i)
+		}
+	}
+
+	// Page 0 (:first, 144pt top) must sit lower on the page than pages 1 and 2
+	// (base, 36pt top): a larger top margin means a smaller y.
+	if !(y0 < y1) {
+		t.Errorf(":first top margin did not apply to page 0 only: y0=%.1f y1=%.1f (want y0 < y1)", y0, y1)
+	}
+	// Pages 1 and 2 (both base margins) must share the same first-line y.
+	if y1 != y2 {
+		t.Errorf("pages 1 and 2 should use the same base margin: y1=%.1f y2=%.1f", y1, y2)
+	}
+	// The gap between page 0 and the base pages must equal the margin delta
+	// (144 - 36 = 108pt), confirming page 0 alone got the :first top.
+	if delta := y1 - y0; delta < 107 || delta > 109 {
+		t.Errorf("page 0 top-margin delta = %.1f, want ~108 (144pt :first - 36pt base)", delta)
+	}
+}
+
+// TestEmptyFirstMarginBoxSuppressesDefault is the regression guard for the bug
+// where @page :first { @bottom-center { content: "" } } failed to blank the
+// first-page footer. An empty-content :first margin box must OVERRIDE the
+// inherited default @bottom-center for page 0 (drawing nothing), while pages 1+
+// keep the default footer.
+//
+// Fail-before/pass-after: before the fix the empty :first box was dropped at
+// parse time, so marginBoxesForPage(0) fell back to the default and page 0
+// showed the footer like every other page.
+func TestEmptyFirstMarginBoxSuppressesDefault(t *testing.T) {
+	r := NewRenderer(612, 792, Margins{Top: 36, Right: 36, Bottom: 36, Left: 36})
+	r.SetMarginBoxes(map[string]MarginBox{
+		"bottom-center": {Content: "FOOTER"},
+	})
+	// Empty :first box overrides (blanks) the default for page 0 only.
+	r.SetFirstMarginBoxes(map[string]MarginBox{
+		"bottom-center": {Content: ""},
+	})
+
+	r.Add(NewParagraph("Page one", font.Helvetica, 12))
+	r.Add(NewAreaBreak())
+	r.Add(NewParagraph("Page two", font.Helvetica, 12))
+
+	pages := r.Render()
+	if len(pages) != 2 {
+		t.Fatalf("expected 2 pages, got %d", len(pages))
+	}
+
+	p0 := string(pages[0].Stream.Bytes())
+	p1 := string(pages[1].Stream.Bytes())
+	if strings.Contains(p0, "FOOTER") {
+		t.Errorf("page 0 footer should be suppressed by empty :first box, but FOOTER is present")
+	}
+	if !strings.Contains(p1, "FOOTER") {
+		t.Errorf("page 1 should keep the default FOOTER, but it is missing")
+	}
+
+	// Per-slot merge sanity: the empty :first box must replace the default box
+	// for page 0, while page 1 retains the default content.
+	if box := r.marginBoxesForPage(0)["bottom-center"]; box.Content != "" {
+		t.Errorf("page 0 bottom-center content = %q, want empty (suppressed)", box.Content)
+	}
+	if box := r.marginBoxesForPage(1)["bottom-center"]; box.Content != "FOOTER" {
+		t.Errorf("page 1 bottom-center content = %q, want \"FOOTER\"", box.Content)
 	}
 }
 

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -328,6 +328,12 @@ func buildDocumentFromResult(result *foliohtml.ConvertResult, opts *Options) *do
 	if len(result.FirstMarginBoxes) > 0 {
 		doc.SetFirstMarginBoxes(result.FirstMarginBoxes)
 	}
+	if len(result.LeftMarginBoxes) > 0 {
+		doc.SetLeftMarginBoxes(result.LeftMarginBoxes)
+	}
+	if len(result.RightMarginBoxes) > 0 {
+		doc.SetRightMarginBoxes(result.RightMarginBoxes)
+	}
 
 	// Apply @page :first / :left / :right margin overrides.
 	if pc := result.PageConfig; pc != nil {
@@ -335,6 +341,18 @@ func buildDocumentFromResult(result *foliohtml.ConvertResult, opts *Options) *do
 			doc.SetFirstMargins(layout.Margins{
 				Top: pc.First.Top, Right: pc.First.Right,
 				Bottom: pc.First.Bottom, Left: pc.First.Left,
+			})
+		}
+		if pc.Left != nil && pc.Left.HasMargins {
+			doc.SetLeftMargins(layout.Margins{
+				Top: pc.Left.Top, Right: pc.Left.Right,
+				Bottom: pc.Left.Bottom, Left: pc.Left.Left,
+			})
+		}
+		if pc.Right != nil && pc.Right.HasMargins {
+			doc.SetRightMargins(layout.Margins{
+				Top: pc.Right.Top, Right: pc.Right.Right,
+				Bottom: pc.Right.Bottom, Left: pc.Right.Left,
 			})
 		}
 	}

--- a/tmpl/tmpl_test.go
+++ b/tmpl/tmpl_test.go
@@ -186,6 +186,39 @@ func TestRenderDocumentPageRulesOverrideOptions(t *testing.T) {
 	}
 }
 
+// TestRenderDocumentPagePseudoMargins exercises the tmpl entry point's wiring
+// of @page :first / :left / :right margins and margin boxes. Prior to the
+// Defect A fix, buildDocumentFromResult wired only :first margins and dropped
+// :left/:right entirely. This renders a multi-page document and asserts a valid
+// PDF is produced (the document fields are unexported across packages; field-
+// level merge assertions live in document/html_test.go and html/features_test.go).
+func TestRenderDocumentPagePseudoMargins(t *testing.T) {
+	tpl := `<html><head><style>
+		@page { margin: 2cm; }
+		@page :first { margin-top: 4cm; }
+		@page :left { margin-left: 3cm; @top-left { content: "L"; } }
+		@page :right { margin-right: 3cm; @top-right { content: "R"; } }
+	</style></head><body>
+		<p style="page-break-after: always;">one</p>
+		<p style="page-break-after: always;">two</p>
+		<p>three</p>
+	</body></html>`
+	doc, err := RenderDocument(tpl, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil document")
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	if !bytes.HasPrefix(buf.Bytes(), []byte("%PDF-")) {
+		t.Error("output does not start with %PDF-")
+	}
+}
+
 // --- RenderFile tests ---
 
 func TestRenderFile(t *testing.T) {


### PR DESCRIPTION
Part of #327 (the `@page :first { margin }` half) plus adjacent page-selector defects.

`@page :first` margins were applied but did not inherit the base `@page` rule, so a partial `@page :first { margin-top: 4cm }` over `@page { margin: 2cm }` zeroed the other three sides (the symptom that reads as ":first ignored"). Named pages and `:blank` also leaked into the default rule, and `:left`/`:right` margins and margin boxes were dropped on several entry points.

## Fix
- Resolve the base `@page` rule first, then seed each `:first`/`:left`/`:right` pseudo from it before overlaying its own declarations (CSS cascade); source-order independent; explicit `0` is preserved.
- Stop named pages (`@page name`) and unknown pseudos (`:blank`) from polluting the default rule; pseudo names matched case-insensitively.
- Plumb `:left`/`:right` margins and margin boxes through Document and the renderer with page-parity selection (LTR: page 0 is `:right`, alternating; `:first` wins on page 0), merged per-slot over the base; wired through AddHTML, the C ABI, tmpl, and wasm.
- Auto-height pages now size against the first-page margins.

## Tests
Fail-before/pass-after for the partial-margin cascade and the named/`:blank` no-pollution cases; parity selection, per-slot margin-box merge, `:first` beats `:right` on page 0, capitalized pseudos, and auto-height + `:first`.

Note: documents an LTR parity assumption (RTL not modelled).

## Before / after — `@page :first` on the #327 reduction

Rendered from the issue's actual invoice doc: `@page { margin: 36pt 72pt 72pt 24pt; @bottom-center { counter(page) } }` + `@page :first { margin-top: 144pt; @bottom-center { content: "" } }`, with explicit page breaks. (The masthead is `position:fixed`, fixed in #335 — present in both shots.)

**Before** — `:first`'s 144pt top margin *and* the blank footer leak to **every** page: all pages are identical, the red content-marker sits low on page 2, and no page numbers render anywhere.

<img width="320" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/336/before_p1.png"> <img width="320" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/336/before_p2.png">

**After** — only page 1 takes the 144pt top margin and blank footer; page 2+ use the 36pt base margin (red marker at top) and show "Page N of 3". Left margin also inherits the base 24pt instead of collapsing to 0.

<img width="320" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/336/after_p1.png"> <img width="320" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/336/after_p2.png">

_Two bugs that surfaced from this exact reduction are fixed here: `:first` margins leaking across explicit page breaks, and an empty `@bottom-center { content: "" }` not suppressing the first-page footer._
