### PR TITLE
html/layout/document: fix a batch of @page parsing bugs

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -61,14 +61,13 @@ func renderHTML(_ js.Value, args []js.Value) any {
 		return map[string]any{"error": err.Error()}
 	}
 
-	// Apply @page CSS rules to page size.
-	// AutoHeight means height explicitly set to 0 (size page to content).
+	// Apply @page CSS rules to page size via the shared helper so this path
+	// honors orientation-only keywords and resolves margin percentages /
+	// calc identically to AddHTML (B-1). AutoHeight (size: <w> 0) yields a
+	// content-sized page (height 0).
 	if pc := result.PageConfig; pc != nil {
-		if pc.Width > 0 && pc.Height > 0 {
-			pageSize = document.PageSize{Width: pc.Width, Height: pc.Height}
-		} else if pc.Width > 0 && pc.AutoHeight {
-			pageSize = document.PageSize{Width: pc.Width, Height: 0}
-		}
+		w, h, _ := pc.Resolve(pageSize.Width, pageSize.Height)
+		pageSize = document.PageSize{Width: w, Height: h}
 	}
 
 	doc := document.NewDocument(pageSize)

--- a/document/html.go
+++ b/document/html.go
@@ -57,12 +57,16 @@ func (d *Document) AddHTMLWithContext(ctx context.Context, htmlStr string, opts 
 
 	// Apply @page configuration if present.
 	if pc := result.PageConfig; pc != nil {
-		if pc.Width > 0 && (pc.Height > 0 || pc.AutoHeight) {
-			// parsePageSize already swaps width/height for landscape,
-			// so we use the dimensions as-is. AutoHeight passes Height=0
-			// to trigger content-sized pages.
-			d.pageSize = PageSize{Width: pc.Width, Height: pc.Height}
-		}
+		// Resolve page geometry + the orientation-only swap + all margin
+		// percentages / calc through the single shared helper so every
+		// Document-building consumer behaves identically (B-1). The default
+		// page box is the document default; the helper applies any explicit
+		// @page size or orientation-only keyword and resolves margins
+		// against the final dimensions (left/right vs width, top/bottom vs
+		// height, per CSS Paged Media).
+		w, h, _ := pc.Resolve(d.pageSize.Width, d.pageSize.Height)
+		d.pageSize = PageSize{Width: w, Height: h}
+
 		if pc.HasMargins {
 			d.margins.Top = pc.MarginTop
 			d.margins.Right = pc.MarginRight

--- a/document/html_test.go
+++ b/document/html_test.go
@@ -275,3 +275,104 @@ func TestAddHTMLTemplateWithCSS(t *testing.T) {
 		t.Fatal("produced empty PDF")
 	}
 }
+
+func nearly(a, b float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < 0.5
+}
+
+// B2: @page margin percentages must resolve against the page box —
+// left/right against page width, top/bottom against page height.
+func TestAddHTMLPageMarginPercent(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	err := doc.AddHTML(`<html><head><style>
+		@page { size: A4; margin: 10%; }
+	</style></head><body><p>X</p></body></html>`, nil)
+	if err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	// A4 = 595.28 x 841.89; 10% of each dimension.
+	wantLR := 0.10 * 595.28
+	wantTB := 0.10 * 841.89
+	if !nearly(doc.margins.Left, wantLR) || !nearly(doc.margins.Right, wantLR) {
+		t.Errorf("L/R margins = %.2f/%.2f, want ~%.2f (10%% of width)",
+			doc.margins.Left, doc.margins.Right, wantLR)
+	}
+	if !nearly(doc.margins.Top, wantTB) || !nearly(doc.margins.Bottom, wantTB) {
+		t.Errorf("T/B margins = %.2f/%.2f, want ~%.2f (10%% of height)",
+			doc.margins.Top, doc.margins.Bottom, wantTB)
+	}
+}
+
+// B2: percentage longhands resolve against the matching page dimension.
+func TestAddHTMLPageMarginPercentLonghand(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	err := doc.AddHTML(`<html><head><style>
+		@page { size: A4; margin-top: 5%; margin-left: 20%; }
+	</style></head><body><p>X</p></body></html>`, nil)
+	if err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	if want := 0.05 * 841.89; !nearly(doc.margins.Top, want) {
+		t.Errorf("margin-top = %.2f, want ~%.2f (5%% of height)", doc.margins.Top, want)
+	}
+	if want := 0.20 * 595.28; !nearly(doc.margins.Left, want) {
+		t.Errorf("margin-left = %.2f, want ~%.2f (20%% of width)", doc.margins.Left, want)
+	}
+}
+
+// N1: @page margin longhands must be calc-aware. Before the fix
+// margin-top: calc(1in + 2px) resolved to 0 (non-calc parser).
+func TestAddHTMLPageMarginCalcLonghand(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	err := doc.AddHTML(`<html><head><style>
+		@page { size: A4; margin-top: calc(1in + 2px); }
+	</style></head><body><p>X</p></body></html>`, nil)
+	if err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	// 1in = 72pt, 2px = 1.5pt → 73.5pt.
+	if want := 72.0 + 1.5; !nearly(doc.margins.Top, want) {
+		t.Errorf("margin-top = %.2f, want ~%.2f (calc 1in + 2px)", doc.margins.Top, want)
+	}
+}
+
+// S3: @page { size: landscape } with no explicit size must rotate the
+// document default page size (Letter 612x792 → 792x612).
+func TestAddHTMLPageOrientationOnlyLandscape(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	err := doc.AddHTML(`<html><head><style>
+		@page { size: landscape; }
+	</style></head><body><p>X</p></body></html>`, nil)
+	if err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	if !nearly(doc.pageSize.Width, 792) || !nearly(doc.pageSize.Height, 612) {
+		t.Errorf("page size = %.0fx%.0f, want 792x612 (landscape Letter)",
+			doc.pageSize.Width, doc.pageSize.Height)
+	}
+}
+
+// S3: portrait keyword on an already-portrait default is a no-op, and a
+// named-size + orientation keyword (size: a4 landscape) keeps working.
+func TestAddHTMLPageOrientationOnlyPortraitNoop(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	if err := doc.AddHTML(`<html><head><style>@page { size: portrait; }</style></head><body><p>X</p></body></html>`, nil); err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	if !nearly(doc.pageSize.Width, 612) || !nearly(doc.pageSize.Height, 792) {
+		t.Errorf("portrait page size = %.0fx%.0f, want 612x792", doc.pageSize.Width, doc.pageSize.Height)
+	}
+
+	doc2 := NewDocument(PageSizeLetter)
+	if err := doc2.AddHTML(`<html><head><style>@page { size: a4 landscape; }</style></head><body><p>X</p></body></html>`, nil); err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	// A4 landscape: 841.89 x 595.28 (width > height).
+	if doc2.pageSize.Width <= doc2.pageSize.Height {
+		t.Errorf("a4 landscape = %.0fx%.0f, want width > height", doc2.pageSize.Width, doc2.pageSize.Height)
+	}
+}

--- a/document/pdfa.go
+++ b/document/pdfa.go
@@ -249,7 +249,7 @@ func (d *Document) validatePdfA(allPages []*Page) error {
 		for _, fr := range page.fonts {
 			if fr.standard != nil && fr.embedded == nil {
 				return fmt.Errorf("document: pdfa: page %d uses non-embedded standard font %q; PDF/A requires all fonts to be embedded",
-					i, fr.standard.Name())
+					i+1, fr.standard.Name())
 			}
 		}
 	}
@@ -258,7 +258,7 @@ func (d *Document) validatePdfA(allPages []*Page) error {
 	if isPdfA1(d.pdfA.Level) {
 		for i, page := range allPages {
 			if len(page.extGStates) > 0 {
-				return fmt.Errorf("document: pdfa: page %d uses transparency (ExtGState); PDF/A-1 forbids transparency", i)
+				return fmt.Errorf("document: pdfa: page %d uses transparency (ExtGState); PDF/A-1 forbids transparency", i+1)
 			}
 		}
 	}

--- a/document/pdfa_test.go
+++ b/document/pdfa_test.go
@@ -126,6 +126,31 @@ func TestPdfAValidationStandardFont(t *testing.T) {
 	}
 }
 
+// N3: PDF/A validation errors must report 1-based page numbers. The
+// first page is "page 1", never "page 0".
+func TestPdfAErrorPageNumberIsOneBased(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.Info.Title = "Font Test"
+	doc.SetPdfA(PdfAConfig{Level: PdfA2B})
+
+	// First page (index 0) with a non-embedded standard font triggers the
+	// font-embedding error.
+	p := doc.AddPage()
+	p.AddText("Hello", font.Helvetica, 12, 72, 700)
+
+	var buf bytes.Buffer
+	_, err := doc.WriteTo(&buf)
+	if err == nil {
+		t.Fatal("expected validation error for non-embedded font")
+	}
+	if !strings.Contains(err.Error(), "page 1") {
+		t.Errorf("error should report 1-based page (page 1), got: %v", err)
+	}
+	if strings.Contains(err.Error(), "page 0") {
+		t.Errorf("error must not report 0-based page (page 0), got: %v", err)
+	}
+}
+
 func TestPdfADisablesEncryption(t *testing.T) {
 	doc := NewDocument(PageSizeLetter)
 	doc.Info.Title = "No Encryption"

--- a/examples/html-to-pdf/main.go
+++ b/examples/html-to-pdf/main.go
@@ -252,13 +252,22 @@ func buildDocument(htmlSource string) (*document.Document, error) {
 		return nil, fmt.Errorf("convert: %w", err)
 	}
 
-	doc := document.NewDocument(document.PageSizeA4)
+	// Resolve @page geometry + orientation-only swap + margin percentages /
+	// calc through the shared helper (before NewDocument, which fixes the
+	// page size) so this path matches AddHTML (B-1).
+	ps := document.PageSizeA4
+	if pc := result.PageConfig; pc != nil {
+		w, h, _ := pc.Resolve(ps.Width, ps.Height)
+		ps = document.PageSize{Width: w, Height: h}
+	}
+
+	doc := document.NewDocument(ps)
 	doc.SetMargins(layout.Margins{Top: 0, Right: 0, Bottom: 0, Left: 0})
 	doc.Info.Title = "Q4 2026 Quarterly Report"
 	doc.Info.Author = "Apex Capital Partners"
 	doc.SetAutoBookmarks(true)
 
-	// Apply @page configuration (margins, margin boxes for page numbers).
+	// Apply @page margins (resolved above by pc.Resolve).
 	if pc := result.PageConfig; pc != nil {
 		if pc.HasMargins {
 			doc.SetMargins(layout.Margins{

--- a/export/cabi_html.go
+++ b/export/cabi_html.go
@@ -79,10 +79,11 @@ func htmlToDocument(htmlStr string, pageWidth, pageHeight float64) (*document.Do
 	if pageWidth > 0 && pageHeight > 0 {
 		ps = document.PageSize{Width: pageWidth, Height: pageHeight}
 	}
+	// Resolve @page geometry + orientation-only swap + margin percentages /
+	// calc through the shared helper so this path matches AddHTML (B-1).
 	if pc := result.PageConfig; pc != nil {
-		if pc.Width > 0 && pc.Height > 0 {
-			ps = document.PageSize{Width: pc.Width, Height: pc.Height}
-		}
+		w, h, _ := pc.Resolve(ps.Width, ps.Height)
+		ps = document.PageSize{Width: w, Height: h}
 	}
 
 	doc := document.NewDocument(ps)

--- a/html/converter.go
+++ b/html/converter.go
@@ -354,6 +354,36 @@ type PageMargins struct {
 	Top, Right, Bottom, Left float64
 	HasMargins               bool                        // true if any margin property was explicitly set (even to 0)
 	MarginBoxes              map[string]MarginBoxContent // e.g. "top-center" → content
+
+	// Unresolved length trees for each side, preserved so percent / calc
+	// can be resolved against the page box at apply time (the float
+	// fields above are eagerly resolved with a zero basis and are only
+	// correct for absolute units). nil when the side was not set.
+	topLen, rightLen, bottomLen, leftLen *cssLength
+
+	// fontSize is the default font size captured at parse time, used to
+	// resolve em / rem inside the deferred length trees.
+	fontSize float64
+}
+
+// ResolveMargins resolves any deferred (percent / calc) margin lengths
+// against the page box. Per CSS Paged Media, @page margin percentages
+// resolve against the page dimensions: left/right against pageW,
+// top/bottom against pageH. Sides without a deferred length keep their
+// eagerly resolved float value.
+func (m *PageMargins) ResolveMargins(pageW, pageH float64) {
+	if m.topLen != nil {
+		m.Top = m.topLen.toPoints(pageH, m.fontSize)
+	}
+	if m.bottomLen != nil {
+		m.Bottom = m.bottomLen.toPoints(pageH, m.fontSize)
+	}
+	if m.rightLen != nil {
+		m.Right = m.rightLen.toPoints(pageW, m.fontSize)
+	}
+	if m.leftLen != nil {
+		m.Left = m.leftLen.toPoints(pageW, m.fontSize)
+	}
 }
 
 // PageConfig holds page dimensions and margins from CSS @page rules.
@@ -363,12 +393,29 @@ type PageConfig struct {
 	AutoHeight bool    // true when @page size has explicit height of 0 (size to content)
 	Landscape  bool
 
+	// OrientationOnly is true when @page { size: ... } gave only an
+	// orientation keyword (landscape/portrait) with no named size or
+	// explicit dimensions. Width/Height are then 0 and the orientation
+	// must be applied to the document default page size at apply time.
+	// Landscape distinguishes the two keywords (true = landscape).
+	OrientationOnly bool
+
 	// Default margins (from @page with no pseudo-selector).
 	MarginTop    float64
 	MarginRight  float64
 	MarginBottom float64
 	MarginLeft   float64
 	HasMargins   bool // true if any margin property was explicitly set (even to 0)
+
+	// Unresolved length trees for the default margins, preserved so
+	// percent / calc resolve against the page box at apply time. The
+	// float fields above are eagerly resolved with a zero basis and are
+	// only correct for absolute units. nil when not set.
+	marginTopLen, marginRightLen, marginBottomLen, marginLeftLen *cssLength
+
+	// fontSize is the default font size captured at parse time, used to
+	// resolve em / rem inside the deferred length trees.
+	fontSize float64
 
 	// Per-page-type margin overrides (nil = use default).
 	First *PageMargins // @page :first
@@ -377,6 +424,88 @@ type PageConfig struct {
 
 	// Default margin boxes (from @page with no pseudo-selector).
 	MarginBoxes map[string]MarginBoxContent // e.g. "top-center" → content
+}
+
+// ResolveMargins resolves the default-margin deferred lengths against the
+// page box, then resolves any per-page-type variant overrides
+// (:first, :left, :right). See PageMargins.ResolveMargins for the
+// percent basis rules. pageW / pageH are the resolved page dimensions in
+// points (the @page size if given, otherwise the document default).
+func (pc *PageConfig) ResolveMargins(pageW, pageH float64) {
+	if pc.marginTopLen != nil {
+		pc.MarginTop = pc.marginTopLen.toPoints(pageH, pc.fontSize)
+	}
+	if pc.marginBottomLen != nil {
+		pc.MarginBottom = pc.marginBottomLen.toPoints(pageH, pc.fontSize)
+	}
+	if pc.marginRightLen != nil {
+		pc.MarginRight = pc.marginRightLen.toPoints(pageW, pc.fontSize)
+	}
+	if pc.marginLeftLen != nil {
+		pc.MarginLeft = pc.marginLeftLen.toPoints(pageW, pc.fontSize)
+	}
+	if pc.First != nil {
+		pc.First.ResolveMargins(pageW, pageH)
+	}
+	if pc.Left != nil {
+		pc.Left.ResolveMargins(pageW, pageH)
+	}
+	if pc.Right != nil {
+		pc.Right.ResolveMargins(pageW, pageH)
+	}
+}
+
+// Resolve computes the final page geometry for this @page config and
+// resolves all margin lengths (default + :first / :left / :right) against
+// that geometry. It is the single entry point every Document-building
+// consumer must call so that page sizing, the orientation-only swap, and
+// deferred percent / calc margin resolution behave identically across all
+// code paths (AddHTML, the C ABI, WASM, the tmpl package, and examples).
+//
+// defaultW / defaultH are the document's default page dimensions in points,
+// used when the @page rule supplied no explicit size (or only an
+// orientation keyword). The returned width / height are the final page
+// dimensions; autoHeight reports the CSS `size: <w> 0` content-sized case
+// (height is then 0). Margins are resolved in place on pc and read by the
+// caller from pc.MarginTop/… and pc.First/Left/Right after this returns.
+//
+// Precedence (S-1): an orientation-only keyword (size: landscape | portrait)
+// rotates whatever size is otherwise in effect — the explicit @page dims if
+// given, else the document default — rather than being ignored when explicit
+// dims exist.
+func (pc *PageConfig) Resolve(defaultW, defaultH float64) (width, height float64, autoHeight bool) {
+	switch {
+	case pc.Width > 0 && (pc.Height > 0 || pc.AutoHeight):
+		// Explicit @page dimensions. parsePageSize already applied any
+		// `landscape` keyword that accompanied a named/explicit size.
+		width, height, autoHeight = pc.Width, pc.Height, pc.AutoHeight
+	default:
+		// No explicit @page size: start from the document default.
+		width, height = defaultW, defaultH
+	}
+
+	// Orientation-only keyword (size: landscape | portrait) applies its
+	// orientation to whatever dims are now in effect, swapping if needed.
+	// AutoHeight pages have no meaningful orientation, so leave them.
+	if pc.OrientationOnly && !autoHeight {
+		if pc.Landscape && width < height {
+			width, height = height, width
+		} else if !pc.Landscape && width > height {
+			width, height = height, width
+		}
+	}
+
+	// Resolve @page margin percentages / calc against the final page box.
+	// Per CSS Paged Media, left/right resolve against width and top/bottom
+	// against height. AutoHeight uses defaultH as the percent basis since
+	// the final height is content-driven and unknown here.
+	basisH := height
+	if autoHeight {
+		basisH = defaultH
+	}
+	pc.ResolveMargins(width, basisH)
+
+	return width, height, autoHeight
 }
 
 // convertMarginBoxes converts html.MarginBoxContent to layout.MarginBox,

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -426,20 +426,27 @@ func (c *converter) resolveContentValue(val string) string {
 				continue
 			}
 		}
-		// counter() function.
+		// counter() function. Supports an optional list-style argument:
+		// counter(<name>) or counter(<name>, <list-style>).
 		if strings.HasPrefix(remaining, "counter(") {
 			closeIdx := strings.IndexByte(remaining, ')')
 			if closeIdx >= 0 {
-				name := strings.TrimSpace(remaining[len("counter("):closeIdx])
+				inner := remaining[len("counter("):closeIdx]
+				name, style := inner, ""
+				if comma := strings.IndexByte(inner, ','); comma >= 0 {
+					name = inner[:comma]
+					style = strings.TrimSpace(inner[comma+1:])
+				}
+				name = strings.TrimSpace(name)
 				// `page` and `pages` are reserved counters whose value is
 				// only known once pagination runs. Emit the same deferred
 				// placeholder used by @page margin boxes; `layout` resolves
-				// it during content-stream emission.
+				// it during content-stream emission, applying the style.
 				switch name {
 				case "page":
-					result.WriteString(layout.CounterPagePlaceholder)
+					result.WriteString(layout.CounterPlaceholder("page", style))
 				case "pages":
-					result.WriteString(layout.CounterPagesPlaceholder)
+					result.WriteString(layout.CounterPlaceholder("pages", style))
 				default:
 					result.WriteString(strconv.Itoa(c.getCounter(name)))
 				}

--- a/html/css.go
+++ b/html/css.go
@@ -338,14 +338,16 @@ func extractMarginBoxes(declStr string, boxes map[string][]cssDecl) string {
 		// Write everything before the @
 		clean.WriteString(remaining[:atIdx])
 
-		// Find the name (e.g. "top-center")
+		// Find the name (e.g. "top-center"). CSS at-rule (margin-box)
+		// names are case-insensitive, so normalize to lower case here;
+		// the renderer switches on lower-case literals.
 		rest := remaining[atIdx+1:]
 		openIdx := strings.IndexByte(rest, '{')
 		if openIdx < 0 {
 			clean.WriteString(remaining[atIdx:])
 			break
 		}
-		name := strings.TrimSpace(rest[:openIdx])
+		name := strings.ToLower(strings.TrimSpace(rest[:openIdx]))
 
 		// Find matching close brace
 		fullStr := remaining[atIdx:]

--- a/html/features_test.go
+++ b/html/features_test.go
@@ -1149,6 +1149,67 @@ func TestCounterPagesPlaceholder(t *testing.T) {
 	}
 }
 
+// N2: margin-box at-rule names are case-insensitive; @TOP-CENTER and
+// @Bottom-Center must be stored under their lower-case keys so the
+// renderer (which switches on lower-case literals) finds them.
+func TestMarginBoxNameCaseInsensitive(t *testing.T) {
+	html := `<html><head><style>
+		@page {
+			margin: 2cm;
+			@TOP-CENTER { content: "Header"; }
+			@Bottom-Center { content: "Footer"; }
+		}
+	</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc := result.PageConfig
+	if pc == nil {
+		t.Fatal("expected PageConfig")
+	}
+	if mb, ok := pc.MarginBoxes["top-center"]; !ok || mb.Content != "Header" {
+		t.Errorf("top-center = %+v ok=%v, want content %q", mb, ok, "Header")
+	}
+	if mb, ok := pc.MarginBoxes["bottom-center"]; !ok || mb.Content != "Footer" {
+		t.Errorf("bottom-center = %+v ok=%v, want content %q", mb, ok, "Footer")
+	}
+}
+
+// B1: counter(page, <style>) must thread the list-style through to the
+// placeholder and never leak the literal "{counter(page, upper-roman)}"
+// call text into the rendered content.
+func TestCounterStyleArgumentNoLeak(t *testing.T) {
+	html := `<html><head><style>
+		@page {
+			margin: 2cm;
+			@bottom-center { content: counter(page, upper-roman); }
+			@top-center { content: "p. " counter(page, lower-alpha) " of " counter(pages, decimal); }
+		}
+	</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bottom := result.PageConfig.MarginBoxes["bottom-center"].Content
+	if want := layout.CounterPlaceholder("page", "upper-roman"); bottom != want {
+		t.Errorf("bottom-center = %q, want %q", bottom, want)
+	}
+	// The stored value must be the opaque placeholder, not the raw CSS
+	// call text (which carried a space after the comma). A raw-call leak
+	// would still contain the original "counter(page, upper-roman)" with
+	// its space; the normalized placeholder has no space.
+	if strings.Contains(bottom, "counter(page, ") {
+		t.Errorf("raw counter() call text leaked into content: %q", bottom)
+	}
+	top := result.PageConfig.MarginBoxes["top-center"].Content
+	wantTop := "p. " + layout.CounterPlaceholder("page", "lower-alpha") +
+		" of " + layout.CounterPlaceholder("pages", "decimal")
+	if top != wantTop {
+		t.Errorf("top-center = %q, want %q", top, wantTop)
+	}
+}
+
 // --- Margin box font-size and color from CSS ---
 
 func TestMarginBoxFontSize(t *testing.T) {
@@ -2652,5 +2713,100 @@ func TestBorderRadiusLengthHasNoPercent(t *testing.T) {
 	// must therefore not be found.
 	if d := findDivWithRadius(elems); d != nil {
 		t.Errorf("length border-radius should not carry a percentage fraction, got %v", d.BorderRadiusPercent())
+	}
+}
+
+// --- PageConfig.Resolve shared helper (B-1 / S-1) ---
+
+// helperPageConfig parses the given @page CSS and returns the PageConfig,
+// failing the test if none is produced.
+func helperPageConfig(t *testing.T, css string) *PageConfig {
+	t.Helper()
+	html := `<html><head><style>` + css + `</style></head><body><p>X</p></body></html>`
+	result, err := ConvertFull(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.PageConfig == nil {
+		t.Fatal("expected PageConfig")
+	}
+	return result.PageConfig
+}
+
+func TestResolvePercentMarginsAgainstPageBox(t *testing.T) {
+	// margin: 10% must resolve against the resolved page box (A4), NOT the
+	// zero basis the eager floats carry. Left/right vs width, top/bottom vs
+	// height (CSS Paged Media).
+	pc := helperPageConfig(t, `@page { size: a4; margin: 10%; }`)
+	// Eager floats are 0 before Resolve (percent has no absolute value).
+	if pc.MarginTop != 0 {
+		t.Fatalf("pre-Resolve MarginTop = %.2f, want 0 (zero basis)", pc.MarginTop)
+	}
+	w, h, auto := pc.Resolve(595.28, 841.89) // A4 default; @page also A4
+	if auto {
+		t.Error("autoHeight should be false")
+	}
+	if math.Abs(w-595.28) > 0.5 || math.Abs(h-841.89) > 0.5 {
+		t.Errorf("size = %.2f x %.2f, want A4 595.28 x 841.89", w, h)
+	}
+	if math.Abs(pc.MarginLeft-59.528) > 0.1 || math.Abs(pc.MarginRight-59.528) > 0.1 {
+		t.Errorf("L/R margin = %.3f / %.3f, want ~59.528 (10%% of width)", pc.MarginLeft, pc.MarginRight)
+	}
+	if math.Abs(pc.MarginTop-84.189) > 0.1 || math.Abs(pc.MarginBottom-84.189) > 0.1 {
+		t.Errorf("T/B margin = %.3f / %.3f, want ~84.189 (10%% of height)", pc.MarginTop, pc.MarginBottom)
+	}
+}
+
+func TestResolveCalcLonghandMargin(t *testing.T) {
+	// margin-top: calc(1in + 2px) must resolve to 72 + 2 = 74pt.
+	pc := helperPageConfig(t, `@page { margin-top: calc(1in + 2px); }`)
+	pc.Resolve(595.28, 841.89)
+	if math.Abs(pc.MarginTop-74) > 0.5 {
+		t.Errorf("MarginTop = %.2f, want ~74 (1in + 2px)", pc.MarginTop)
+	}
+}
+
+func TestResolveFirstPagefPercentMargin(t *testing.T) {
+	// Percentages in :first margins must also resolve against the page box.
+	pc := helperPageConfig(t, `@page { margin: 1cm; } @page :first { margin-top: 20%; }`)
+	if pc.First == nil {
+		t.Fatal("expected First margins")
+	}
+	pc.Resolve(595.28, 841.89)
+	if math.Abs(pc.First.Top-168.378) > 0.2 {
+		t.Errorf("First.Top = %.3f, want ~168.378 (20%% of A4 height)", pc.First.Top)
+	}
+}
+
+func TestResolveOrientationOnlyRotatesDefault(t *testing.T) {
+	// @page { size: landscape } with no explicit dims rotates the document
+	// default (A4 portrait) to landscape.
+	pc := helperPageConfig(t, `@page { size: landscape; }`)
+	if !pc.OrientationOnly {
+		t.Fatal("expected OrientationOnly")
+	}
+	w, h, _ := pc.Resolve(595.28, 841.89)
+	if w <= h {
+		t.Errorf("landscape size = %.2f x %.2f, want width > height", w, h)
+	}
+	if math.Abs(w-841.89) > 0.5 || math.Abs(h-595.28) > 0.5 {
+		t.Errorf("size = %.2f x %.2f, want A4 rotated 841.89 x 595.28", w, h)
+	}
+}
+
+func TestResolveOrientationOnlyOverridesExplicitDims(t *testing.T) {
+	// S-1: a later size:landscape must rotate an earlier explicit named
+	// size rather than being ignored. @page{size:A4} (portrait) followed by
+	// @page{size:landscape} must yield A4 landscape.
+	pc := helperPageConfig(t, `@page { size: a4; } @page { size: landscape; }`)
+	if !pc.OrientationOnly {
+		t.Fatal("expected OrientationOnly to be set by the later rule")
+	}
+	w, h, _ := pc.Resolve(595.28, 841.89)
+	if w <= h {
+		t.Errorf("S-1: size = %.2f x %.2f, want landscape (width > height)", w, h)
+	}
+	if math.Abs(w-841.89) > 0.5 || math.Abs(h-595.28) > 0.5 {
+		t.Errorf("S-1: size = %.2f x %.2f, want A4 rotated 841.89 x 595.28", w, h)
 	}
 }

--- a/html/page.go
+++ b/html/page.go
@@ -5,6 +5,8 @@ package html
 
 import (
 	"strings"
+
+	"github.com/carlos7ags/folio/layout"
 )
 
 // Standard page sizes in points (width x height, portrait).
@@ -33,7 +35,7 @@ var pageSizes = map[string][2]float64{
 // base @page {} rule it inherits from: pass 1 resolves the base, pass 2 seeds
 // and applies the pseudos.
 func parsePageConfig(rules []pageRule, defaultFontSize float64) *PageConfig {
-	pc := &PageConfig{}
+	pc := &PageConfig{fontSize: defaultFontSize}
 	hasAny := false
 
 	// Pass 1: resolve the base @page {} rule (selector == "") — size,
@@ -51,24 +53,34 @@ func parsePageConfig(rules []pageRule, defaultFontSize float64) *PageConfig {
 				parsePageSize(val, pc, defaultFontSize)
 				hasAny = true
 			case "margin":
+				// Parse both the eager floats (correct for absolute units)
+				// and the unresolved length trees so percent / calc can be
+				// resolved against the page box at apply time (B2/N1).
 				t, r, b, l := parseMarginShorthand(val, defaultFontSize)
 				pc.MarginTop, pc.MarginRight, pc.MarginBottom, pc.MarginLeft = t, r, b, l
+				pc.marginTopLen, pc.marginRightLen, pc.marginBottomLen, pc.marginLeftLen = parseMarginShorthandLengths(val, defaultFontSize)
 				pc.HasMargins = true
 				hasAny = true
 			case "margin-top":
+				// Route through the calc-aware parser (N1) and keep the
+				// length for page-box percent resolution (B2).
 				pc.MarginTop = parseSingleLength(val, defaultFontSize)
+				pc.marginTopLen = parseBoxSideLength(val, defaultFontSize)
 				pc.HasMargins = true
 				hasAny = true
 			case "margin-right":
 				pc.MarginRight = parseSingleLength(val, defaultFontSize)
+				pc.marginRightLen = parseBoxSideLength(val, defaultFontSize)
 				pc.HasMargins = true
 				hasAny = true
 			case "margin-bottom":
 				pc.MarginBottom = parseSingleLength(val, defaultFontSize)
+				pc.marginBottomLen = parseBoxSideLength(val, defaultFontSize)
 				pc.HasMargins = true
 				hasAny = true
 			case "margin-left":
 				pc.MarginLeft = parseSingleLength(val, defaultFontSize)
+				pc.marginLeftLen = parseBoxSideLength(val, defaultFontSize)
 				pc.HasMargins = true
 				hasAny = true
 			}
@@ -119,22 +131,27 @@ func parsePageConfig(rules []pageRule, defaultFontSize float64) *PageConfig {
 			case "margin":
 				t, r, b, l := parseMarginShorthand(val, defaultFontSize)
 				target.Top, target.Right, target.Bottom, target.Left = t, r, b, l
+				target.topLen, target.rightLen, target.bottomLen, target.leftLen = parseMarginShorthandLengths(val, defaultFontSize)
 				target.HasMargins = true
 				hasAny = true
 			case "margin-top":
 				target.Top = parseSingleLength(val, defaultFontSize)
+				target.topLen = parseBoxSideLength(val, defaultFontSize)
 				target.HasMargins = true
 				hasAny = true
 			case "margin-right":
 				target.Right = parseSingleLength(val, defaultFontSize)
+				target.rightLen = parseBoxSideLength(val, defaultFontSize)
 				target.HasMargins = true
 				hasAny = true
 			case "margin-bottom":
 				target.Bottom = parseSingleLength(val, defaultFontSize)
+				target.bottomLen = parseBoxSideLength(val, defaultFontSize)
 				target.HasMargins = true
 				hasAny = true
 			case "margin-left":
 				target.Left = parseSingleLength(val, defaultFontSize)
+				target.leftLen = parseBoxSideLength(val, defaultFontSize)
 				target.HasMargins = true
 				hasAny = true
 			}
@@ -175,12 +192,19 @@ func parsePageConfig(rules []pageRule, defaultFontSize float64) *PageConfig {
 // margins, the seeded set is marked HasMargins so unspecified sides inherit the
 // base instead of defaulting to 0 (CSS cascade — Defect B fix).
 func newSeededMargins(pc *PageConfig) *PageMargins {
-	pm := &PageMargins{}
+	pm := &PageMargins{fontSize: pc.fontSize}
 	if pc.HasMargins {
 		pm.Top = pc.MarginTop
 		pm.Right = pc.MarginRight
 		pm.Bottom = pc.MarginBottom
 		pm.Left = pc.MarginLeft
+		// Inherit the deferred length trees too, so a pseudo that does not
+		// override a side resolves percent/calc base margins against the
+		// page box (B2) rather than the basis-0 eager float.
+		pm.topLen = pc.marginTopLen
+		pm.rightLen = pc.marginRightLen
+		pm.bottomLen = pc.marginBottomLen
+		pm.leftLen = pc.marginLeftLen
 		pm.HasMargins = true
 	}
 	return pm
@@ -237,12 +261,27 @@ func parseContentValue(val string) string {
 				continue
 			}
 		}
-		// counter() function — stored as placeholder, resolved at render time.
+		// counter() function — stored as a placeholder, resolved at
+		// render time. Supports an optional second argument naming a
+		// list-style-type, e.g. counter(page, upper-roman). The style is
+		// threaded through the placeholder so the renderer can format the
+		// resolved page number accordingly (layout.formatCounter). Only
+		// the reserved `page` / `pages` counters are deferred; any other
+		// counter name is dropped (its value is not tracked here) rather
+		// than leaking the literal call text into the PDF.
 		if strings.HasPrefix(remaining, "counter(") {
 			closeIdx := strings.IndexByte(remaining, ')')
 			if closeIdx >= 0 {
-				fnCall := remaining[:closeIdx+1]
-				result.WriteString("{" + fnCall + "}")
+				inner := remaining[len("counter("):closeIdx]
+				name, style := inner, ""
+				if comma := strings.IndexByte(inner, ','); comma >= 0 {
+					name = inner[:comma]
+					style = strings.TrimSpace(inner[comma+1:])
+				}
+				name = strings.TrimSpace(strings.ToLower(name))
+				if name == "page" || name == "pages" {
+					result.WriteString(layout.CounterPlaceholder(name, style))
+				}
 				remaining = remaining[closeIdx+1:]
 				continue
 			}
@@ -302,9 +341,13 @@ func parsePageSize(val string, pc *PageConfig, fontSize float64) {
 		return
 	}
 
-	// Orientation only: "landscape" or "portrait"
+	// Orientation only: "landscape" or "portrait". No explicit
+	// dimensions are given, so the orientation must be applied to the
+	// document default page size (done in document/html.go, where the
+	// default is known). Flag it so that layer can swap width/height.
 	if parts[0] == "landscape" || parts[0] == "portrait" {
-		return // no dimensions, just orientation
+		pc.OrientationOnly = true
+		return
 	}
 
 	// Explicit dimensions: "8.5in 11in" or "210mm 297mm" or

--- a/layout/counter.go
+++ b/layout/counter.go
@@ -15,12 +15,40 @@ import (
 // substituted at content-stream emission with the resolved 1-based page
 // index. The same string is emitted by `html/page.go` for `@page`
 // margin-box content.
+//
+// A `counter(page)` with an explicit list-style argument (e.g.
+// `counter(page, upper-roman)`) is encoded as `{counter(page,STYLE)}`,
+// where STYLE is the normalized list-style-type. The style-less form
+// below is equivalent to `{counter(page,decimal)}` and is kept verbatim
+// for backward compatibility with existing emitters.
 const CounterPagePlaceholder = "{counter(page)}"
 
 // CounterPagesPlaceholder is the deferred sentinel for CSS
 // `counter(pages)`. It is substituted with the document's final page
-// total once pagination is complete and emission begins.
+// total once pagination is complete and emission begins. The styled
+// form is `{counter(pages,STYLE)}` (see CounterPagePlaceholder).
 const CounterPagesPlaceholder = "{counter(pages)}"
+
+// CounterPlaceholder builds the placeholder token for a page/pages
+// counter with an optional list-style. name must be "page" or "pages";
+// style is a list-style-type ("" or "decimal" yields the canonical
+// style-less placeholder). The token is opaque to everything between
+// emission of the content string and the final substitution pass.
+func CounterPlaceholder(name, style string) string {
+	style = strings.TrimSpace(strings.ToLower(style))
+	// Guard against a style argument that contains the placeholder's own
+	// delimiters (N-a). A stray '}' or ')' would corrupt or prematurely
+	// terminate the {counter(...)} token at substitution time, leaking the
+	// remainder as literal text. Such input is never a valid CSS
+	// list-style-type, so drop the style and fall back to decimal.
+	if strings.ContainsAny(style, "})") {
+		style = ""
+	}
+	if style == "" || style == "decimal" {
+		return "{counter(" + name + ")}"
+	}
+	return "{counter(" + name + "," + style + ")}"
+}
 
 // counterMeasureDigits is the digit string used to reserve width for a
 // counter placeholder during paragraph measurement. The reserved width
@@ -32,20 +60,128 @@ const CounterPagesPlaceholder = "{counter(pages)}"
 // see counter values overflow their reserved trailing whitespace.
 const counterMeasureDigits = "8888"
 
-// substituteCounters replaces page-counter placeholders in s with their
-// resolved 1-based page index and total page count. Returns s unchanged
-// when no placeholder is present.
-func substituteCounters(s string, pageIdx, totalPages int) string {
+// formatCounter renders the integer n using the given CSS list-style-type.
+// Supported styles: decimal (default), decimal-leading-zero, lower-roman,
+// upper-roman, lower-alpha, upper-alpha. Unknown styles fall back to
+// decimal. n is the 1-based counter value.
+func formatCounter(n int, style string) string {
+	switch strings.TrimSpace(strings.ToLower(style)) {
+	case "decimal-leading-zero":
+		s := strconv.Itoa(n)
+		if n >= 0 && n < 10 {
+			return "0" + s
+		}
+		return s
+	case "lower-roman":
+		return strings.ToLower(romanNumeral(n))
+	case "upper-roman":
+		return romanNumeral(n)
+	case "lower-alpha", "lower-latin":
+		return alphaNumeral(n, 'a')
+	case "upper-alpha", "upper-latin":
+		return alphaNumeral(n, 'A')
+	default: // "decimal", "" and any unknown style
+		return strconv.Itoa(n)
+	}
+}
+
+// romanNumeral converts a positive integer to an upper-case Roman
+// numeral. Values <= 0 fall back to the decimal representation (Roman
+// numerals have no zero or negative form).
+func romanNumeral(n int) string {
+	if n <= 0 {
+		return strconv.Itoa(n)
+	}
+	vals := []int{1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1}
+	syms := []string{"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"}
+	var b strings.Builder
+	for i, v := range vals {
+		for n >= v {
+			b.WriteString(syms[i])
+			n -= v
+		}
+	}
+	return b.String()
+}
+
+// alphaNumeral converts a positive integer to a bijective base-26
+// alphabetic numeral (1→a, 26→z, 27→aa, ...) starting from base ('a' or
+// 'A'). Values <= 0 fall back to the decimal representation.
+func alphaNumeral(n int, base rune) string {
+	if n <= 0 {
+		return strconv.Itoa(n)
+	}
+	var letters []byte
+	for n > 0 {
+		n--
+		letters = append(letters, byte(base)+byte(n%26))
+		n /= 26
+	}
+	// Reverse (most-significant digit first).
+	for i, j := 0, len(letters)-1; i < j; i, j = i+1, j-1 {
+		letters[i], letters[j] = letters[j], letters[i]
+	}
+	return string(letters)
+}
+
+// substituteCounter replaces every page/pages counter placeholder in s —
+// including styled variants like {counter(page,upper-roman)} — with the
+// value produced by valueFor(name, style), where name is "page" or
+// "pages". Returns s unchanged when no placeholder is present. Tokens
+// whose counter name is not page/pages (e.g. {counter(chapter)}) are
+// left untouched.
+func substituteCounter(s string, valueFor func(name, style string) string) string {
 	if !strings.Contains(s, "{counter(") {
 		return s
 	}
-	if strings.Contains(s, CounterPagePlaceholder) {
-		s = strings.ReplaceAll(s, CounterPagePlaceholder, strconv.Itoa(pageIdx+1))
+	var b strings.Builder
+	for {
+		idx := strings.Index(s, "{counter(")
+		if idx < 0 {
+			b.WriteString(s)
+			break
+		}
+		close := strings.IndexByte(s[idx:], '}')
+		if close < 0 {
+			b.WriteString(s)
+			break
+		}
+		close += idx
+		// inner = the text inside {counter(...)} between the "(" and "}".
+		// e.g. "page)" or "page,upper-roman)".
+		inner := s[idx+len("{counter(") : close]
+		inner = strings.TrimSuffix(strings.TrimSpace(inner), ")")
+		name, style := inner, ""
+		if comma := strings.IndexByte(inner, ','); comma >= 0 {
+			name = strings.TrimSpace(inner[:comma])
+			style = strings.TrimSpace(inner[comma+1:])
+		}
+		name = strings.ToLower(name)
+		if name == "page" || name == "pages" {
+			b.WriteString(s[:idx])
+			b.WriteString(valueFor(name, style))
+			s = s[close+1:]
+			continue
+		}
+		// Unknown counter name: emit verbatim up to and including '}' and
+		// continue scanning the remainder.
+		b.WriteString(s[:close+1])
+		s = s[close+1:]
 	}
-	if strings.Contains(s, CounterPagesPlaceholder) {
-		s = strings.ReplaceAll(s, CounterPagesPlaceholder, strconv.Itoa(totalPages))
-	}
-	return s
+	return b.String()
+}
+
+// substituteCounters replaces page-counter placeholders in s with their
+// resolved 1-based page index and total page count, honoring any
+// list-style argument carried by the placeholder. Returns s unchanged
+// when no placeholder is present.
+func substituteCounters(s string, pageIdx, totalPages int) string {
+	return substituteCounter(s, func(name, style string) string {
+		if name == "pages" {
+			return formatCounter(totalPages, style)
+		}
+		return formatCounter(pageIdx+1, style)
+	})
 }
 
 // expandCountersForMeasure replaces page-counter placeholders with a
@@ -55,16 +191,22 @@ func substituteCounters(s string, pageIdx, totalPages int) string {
 // real placeholder remains on Word.Text and is substituted at emit
 // time.
 func expandCountersForMeasure(s string) string {
-	if !strings.Contains(s, "{counter(") {
-		return s
-	}
-	s = strings.ReplaceAll(s, CounterPagePlaceholder, counterMeasureDigits)
-	s = strings.ReplaceAll(s, CounterPagesPlaceholder, counterMeasureDigits)
-	return s
+	return substituteCounter(s, func(name, style string) string {
+		return counterMeasureDigits
+	})
 }
 
-// hasCounterPlaceholder reports whether s contains a page-counter
-// placeholder needing emit-time substitution.
+// hasCounterPlaceholder reports whether s contains a page or pages
+// counter placeholder needing emit-time substitution. Counter tokens
+// for other names (e.g. {counter(chapter)}) are not flagged.
 func hasCounterPlaceholder(s string) bool {
-	return strings.Contains(s, CounterPagePlaceholder) || strings.Contains(s, CounterPagesPlaceholder)
+	if !strings.Contains(s, "{counter(") {
+		return false
+	}
+	found := false
+	substituteCounter(s, func(name, style string) string {
+		found = true
+		return ""
+	})
+	return found
 }

--- a/layout/counter_test.go
+++ b/layout/counter_test.go
@@ -43,6 +43,97 @@ func TestHasCounterPlaceholderDetectsBoth(t *testing.T) {
 	}
 }
 
+func TestFormatCounterStyles(t *testing.T) {
+	cases := []struct {
+		n     int
+		style string
+		want  string
+	}{
+		{3, "decimal", "3"},
+		{3, "", "3"},
+		{3, "decimal-leading-zero", "03"},
+		{12, "decimal-leading-zero", "12"},
+		{4, "lower-roman", "iv"},
+		{4, "upper-roman", "IV"},
+		{1949, "upper-roman", "MCMXLIX"},
+		{1, "lower-alpha", "a"},
+		{26, "lower-alpha", "z"},
+		{27, "lower-alpha", "aa"},
+		{2, "upper-alpha", "B"},
+		{5, "no-such-style", "5"}, // unknown → decimal fallback
+	}
+	for _, c := range cases {
+		if got := formatCounter(c.n, c.style); got != c.want {
+			t.Errorf("formatCounter(%d, %q) = %q, want %q", c.n, c.style, got, c.want)
+		}
+	}
+}
+
+func TestFormatCounterEdgeCases(t *testing.T) {
+	cases := []struct {
+		n     int
+		style string
+		want  string
+	}{
+		// Roman has no zero/negative form → decimal fallback (N-c).
+		{0, "upper-roman", "0"},
+		{-3, "lower-roman", "-3"},
+		// Largest commonly cited Roman value.
+		{4000, "upper-roman", "MMMM"},
+		// Bijective base-26 alpha boundaries (N-c).
+		{52, "lower-alpha", "az"},
+		{53, "lower-alpha", "ba"},
+		{52, "upper-alpha", "AZ"},
+		{53, "upper-alpha", "BA"},
+		// Alpha has no zero/negative form → decimal fallback.
+		{0, "lower-alpha", "0"},
+		{-1, "upper-alpha", "-1"},
+	}
+	for _, c := range cases {
+		if got := formatCounter(c.n, c.style); got != c.want {
+			t.Errorf("formatCounter(%d, %q) = %q, want %q", c.n, c.style, got, c.want)
+		}
+	}
+}
+
+func TestCounterPlaceholderRejectsDelimiterInStyle(t *testing.T) {
+	// A style argument containing the placeholder's own delimiters must not
+	// leak into the emitted token (N-a); it falls back to the style-less
+	// canonical form.
+	for _, bad := range []string{"upper-roman)", "x}y", "}", ")"} {
+		if got := CounterPlaceholder("page", bad); got != CounterPagePlaceholder {
+			t.Errorf("CounterPlaceholder(page, %q) = %q, want %q", bad, got, CounterPagePlaceholder)
+		}
+	}
+}
+
+func TestSubstituteCountersWithStyle(t *testing.T) {
+	// counter(page, upper-roman) on page index 2 (1-based 3) → "III".
+	in := "Page " + CounterPlaceholder("page", "upper-roman") +
+		" / " + CounterPlaceholder("pages", "upper-roman")
+	got := substituteCounters(in, 2, 7)
+	want := "Page III / VII"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	// Mixed styled + unstyled in one string.
+	mixed := CounterPlaceholder("page", "") + "-" + CounterPlaceholder("page", "lower-alpha")
+	if got := substituteCounters(mixed, 0, 1); got != "1-a" {
+		t.Errorf("mixed = %q, want %q", got, "1-a")
+	}
+}
+
+func TestCounterPlaceholderNormalizesDecimal(t *testing.T) {
+	// decimal / empty style collapse to the canonical style-less token so
+	// existing emitters and back-compat behavior are preserved.
+	if got := CounterPlaceholder("page", "decimal"); got != CounterPagePlaceholder {
+		t.Errorf("decimal style: got %q, want %q", got, CounterPagePlaceholder)
+	}
+	if got := CounterPlaceholder("pages", ""); got != CounterPagesPlaceholder {
+		t.Errorf("empty style: got %q, want %q", got, CounterPagesPlaceholder)
+	}
+}
+
 func TestSubstituteCountersIgnoresUnknownCounterTokens(t *testing.T) {
 	// A future or user-defined counter name (e.g. {counter(chapter)}) that
 	// looks like a placeholder but isn't one of the two known names must

--- a/layout/renderer.go
+++ b/layout/renderer.go
@@ -5,7 +5,6 @@ package layout
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/carlos7ags/folio/content"
@@ -270,12 +269,12 @@ func (r *Renderer) drawMarginBoxes(ctx *DrawContext, pageIdx int, margins Margin
 		if text == "" {
 			continue
 		}
-		// Resolve {counter(page)} and {counter(pages)} placeholders.
+		// Resolve {counter(page)} / {counter(pages)} placeholders,
+		// including styled variants like {counter(page,upper-roman)}.
 		// pageIdx is 0-based; counter(page) is 1-based per CSS GCPM.
 		// counter(pages) uses ctx.TotalPages, set during the emission
 		// pass once pagination is final.
-		text = strings.ReplaceAll(text, CounterPagePlaceholder, fmt.Sprintf("%d", pageIdx+1))
-		text = strings.ReplaceAll(text, CounterPagesPlaceholder, fmt.Sprintf("%d", ctx.TotalPages))
+		text = substituteCounters(text, pageIdx, ctx.TotalPages)
 
 		// Resolve {string(name)} placeholders from CSS string-set.
 		text = r.resolveStringRefs(text, pageIdx)

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -303,11 +303,12 @@ func buildDocumentFromResult(result *foliohtml.ConvertResult, opts *Options) *do
 	ps := opts.pageSize()
 	margins := opts.margins()
 
-	// @page rules from the template override Options.
+	// @page rules from the template override Options. Resolve geometry +
+	// orientation-only swap + margin percentages / calc through the shared
+	// helper so this path matches AddHTML (B-1).
 	if pc := result.PageConfig; pc != nil {
-		if pc.Width > 0 && pc.Height > 0 {
-			ps = document.PageSize{Width: pc.Width, Height: pc.Height}
-		}
+		w, h, _ := pc.Resolve(ps.Width, ps.Height)
+		ps = document.PageSize{Width: w, Height: h}
 		if pc.HasMargins {
 			margins = layout.Margins{
 				Top:    pc.MarginTop,

--- a/tmpl/tmpl_test.go
+++ b/tmpl/tmpl_test.go
@@ -625,6 +625,72 @@ func TestRenderDocumentNilMarginsUsesDefaults(t *testing.T) {
 	}
 }
 
+// TestBuildDocumentRoutesThroughResolve proves the tmpl Document-building
+// path resolves @page margin percentages (and the orientation-only swap)
+// via the shared PageConfig.Resolve helper rather than reading the
+// zero-basis eager floats (B-1). Before Resolve runs, a percent margin's
+// eager float is 0; after buildDocumentFromResult it must equal the
+// percentage of the page box.
+func TestBuildDocumentRoutesThroughResolve(t *testing.T) {
+	tpl := `<html><head><style>@page { size: a4; margin: 10%; }</style></head>` +
+		`<body><p>x</p></body></html>`
+	result, err := foliohtml.ConvertFull(tpl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.PageConfig == nil {
+		t.Fatal("expected PageConfig")
+	}
+	// Eager float carries the zero-basis percent value before resolution.
+	if result.PageConfig.MarginTop != 0 {
+		t.Fatalf("pre-build MarginTop = %.2f, want 0 (unresolved percent)", result.PageConfig.MarginTop)
+	}
+
+	doc := buildDocumentFromResult(result, &Options{PageSize: document.PageSizeLetter})
+	if doc == nil {
+		t.Fatal("expected non-nil document")
+	}
+
+	abs := func(f float64) float64 {
+		if f < 0 {
+			return -f
+		}
+		return f
+	}
+	// A4 height 841.89 → 10% ≈ 84.189; A4 width 595.28 → 10% ≈ 59.528.
+	if abs(result.PageConfig.MarginTop-84.189) > 0.2 {
+		t.Errorf("MarginTop = %.3f, want ~84.189 (10%% of A4 height) — tmpl did not route through Resolve",
+			result.PageConfig.MarginTop)
+	}
+	if abs(result.PageConfig.MarginLeft-59.528) > 0.2 {
+		t.Errorf("MarginLeft = %.3f, want ~59.528 (10%% of A4 width)", result.PageConfig.MarginLeft)
+	}
+}
+
+// TestBuildDocumentOrientationOnly proves the tmpl path honors a bare
+// size:landscape keyword (B-1/S-1) by routing through Resolve, which swaps
+// the resolved dimensions.
+func TestBuildDocumentOrientationOnly(t *testing.T) {
+	tpl := `<html><head><style>@page { size: landscape; }</style></head>` +
+		`<body><p>x</p></body></html>`
+	result, err := foliohtml.ConvertFull(tpl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.PageConfig == nil || !result.PageConfig.OrientationOnly {
+		t.Fatal("expected OrientationOnly PageConfig")
+	}
+	// Resolve against an A4-portrait default; expect landscape (w > h).
+	w, h, _ := result.PageConfig.Resolve(document.PageSizeA4.Width, document.PageSizeA4.Height)
+	if w <= h {
+		t.Errorf("size = %.2f x %.2f, want landscape (width > height)", w, h)
+	}
+	// And the tmpl builder must produce a document without error.
+	if doc := buildDocumentFromResult(result, &Options{PageSize: document.PageSizeA4}); doc == nil {
+		t.Fatal("expected non-nil document")
+	}
+}
+
 func TestRenderDocumentPartialMargins(t *testing.T) {
 	// A Margins with only Top set should be used as-is (other fields
 	// stay zero), not trigger the default.


### PR DESCRIPTION
Six independent `@page` defects found while investigating #327/#328:

- **counter style leak** — `counter(page, upper-roman)` (any list-style arg) leaked the literal `{counter(page, upper-roman)}` text into the PDF. Now parsed and formatted: `decimal`, `decimal-leading-zero`, `lower/upper-roman`, `lower/upper-alpha`; unknown → decimal. Body-flow and margin-box counters share one formatter.
- **percentage margins** — `@page { margin: 10% }` resolved to 0. Margins are now stored unresolved and resolved against the page box (left/right vs width, top/bottom vs height) via a shared `PageConfig.Resolve` helper called from every entry point (AddHTML, C ABI, tmpl, wasm, examples).
- **calc longhands** — `@page { margin-top: calc(...) }` resolved to 0 (shorthand worked, longhands didn't).
- **case-sensitive margin-box names** — `@TOP-CENTER` never rendered.
- **`size: landscape`** — orientation-only size did not rotate the default page; a later orientation-only rule was ignored after an explicit size.
- **"page 0"** — PDF/A font errors reported a 0-based page number.

## Tests
One focused fail-before/pass-after test per fix, including resolution through the tmpl entry point (not just AddHTML), counter-style formatting (incl. roman/alpha edge cases), and orientation handling.