### PR TITLE
html/layout: lay out <li> block children and honor the <li> box (#342, #339)

### DIFF
--- a/html/converter_list.go
+++ b/html/converter_list.go
@@ -86,30 +86,115 @@ func (c *converter) convertList(n *html.Node, style computedStyle, ordered bool)
 }
 
 // populateList fills a list with items from <li> children, handling nesting.
-// Uses collectRuns (instead of collectDirectText) so inline elements like
-// <a href="..."> are preserved as styled TextRuns with LinkURI.
+//
+// Each <li> takes one of two paths:
+//
+//   - Fast (inline) path: the <li> has no box-model styles and contains only
+//     inline content (optionally followed by a nested <ul>/<ol>). The item
+//     renders as styled TextRuns with the marker inline, exactly as before.
+//     Uses collectListItemRuns so inline elements like <a href="..."> are
+//     preserved as styled TextRuns with LinkURI.
+//
+//   - Element path: the <li> has block-level flow children (<div>, <p>, <br>,
+//     display:block) and/or its own box-model styles. The <li>'s children are
+//     run through the normal block-flow converter (walkChildren) and wrapped
+//     in a Div, so block children flow onto separate lines and any
+//     background/border/border-radius/padding on the <li> is painted. The
+//     marker is aligned to the first text line of the element.
 func (c *converter) populateList(n *html.Node, list *layout.List, style computedStyle) {
 	for child := n.FirstChild; child != nil; child = child.NextSibling {
 		if child.Type != html.ElementNode || child.DataAtom != atom.Li {
 			continue
 		}
 
-		runs := c.collectListItemRuns(child, style)
+		liStyle := c.computeElementStyle(child, style)
+		hasBox := liHasBoxModel(liStyle)
 		nestedList := findNestedList(child)
 
-		if nestedList != nil {
-			if len(runs) == 0 {
-				runs = []layout.TextRun{{Text: " ", Font: font.Helvetica, FontSize: style.FontSize}}
-			}
-			sub := list.AddItemRunsWithSubList(runs)
-			if nestedList.DataAtom == atom.Ol {
-				sub.SetStyle(layout.ListOrdered)
-			}
-			c.populateList(nestedList, sub, style)
-		} else {
-			if len(runs) > 0 {
+		// Fast path: plain inline item (optionally with a nested list as a
+		// sub-list) and no box-model styles. Preserves existing rendering
+		// and indentation for the common case.
+		if !hasBox && !liHasBlockFlowChildren(c, child, liStyle) {
+			runs := c.collectListItemRuns(child, style)
+			if nestedList != nil {
+				if len(runs) == 0 {
+					runs = []layout.TextRun{{Text: " ", Font: font.Helvetica, FontSize: style.FontSize}}
+				}
+				sub := list.AddItemRunsWithSubList(runs)
+				if nestedList.DataAtom == atom.Ol {
+					sub.SetStyle(layout.ListOrdered)
+				}
+				c.populateList(nestedList, sub, style)
+			} else if len(runs) > 0 {
 				list.AddItemRuns(runs)
 			}
+			continue
+		}
+
+		// Element path: convert the <li>'s children via the normal
+		// block-flow path so block elements, <br>, and nested lists lay
+		// out correctly. Apply the <li>'s own box styles when present.
+		c.addElementListItem(child, list, liStyle, hasBox)
+	}
+}
+
+// addElementListItem converts an <li> with block-level children and/or
+// box-model styles into a rich-element list item.
+func (c *converter) addElementListItem(li *html.Node, list *layout.List, liStyle computedStyle, hasBox bool) {
+	children := c.walkChildren(li, liStyle)
+	if len(children) == 0 {
+		// Nothing renderable; still emit an (empty) marker for an empty <li>.
+		list.AddItemElement(layout.NewDiv())
+		return
+	}
+
+	div := layout.NewDiv()
+	if hasBox {
+		// The element item is laid out in the content column (to the right of
+		// the marker), i.e. the available width minus the list indent. Resolve
+		// percentage box-model values (padding, border, border-radius) against
+		// that narrower width so they match where the box is actually placed
+		// rather than overflowing against the full container width.
+		contentWidth := c.containerWidth - list.Indent()
+		if contentWidth < 0 {
+			contentWidth = 0
+		}
+		applyDivStyles(div, liStyle, contentWidth)
+	}
+	for _, e := range children {
+		div.Add(e)
+	}
+	list.AddItemElement(div)
+}
+
+// liHasBoxModel reports whether an <li>'s computed style carries box-model
+// decoration that requires a Div wrapper to render (background, border,
+// border-radius, or padding).
+func liHasBoxModel(s computedStyle) bool {
+	return s.hasPadding() || s.hasBorder() || s.hasBorderRadius() ||
+		s.BackgroundColor != nil
+}
+
+// liHasBlockFlowChildren reports whether an <li> contains any child that
+// participates in block flow (block element, <br>, or display:block), which
+// requires the block-flow conversion path rather than inline text runs. A
+// nested <ul>/<ol> alone does not count: it is handled by the sub-list fast
+// path.
+func liHasBlockFlowChildren(c *converter, li *html.Node, liStyle computedStyle) bool {
+	for child := li.FirstChild; child != nil; child = child.NextSibling {
+		if child.Type != html.ElementNode {
+			continue
+		}
+		// A nested list is handled by the sub-list fast path.
+		if child.DataAtom == atom.Ul || child.DataAtom == atom.Ol {
+			continue
+		}
+		if child.DataAtom == atom.Br {
+			return true
+		}
+		if !c.isInlineFlowChild(child, liStyle) {
+			return true
 		}
 	}
+	return false
 }

--- a/html/li_block_box_test.go
+++ b/html/li_block_box_test.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/content"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// distinctContentYs returns the number of distinct y-positions of leaf content
+// blocks in a plan, used to count rendered text lines.
+func distinctContentYs(plan layout.LayoutPlan) int {
+	ys := map[float64]bool{}
+	var walk func(bs []layout.PlacedBlock, off float64)
+	walk = func(bs []layout.PlacedBlock, off float64) {
+		for _, b := range bs {
+			if len(b.Children) > 0 {
+				walk(b.Children, off+b.Y)
+				continue
+			}
+			if b.Height > 0 {
+				ys[off+b.Y] = true
+			}
+		}
+	}
+	walk(plan.Blocks, 0)
+	return len(ys)
+}
+
+// drawPlanToStream draws every block (and its children) of a plan into a fresh
+// content stream and returns the operators as a string.
+func drawPlanToStream(plan layout.LayoutPlan) string {
+	page := &layout.PageResult{Stream: content.NewStream()}
+	ctx := layout.DrawContext{Stream: page.Stream, Page: page}
+	var draw func(bs []layout.PlacedBlock, topY float64)
+	draw = func(bs []layout.PlacedBlock, topY float64) {
+		for _, b := range bs {
+			if b.Draw != nil {
+				b.Draw(ctx, b.X, topY-b.Y)
+			}
+			if len(b.Children) > 0 {
+				draw(b.Children, topY-b.Y)
+			}
+		}
+	}
+	draw(plan.Blocks, 1000)
+	return string(page.Stream.Bytes())
+}
+
+// TestLiBlockChildrenProduceMultipleLines is the structural regression for
+// #342: an <li> with block-level children must lay out on multiple lines, not
+// flattened onto one.
+func TestLiBlockChildrenProduceMultipleLines(t *testing.T) {
+	htmlStr := `<ol><li><u>Title.</u><div>First body.</div><div>Second body.</div></li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elems))
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if n := distinctContentYs(plan); n < 3 {
+		t.Errorf("expected >=3 distinct content lines for block <li> children, got %d", n)
+	}
+}
+
+// TestLiBlockChildrenMatchDivEquivalent confirms that the same block markup
+// inside an <li> produces the same number of lines as inside a <div>.
+func TestLiBlockChildrenMatchDivEquivalent(t *testing.T) {
+	inner := `<u>Title.</u><div>First body.</div><div>Second body.</div>`
+
+	liElems, err := Convert(`<ol><li>`+inner+`</li></ol>`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Wrap the div equivalent in an outer box so Convert keeps it as a single
+	// element (bare top-level block children are hoisted to siblings).
+	divElems, err := Convert(`<div style="padding:0.1px">`+inner+`</div>`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	liLines := distinctContentYs(liElems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000}))
+	divLines := distinctContentYs(divElems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000}))
+	if liLines != divLines {
+		t.Errorf("li produced %d lines, div produced %d; expected equal", liLines, divLines)
+	}
+}
+
+// TestLiStyledBoxRendersRoundedFill is the structural regression for #339: a
+// styled <li> (background + border-radius + padding) must paint a rounded
+// filled box.
+func TestLiStyledBoxRendersRoundedFill(t *testing.T) {
+	htmlStr := `<ul><li style="background:#4F46E5;color:#fff;border-radius:8px;padding:6px 10px">item</li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	ops := drawPlanToStream(plan)
+
+	// Background fill color #4F46E5 => 0.309804 0.27451 0.898039 rg.
+	if !strings.Contains(ops, "0.309804 0.27451 0.898039 rg") {
+		t.Errorf("expected indigo background fill in content stream, got:\n%s", ops)
+	}
+	// Rounded corners are emitted as Bézier curves (`c` operator).
+	if !strings.Contains(ops, " c\n") && !strings.Contains(ops, " c ") {
+		t.Errorf("expected Bézier curves for rounded corners, got:\n%s", ops)
+	}
+	// A fill operator must follow the box path.
+	if !strings.Contains(ops, "\nf\n") && !strings.HasSuffix(strings.TrimSpace(ops), "f") &&
+		!strings.Contains(ops, " f\n") {
+		t.Errorf("expected fill operator for the box, got:\n%s", ops)
+	}
+}
+
+// TestLiPlainInlineUsesRunsPath is a regression guard: a plain inline <li>
+// must keep the existing runs path (marker inline with text on one line) and
+// not be wrapped in an element/Div.
+func TestLiPlainInlineUsesRunsPath(t *testing.T) {
+	htmlStr := `<ul><li>Just text</li><li>Another</li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	// Two single-line items => two content lines.
+	if n := distinctContentYs(plan); n != 2 {
+		t.Errorf("expected 2 content lines for two plain inline items, got %d", n)
+	}
+	// The inline runs path draws marker + text in the same LI line block; no
+	// Bézier curve fill should appear (no box).
+	ops := drawPlanToStream(plan)
+	if strings.Contains(ops, " c\n") {
+		t.Errorf("plain inline <li> should not emit a rounded box, got:\n%s", ops)
+	}
+}
+
+// TestLiNestedListStillRenders verifies a nested list inside an <li> renders
+// with its own marker and deeper indentation (sub-list fast path preserved).
+func TestLiNestedListStillRenders(t *testing.T) {
+	htmlStr := `<ul><li>Parent<ul><li>Child</li></ul></li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	ops := drawPlanToStream(plan)
+
+	// The runs path applies item indentation at draw time via the text Td
+	// x-offset. Both the parent text and the deeper child text must appear,
+	// with the child drawn at a larger x-offset than the parent.
+	parentX, parentOK := textTdX(ops, "arent")
+	childX, childOK := textTdX(ops, "Child")
+	if !parentOK || !childOK {
+		t.Fatalf("expected both parent and child text drawn; parent=%v child=%v\n%s", parentOK, childOK, ops)
+	}
+	if childX <= parentX {
+		t.Errorf("expected nested child more indented than parent (parentX=%f childX=%f)", parentX, childX)
+	}
+}
+
+// textTdX scans content-stream operators for a Td positioning command
+// immediately preceding a text-show operator (Tj/TJ) whose payload contains
+// the given substring, returning the Td x-coordinate.
+func textTdX(ops, substr string) (float64, bool) {
+	lines := strings.Split(ops, "\n")
+	lastX := 0.0
+	haveX := false
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if strings.HasSuffix(l, " Td") {
+			var x, y float64
+			if _, err := fmt.Sscanf(l, "%f %f Td", &x, &y); err == nil {
+				lastX = x
+				haveX = true
+			}
+		}
+		if (strings.Contains(l, "Tj") || strings.Contains(l, "TJ")) &&
+			strings.Contains(l, substr) && haveX {
+			return lastX, true
+		}
+	}
+	return 0, false
+}
+
+// firstLeafX returns the X of the first (topmost) leaf content block in a
+// subtree, relative to the root of the supplied slice (X accumulated).
+func firstLeafX(blocks []layout.PlacedBlock) (float64, bool) {
+	bestSet := false
+	bestY := 0.0
+	bestX := 0.0
+	var walk func(bs []layout.PlacedBlock, offX, offY float64)
+	walk = func(bs []layout.PlacedBlock, offX, offY float64) {
+		for _, b := range bs {
+			if len(b.Children) > 0 {
+				walk(b.Children, offX+b.X, offY+b.Y)
+				continue
+			}
+			if b.Height <= 0 {
+				continue
+			}
+			// Skip the marker block (leaf "LI" at X==0 with width == indent).
+			if b.Tag == "LI" && offX+b.X == 0 && b.Width == 18 {
+				continue
+			}
+			if !bestSet || offY+b.Y < bestY {
+				bestSet = true
+				bestY = offY + b.Y
+				bestX = offX + b.X
+			}
+		}
+	}
+	walk(blocks, 0, 0)
+	return bestX, bestSet
+}
+
+// TestLiPercentPaddingResolvesAgainstContentColumn verifies the SHOULD-FIX:
+// percentage padding on a styled <li> resolves against the content column
+// (page width minus the list indent), not the full page width. With a
+// PageWidth of 618 and the default list indent of 18, the content column is
+// 600pt, so padding:10% must be 60pt — not 61.8pt (10% of the full page).
+func TestLiPercentPaddingResolvesAgainstContentColumn(t *testing.T) {
+	const pageW = 618.0
+	htmlStr := `<ul><li style="padding:10%;background:#eee">item</li></ul>`
+	elems, err := Convert(htmlStr, &Options{PageWidth: pageW})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: pageW, Height: 1000})
+
+	// The first text leaf sits inset from the left edge by (list indent +
+	// padding-left). The list draws the element column at indent=18, and the
+	// Div insets its content by padding-left. So leafX = indent + paddingLeft.
+	const indent = 18.0
+	leafX, ok := firstLeafX(plan.Blocks)
+	if !ok {
+		t.Fatal("no content leaf found")
+	}
+	paddingLeft := leafX - indent
+
+	contentCol := pageW - indent // 600
+	wantPad := 0.10 * contentCol // 60
+	wrongPad := 0.10 * pageW     // 61.8
+
+	if diff := paddingLeft - wantPad; diff < -1 || diff > 1 {
+		t.Errorf("padding-left = %.3f, want ≈%.3f (10%% of content column %.0f); got closer to %.3f (10%% of full page)",
+			paddingLeft, wantPad, contentCol, wrongPad)
+	}
+
+	// The styled box must not exceed the content column. The Div container
+	// block width should be <= contentCol.
+	var maxRight float64
+	var walk func(bs []layout.PlacedBlock, offX float64)
+	walk = func(bs []layout.PlacedBlock, offX float64) {
+		for _, b := range bs {
+			if r := offX + b.X + b.Width; r > maxRight {
+				maxRight = r
+			}
+			walk(b.Children, offX+b.X)
+		}
+	}
+	walk(plan.Blocks, 0)
+	if maxRight > pageW+0.5 {
+		t.Errorf("box right edge %.3f exceeds page width %.0f", maxRight, pageW)
+	}
+}
+
+// TestLiStyledBoxIsElementItem confirms a styled <li> goes through the element
+// path (single multi-line-capable item) rather than the inline runs path.
+func TestLiStyledBoxIsElementItem(t *testing.T) {
+	htmlStr := `<ul><li style="background:#eee;border-radius:6px;padding:4px 8px">item</li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	ops := drawPlanToStream(plan)
+	// #eee => 0.933333 grey fill.
+	if !strings.Contains(ops, "0.933333 0.933333 0.933333 rg") {
+		t.Errorf("expected #eee background fill, got:\n%s", ops)
+	}
+	if !strings.Contains(ops, " c\n") && !strings.Contains(ops, " c ") {
+		t.Errorf("expected rounded-corner Bézier curves, got:\n%s", ops)
+	}
+}

--- a/layout/list.go
+++ b/layout/list.go
@@ -37,18 +37,32 @@ type List struct {
 }
 
 // listItem is a single entry in a list, optionally containing a nested sub-list.
-// When runs is non-nil, the item renders as a styled paragraph (supporting
-// links, mixed fonts, etc.); otherwise it uses the plain text field.
+// When element is non-nil, the item renders that rich element (block-level
+// children, a styled box, etc.) and the marker is aligned to the first text
+// line of the element. Otherwise, when runs is non-nil the item renders as a
+// styled paragraph (supporting links, mixed fonts, etc.); otherwise it uses
+// the plain text field.
 type listItem struct {
 	text    string
 	runs    []TextRun // styled runs (nil = use plain text)
+	element Element   // rich content; overrides text/runs when set
 	subList *List     // optional nested list
+
+	// suppressMarker is set on a continuation fragment produced when an
+	// element item splits across pages. The marker (bullet/number) is drawn
+	// only on the first fragment, so continuation fragments suppress it.
+	suppressMarker bool
 }
 
 // listLayoutRef carries list-specific rendering info on a Line.
 type listLayoutRef struct {
 	markerWords []Word  // words for the bullet/number (first line only)
 	indent      float64 // left indent for the item text
+
+	// element item fields (set when the item renders a rich Element)
+	element       Element // non-nil for rich-content items
+	elementWidth  float64 // layout width for the element (content column)
+	markerOffsetY float64 // baseline of the first text line, from the line top
 }
 
 // NewList creates an unordered list with a standard font.
@@ -83,6 +97,14 @@ func (l *List) SetStyle(s ListStyle) *List {
 func (l *List) SetIndent(indent float64) *List {
 	l.indent = indent
 	return l
+}
+
+// Indent returns the left indent for item text. Item content (text runs or a
+// rich element) is laid out in the column from this indent to the available
+// width, so percentage box-model values on an element item must resolve
+// against (availableWidth - Indent).
+func (l *List) Indent() float64 {
+	return l.indent
 }
 
 // SetLeading sets the line height multiplier.
@@ -147,6 +169,31 @@ func (l *List) AddItemRunsWithSubList(runs []TextRun) *List {
 	return sub
 }
 
+// AddItemElement adds an item whose content is a rich Element (for
+// block-level <li> children or a styled <li> box). The list marker is
+// aligned to the first text line of the element rather than rendered
+// inline with text runs. The element is laid out within the item's
+// content column (to the right of the marker).
+func (l *List) AddItemElement(elem Element) *List {
+	l.items = append(l.items, listItem{element: elem})
+	return l
+}
+
+// AddItemElementWithSubList adds a rich-element item and returns a nested
+// sub-list under it. The sub-list inherits the parent's font and font size.
+func (l *List) AddItemElementWithSubList(elem Element) *List {
+	sub := &List{
+		style:    ListUnordered,
+		font:     l.font,
+		embedded: l.embedded,
+		fontSize: l.fontSize,
+		indent:   l.indent,
+		leading:  l.leading,
+	}
+	l.items = append(l.items, listItem{element: elem, subList: sub})
+	return sub
+}
+
 // AddItemWithSubList adds a text item and returns a nested sub-list
 // under that item. The sub-list inherits the parent's font and font size.
 func (l *List) AddItemWithSubList(text string) *List {
@@ -176,23 +223,17 @@ func (l *List) layoutAt(maxWidth float64, baseIndent float64) []Line {
 	itemWidth := maxWidth - totalIndent
 
 	for i, item := range l.items {
-		marker := l.marker(i)
+		// Element items: lay the element out in the content column and
+		// align the marker to the first text line of the element.
+		if item.element != nil {
+			allLines = append(allLines, l.layoutElementItem(item, i, maxWidth, totalIndent, itemWidth)...)
+			if item.subList != nil {
+				allLines = append(allLines, item.subList.layoutAt(maxWidth, totalIndent)...)
+			}
+			continue
+		}
 
-		// Create a paragraph for the marker.
-		markerSize := l.fontSize
-		if l.markerFontSize > 0 {
-			markerSize = l.markerFontSize
-		}
-		var markerPara *Paragraph
-		if l.embedded != nil {
-			markerPara = NewParagraphEmbedded(marker, l.embedded, markerSize)
-		} else {
-			markerPara = NewParagraph(marker, l.font, markerSize)
-		}
-		if l.markerColor != nil {
-			markerPara.runs[0].Color = *l.markerColor
-		}
-		markerPara.SetLeading(l.leading)
+		markerPara := l.markerParagraph(i)
 		markerLines := markerPara.Layout(l.indent)
 
 		// Create a paragraph for the item text.
@@ -239,12 +280,57 @@ func (l *List) layoutAt(maxWidth float64, baseIndent float64) []Line {
 	return allLines
 }
 
+// layoutElementItem produces the lines for a rich-element list item. The
+// element is laid out in the content column (width = itemWidth) and emitted
+// as a single synthetic line carrying the element; the marker is aligned to
+// the first text line of the element via markerOffsetY.
+func (l *List) layoutElementItem(item listItem, index int, maxWidth, totalIndent, itemWidth float64) []Line {
+	plan := item.element.PlanLayout(LayoutArea{Width: itemWidth, Height: 1e9})
+
+	markerPara := l.markerParagraph(index)
+	markerLines := markerPara.Layout(l.indent)
+	var markerWords []Word
+	if len(markerLines) > 0 {
+		markerWords = markerLines[0].Words
+	}
+
+	// Align the marker baseline to the first text line of the element.
+	firstY, firstH, ok := firstLeafLine(plan.Blocks)
+	markerOffsetY := 0.0
+	if ok {
+		markerOffsetY = firstY + computeBaseline(markerWords, firstH)
+	} else {
+		markerOffsetY = computeBaseline(markerWords, l.fontSize*l.leading)
+	}
+
+	line := Line{
+		Height: plan.Consumed,
+		IsLast: true,
+		listRef: &listLayoutRef{
+			markerWords:   markerWords,
+			indent:        totalIndent,
+			element:       item.element,
+			elementWidth:  itemWidth,
+			markerOffsetY: markerOffsetY,
+		},
+	}
+	return []Line{line}
+}
+
 // MinWidth implements Measurable. Returns indent + widest word.
 func (l *List) MinWidth() float64 {
 	maxW := 0.0
+	measurer := l.measurer()
 	for _, item := range l.items {
+		if item.element != nil {
+			if m, ok := item.element.(Measurable); ok {
+				if w := m.MinWidth(); w > maxW {
+					maxW = w
+				}
+			}
+			continue
+		}
 		text := l.itemText(item)
-		measurer := l.measurer()
 		for _, w := range splitWords(text) {
 			ww := measurer.MeasureString(w, l.fontSize)
 			if ww > maxW {
@@ -260,6 +346,14 @@ func (l *List) MaxWidth() float64 {
 	maxW := 0.0
 	measurer := l.measurer()
 	for _, item := range l.items {
+		if item.element != nil {
+			if m, ok := item.element.(Measurable); ok {
+				if w := m.MaxWidth(); w > maxW {
+					maxW = w
+				}
+			}
+			continue
+		}
 		text := l.itemText(item)
 		ww := measurer.MeasureString(text, l.fontSize)
 		if ww > maxW {
@@ -279,6 +373,57 @@ func (l *List) itemParagraph(item listItem) *Paragraph {
 		return NewParagraphEmbedded(item.text, l.embedded, l.fontSize)
 	}
 	return NewParagraph(item.text, l.font, l.fontSize)
+}
+
+// markerParagraph builds the marker paragraph for the item at index,
+// applying the list's marker font size and color overrides.
+func (l *List) markerParagraph(index int) *Paragraph {
+	marker := l.marker(index)
+	markerSize := l.fontSize
+	if l.markerFontSize > 0 {
+		markerSize = l.markerFontSize
+	}
+	var markerPara *Paragraph
+	if l.embedded != nil {
+		markerPara = NewParagraphEmbedded(marker, l.embedded, markerSize)
+	} else {
+		markerPara = NewParagraph(marker, l.font, markerSize)
+	}
+	if l.markerColor != nil {
+		markerPara.runs[0].Color = *l.markerColor
+	}
+	markerPara.SetLeading(l.leading)
+	return markerPara
+}
+
+// firstLeafLine descends a placed-block tree and returns the relative Y
+// offset and height of the first (topmost, then leftmost) leaf block that
+// carries content (non-zero height). The Y is accumulated through container
+// blocks so it is relative to the top of the supplied block slice. The
+// boolean is false when no content leaf is found (e.g. an empty element).
+func firstLeafLine(blocks []PlacedBlock) (y, height float64, ok bool) {
+	bestSet := false
+	var bestY, bestH float64
+	var walk func(bs []PlacedBlock, offY float64)
+	walk = func(bs []PlacedBlock, offY float64) {
+		for _, b := range bs {
+			absY := offY + b.Y
+			if len(b.Children) > 0 {
+				walk(b.Children, absY)
+				continue
+			}
+			if b.Height <= 0 {
+				continue
+			}
+			if !bestSet || absY < bestY {
+				bestSet = true
+				bestY = absY
+				bestH = b.Height
+			}
+		}
+	}
+	walk(blocks, 0)
+	return bestY, bestH, bestSet
 }
 
 // itemText returns the plain text of a list item for measurement.
@@ -323,23 +468,66 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 	allFit := true
 
 	for i, item := range l.items {
-		marker := l.marker(i)
+		// Element items: lay the element out in the content column and
+		// align the marker to the first text line of the element.
+		if item.element != nil {
+			elemBlocks, consumed, status, elemOverflow := l.planElementItem(item, i, area, totalIndent, itemWidth, curY)
 
-		// Measure marker words.
-		markerSize := l.fontSize
-		if l.markerFontSize > 0 {
-			markerSize = l.markerFontSize
+			// The element could not place anything in the remaining area.
+			// If other content already sits on this page, defer the whole
+			// item (and the rest of the list) to the next page. Otherwise we
+			// are at the top of an empty area: fall through to place whatever
+			// the element can produce (LayoutNothing yields no blocks) so we
+			// never loop forever on a too-tall first item.
+			if status == LayoutNothing && len(blocks) > 0 {
+				return LayoutPlan{
+					Status: LayoutPartial, Consumed: curY,
+					Blocks: wrapListBlocks(blocks, area.Width, curY), Overflow: l.overflowFrom(i),
+				}
+			}
+
+			// The element partially fit: emit the part that fit (marker on
+			// this fragment only) and continue the remaining list with the
+			// element replaced by its overflow, marker suppressed.
+			if status == LayoutPartial {
+				// Guard against an infinite loop: if nothing actually fit
+				// (consumed == 0) and there is already content on the page,
+				// move the whole item to a fresh page instead of emitting an
+				// empty fragment. At the top of an empty page we fall through
+				// and accept the partial fragment to make progress.
+				if consumed == 0 && len(blocks) > 0 {
+					return LayoutPlan{
+						Status: LayoutPartial, Consumed: curY,
+						Blocks: wrapListBlocks(blocks, area.Width, curY), Overflow: l.overflowFrom(i),
+					}
+				}
+				blocks = append(blocks, elemBlocks...)
+				curY += consumed
+				return LayoutPlan{
+					Status: LayoutPartial, Consumed: curY,
+					Blocks:   wrapListBlocks(blocks, area.Width, curY),
+					Overflow: l.overflowContinuingElement(i, elemOverflow),
+				}
+			}
+
+			blocks = append(blocks, elemBlocks...)
+			curY += consumed
+
+			if item.subList != nil {
+				subPlan := item.subList.planAt(
+					LayoutArea{Width: area.Width, Height: area.Height - curY},
+					totalIndent,
+				)
+				for _, b := range subPlan.Blocks {
+					b.Y += curY
+					blocks = append(blocks, b)
+				}
+				curY += subPlan.Consumed
+			}
+			continue
 		}
-		var markerPara *Paragraph
-		if l.embedded != nil {
-			markerPara = NewParagraphEmbedded(marker, l.embedded, markerSize)
-		} else {
-			markerPara = NewParagraph(marker, l.font, markerSize)
-		}
-		if l.markerColor != nil {
-			markerPara.runs[0].Color = *l.markerColor
-		}
-		markerPara.SetLeading(l.leading)
+
+		markerPara := l.markerParagraph(i)
 		markerWords, _ := markerPara.measureWords(l.indent)
 
 		// Measure and wrap item text directly.
@@ -401,15 +589,7 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 
 		if !allFit {
 			// Build overflow with remaining items.
-			overflowList := &List{
-				items:    l.items[i+1:],
-				style:    l.style,
-				font:     l.font,
-				embedded: l.embedded,
-				fontSize: l.fontSize,
-				indent:   l.indent,
-				leading:  l.leading,
-			}
+			overflowList := l.overflowFrom(i + 1)
 			return LayoutPlan{
 				Status: LayoutPartial, Consumed: curY,
 				Blocks: wrapListBlocks(blocks, area.Width, curY), Overflow: overflowList,
@@ -431,6 +611,122 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 	}
 
 	return LayoutPlan{Status: LayoutFull, Consumed: curY, Blocks: wrapListBlocks(blocks, area.Width, curY)}
+}
+
+// overflowFrom builds a List carrying the items from index start onward,
+// preserving the list's rendering attributes for page-break continuation.
+func (l *List) overflowFrom(start int) *List {
+	return l.cloneWithItems(l.items[start:])
+}
+
+// overflowContinuingElement builds the continuation List for a partially-laid-out
+// element item at index i. The item at i is replaced by a continuation whose
+// element is the element's overflow and whose marker is suppressed (the
+// bullet/number is drawn only on the first fragment). Remaining items i+1...
+// follow unchanged. The nested sub-list (if any) is preserved on the
+// continuation so it still renders after the element's tail content.
+func (l *List) overflowContinuingElement(i int, elemOverflow Element) *List {
+	cont := l.items[i]
+	cont.element = elemOverflow
+	cont.suppressMarker = true
+
+	items := make([]listItem, 0, len(l.items)-i)
+	items = append(items, cont)
+	items = append(items, l.items[i+1:]...)
+	return l.cloneWithItems(items)
+}
+
+// cloneWithItems returns a List with the supplied items and this list's
+// rendering attributes, for page-break continuation.
+func (l *List) cloneWithItems(items []listItem) *List {
+	return &List{
+		items:          items,
+		style:          l.style,
+		font:           l.font,
+		embedded:       l.embedded,
+		fontSize:       l.fontSize,
+		indent:         l.indent,
+		leading:        l.leading,
+		direction:      l.direction,
+		markerColor:    l.markerColor,
+		markerFontSize: l.markerFontSize,
+	}
+}
+
+// planElementItem lays out a rich-element list item into placed blocks. The
+// element occupies the content column (offset by totalIndent); the marker is
+// drawn aligned to the baseline of the element's first text line (unless the
+// item is a continuation fragment, in which case the marker is suppressed).
+// Returns the blocks (Y offsets relative to the list, already shifted by curY),
+// the height consumed, and the element's own LayoutPlan status and overflow so
+// the caller can split the item across pages.
+func (l *List) planElementItem(item listItem, index int, area LayoutArea, totalIndent, itemWidth, curY float64) (blocks []PlacedBlock, consumed float64, status LayoutStatus, overflow Element) {
+	plan := item.element.PlanLayout(LayoutArea{Width: itemWidth, Height: area.Height - curY})
+	if plan.Status == LayoutNothing {
+		return nil, 0, LayoutNothing, nil
+	}
+
+	var markerWords []Word
+	if !item.suppressMarker {
+		markerPara := l.markerParagraph(index)
+		markerWords, _ = markerPara.measureWords(l.indent)
+	}
+
+	// Marker baseline: align to the first text line of the element.
+	firstY, firstH, ok := firstLeafLine(plan.Blocks)
+	markerBaseline := 0.0
+	if ok {
+		markerBaseline = firstY + computeBaseline(markerWords, firstH)
+	} else {
+		markerBaseline = computeBaseline(markerWords, l.fontSize*l.leading)
+	}
+
+	// Shift the element's blocks into the content column at curY.
+	contentBlocks := offsetBlocks(plan.Blocks, totalIndent, curY)
+
+	out := make([]PlacedBlock, 0, len(contentBlocks)+1)
+
+	// Only emit a marker block when there is a marker to draw. Continuation
+	// fragments suppress the marker (markerWords is nil), so they carry no
+	// marker block and the bullet/number is never repeated on later pages.
+	if len(markerWords) > 0 {
+		capturedMarker := markerWords
+		capturedIndent := totalIndent
+		capturedMaxW := area.Width
+		capturedBaseline := markerBaseline
+		capturedRTL := l.direction == DirectionRTL
+
+		// The marker is drawn relative to its block's top, which sits at the
+		// element's top (curY). markerBaseline is measured from that top.
+		markerBlock := PlacedBlock{
+			X: 0, Y: curY, Width: l.indent, Height: firstH,
+			Tag: "LI",
+			Draw: func(ctx DrawContext, absX, absTopY float64) {
+				baselineY := absTopY - capturedBaseline
+				if capturedRTL {
+					drawTextLine(ctx, capturedMarker, absX+capturedMaxW-capturedIndent, baselineY, capturedIndent, AlignRight, true)
+				} else {
+					drawTextLine(ctx, capturedMarker, absX, baselineY, capturedIndent, AlignLeft, true)
+				}
+			},
+		}
+		out = append(out, markerBlock)
+	}
+
+	out = append(out, contentBlocks...)
+	return out, plan.Consumed, plan.Status, plan.Overflow
+}
+
+// offsetBlocks returns a deep-enough copy of blocks shifted by (dx, dy) at the
+// top level. Child blocks keep their relative offsets.
+func offsetBlocks(blocks []PlacedBlock, dx, dy float64) []PlacedBlock {
+	out := make([]PlacedBlock, len(blocks))
+	for i, b := range blocks {
+		b.X += dx
+		b.Y += dy
+		out[i] = b
+	}
+	return out
 }
 
 // wrapListBlocks wraps list item blocks in a parent "L" block for structure tree nesting.

--- a/layout/list_test.go
+++ b/layout/list_test.go
@@ -292,3 +292,263 @@ func TestListBulletCharacter(t *testing.T) {
 		t.Errorf("expected bullet character U+2022 (%q), got %q", "\u2022", bullet)
 	}
 }
+
+// TestListElementItemMultipleLines verifies that an element list item with
+// multiple block children produces multiple content lines (not flattened
+// onto one line) and that the marker is aligned to the first text line.
+// Regression test for #342.
+func TestListElementItemMultipleLines(t *testing.T) {
+	div := NewDiv()
+	div.Add(NewParagraph("Title.", font.Helvetica, 12))
+	div.Add(NewParagraph("First body.", font.Helvetica, 12))
+	div.Add(NewParagraph("Second body.", font.Helvetica, 12))
+
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	l.AddItemElement(div)
+
+	plan := l.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != LayoutFull {
+		t.Fatalf("expected LayoutFull, got %v", plan.Status)
+	}
+
+	// Gather distinct y positions of leaf text blocks.
+	ys := map[float64]bool{}
+	var walk func(bs []PlacedBlock, off float64)
+	walk = func(bs []PlacedBlock, off float64) {
+		for _, b := range bs {
+			if len(b.Children) > 0 {
+				walk(b.Children, off+b.Y)
+				continue
+			}
+			if b.Height > 0 {
+				ys[off+b.Y] = true
+			}
+		}
+	}
+	walk(plan.Blocks, 0)
+	if len(ys) < 3 {
+		t.Errorf("expected >=3 distinct content lines, got %d", len(ys))
+	}
+}
+
+// TestListElementItemMarkerAligned verifies the marker baseline aligns to the
+// first text line of the element rather than the item top or center.
+func TestListElementItemMarkerAligned(t *testing.T) {
+	div := NewDiv()
+	div.Add(NewParagraph("Title.", font.Helvetica, 12))
+	div.Add(NewParagraph("Body.", font.Helvetica, 12))
+
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	l.AddItemElement(div)
+
+	lines := l.Layout(400)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 synthetic line for element item, got %d", len(lines))
+	}
+	ref := lines[0].listRef
+	if ref == nil || ref.element == nil {
+		t.Fatal("expected listRef with element on element item line")
+	}
+	if len(ref.markerWords) == 0 || ref.markerWords[0].Text != "1." {
+		t.Fatalf("expected marker '1.', got %+v", ref.markerWords)
+	}
+	// The marker baseline must fall within the first text line, i.e. less
+	// than one line height from the top — not the item center or bottom.
+	firstLineH := 12 * 1.2
+	if ref.markerOffsetY <= 0 || ref.markerOffsetY > firstLineH {
+		t.Errorf("markerOffsetY %f not within first line [0,%f]", ref.markerOffsetY, firstLineH)
+	}
+}
+
+// TestListElementItemWithSubList verifies a nested sub-list under an element
+// item still renders with its own marker and indentation.
+func TestListElementItemWithSubList(t *testing.T) {
+	div := NewDiv()
+	div.Add(NewParagraph("Parent.", font.Helvetica, 12))
+
+	l := NewList(font.Helvetica, 12)
+	sub := l.AddItemElementWithSubList(div)
+	sub.AddItem("Child")
+
+	plan := l.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	if plan.Consumed <= 0 {
+		t.Fatalf("expected positive consumed, got %f", plan.Consumed)
+	}
+	// The sub-list child should be more indented than the parent content.
+	var indents []float64
+	var walk func(bs []PlacedBlock, off float64)
+	walk = func(bs []PlacedBlock, off float64) {
+		for _, b := range bs {
+			if len(b.Children) > 0 {
+				walk(b.Children, off+b.Y)
+				continue
+			}
+			if b.Height > 0 {
+				indents = append(indents, b.X)
+			}
+		}
+	}
+	walk(plan.Blocks, 0)
+	if len(indents) < 2 {
+		t.Fatalf("expected parent and child content blocks, got %d", len(indents))
+	}
+}
+
+// markerBlockCount returns the number of drawn list markers in a block tree.
+// A drawn marker is a leaf "LI" block at X==0 with positive height (see
+// planElementItem, which only emits a marker block when there is a marker).
+func markerBlockCount(blocks []PlacedBlock, indent float64) int {
+	n := 0
+	var walk func(bs []PlacedBlock)
+	walk = func(bs []PlacedBlock) {
+		for _, b := range bs {
+			if len(b.Children) > 0 {
+				walk(b.Children)
+				continue
+			}
+			if b.Tag == "LI" && b.X == 0 && b.Width == indent && b.Height > 0 {
+				n++
+			}
+		}
+	}
+	walk(blocks)
+	return n
+}
+
+// contentLineCount returns the number of distinct content text leaves (height
+// > 0) that are NOT marker blocks, i.e. the actual element body lines.
+func contentLineCount(blocks []PlacedBlock, indent float64) int {
+	n := 0
+	var walk func(bs []PlacedBlock)
+	walk = func(bs []PlacedBlock) {
+		for _, b := range bs {
+			if len(b.Children) > 0 {
+				walk(b.Children)
+				continue
+			}
+			if b.Height <= 0 {
+				continue
+			}
+			// Skip marker blocks (leaf LI at X==0, width==indent).
+			if b.Tag == "LI" && b.X == 0 && b.Width == indent {
+				continue
+			}
+			n++
+		}
+	}
+	walk(blocks)
+	return n
+}
+
+// TestListElementItemSplitFirstItem verifies that an oversized element list
+// item that is the FIRST thing on the page splits across pages: the List
+// returns LayoutPartial with a non-nil Overflow, no content is lost across the
+// fragments, and the marker is drawn only on the first fragment. Regression
+// for the dropped-tail BLOCKER (#342/#339 follow-up).
+func TestListElementItemSplitFirstItem(t *testing.T) {
+	const nParas = 60
+	div := NewDiv()
+	for i := 0; i < nParas; i++ {
+		div.Add(NewParagraph("Line.", font.Helvetica, 12))
+	}
+
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	l.AddItemElement(div)
+
+	const pageH = 100.0
+	indent := l.Indent()
+
+	// Walk the page chain, summing content lines and markers.
+	totalContent := 0
+	totalMarkers := 0
+	fragments := 0
+	var cur Element = l
+	for cur != nil {
+		plan := cur.PlanLayout(LayoutArea{Width: 400, Height: pageH})
+		fragments++
+		totalContent += contentLineCount(plan.Blocks, indent)
+		totalMarkers += markerBlockCount(plan.Blocks, indent)
+
+		if fragments == 1 {
+			if plan.Status != LayoutPartial {
+				t.Fatalf("first page: expected LayoutPartial, got %v", plan.Status)
+			}
+			if plan.Overflow == nil {
+				t.Fatal("first page: expected non-nil Overflow")
+			}
+			if markerBlockCount(plan.Blocks, indent) != 1 {
+				t.Fatalf("first fragment: expected exactly 1 marker, got %d", markerBlockCount(plan.Blocks, indent))
+			}
+		} else {
+			// Continuation fragments must NOT repeat the marker.
+			if markerBlockCount(plan.Blocks, indent) != 0 {
+				t.Errorf("continuation fragment %d: marker repeated", fragments)
+			}
+		}
+
+		if plan.Status == LayoutFull {
+			break
+		}
+		cur = plan.Overflow
+		if fragments > nParas+5 {
+			t.Fatal("did not converge: too many fragments (possible infinite loop)")
+		}
+	}
+
+	if fragments < 2 {
+		t.Fatalf("expected the item to split across >=2 pages, got %d", fragments)
+	}
+	if totalContent != nParas {
+		t.Errorf("content lost: expected %d content lines across fragments, got %d", nParas, totalContent)
+	}
+	if totalMarkers != 1 {
+		t.Errorf("marker drawn %d times across fragments, want exactly 1 (first fragment only)", totalMarkers)
+	}
+}
+
+// TestListElementItemSplitAfterItem verifies the same split behavior when the
+// oversized element item is NOT first: a preceding plain item occupies part of
+// the page, then the tall element item splits, and no content is lost.
+func TestListElementItemSplitAfterItem(t *testing.T) {
+	const nParas = 60
+	div := NewDiv()
+	for i := 0; i < nParas; i++ {
+		div.Add(NewParagraph("Line.", font.Helvetica, 12))
+	}
+
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	l.AddItem("First plain item.")
+	l.AddItemElement(div)
+
+	const pageH = 100.0
+	indent := l.Indent()
+
+	totalContent := 0
+	fragments := 0
+	sawOverflow := false
+	var cur Element = l
+	for cur != nil {
+		plan := cur.PlanLayout(LayoutArea{Width: 400, Height: pageH})
+		fragments++
+		totalContent += contentLineCount(plan.Blocks, indent)
+
+		if plan.Status == LayoutPartial && plan.Overflow != nil {
+			sawOverflow = true
+		}
+		if plan.Status == LayoutFull {
+			break
+		}
+		cur = plan.Overflow
+		if fragments > nParas+5 {
+			t.Fatal("did not converge: too many fragments (possible infinite loop)")
+		}
+	}
+
+	if !sawOverflow {
+		t.Fatal("expected the list to overflow across pages")
+	}
+	// nParas element body lines + 1 plain item line.
+	if totalContent != nParas+1 {
+		t.Errorf("content lost: expected %d content lines, got %d", nParas+1, totalContent)
+	}
+}


### PR DESCRIPTION
Addresses #342 and #339 — two symptoms of the same root cause: list-item content was collected as **inline text runs only**, so an `<li>`'s children never went through normal block-flow layout and the `<li>`'s own style was never read.

- **#342** — block-level children of an `<li>` (`<div>`, `<p>`, `<br>`) were flattened onto a single line (the same markup in a `<div>` laid out correctly).
- **#339** — a styled `<li>` (background/border/border-radius/padding) dropped its entire box.

## Fix
- **layout** (`list.go`): `listItem` gains an optional `element`. The List lays an element item out in the content column and aligns the marker to the element's **first text line**. Element items **split across pages** (the element's `Overflow` is threaded through; the marker is drawn on the first fragment only). Plain inline items and nested lists keep the existing runs/sublist path unchanged.
- **html** (`converter_list.go`): `populateList` computes the `<li>`'s own style and routes `<li>`s that have block-flow children or box-model styles through `walkChildren` → a `Div` (`applyDivStyles`, reusing the rounded-box drawing from #340) added as an element item. Percentage box-model resolves against the content column, not the full page.

## Before / after — the reporter's exact repro (#342)
`<ol><li><u>Title.</u><div>First body.</div><div>Second body.</div></li></ol>`

| Before (`main`) — one flattened line | After — three lines, marker on line 1 |
|---|---|
| <img width="380" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/342/before_li.png"> | <img width="380" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/342/after_li.png"> |

The `<li>` now matches the `<div>` control exactly. A styled `<li>` also paints its rounded box (#339):

<img width="420" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/342/li_styled_box.png">

## Verification
Reporter's exact code rendered before/after (`li.pdf`: 1 line → 3 lines; `div.pdf` control unchanged at 3). A tall `<li>` (40 block children) splits across 4 pages with no content lost and the marker once. New layout + html tests (block children, marker alignment, page-split first/non-first item with no content loss, styled box, %-padding against content column, plain/nested regression guards). Full suite + vet + gofmt green.

## Out of scope
`display:inline-block`/explicit-width `<li>` hugging content, and margin/box-shadow/outline-only `<li>` decorations on the inline fast path — noted for follow-up.