### PR TITLE
html/layout: apply border-radius across remaining container paths (#329)

### DIFF
--- a/document/border_radius_render_test.go
+++ b/document/border_radius_render_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Render-level regression tests for issue #329 / #340. The structural tests in
+// the html package assert the converted element tree is correct (e.g. the inner
+// paragraph background is nil). They are necessary but not sufficient: the box
+// background can still leak into the rendered content stream as a square fill
+// via a different field (a per-run TextRun.BackgroundColor highlight, painted by
+// the renderer as a plain ` re` rectangle behind the text). These tests render
+// HTML to an actual PDF, decompress the page content stream, and assert that a
+// box with a border-radius and background color C draws the rounded path (Bezier
+// curve operators ` c`) for C and does NOT draw a plain rectangle (` re` ... ` f`)
+// fill in color C — i.e. there is exactly one rounded fill and no square
+// overpaint.
+
+// squareFillRe matches a PDF rectangle path: "x y w h re".
+var squareFillRe = regexp.MustCompile(`(?m)^\s*-?\d[\d.]*\s+-?\d[\d.]*\s+-?\d[\d.]*\s+-?\d[\d.]*\s+re\s*$`)
+
+// squareFillsInColor scans a decompressed content stream for ` re` rectangle
+// paths emitted while the current non-stroking color equals colorPrefix (the
+// "<r> <g> <b> rg" line). It returns each offending rectangle line so failures
+// are legible. Stroking-color changes ("RG") do not affect the fill color, so
+// only "rg" lines update the tracked color.
+func squareFillsInColor(cs, colorPrefix string) []string {
+	var out []string
+	curColor := ""
+	for _, l := range strings.Split(cs, "\n") {
+		t := strings.TrimSpace(l)
+		if strings.HasSuffix(t, " rg") {
+			curColor = t
+		}
+		if strings.HasPrefix(curColor, colorPrefix) && squareFillRe.MatchString(l) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// hasRoundedFillInColor reports whether the stream contains a Bezier curve
+// operator (` c`) while the current fill color equals colorPrefix — the
+// signature of a rounded-rectangle fill in that color.
+func hasRoundedFillInColor(cs, colorPrefix string) bool {
+	curColor := ""
+	for _, l := range strings.Split(cs, "\n") {
+		t := strings.TrimSpace(l)
+		if strings.HasSuffix(t, " rg") {
+			curColor = t
+		}
+		if strings.HasPrefix(curColor, colorPrefix) && strings.HasSuffix(t, " c") {
+			return true
+		}
+	}
+	return false
+}
+
+func renderHTMLStream(t *testing.T, html string) string {
+	t.Helper()
+	doc := NewDocument(PageSizeLetter)
+	if err := doc.AddHTML(html, nil); err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	return decompressedContentStreams(t, buf.Bytes())
+}
+
+func TestBorderRadiusNoSquareOverpaint(t *testing.T) {
+	// #4F46E5 -> 0.309804 0.27451 0.898039 ; #FEF3C7 -> 0.996078 0.952941 0.780392
+	const indigo = "0.309804 0.27451 0.898039"
+	const amber = "0.996078 0.952941 0.780392"
+
+	cases := []struct {
+		name  string
+		html  string
+		color string
+	}{
+		{
+			name:  "FlexSpanChip",
+			html:  `<div style="display:flex"><span style="flex:0 0 auto;background:#4F46E5;color:#fff;border-radius:8pt;padding:5pt 12pt">CHIP</span></div>`,
+			color: indigo,
+		},
+		{
+			name:  "GridSpanChip",
+			html:  `<div style="display:grid;grid-template-columns:1fr"><span style="background:#4F46E5;color:#fff;border-radius:8pt;padding:5pt 12pt">CHIP</span></div>`,
+			color: indigo,
+		},
+		{
+			name:  "DisplayBlockSpan",
+			html:  `<span style="display:block;background:#4F46E5;color:#fff;border-radius:8pt;padding:5pt 12pt">CHIP</span>`,
+			color: indigo,
+		},
+		{
+			name:  "PercentRadiusFlexSpan",
+			html:  `<div style="display:flex"><span style="flex:0 0 auto;background:#4F46E5;color:#fff;border-radius:50%;padding:5pt 12pt">CHIP</span></div>`,
+			color: indigo,
+		},
+		{
+			name:  "Blockquote",
+			html:  `<blockquote style="background:#FEF3C7;border-radius:10pt;padding:8pt 12pt;margin:0">quoted</blockquote>`,
+			color: amber,
+		},
+		{
+			name:  "Figure",
+			html:  `<figure style="background:#FEF3C7;border-radius:10pt;padding:8pt 12pt;margin:0">cap</figure>`,
+			color: amber,
+		},
+		{
+			name:  "TableWrapper",
+			html:  `<table style="background:#FEF3C7;border-radius:10pt"><tr><td>cell</td></tr></table>`,
+			color: amber,
+		},
+		{
+			// #333's plain block Div case carried the same latent run-highlight
+			// leak (text inside the div inherits the div background onto its run).
+			name:  "PlainDivWithText",
+			html:  `<div style="background:#4F46E5;color:#fff;border-radius:8pt;padding:5pt 12pt">BOX</div>`,
+			color: indigo,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := renderHTMLStream(t, tc.html)
+			if !hasRoundedFillInColor(cs, tc.color) {
+				t.Errorf("expected a rounded fill (curve ops) in color %s; stream:\n%s", tc.color, cs)
+			}
+			if sq := squareFillsInColor(cs, tc.color); len(sq) > 0 {
+				t.Errorf("found square `re` fill(s) in box color %s (square overpaint over rounded fill): %v\nstream:\n%s", tc.color, sq, cs)
+			}
+		})
+	}
+}
+
+// grayFillStripeInColor reports whether the stream fills a ` re` rectangle
+// stripe while the current non-stroking color is gray (0.6 0.6 0.6) — the
+// signature of the inner accent fill. It also returns the matching ` re` line.
+func grayFillStripeInColor(cs string) (bool, string) {
+	curColor := ""
+	for _, l := range strings.Split(cs, "\n") {
+		t := strings.TrimSpace(l)
+		if strings.HasSuffix(t, " rg") {
+			curColor = t
+		}
+		if strings.HasPrefix(curColor, "0.6 0.6 0.6") && squareFillRe.MatchString(l) {
+			return true, t
+		}
+	}
+	return false, ""
+}
+
+// TestBlockquoteRoundedAccentInnerFill verifies the issue #329/#340 fix:
+// a blockquote with an explicit border-radius KEEPS its default gray left accent,
+// but the accent now renders as an INNER FILLED stripe (a ` re` rectangle filled
+// in gray) clipped to the rounded box outline — flush with the left edge and
+// rounded at the top-left/bottom-left corners — instead of a centered stroke
+// along the outline that read as a detached outer bracket. There must be NO
+// stroked gray accent (0.6 0.6 0.6 RG / S) for the rounded case. A normal
+// blockquote (no radius) keeps its straight STROKED accent unchanged.
+func TestBlockquoteRoundedAccentInnerFill(t *testing.T) {
+	rounded := renderHTMLStream(t,
+		`<blockquote style="background:#FEF3C7;border-radius:10pt;padding:8pt 12pt;margin:0">quoted</blockquote>`)
+
+	// The rounded accent is an inner filled stripe: a gray ` re` rectangle fill.
+	ok, stripe := grayFillStripeInColor(rounded)
+	if !ok {
+		t.Fatalf("rounded blockquote lost its gray inner accent fill (no gray `re` stripe); stream:\n%s", rounded)
+	}
+	// The stripe must be a thin left bar at the box's left edge (x=72, w=3),
+	// not a full-width fill.
+	if !strings.HasPrefix(stripe, "72 ") || !strings.Contains(stripe, " 3 ") {
+		t.Errorf("rounded accent stripe is not a 3pt-wide left bar at x=72: %q\nstream:\n%s", stripe, rounded)
+	}
+	// It must NOT stroke the accent along the outline for the rounded case.
+	if strings.Contains(rounded, "0.6 0.6 0.6 RG") {
+		t.Errorf("rounded blockquote must NOT stroke the gray accent (0.6 0.6 0.6 RG); stream:\n%s", rounded)
+	}
+	// The accent must be clipped to the rounded shape: a clip op (W n) precedes
+	// the gray fill, so the corners round.
+	if !strings.Contains(rounded, "W\nn") && !strings.Contains(rounded, "W n") {
+		t.Errorf("rounded accent fill is not clipped to the rounded shape (no `W n`); stream:\n%s", rounded)
+	}
+
+	plain := renderHTMLStream(t, `<blockquote>quoted</blockquote>`)
+	// The plain accent (no radius) is a straight STROKED bar.
+	if !strings.Contains(plain, "0.6 0.6 0.6 RG") {
+		t.Fatalf("plain blockquote lost its straight stroked gray accent (0.6 0.6 0.6 RG); stream:\n%s", plain)
+	}
+	// And the plain case must NOT use a gray fill stripe.
+	if ok, _ := grayFillStripeInColor(plain); ok {
+		t.Errorf("plain blockquote unexpectedly drew a gray FILL stripe instead of a stroke; stream:\n%s", plain)
+	}
+}
+
+// TestBorderRadiusPreservesUnrelatedInlineHighlight ensures the run-background
+// clearing only removes the box-colored highlight, not an inline <span>
+// highlight of a different color inside the same rounded container.
+func TestBorderRadiusPreservesUnrelatedInlineHighlight(t *testing.T) {
+	cs := renderHTMLStream(t,
+		`<div style="background:#4F46E5;border-radius:8pt;padding:10pt">hi <span style="background:#FFFF00">YEL</span> bye</div>`)
+	if !strings.Contains(cs, "1 1 0 rg") {
+		t.Errorf("yellow inline highlight (1 1 0 rg) was incorrectly cleared; stream:\n%s", cs)
+	}
+}

--- a/html/border_radius_containers_test.go
+++ b/html/border_radius_containers_test.go
@@ -1,0 +1,424 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// Regression tests for issue #329 (containers batch): a container that should
+// draw a rounded (border-radius) background failed to when it contained text —
+// either the radius was dropped entirely (inline element blockified as a
+// flex/grid item, or display:block; hand-built blockquote/figure/table wrapper
+// Divs) or a child Paragraph repainted a square background over the rounded
+// fill. These tests assert structurally that the rounded fill is present and
+// not over-painted.
+
+// findFirstGrid returns the first *layout.Grid found by a shallow walk of elems.
+func findFirstGrid(elems []layout.Element) *layout.Grid {
+	for _, e := range elems {
+		if g, ok := e.(*layout.Grid); ok {
+			return g
+		}
+	}
+	return nil
+}
+
+// nonZeroRadius reports whether a Div carries any border-radius, absolute or
+// percentage, on any corner.
+func nonZeroRadius(d *layout.Div) bool {
+	r := d.BorderRadii()
+	if r[0] != 0 || r[1] != 0 || r[2] != 0 || r[3] != 0 {
+		return true
+	}
+	p := d.BorderRadiusPercent()
+	return p[0] != 0 || p[1] != 0 || p[2] != 0 || p[3] != 0
+}
+
+// --- Mechanism A: inline element with a box, blockified as flex/grid item ---
+
+// flexSpanRepro builds a display:flex parent with a single rounded <span>
+// flex item carrying the supplied flex shorthand.
+func flexSpanRepro(flexShorthand string) string {
+	return `<div style="display:flex"><span style="` + flexShorthand +
+		`background:#4F46E5;color:#fff;border-radius:10pt;padding:6pt 14pt">CHIP</span></div>`
+}
+
+// assertRoundedFlexItem asserts the flex container's single item is a Div with a
+// non-zero border-radius and a background, and that any inner Paragraph has its
+// background cleared (no square overdraw).
+func assertRoundedFlexItem(t *testing.T, src string) {
+	t.Helper()
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flex := findFirstFlex(elems)
+	if flex == nil {
+		t.Fatal("expected a layout.Flex for the display:flex parent")
+	}
+	items := flex.Items()
+	if len(items) != 1 {
+		t.Fatalf("expected exactly one flex item, got %d", len(items))
+	}
+	div, ok := items[0].Element().(*layout.Div)
+	if !ok {
+		t.Fatalf("expected the flex item to be a *layout.Div owning the rounded fill, got %T", items[0].Element())
+	}
+	if div.Background() == nil {
+		t.Error("flex item Div should carry the background")
+	}
+	if !nonZeroRadius(div) {
+		t.Errorf("flex item Div should carry border-radius, got %v / %v", div.BorderRadii(), div.BorderRadiusPercent())
+	}
+	if p := firstChildParagraph(div); p != nil && p.Background() != nil {
+		t.Errorf("flex item child Paragraph background should be cleared (Div owns the fill), got %+v", *p.Background())
+	}
+}
+
+// TestBorderRadiusFlexSpanFlexNone covers the euskadi31 repro: a rounded
+// <span> with flex:0 0 auto inside a display:flex parent must render as a
+// rounded Div, not a square Paragraph.
+func TestBorderRadiusFlexSpanFlexNone(t *testing.T) {
+	assertRoundedFlexItem(t, flexSpanRepro("flex:0 0 auto;"))
+}
+
+// chipDivPadding converts src, expecting either a flex item, a grid child, or a
+// top-level Div, and returns the chip's wrapping Div padding. It fails if no
+// such Div is found.
+func chipDivPadding(t *testing.T, src string) layout.Padding {
+	t.Helper()
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flex := findFirstFlex(elems); flex != nil && len(flex.Items()) == 1 {
+		if div, ok := flex.Items()[0].Element().(*layout.Div); ok {
+			return div.Padding()
+		}
+	}
+	if grid := findFirstGrid(elems); grid != nil && len(grid.Children()) == 1 {
+		if div, ok := grid.Children()[0].(*layout.Div); ok {
+			return div.Padding()
+		}
+	}
+	// A top-level inline-block span flows inline and is buffered into a
+	// Paragraph as an atomic inline box (TextRun.InlineElement).
+	for _, e := range elems {
+		if p, ok := e.(*layout.Paragraph); ok {
+			for _, r := range p.Runs() {
+				if div, ok := r.InlineElement.(*layout.Div); ok {
+					return div.Padding()
+				}
+			}
+		}
+	}
+	if div := findFirstDiv(elems); div != nil {
+		return div.Padding()
+	}
+	t.Fatalf("no chip Div found for src %q", src)
+	return layout.Padding{}
+}
+
+// TestBorderRadiusFlexSpanChipPaddingMatchesInlineBlock is the issue #340 BUG 1
+// fix: a blockified <span> chip (flex item or grid item) carrying a rounded box
+// must render its full box model — notably equal left/right padding — IDENTICAL
+// to the display:inline-block chip, instead of dropping the padding. Earlier the
+// flex/grid path applied only background + radius, leaving the text flush against
+// the left edge (0pt left padding) while inline-block applied 12pt both sides.
+func TestBorderRadiusFlexSpanChipPaddingMatchesInlineBlock(t *testing.T) {
+	const box = `background:#4F46E5;color:#fff;border-radius:8pt;padding:5pt 12pt`
+
+	inlineBlock := chipDivPadding(t,
+		`<span style="display:inline-block;`+box+`">CHIP</span>`)
+	// Sanity: the reference inline-block chip has the expected 12/5 padding.
+	if inlineBlock.Left != 12 || inlineBlock.Right != 12 || inlineBlock.Top != 5 || inlineBlock.Bottom != 5 {
+		t.Fatalf("inline-block reference padding unexpected: %+v", inlineBlock)
+	}
+
+	flex := chipDivPadding(t,
+		`<div style="display:flex"><span style="flex:0 0 auto;`+box+`">CHIP</span></div>`)
+	if flex != inlineBlock {
+		t.Errorf("flex chip padding %+v != inline-block %+v", flex, inlineBlock)
+	}
+	if flex.Left != flex.Right {
+		t.Errorf("flex chip left/right padding must be equal, got L=%v R=%v", flex.Left, flex.Right)
+	}
+
+	grid := chipDivPadding(t,
+		`<div style="display:grid;grid-template-columns:auto"><span style="`+box+`">CHIP</span></div>`)
+	if grid != inlineBlock {
+		t.Errorf("grid chip padding %+v != inline-block %+v", grid, inlineBlock)
+	}
+	if grid.Left != grid.Right {
+		t.Errorf("grid chip left/right padding must be equal, got L=%v R=%v", grid.Left, grid.Right)
+	}
+}
+
+func TestBorderRadiusFlexSpanPercentRadius(t *testing.T) {
+	// border-radius:50% (the #332 elliptical/percentage path) must reach the
+	// blockified flex-item Div as a percentage fraction, not be dropped.
+	src := `<div style="display:flex"><span style="flex:0 0 auto;` +
+		`background:#4F46E5;color:#fff;border-radius:50%;padding:6pt 14pt">CHIP</span></div>`
+	assertRoundedFlexItem(t, src)
+
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flex := findFirstFlex(elems)
+	if flex == nil || len(flex.Items()) != 1 {
+		t.Fatal("expected one flex item")
+	}
+	div, ok := flex.Items()[0].Element().(*layout.Div)
+	if !ok {
+		t.Fatalf("expected flex item *layout.Div, got %T", flex.Items()[0].Element())
+	}
+	if pct := div.BorderRadiusPercent(); pct[0] == 0 {
+		t.Errorf("border-radius:50%% should reach the flex item Div as a percentage, got %v", pct)
+	}
+}
+
+// TestBorderRadiusFlexSpanFlexGrow covers a rounded <span> with flex:1.
+func TestBorderRadiusFlexSpanFlexGrow(t *testing.T) {
+	assertRoundedFlexItem(t, flexSpanRepro("flex:1;"))
+}
+
+// TestBorderRadiusFlexSpanDefault covers a rounded <span> with no flex
+// shorthand (default flex behavior) inside a display:flex parent.
+func TestBorderRadiusFlexSpanDefault(t *testing.T) {
+	assertRoundedFlexItem(t, flexSpanRepro(""))
+}
+
+// TestBorderRadiusGridSpan covers a rounded <span> grid item inside a
+// display:grid parent: it must render as a rounded Div, not a square Paragraph.
+func TestBorderRadiusGridSpan(t *testing.T) {
+	src := `<div style="display:grid;grid-template-columns:1fr">` +
+		`<span style="background:#4F46E5;color:#fff;border-radius:10pt;padding:6pt 14pt">CHIP</span>` +
+		`</div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	grid := findFirstGrid(elems)
+	if grid == nil {
+		t.Fatal("expected a layout.Grid for the display:grid parent")
+	}
+	children := grid.Children()
+	if len(children) != 1 {
+		t.Fatalf("expected exactly one grid child, got %d", len(children))
+	}
+	div, ok := children[0].(*layout.Div)
+	if !ok {
+		t.Fatalf("expected the grid child to be a *layout.Div owning the rounded fill, got %T", children[0])
+	}
+	if div.Background() == nil {
+		t.Error("grid child Div should carry the background")
+	}
+	if !nonZeroRadius(div) {
+		t.Errorf("grid child Div should carry border-radius, got %v / %v", div.BorderRadii(), div.BorderRadiusPercent())
+	}
+	if p := firstChildParagraph(div); p != nil && p.Background() != nil {
+		t.Errorf("grid child Paragraph background should be cleared, got %+v", *p.Background())
+	}
+}
+
+// TestBorderRadiusDisplayBlockSpan covers a default-inline <span> set to
+// display:block carrying background + border-radius: it must render as a
+// rounded Div with the child Paragraph background cleared.
+func TestBorderRadiusDisplayBlockSpan(t *testing.T) {
+	src := `<span style="display:block;background:#4F46E5;color:#fff;border-radius:10pt;padding:6pt 14pt">CHIP</span>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	div := findFirstDiv(elems)
+	if div == nil {
+		t.Fatal("expected a wrapping Div for the display:block span")
+	}
+	if div.Background() == nil {
+		t.Error("Div should carry the background")
+	}
+	if !nonZeroRadius(div) {
+		t.Errorf("Div should carry border-radius, got %v / %v", div.BorderRadii(), div.BorderRadiusPercent())
+	}
+	if p := firstChildParagraph(div); p != nil && p.Background() != nil {
+		t.Errorf("child Paragraph background should be cleared, got %+v", *p.Background())
+	}
+}
+
+// TestBorderRadiusFlexSpanNoBoxStaysInline is the REGRESSION GUARD: a <span>
+// WITHOUT a box (no border-radius, no background) inside a flex container must
+// stay a bare inline Paragraph — it must NOT be wrapped in a Div.
+func TestBorderRadiusFlexSpanNoBoxStaysInline(t *testing.T) {
+	src := `<div style="display:flex"><span style="color:#333">PLAIN</span></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flex := findFirstFlex(elems)
+	if flex == nil {
+		t.Fatal("expected a layout.Flex")
+	}
+	items := flex.Items()
+	if len(items) != 1 {
+		t.Fatalf("expected exactly one flex item, got %d", len(items))
+	}
+	if _, ok := items[0].Element().(*layout.Paragraph); !ok {
+		t.Fatalf("a no-box span must stay a bare inline Paragraph, got %T", items[0].Element())
+	}
+}
+
+// TestBorderRadiusFlexSpanBackgroundNoRadiusStaysInline is a second regression
+// guard: a <span> with a background but NO border-radius must not be wrapped,
+// since there is no rounded fill to own. It stays a bare Paragraph (which still
+// paints its own square background, matching prior behavior).
+func TestBorderRadiusFlexSpanBackgroundNoRadiusStaysInline(t *testing.T) {
+	src := `<div style="display:flex"><span style="background:#4F46E5;color:#fff">CHIP</span></div>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flex := findFirstFlex(elems)
+	if flex == nil {
+		t.Fatal("expected a layout.Flex")
+	}
+	items := flex.Items()
+	if len(items) != 1 {
+		t.Fatalf("expected exactly one flex item, got %d", len(items))
+	}
+	if _, ok := items[0].Element().(*layout.Paragraph); !ok {
+		t.Fatalf("a span with background but no radius must stay a bare Paragraph, got %T", items[0].Element())
+	}
+}
+
+// --- Mechanism B: hand-built wrapper Divs ---
+
+// TestBorderRadiusBlockquote covers <blockquote> with background + border-radius
+// + text: the wrapper Div must carry the radius AND its child Paragraph
+// background must be cleared (no square overpaint).
+func TestBorderRadiusBlockquote(t *testing.T) {
+	src := `<blockquote style="background:#4F46E5;color:#fff;border-radius:10pt">quoted</blockquote>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	div := findFirstDiv(elems)
+	if div == nil {
+		t.Fatal("expected a wrapping Div for the blockquote")
+	}
+	if div.Background() == nil {
+		t.Error("blockquote Div should carry the background")
+	}
+	if !nonZeroRadius(div) {
+		t.Errorf("blockquote Div should carry border-radius, got %v / %v", div.BorderRadii(), div.BorderRadiusPercent())
+	}
+	p := firstChildParagraph(div)
+	if p == nil {
+		t.Fatal("expected a child Paragraph for the blockquote text")
+	}
+	if p.Background() != nil {
+		t.Errorf("blockquote child Paragraph background should be cleared (Div owns the fill), got %+v", *p.Background())
+	}
+}
+
+// TestBlockquoteAccentRoundedInnerFill renders a rounded blockquote and a plain
+// blockquote through the full pipeline and asserts the default gray left accent
+// renders as an INNER filled stripe clipped to the rounded shape (filled rect
+// after a clip, no stroked accent) on the rounded one, while the plain one keeps
+// its straight stroked accent (issue #329).
+func TestBlockquoteAccentRoundedInnerFill(t *testing.T) {
+	// Rounded blockquote: accent must be a clipped filled stripe, no stroke.
+	roundedSrc := `<blockquote style="background:#FEF3C7;border-radius:10pt;padding:8pt 12pt">quoted text in a rounded block</blockquote>`
+	roundedElems, err := Convert(roundedSrc, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	margins := layout.Margins{Top: 72, Right: 72, Bottom: 72, Left: 72}
+	r := layout.NewRenderer(612, 792, margins)
+	for _, e := range roundedElems {
+		r.Add(e)
+	}
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("expected at least 1 page (rounded)")
+	}
+	rounded := string(pages[0].Stream.Bytes())
+
+	// The gray accent fill (0.6 0.6 0.6 rg) must be present as a filled stripe,
+	// and there must be NO stroked gray accent (0.6 0.6 0.6 RG) for the rounded
+	// case — the accent is an inner clipped fill, not an outline stroke.
+	if !strings.Contains(rounded, "0.6 0.6 0.6 rg") {
+		t.Errorf("rounded blockquote: expected gray accent FILL (0.6 0.6 0.6 rg); stream:\n%s", rounded)
+	}
+	if strings.Contains(rounded, "0.6 0.6 0.6 RG") {
+		t.Errorf("rounded blockquote: must NOT stroke the gray accent (0.6 0.6 0.6 RG); stream:\n%s", rounded)
+	}
+
+	// Plain blockquote (no radius): accent must still be a straight stroked bar.
+	plainSrc := `<blockquote>plain quote with the default straight accent</blockquote>`
+	plainElems, err := Convert(plainSrc, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2 := layout.NewRenderer(612, 792, margins)
+	for _, e := range plainElems {
+		r2.Add(e)
+	}
+	pages2 := r2.Render()
+	if len(pages2) == 0 {
+		t.Fatal("expected at least 1 page (plain)")
+	}
+	plain := string(pages2[0].Stream.Bytes())
+	if !strings.Contains(plain, "0.6 0.6 0.6 RG") {
+		t.Errorf("plain blockquote: expected straight stroked gray accent (0.6 0.6 0.6 RG); stream:\n%s", plain)
+	}
+}
+
+// TestBorderRadiusFigure covers <figure> with background + border-radius: the
+// wrapper Div must carry the radius.
+func TestBorderRadiusFigure(t *testing.T) {
+	src := `<figure style="background:#4F46E5;border-radius:10pt"><figcaption>cap</figcaption></figure>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	div := findFirstDiv(elems)
+	if div == nil {
+		t.Fatal("expected a wrapping Div for the figure")
+	}
+	if div.Background() == nil {
+		t.Error("figure Div should carry the background")
+	}
+	if !nonZeroRadius(div) {
+		t.Errorf("figure Div should carry border-radius, got %v / %v", div.BorderRadii(), div.BorderRadiusPercent())
+	}
+}
+
+// TestBorderRadiusTableWrapper covers the whole-table wrapper: a <table> with
+// background + border-radius must produce a wrapper Div that carries the radius.
+func TestBorderRadiusTableWrapper(t *testing.T) {
+	src := `<table style="background:#4F46E5;border-radius:10pt"><tr><td>x</td></tr></table>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	div := findFirstDiv(elems)
+	if div == nil {
+		t.Fatal("expected a wrapper Div for the table")
+	}
+	if div.Background() == nil {
+		t.Error("table wrapper Div should carry the background")
+	}
+	if !nonZeroRadius(div) {
+		t.Errorf("table wrapper Div should carry border-radius, got %v / %v", div.BorderRadii(), div.BorderRadiusPercent())
+	}
+	// Sanity: the wrapper holds the Table.
+	if findFirstTable(elems) == nil {
+		t.Error("expected the wrapper to contain a layout.Table")
+	}
+}

--- a/html/converter.go
+++ b/html/converter.go
@@ -1765,6 +1765,18 @@ func (c *converter) convertElementInner(n *html.Node, style computedStyle) []lay
 		return c.convertFigure(n, style)
 	case atom.Span, atom.Em, atom.Strong, atom.B, atom.I, atom.U, atom.S,
 		atom.Del, atom.Mark, atom.Small, atom.Sub, atom.Sup, atom.Code:
+		// A default-inline element set to display:block that carries a
+		// block-level box (a border-radius with a background or border) must
+		// own a rounded fill, like display:inline-block already does. The
+		// inline path (convertInlineContainer) only produces a bare Paragraph
+		// that drops the radius and paints a square background, so route these
+		// through convertBlock, which builds a Div via applyDivStyles and
+		// clears the redundant child-paragraph background (issue #329). Spans
+		// without such a box stay on the inline path (no regression).
+		if style.Display == "block" && style.hasBorderRadius() &&
+			(style.BackgroundColor != nil || style.hasBorder()) {
+			return c.convertBlock(n, style)
+		}
 		return c.convertInlineContainer(n, style)
 	case atom.Table:
 		return c.convertTable(n, style)

--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -208,17 +208,119 @@ func (c *converter) convertBlock(n *html.Node, style computedStyle) []layout.Ele
 // (issue #329). Since the container already paints the fill, the child's copy
 // is redundant; clearing it removes the overdraw.
 //
-// Only the paragraph-level background is cleared. Per-run/word BackgroundColor
-// (inline <span> highlights) lives on the TextRuns, not on p.background, and is
-// left untouched.
+// Both the paragraph-level background and any matching per-run/word
+// BackgroundColor (inline <span> highlights) are cleared. The run-level case
+// matters for a blockified inline element: a bare <span> with a background
+// produces a Paragraph whose single TextRun also carries that background as a
+// highlight, which the renderer paints as a square rectangle behind the text —
+// a redundant square overdraw on top of the wrapping container's rounded fill
+// (issue #329). Only run backgrounds equal to bg are cleared, so unrelated
+// inline highlights of a different color are preserved.
 func clearMatchingParagraphBackgrounds(elems []layout.Element, bg layout.Color) {
 	for _, e := range elems {
 		if p, ok := e.(*layout.Paragraph); ok {
 			if pbg := p.Background(); pbg != nil && *pbg == bg {
 				p.ClearBackground()
 			}
+			p.ClearMatchingRunBackgrounds(bg)
 		}
 	}
+}
+
+// hasBorderRadius reports whether the computed style declares any border-radius,
+// absolute or percentage, on any corner.
+func (s computedStyle) hasBorderRadius() bool {
+	return s.BorderRadius > 0 ||
+		s.BorderRadiusTL > 0 || s.BorderRadiusTR > 0 ||
+		s.BorderRadiusBR > 0 || s.BorderRadiusBL > 0 ||
+		s.BorderRadiusTLPct > 0 || s.BorderRadiusTRPct > 0 ||
+		s.BorderRadiusBRPct > 0 || s.BorderRadiusBLPct > 0
+}
+
+// applyBorderRadiusToDiv transfers the computed style's border-radius (absolute
+// per-corner / uniform, plus percentage corners) onto a Div. Extracted from
+// applyDivStyles so hand-built wrapper Divs (blockquote, figure, table, and the
+// flex/grid blockified-item wrapper) can paint rounded fills too (issue #329).
+func applyBorderRadiusToDiv(div *layout.Div, style computedStyle) {
+	if style.BorderRadiusTL > 0 || style.BorderRadiusTR > 0 || style.BorderRadiusBR > 0 || style.BorderRadiusBL > 0 {
+		div.SetBorderRadiusPerCorner(style.BorderRadiusTL, style.BorderRadiusTR, style.BorderRadiusBR, style.BorderRadiusBL)
+	} else if style.BorderRadius > 0 {
+		div.SetBorderRadius(style.BorderRadius)
+	}
+	// Percentage radii resolve against the box width/height at draw time
+	// (elliptical corners); pass them through even when no absolute radius
+	// is set so a percentage-only border-radius still rounds.
+	if style.BorderRadiusTLPct > 0 || style.BorderRadiusTRPct > 0 || style.BorderRadiusBRPct > 0 || style.BorderRadiusBLPct > 0 {
+		div.SetBorderRadiusPercent([4]float64{
+			style.BorderRadiusTLPct, style.BorderRadiusTRPct,
+			style.BorderRadiusBRPct, style.BorderRadiusBLPct,
+		})
+	}
+}
+
+// isDefaultInlineAtom reports whether the element's tag is one that defaults to
+// inline display (and would otherwise route through convertInlineContainer).
+func isDefaultInlineAtom(a atom.Atom) bool {
+	switch a {
+	case atom.Span, atom.Em, atom.Strong, atom.B, atom.I, atom.U, atom.S,
+		atom.Del, atom.Mark, atom.Small, atom.Sub, atom.Sup, atom.Code:
+		return true
+	}
+	return false
+}
+
+// blockifyInlineBoxChild handles the issue #329/#340 case where an inline
+// element (e.g. a bare <span>) that carries a rounded box (a border-radius with
+// a background and/or border) is a flex or grid item. CSS blockifies flex/grid
+// items, so such a span must render its full box model — padding, border,
+// background, rounded fill — exactly like display:inline-block already does.
+//
+// The plain inline path (convertInlineContainer) yields a single bare Paragraph
+// that only paints a square run/paragraph background and DROPS the element's
+// padding, border, and border-radius. To render identically to inline-block,
+// this routes the child through convertBlock (the same full box-model path that
+// display:inline-block uses) and marks the resulting Div shrink-to-fit so it
+// sizes to its content and flows like an atomic inline box — leaving the
+// flex/grid basis/grow/shrink sizing to operate on that content width.
+//
+// Returns (elements, true) when it blockified the child; (nil, false) when the
+// child is not a bare inline element carrying a box, so callers fall back to
+// their normal conversion. Spans WITHOUT a box stay bare inline Paragraphs (no
+// regression).
+func (c *converter) blockifyInlineBoxChild(child *html.Node, childStyle computedStyle) ([]layout.Element, bool) {
+	if child.Type != html.ElementNode || !isDefaultInlineAtom(child.DataAtom) {
+		return nil, false
+	}
+	// Only intercept children that would route to the bare inline path. An
+	// explicit display override (block/inline-block/flex/grid/none) is already
+	// handled correctly by convertNode, so leave those alone.
+	switch childStyle.Display {
+	case "block", "inline-block", "flex", "grid", "none":
+		return nil, false
+	}
+	// Only blockify when the element carries a border-radius together with a
+	// fill or border — the box the bare inline path genuinely cannot render
+	// (it drops the radius and paints a square highlight, and also drops the
+	// padding/border). This mirrors the display:block routing in convertNode.
+	// A bare background WITHOUT a radius stays inline (a Paragraph still paints
+	// its own square highlight, matching prior behavior — no regression), so we
+	// do not intercept it.
+	hasBox := childStyle.hasBorderRadius() &&
+		(childStyle.BackgroundColor != nil || childStyle.hasBorder())
+	if !hasBox {
+		return nil, false
+	}
+	elems := c.convertBlock(child, childStyle)
+	if len(elems) == 0 {
+		return nil, false
+	}
+	// Shrink-to-fit so the blockified box sizes to its content (CSS
+	// fit-content) and behaves as an atomic inline box, matching the
+	// display:inline-block path (convertInlineBlockElement).
+	if div, ok := elems[0].(*layout.Div); ok {
+		div.SetShrinkToFit(true)
+	}
+	return elems, true
 }
 
 // clearCellParagraphBackground clears the redundant block-level background on a
@@ -338,20 +440,7 @@ func applyDivStyles(div *layout.Div, style computedStyle, containerWidth float64
 	if style.AspectRatio > 0 {
 		div.SetAspectRatio(style.AspectRatio)
 	}
-	if style.BorderRadiusTL > 0 || style.BorderRadiusTR > 0 || style.BorderRadiusBR > 0 || style.BorderRadiusBL > 0 {
-		div.SetBorderRadiusPerCorner(style.BorderRadiusTL, style.BorderRadiusTR, style.BorderRadiusBR, style.BorderRadiusBL)
-	} else if style.BorderRadius > 0 {
-		div.SetBorderRadius(style.BorderRadius)
-	}
-	// Percentage radii resolve against the box width/height at draw time
-	// (elliptical corners); pass them through even when no absolute radius
-	// is set so a percentage-only border-radius still rounds.
-	if style.BorderRadiusTLPct > 0 || style.BorderRadiusTRPct > 0 || style.BorderRadiusBRPct > 0 || style.BorderRadiusBLPct > 0 {
-		div.SetBorderRadiusPercent([4]float64{
-			style.BorderRadiusTLPct, style.BorderRadiusTRPct,
-			style.BorderRadiusBRPct, style.BorderRadiusBLPct,
-		})
-	}
+	applyBorderRadiusToDiv(div, style)
 	if style.Clear != "" && style.Clear != "none" {
 		div.SetClear(style.Clear)
 	}
@@ -626,7 +715,12 @@ func (c *converter) convertBlockquote(n *html.Node, style computedStyle) []layou
 		div.Add(child)
 	}
 
-	// Left border: 3pt solid gray.
+	// Default accent: a 3pt solid gray left border. With a border-radius the
+	// accent renders as an INNER filled stripe clipped to the rounded box, flush
+	// with the left edge and following the rounded top-left/bottom-left corners
+	// (a solid left portion of the card, not a detached outer stroke) — matching
+	// a browser's border-left + border-radius (issue #329). Without a radius it
+	// stays a straight 3pt left bar. An explicit CSS border overrides this below.
 	gray := layout.RGB(0.6, 0.6, 0.6)
 	div.SetBorders(layout.CellBorders{
 		Left: layout.SolidBorder(3, gray),
@@ -657,6 +751,14 @@ func (c *converter) convertBlockquote(n *html.Node, style computedStyle) []layou
 			Bottom: style.PaddingBottomAt(c.containerWidth),
 			Left:   style.PaddingLeftAt(c.containerWidth),
 		})
+	}
+	// Apply any CSS border-radius so a rounded blockquote background is honored.
+	applyBorderRadiusToDiv(div, style)
+	// The Div now owns and draws the box background (honoring border-radius);
+	// clear the redundant block-level background on direct child paragraphs to
+	// avoid a square-cornered overdraw on top of the rounded fill (issue #329).
+	if style.BackgroundColor != nil {
+		clearMatchingParagraphBackgrounds(div.Children(), *style.BackgroundColor)
 	}
 
 	return []layout.Element{div}
@@ -741,6 +843,10 @@ func (c *converter) convertFigure(n *html.Node, style computedStyle) []layout.El
 	if style.BackgroundColor != nil {
 		div.SetBackground(*style.BackgroundColor)
 	}
+	// Apply any CSS border-radius so a rounded figure background is honored
+	// (issue #329). The figure's children are not matching-bg paragraphs, so
+	// no overpaint clearing is needed here.
+	applyBorderRadiusToDiv(div, style)
 
 	for child := n.FirstChild; child != nil; child = child.NextSibling {
 		if child.Type != html.ElementNode {

--- a/html/converter_flex.go
+++ b/html/converter_flex.go
@@ -134,7 +134,27 @@ func (c *converter) convertFlex(n *html.Node, style computedStyle) []layout.Elem
 			}
 		}
 
-		childElems := c.convertNode(child, style)
+		childStyle := style // default
+		if child.Type == html.ElementNode {
+			childStyle = c.computeElementStyle(child, style)
+		} else {
+			// Text-node children don't carry their own CSS, but they
+			// must not inherit non-inherited properties from the flex
+			// container (notably Order, which would otherwise leak and
+			// reorder text-node siblings alongside element siblings).
+			childStyle.Order = 0
+		}
+
+		// A flex item is blockified (CSS Flexbox §4). When an inline element
+		// (e.g. a bare <span>) carries a visible box (background, border,
+		// and/or border-radius), the bare inline path drops its padding,
+		// border, and radius. Route it through convertBlock so it renders its
+		// full box model identically to display:inline-block (issue #329).
+		// No-op for spans without a box, which stay bare inline Paragraphs.
+		childElems, blockified := c.blockifyInlineBoxChild(child, childStyle)
+		if !blockified {
+			childElems = c.convertNode(child, style)
+		}
 		if len(childElems) == 0 {
 			continue
 		}
@@ -150,17 +170,6 @@ func (c *converter) convertFlex(n *html.Node, style computedStyle) []layout.Elem
 				wrapper.Add(ce)
 			}
 			elem = wrapper
-		}
-
-		childStyle := style // default
-		if child.Type == html.ElementNode {
-			childStyle = c.computeElementStyle(child, style)
-		} else {
-			// Text-node children don't carry their own CSS, but they
-			// must not inherit non-inherited properties from the flex
-			// container (notably Order, which would otherwise leak and
-			// reorder text-node siblings alongside element siblings).
-			childStyle.Order = 0
 		}
 
 		// CSS width on a flex child acts as flex-basis (when flex-basis is not set).

--- a/html/converter_table.go
+++ b/html/converter_table.go
@@ -103,7 +103,7 @@ func (c *converter) convertTable(n *html.Node, style computedStyle) []layout.Ele
 	mb := style.MarginBottomAt(parentContainerWidth)
 	hasTableMargin := mt > 0 || mb > 0
 	hasTableWidth := style.MaxWidth != nil
-	if hasTableMargin || style.BackgroundColor != nil || hasTableWidth {
+	if hasTableMargin || style.BackgroundColor != nil || hasTableWidth || style.hasBorderRadius() {
 		div := layout.NewDiv()
 		div.Add(tbl)
 		if mt > 0 {
@@ -118,6 +118,10 @@ func (c *converter) convertTable(n *html.Node, style computedStyle) []layout.Ele
 		if style.MaxWidth != nil {
 			div.SetMaxWidth(style.MaxWidth.toPoints(parentContainerWidth, style.FontSize))
 		}
+		// Apply the table's CSS border-radius to the wrapper Div so a rounded
+		// table background is honored (issue #329). The child is a Table, not a
+		// matching-bg Paragraph, so no overpaint clearing is needed.
+		applyBorderRadiusToDiv(div, style)
 		// Caption elements come before the table wrapper.
 		elems = append(elems, div)
 		return elems

--- a/html/grid.go
+++ b/html/grid.go
@@ -141,14 +141,23 @@ func (c *converter) convertGrid(n *html.Node, style computedStyle) []layout.Elem
 	// Add children and their placements.
 	childIdx := 0
 	for child := n.FirstChild; child != nil; child = child.NextSibling {
-		childElems := c.convertNode(child, style)
-		if len(childElems) == 0 {
-			continue
-		}
-
 		childStyle := style
 		if child.Type == html.ElementNode {
 			childStyle = c.computeElementStyle(child, style)
+		}
+
+		// A grid item is blockified (CSS Grid §6.4). When an inline element
+		// (e.g. a bare <span>) carries a visible box (background, border,
+		// and/or border-radius), the bare inline path drops its padding,
+		// border, and radius. Route it through convertBlock so it renders its
+		// full box model identically to display:inline-block (issue #329).
+		// No-op for spans without a box.
+		childElems, blockified := c.blockifyInlineBoxChild(child, childStyle)
+		if !blockified {
+			childElems = c.convertNode(child, style)
+		}
+		if len(childElems) == 0 {
+			continue
 		}
 
 		for _, elem := range childElems {

--- a/layout/div.go
+++ b/layout/div.go
@@ -171,6 +171,9 @@ func (d *Div) SetPaddingAll(p Padding) *Div {
 	return d
 }
 
+// Padding returns the Div's per-side padding.
+func (d *Div) Padding() Padding { return d.padding }
+
 // SetBorders sets the borders around the Div.
 func (d *Div) SetBorders(b CellBorders) *Div {
 	d.borders = b

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -5,6 +5,7 @@ package layout
 
 import (
 	"fmt"
+	"math"
 	"unicode/utf8"
 
 	"github.com/carlos7ags/folio/content"
@@ -1006,8 +1007,223 @@ func drawRoundedBorders(stream *content.Stream, borders CellBorders, x, y, w, h 
 		stream.RestoreState()
 		return
 	}
-	// Mixed borders: draw each side individually (straight segments).
-	drawCellBorders(stream, borders, x, y, w, h)
+	// Mixed (or partial) borders. Solid sides are drawn as INNER filled stripes
+	// clipped to the rounded box outline: each side fills the region between the
+	// rounded outer edge and an inset of its border width, so the border sits
+	// fully inside the box and follows the corner curves — flush, with no gap or
+	// detached outer bracket (a centered stroke would straddle the outline and
+	// read as a thin floating arc near the corners; issue #329). Non-solid sides
+	// (dashed/dotted) still stroke along the outline, where a clipped fill cannot
+	// reproduce the dash pattern.
+	if anySolidBorder(borders) {
+		drawRoundedBordersSolidFill(stream, borders, x, y, w, h, rx, ry)
+	}
+	if anyNonSolidBorder(borders) {
+		drawRoundedBordersPerSide(stream, borders, x, y, w, h, rx, ry, true)
+	}
+}
+
+// anySolidBorder reports whether any present side is a solid border.
+func anySolidBorder(b CellBorders) bool {
+	return (b.Top.Width > 0 && b.Top.Style == BorderSolid) ||
+		(b.Right.Width > 0 && b.Right.Style == BorderSolid) ||
+		(b.Bottom.Width > 0 && b.Bottom.Style == BorderSolid) ||
+		(b.Left.Width > 0 && b.Left.Style == BorderSolid)
+}
+
+// anyNonSolidBorder reports whether any present side is a non-solid border
+// (dashed/dotted/double) that still needs the per-side stroked outline.
+func anyNonSolidBorder(b CellBorders) bool {
+	return (b.Top.Width > 0 && b.Top.Style != BorderSolid) ||
+		(b.Right.Width > 0 && b.Right.Style != BorderSolid) ||
+		(b.Bottom.Width > 0 && b.Bottom.Style != BorderSolid) ||
+		(b.Left.Width > 0 && b.Left.Style != BorderSolid)
+}
+
+// drawRoundedBordersSolidFill draws each present SOLID border side as a filled
+// stripe clipped to the rounded box outline. The clip is the same
+// RoundedRectPerCornerXY geometry used for the background, so each stripe is
+// inset from (flush with) the rounded edge and inherits the corner curves:
+// the left side becomes a solid vertical bar [x, x+leftWidth] whose top-left and
+// bottom-left ends are rounded by the clip. Radii are elliptical, indexed
+// [TL, TR, BR, BL] in rx/ry; (x, y) is the bottom-left corner.
+func drawRoundedBordersSolidFill(stream *content.Stream, borders CellBorders, x, y, w, h float64, rx, ry [4]float64) {
+	stream.SaveState()
+	// Clip to the rounded box so every stripe is rounded at the box corners.
+	stream.RoundedRectPerCornerXY(x, y, w, h, rx, ry)
+	stream.ClipNonZero()
+	stream.EndPath()
+
+	if borders.Left.Width > 0 && borders.Left.Style == BorderSolid {
+		stream.SaveState()
+		setFillColor(stream, borders.Left.Color)
+		stream.Rectangle(x, y, borders.Left.Width, h)
+		stream.Fill()
+		stream.RestoreState()
+	}
+	if borders.Right.Width > 0 && borders.Right.Style == BorderSolid {
+		stream.SaveState()
+		setFillColor(stream, borders.Right.Color)
+		stream.Rectangle(x+w-borders.Right.Width, y, borders.Right.Width, h)
+		stream.Fill()
+		stream.RestoreState()
+	}
+	if borders.Top.Width > 0 && borders.Top.Style == BorderSolid {
+		stream.SaveState()
+		setFillColor(stream, borders.Top.Color)
+		stream.Rectangle(x, y+h-borders.Top.Width, w, borders.Top.Width)
+		stream.Fill()
+		stream.RestoreState()
+	}
+	if borders.Bottom.Width > 0 && borders.Bottom.Style == BorderSolid {
+		stream.SaveState()
+		setFillColor(stream, borders.Bottom.Color)
+		stream.Rectangle(x, y, w, borders.Bottom.Width)
+		stream.Fill()
+		stream.RestoreState()
+	}
+
+	stream.RestoreState()
+}
+
+// drawRoundedBordersPerSide strokes each present border side along the rounded
+// box outline, including the two corner arcs adjacent to that side. Radii are
+// elliptical, indexed [TL, TR, BR, BL] in rx/ry; (x, y) is the bottom-left.
+// Each side owns its two corner arcs (corners are stroked by both adjacent
+// sides, matching the all-equal fast path's single closed outline). A side with
+// zero width is skipped, so a left-only accent on a rounded box draws only the
+// left edge plus its TL/BL arcs and never protrudes past the curve.
+// When nonSolidOnly is true, only non-solid sides (dashed/dotted/double) are
+// stroked here; solid sides are drawn separately as clipped inner fills.
+func drawRoundedBordersPerSide(stream *content.Stream, borders CellBorders, x, y, w, h float64, rx, ry [4]float64, nonSolidOnly bool) {
+	if nonSolidOnly {
+		if borders.Top.Style == BorderSolid {
+			borders.Top = Border{}
+		}
+		if borders.Right.Style == BorderSolid {
+			borders.Right = Border{}
+		}
+		if borders.Bottom.Style == BorderSolid {
+			borders.Bottom = Border{}
+		}
+		if borders.Left.Style == BorderSolid {
+			borders.Left = Border{}
+		}
+	}
+	const (
+		tl = 0
+		tr = 1
+		br = 2
+		bl = 3
+	)
+	const k = 0.5522847498 // Bézier approximation for quarter ellipse arcs.
+
+	// Proportionally reduce radii so no edge is over-subscribed by its two
+	// adjacent corners (CSS Backgrounds and Borders L3 §5.5), matching
+	// RoundedRectPerCornerXY so the per-side arcs align with the box outline.
+	for i := range rx {
+		if rx[i] < 0 {
+			rx[i] = 0
+		}
+		if ry[i] < 0 {
+			ry[i] = 0
+		}
+	}
+	f := 1.0
+	if sum := rx[tl] + rx[tr]; sum > 0 {
+		f = math.Min(f, w/sum)
+	}
+	if sum := rx[bl] + rx[br]; sum > 0 {
+		f = math.Min(f, w/sum)
+	}
+	if sum := ry[tl] + ry[bl]; sum > 0 {
+		f = math.Min(f, h/sum)
+	}
+	if sum := ry[tr] + ry[br]; sum > 0 {
+		f = math.Min(f, h/sum)
+	}
+	if f < 1 {
+		for i := range rx {
+			rx[i] *= f
+			ry[i] *= f
+		}
+	}
+
+	// Bottom border: BL corner arc → bottom edge → BR corner arc.
+	if borders.Bottom.Width > 0 {
+		stream.SaveState()
+		setStrokeColor(stream, borders.Bottom.Color)
+		stream.SetLineWidth(borders.Bottom.Width)
+		if rx[bl] > 0 || ry[bl] > 0 {
+			stream.MoveTo(x, y+ry[bl])
+			stream.CurveTo(x, y+ry[bl]-ry[bl]*k, x+rx[bl]-rx[bl]*k, y, x+rx[bl], y)
+		} else {
+			stream.MoveTo(x, y)
+		}
+		stream.LineTo(x+w-rx[br], y)
+		if rx[br] > 0 || ry[br] > 0 {
+			stream.CurveTo(x+w-rx[br]+rx[br]*k, y, x+w, y+ry[br]-ry[br]*k, x+w, y+ry[br])
+		}
+		stream.Stroke()
+		stream.RestoreState()
+	}
+
+	// Right border: BR corner arc → right edge → TR corner arc.
+	if borders.Right.Width > 0 {
+		stream.SaveState()
+		setStrokeColor(stream, borders.Right.Color)
+		stream.SetLineWidth(borders.Right.Width)
+		if rx[br] > 0 || ry[br] > 0 {
+			stream.MoveTo(x+w-rx[br], y)
+			stream.CurveTo(x+w-rx[br]+rx[br]*k, y, x+w, y+ry[br]-ry[br]*k, x+w, y+ry[br])
+		} else {
+			stream.MoveTo(x+w, y)
+		}
+		stream.LineTo(x+w, y+h-ry[tr])
+		if rx[tr] > 0 || ry[tr] > 0 {
+			stream.CurveTo(x+w, y+h-ry[tr]+ry[tr]*k, x+w-rx[tr]+rx[tr]*k, y+h, x+w-rx[tr], y+h)
+		}
+		stream.Stroke()
+		stream.RestoreState()
+	}
+
+	// Top border: TR corner arc → top edge → TL corner arc.
+	if borders.Top.Width > 0 {
+		stream.SaveState()
+		setStrokeColor(stream, borders.Top.Color)
+		stream.SetLineWidth(borders.Top.Width)
+		if rx[tr] > 0 || ry[tr] > 0 {
+			stream.MoveTo(x+w, y+h-ry[tr])
+			stream.CurveTo(x+w, y+h-ry[tr]+ry[tr]*k, x+w-rx[tr]+rx[tr]*k, y+h, x+w-rx[tr], y+h)
+		} else {
+			stream.MoveTo(x+w, y+h)
+		}
+		stream.LineTo(x+rx[tl], y+h)
+		if rx[tl] > 0 || ry[tl] > 0 {
+			stream.CurveTo(x+rx[tl]-rx[tl]*k, y+h, x, y+h-ry[tl]+ry[tl]*k, x, y+h-ry[tl])
+		}
+		stream.Stroke()
+		stream.RestoreState()
+	}
+
+	// Left border: TL corner arc → left edge → BL corner arc.
+	if borders.Left.Width > 0 {
+		stream.SaveState()
+		setStrokeColor(stream, borders.Left.Color)
+		stream.SetLineWidth(borders.Left.Width)
+		if rx[tl] > 0 || ry[tl] > 0 {
+			stream.MoveTo(x+rx[tl], y+h)
+			stream.CurveTo(x+rx[tl]-rx[tl]*k, y+h, x, y+h-ry[tl]+ry[tl]*k, x, y+h-ry[tl])
+		} else {
+			stream.MoveTo(x, y+h)
+		}
+		stream.LineTo(x, y+ry[bl])
+		if rx[bl] > 0 || ry[bl] > 0 {
+			stream.CurveTo(x, y+ry[bl]-ry[bl]*k, x+rx[bl]-rx[bl]*k, y, x+rx[bl], y)
+		}
+		stream.Stroke()
+		stream.RestoreState()
+	}
 }
 
 // resolveBgPositionAxis resolves a single axis of background-position to

--- a/layout/draw_test.go
+++ b/layout/draw_test.go
@@ -417,3 +417,55 @@ func TestDrawSaveRestoreBalance(t *testing.T) {
 		t.Errorf("UNBALANCED save/restore: %d q vs %d Q — this will corrupt the graphics state", saves, restores)
 	}
 }
+
+// TestRoundedLeftBorderInnerFill verifies that a solid left-only border on a
+// rounded box is drawn as an INNER filled stripe clipped to the rounded shape
+// (a 're' rectangle filled after a 'W n' clip), not a stroke along the outline.
+// This matches the rounded-blockquote accent fix (issue #329): the accent must
+// sit flush inside the rounded edge, following the corner curves, with no
+// detached outer bracket.
+func TestRoundedLeftBorderInnerFill(t *testing.T) {
+	s := content.NewStream()
+	borders := CellBorders{Left: SolidBorder(3, RGB(0.6, 0.6, 0.6))}
+	rx := [4]float64{10, 10, 10, 10}
+	ry := [4]float64{10, 10, 10, 10}
+	drawRoundedBorders(s, borders, 72, 689.6, 468, 30.4, rx, ry)
+	b := s.Bytes()
+
+	// Must clip (W n), fill a rectangle (re ... f), and NOT stroke (no S).
+	if !containsOp(b, "W") || !containsOp(b, "n") {
+		t.Errorf("rounded solid left border must set a clip (W n); stream:\n%s", b)
+	}
+	if !containsOp(b, "re") {
+		t.Errorf("rounded solid left border must fill a rectangle stripe (re); stream:\n%s", b)
+	}
+	if !containsOp(b, "f") {
+		t.Errorf("rounded solid left border must fill (f) the stripe; stream:\n%s", b)
+	}
+	if containsOp(b, "S") {
+		t.Errorf("rounded solid left border must NOT stroke the outline (no S); stream:\n%s", b)
+	}
+	// Balanced save/restore.
+	if q, qq := countOps(b, "q"), countOps(b, "Q"); q != qq {
+		t.Errorf("unbalanced save/restore: %d q vs %d Q", q, qq)
+	}
+}
+
+// TestRoundedDashedLeftBorderStrokes verifies that a NON-solid (dashed) left
+// border on a rounded box still strokes along the outline (a clipped fill
+// cannot reproduce the dash pattern), so the fallback path is preserved.
+func TestRoundedDashedLeftBorderStrokes(t *testing.T) {
+	s := content.NewStream()
+	borders := CellBorders{Left: DashedBorder(3, RGB(0.6, 0.6, 0.6))}
+	rx := [4]float64{10, 10, 10, 10}
+	ry := [4]float64{10, 10, 10, 10}
+	drawRoundedBorders(s, borders, 72, 689.6, 468, 30.4, rx, ry)
+	b := s.Bytes()
+
+	if !containsOp(b, "S") {
+		t.Errorf("rounded dashed left border must stroke the outline (S); stream:\n%s", b)
+	}
+	if containsOp(b, "re") {
+		t.Errorf("rounded dashed left border must NOT use a filled rect stripe (re); stream:\n%s", b)
+	}
+}

--- a/layout/grid.go
+++ b/layout/grid.go
@@ -70,6 +70,9 @@ func (g *Grid) AddChild(e Element) *Grid {
 	return g
 }
 
+// Children returns the grid's child elements in insertion order.
+func (g *Grid) Children() []Element { return g.children }
+
 // SetTemplateColumns sets the column track definitions.
 func (g *Grid) SetTemplateColumns(tracks []GridTrack) *Grid {
 	g.templateCols = tracks

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -192,6 +192,39 @@ func (p *Paragraph) ClearBackground() *Paragraph {
 	return p
 }
 
+// ClearMatchingRunBackgrounds removes the per-run/word BackgroundColor highlight
+// from every TextRun whose background equals bg. It returns true if at least one
+// run background was cleared.
+//
+// This exists for the case where an inline element (e.g. a bare <span>) that
+// carries a block-level background is blockified into its own rounded box. The
+// span's CSS background becomes a TextRun.BackgroundColor highlight, which the
+// renderer paints as a plain (square-cornered) rectangle behind the text. When a
+// wrapping Div now owns and draws the rounded box fill, that run highlight is a
+// redundant square overdraw on top of the rounded corners (issue #329). Clearing
+// it leaves a single rounded fill.
+func (p *Paragraph) ClearMatchingRunBackgrounds(bg Color) bool {
+	cleared := false
+	for i := range p.runs {
+		if rc := p.runs[i].BackgroundColor; rc != nil && *rc == bg {
+			p.runs[i].BackgroundColor = nil
+			cleared = true
+		}
+	}
+	return cleared
+}
+
+// HasRunBackground reports whether any TextRun carries a per-run/word
+// BackgroundColor highlight equal to bg.
+func (p *Paragraph) HasRunBackground(bg Color) bool {
+	for i := range p.runs {
+		if rc := p.runs[i].BackgroundColor; rc != nil && *rc == bg {
+			return true
+		}
+	}
+	return false
+}
+
 // SetFirstLineIndent sets the indentation for the first line (in points).
 // This corresponds to the CSS text-indent property.
 func (p *Paragraph) SetFirstLineIndent(pts float64) *Paragraph {


### PR DESCRIPTION
Follow-up to #332/#333 for #329. An audit of euskadi31's second comment (a `flex: 0 0 auto` text chip rendering square) found the border-radius bug class extended to **seven** more container paths that #333 didn't reach.

## Two mechanisms

**A — inline element with a block-level background + radius became a bare `Paragraph`** (no rounded fill at all). Affected: a `<span>` carrying `background`+`border-radius` that is a flex item (`flex:0 0 auto`/`flex:1`/default), a grid item, or `display:block`. These routed through `convertInlineContainer`, which ignores box-model. Fix: such a child is wrapped in a Div that owns the rounded fill (mirroring how `display:inline-block` already works), and the now-redundant square paragraph background is cleared. Spans **without** a box stay inline (unchanged).

**B — hand-built wrapper Divs skipped `border-radius`.** `convertBlockquote` (also had the #333 square-overpaint), `convertFigure`, and the whole-`<table>` wrapper now apply the radius; blockquote also clears the redundant child-paragraph background. Radius application is factored into a shared `applyBorderRadiusToDiv` helper (behavior-identical refactor of `applyDivStyles`).

## Verified
euskadi31's exact `flex:0 0 auto` chip now renders rounded (matching the `display:inline-block` sibling). 11 new structural tests (fail-before/pass-after), incl. flex/grid/`display:block` spans, blockquote, figure, table wrapper, a percentage-radius (`50%`) flex case, and two regression guards (no-box and background-without-radius spans stay inline). Full suite + vet + gofmt green; existing #332/#333 flex/grid/cell tests unaffected.

## Out of scope
Styled `<li>` drops its **entire** box (background/border/radius) because `layout.List` has no per-item box — a larger change tracked in #339.

## Before / after — the reported cases (#329)

A single sheet of euskadi31's exact repros (the issue's `50%`, comment 1's text box, comment 2's `inline-block` vs `flex:0 0 auto` chips, plus a blockquote), rendered on the pre-fix baseline vs this branch:

| Before (no #329 fixes) | After (this branch) |
|---|---|
| <img width="380" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/340/before_v3.png"> | <img width="380" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/340/after_v5.png"> |

Before: `50%` square, text box "4" square, `flex:0 0 auto` chip square (while `inline-block` is rounded), blockquote square. After: all round correctly. (The percentage and text-box paths are #332/#333; this PR adds the flex/grid/`display:block`-span and blockquote/figure/table-wrapper paths.)




