### PR TITLE
barcode: fix QR Reed-Solomon, format/version info, and ECC tables

### DIFF
--- a/barcode/qr.go
+++ b/barcode/qr.go
@@ -303,26 +303,26 @@ var qrECCPerBlock = [41][4]int{
 	{30, 26, 28, 28}, // version 18
 	{28, 26, 26, 26}, // version 19
 	{28, 26, 30, 28}, // version 20
-	{28, 26, 28, 28}, // version 21
-	{28, 28, 30, 28}, // version 22
-	{30, 28, 30, 28}, // version 23
-	{30, 28, 30, 28}, // version 24
-	{26, 28, 30, 28}, // version 25
-	{28, 28, 28, 28}, // version 26
-	{30, 28, 30, 28}, // version 27
-	{30, 28, 30, 28}, // version 28
-	{30, 28, 30, 28}, // version 29
-	{30, 28, 30, 28}, // version 30
-	{30, 28, 30, 28}, // version 31
-	{30, 28, 30, 28}, // version 32
-	{30, 28, 30, 28}, // version 33
-	{30, 28, 30, 28}, // version 34
-	{30, 28, 30, 28}, // version 35
-	{30, 28, 30, 28}, // version 36
-	{30, 28, 30, 28}, // version 37
-	{30, 28, 30, 28}, // version 38
-	{30, 28, 30, 28}, // version 39
-	{30, 28, 30, 28}, // version 40
+	{28, 26, 28, 30}, // version 21
+	{28, 28, 30, 24}, // version 22
+	{30, 28, 30, 30}, // version 23
+	{30, 28, 30, 30}, // version 24
+	{26, 28, 30, 30}, // version 25
+	{28, 28, 28, 30}, // version 26
+	{30, 28, 30, 30}, // version 27
+	{30, 28, 30, 30}, // version 28
+	{30, 28, 30, 30}, // version 29
+	{30, 28, 30, 30}, // version 30
+	{30, 28, 30, 30}, // version 31
+	{30, 28, 30, 30}, // version 32
+	{30, 28, 30, 30}, // version 33
+	{30, 28, 30, 30}, // version 34
+	{30, 28, 30, 30}, // version 35
+	{30, 28, 30, 30}, // version 36
+	{30, 28, 30, 30}, // version 37
+	{30, 28, 30, 30}, // version 38
+	{30, 28, 30, 30}, // version 39
+	{30, 28, 30, 30}, // version 40
 }
 
 // qrBlockInfo describes the block structure for a version/ECC combination.
@@ -810,8 +810,8 @@ func rsGeneratorPoly(n int) []byte {
 	for i := range n {
 		ng := make([]byte, len(g)+1)
 		for j, coeff := range g {
-			ng[j] ^= gfMul(coeff, gfExp[i])
-			ng[j+1] ^= coeff
+			ng[j] ^= coeff
+			ng[j+1] ^= gfMul(coeff, gfExp[i])
 		}
 		g = ng
 	}
@@ -1093,7 +1093,7 @@ func placeFormatInfo(modules [][]bool, size int, level ECCLevel, mask int) {
 		{8, 7}, {8, 5}, {8, 4}, {8, 3}, {8, 2}, {8, 1}, {8, 0},
 	}
 	for i, pos := range positions {
-		modules[pos[0]][pos[1]] = formatBits[i]
+		modules[pos[0]][pos[1]] = formatBits[14-i]
 	}
 
 	// Place along bottom-left and top-right.
@@ -1114,7 +1114,7 @@ func placeVersionInfo(modules [][]bool, size, version int) {
 	info := qrVersionInfo[version]
 
 	for i := range 18 {
-		bit := (info>>(17-i))&1 == 1
+		bit := (info>>i)&1 == 1
 		// i maps to position: row = i/3, col = i%3
 		// Bottom-left block: rows (size-11)..(size-9), cols 0..5
 		r := i / 3

--- a/barcode/qr_decode_test.go
+++ b/barcode/qr_decode_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package barcode
+
+import "testing"
+
+// GF(256) arithmetic for QR error correction, primitive polynomial 0x11D.
+
+var tExp [512]byte
+var tLog [256]byte
+
+func init() {
+	x := 1
+	for i := 0; i < 255; i++ {
+		tExp[i] = byte(x)
+		tLog[x] = byte(i)
+		x <<= 1
+		if x >= 256 {
+			x ^= 0x11D
+		}
+	}
+	for i := 255; i < 512; i++ {
+		tExp[i] = tExp[i-255]
+	}
+}
+
+func tMul(a, b byte) byte {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	return tExp[int(tLog[a])+int(tLog[b])]
+}
+
+// rsValid reports whether codeword (data codewords followed by ecLen error
+// correction codewords, highest-degree coefficient first) is a valid
+// Reed-Solomon codeword, i.e. every syndrome C(alpha^j) for j in [0,ecLen) is zero.
+func rsValid(codeword []byte, ecLen int) bool {
+	for j := 0; j < ecLen; j++ {
+		var s byte
+		root := tExp[j] // alpha^j
+		for _, c := range codeword {
+			s = tMul(s, root) ^ c // Horner evaluation
+		}
+		if s != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// qrTotalCodewords is the total number of (data + error correction) codewords
+// for each QR version 1-40.
+var qrTotalCodewords = [41]int{
+	0,
+	26, 44, 70, 100, 134, 172, 196, 242, 292, 346,
+	404, 466, 532, 581, 655, 733, 815, 901, 991, 1085,
+	1156, 1258, 1364, 1474, 1588, 1706, 1828, 1921, 2051, 2185,
+	2323, 2465, 2611, 2761, 2876, 3034, 3196, 3362, 3532, 3706,
+}
+
+// TestQRReedSolomonVector checks rsEncode for a version 1, level Q data block
+// against its expected error correction codewords.
+func TestQRReedSolomonVector(t *testing.T) {
+	data := []byte{0x20, 0x5B, 0x0B, 0x78, 0xD1, 0x72, 0xDC, 0x4D, 0x43, 0x40, 0xEC, 0x11, 0xEC}
+	want := []byte{0xA8, 0x48, 0x16, 0x52, 0xD9, 0x36, 0x9C, 0x00, 0x2E, 0x0F, 0xB4, 0x7A, 0x10}
+	got := rsEncode(data, rsGeneratorPoly(13), 13)
+	if len(got) != len(want) {
+		t.Fatalf("ecc length = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ecc = % X, want % X", got, want)
+		}
+	}
+}
+
+// TestQRCodewordTables checks, for every version and ECC level, that the
+// per-block data codewords sum to qrDataCodewords and that data plus error
+// correction codewords equal the total codeword count.
+func TestQRCodewordTables(t *testing.T) {
+	for v := 1; v <= 40; v++ {
+		for l := ECCLevelL; l <= ECCLevelH; l++ {
+			bi := qrBlockTable[v][l]
+			blocks := bi.group1Blocks + bi.group2Blocks
+			dataCW := bi.group1Blocks*bi.group1DataCW + bi.group2Blocks*bi.group2DataCW
+			if dataCW != qrDataCodewords[v][l] {
+				t.Errorf("v%d L%d: block data codewords = %d, qrDataCodewords = %d", v, l, dataCW, qrDataCodewords[v][l])
+			}
+			total := dataCW + blocks*qrECCPerBlock[v][l]
+			if total != qrTotalCodewords[v] {
+				t.Errorf("v%d L%d: data+ecc codewords = %d, want total %d", v, l, total, qrTotalCodewords[v])
+			}
+		}
+	}
+}
+
+// qrFunctionMap returns the function-pattern reservation for a version.
+func qrFunctionMap(version, size int) [][]bool {
+	modules := make([][]bool, size)
+	reserved := make([][]bool, size)
+	for i := range reserved {
+		modules[i] = make([]bool, size)
+		reserved[i] = make([]bool, size)
+	}
+	placeFinder(modules, reserved, 0, 0)
+	placeFinder(modules, reserved, 0, size-7)
+	placeFinder(modules, reserved, size-7, 0)
+	if version >= 2 {
+		pos := alignmentPositions(version)
+		for _, r := range pos {
+			for _, c := range pos {
+				if !reserved[r][c] {
+					placeAlignment(modules, reserved, r, c)
+				}
+			}
+		}
+	}
+	for i := 8; i < size-8; i++ {
+		reserved[6][i] = true
+		reserved[i][6] = true
+	}
+	reserved[size-8][8] = true
+	for i := 0; i < 9; i++ {
+		reserved[8][i] = true
+		reserved[i][8] = true
+	}
+	for i := 0; i < 8; i++ {
+		reserved[8][size-1-i] = true
+		reserved[size-1-i][8] = true
+	}
+	if version >= 7 {
+		for i := 0; i < 6; i++ {
+			for j := 0; j < 3; j++ {
+				reserved[size-11+j][i] = true
+				reserved[i][size-11+j] = true
+			}
+		}
+	}
+	return reserved
+}
+
+// readFormat reads the 15-bit format information from both standard copies and
+// returns (level, mask, ok). ok is false if the two copies disagree or the
+// value is not a valid format string.
+func readFormat(m [][]bool, size int) (ECCLevel, int, bool) {
+	pos1 := [15][2]int{
+		{0, 8}, {1, 8}, {2, 8}, {3, 8}, {4, 8}, {5, 8}, {7, 8}, {8, 8},
+		{8, 7}, {8, 5}, {8, 4}, {8, 3}, {8, 2}, {8, 1}, {8, 0},
+	}
+	var v1 uint16
+	for i, p := range pos1 {
+		if m[p[0]][p[1]] {
+			v1 |= 1 << i
+		}
+	}
+	var v2 uint16
+	for i := 0; i < 8; i++ {
+		if m[8][size-1-i] {
+			v2 |= 1 << i
+		}
+	}
+	for i := 8; i < 15; i++ {
+		if m[size-15+i][8] {
+			v2 |= 1 << i
+		}
+	}
+	if v1 != v2 {
+		return 0, 0, false
+	}
+	for level := ECCLevelL; level <= ECCLevelH; level++ {
+		for mask := 0; mask < 8; mask++ {
+			if qrFormatInfo[level][mask] == v1 {
+				return level, mask, true
+			}
+		}
+	}
+	return 0, 0, false
+}
+
+// readVersionInfo reads the 18-bit version information from the top-right block.
+func readVersionInfo(m [][]bool, size int) uint32 {
+	var info uint32
+	for i := 0; i < 18; i++ {
+		r := i / 3
+		c := i % 3
+		if m[r][size-11+c] {
+			info |= 1 << i
+		}
+	}
+	return info
+}
+
+// extractCodewordStream reads the interleaved codeword bytes from a symbol,
+// undoing the data mask and skipping function modules.
+func extractCodewordStream(m, reserved [][]bool, size, mask int) []byte {
+	var bits []bool
+	upward := true
+	for col := size - 1; col >= 0; col -= 2 {
+		if col == 6 {
+			col--
+		}
+		if col < 0 {
+			break
+		}
+		for k := 0; k < size; k++ {
+			row := k
+			if upward {
+				row = size - 1 - k
+			}
+			for c := col; c >= max(col-1, 0); c-- {
+				if reserved[row][c] {
+					continue
+				}
+				v := m[row][c]
+				if qrMaskFunc(mask, row, c) {
+					v = !v
+				}
+				bits = append(bits, v)
+			}
+		}
+		upward = !upward
+	}
+	out := make([]byte, len(bits)/8)
+	for i := range out {
+		var b byte
+		for j := 0; j < 8; j++ {
+			if bits[i*8+j] {
+				b |= 1 << (7 - j)
+			}
+		}
+		out[i] = b
+	}
+	return out
+}
+
+// deinterleaveBlocks reverses the codeword interleaving, returning each block as
+// its data codewords followed by its error correction codewords.
+func deinterleaveBlocks(stream []byte, version int, level ECCLevel) [][]byte {
+	bi := qrBlockTable[version][level]
+	ecPerBlock := qrECCPerBlock[version][level]
+	totalBlocks := bi.group1Blocks + bi.group2Blocks
+
+	dataLens := make([]int, totalBlocks)
+	for i := 0; i < bi.group1Blocks; i++ {
+		dataLens[i] = bi.group1DataCW
+	}
+	for i := 0; i < bi.group2Blocks; i++ {
+		dataLens[bi.group1Blocks+i] = bi.group2DataCW
+	}
+
+	blocks := make([][]byte, totalBlocks)
+	for i := range blocks {
+		blocks[i] = make([]byte, 0, dataLens[i]+ecPerBlock)
+	}
+
+	maxData := bi.group1DataCW
+	if bi.group2DataCW > maxData {
+		maxData = bi.group2DataCW
+	}
+	idx := 0
+	for j := 0; j < maxData; j++ {
+		for i := 0; i < totalBlocks; i++ {
+			if j < dataLens[i] {
+				blocks[i] = append(blocks[i], stream[idx])
+				idx++
+			}
+		}
+	}
+	for j := 0; j < ecPerBlock; j++ {
+		for i := 0; i < totalBlocks; i++ {
+			blocks[i] = append(blocks[i], stream[idx])
+			idx++
+		}
+	}
+	return blocks
+}
+
+// TestQRDecodeRoundTrip generates QR codes spanning all modes, ECC levels, and a
+// range of versions, then verifies each one decodes structurally: the format
+// reads back identically from both copies, version information (v7+) matches,
+// and every Reed-Solomon block is a valid codeword.
+func TestQRDecodeRoundTrip(t *testing.T) {
+	repeat := func(n int, cs string) string {
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = cs[i%len(cs)]
+		}
+		return string(b)
+	}
+	type tc struct {
+		name string
+		data string
+	}
+	cases := []tc{
+		{"url", "https://example.com/folio"},
+		{"numeric", "1234567890"},
+		{"alphanumeric", "HELLO WORLD $%*+-./:"},
+		{"byte", "Hello, World! lowercase forces byte mode."},
+		{"v7-byte", repeat(180, "abcdefghijklmnopqrstuvwxyz")},   // forces version info
+		{"v10-numeric", repeat(700, "0123456789")},               // multi-block
+		{"v21H-byte", repeat(400, "abcdefghijklmnopqrstuvwxyz")}, // high version, level H
+		{"v32-byte", repeat(1100, "abcdefghijklmnopqrstuvwxyz")}, // very high version
+	}
+	levels := []ECCLevel{ECCLevelL, ECCLevelM, ECCLevelQ, ECCLevelH}
+	for _, c := range cases {
+		for _, level := range levels {
+			bc, err := NewQRWithECC(c.data, level)
+			if err != nil {
+				t.Fatalf("%s L%d: %v", c.name, level, err)
+			}
+			size := bc.width
+			version := (size - 17) / 4
+			m := bc.modules
+
+			gotLevel, mask, ok := readFormat(m, size)
+			if !ok {
+				t.Errorf("%s L%d: format info invalid or copies disagree", c.name, level)
+				continue
+			}
+			if gotLevel != level {
+				t.Errorf("%s L%d: format reads level %d", c.name, level, gotLevel)
+			}
+			if version >= 7 {
+				if got := readVersionInfo(m, size); got != qrVersionInfo[version] {
+					t.Errorf("%s L%d: version info = 0x%05X, want 0x%05X", c.name, level, got, qrVersionInfo[version])
+				}
+			}
+
+			reserved := qrFunctionMap(version, size)
+			stream := extractCodewordStream(m, reserved, size, mask)
+			if len(stream) < qrTotalCodewords[version] {
+				t.Errorf("%s L%d: extracted %d codewords, want >= %d", c.name, level, len(stream), qrTotalCodewords[version])
+				continue
+			}
+			stream = stream[:qrTotalCodewords[version]]
+			for bn, blk := range deinterleaveBlocks(stream, version, level) {
+				if !rsValid(blk, qrECCPerBlock[version][level]) {
+					t.Errorf("%s L%d: block %d is not a valid Reed-Solomon codeword", c.name, level, bn)
+				}
+			}
+		}
+	}
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,7 @@ examples/
 ├── indic/          # Indic script shaping (Devanagari first)
 ├── cjk/            # Chinese, Japanese, Korean with font subsetting
 ├── fonts/          # standard, custom, and Unicode fonts (CJK, Cyrillic)
+├── barcodes/       # QR Code (all ECC levels), Code 128, and EAN-13
 ├── links/          # hyperlinks, bookmarks, internal navigation
 ├── forms/          # interactive AcroForm fields (text, checkbox, radio, dropdown)
 ├── html-to-pdf/    # rich HTML+CSS report (flexbox, tables, page breaks)

--- a/examples/barcodes/main.go
+++ b/examples/barcodes/main.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Barcodes renders every barcode format Folio supports into a single PDF:
+// QR Code (at all four error-correction levels), Code 128, and EAN-13.
+// Each symbol is drawn as vector graphics, so it stays sharp at any zoom.
+//
+// The page is meant to be scanned with a phone or barcode reader to confirm
+// the generated symbols decode to the payloads shown beneath them.
+//
+// Usage:
+//
+//	go run ./examples/barcodes
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/carlos7ags/folio/barcode"
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+)
+
+const (
+	qrPayload    = "https://github.com/carlos7ags/folio"
+	code128Data  = "FOLIO-2026"
+	ean13Data    = "5901234123457"
+	captionColor = 0.39 // gray
+)
+
+func main() {
+	if err := buildDocument().Save("barcodes.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created barcodes.pdf")
+}
+
+// buildDocument assembles the one-page barcode showcase and returns the
+// ready-to-write Document.
+func buildDocument() *document.Document {
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.SetMargins(layout.Margins{Top: 64, Right: 64, Bottom: 64, Left: 64})
+	doc.Info.Title = "Barcodes"
+	doc.Info.Author = "Folio"
+
+	doc.Add(layout.NewHeading("Barcodes", layout.H1))
+	doc.Add(layout.NewParagraph(
+		"Folio generates 1D and 2D barcodes as vector graphics rendered directly "+
+			"into the PDF content stream. Scan any symbol below to verify it decodes "+
+			"to the value printed beneath it.",
+		font.Helvetica, 11,
+	).SetLeading(1.5).SetSpaceAfter(10))
+
+	// --- QR Code, one column per error-correction level ---
+	doc.Add(layout.NewHeading("QR Code (ISO/IEC 18004)", layout.H2))
+	doc.Add(caption(
+		"The same payload encoded at each error-correction level. Higher levels " +
+			"recover more damage at the cost of a denser symbol.",
+	))
+	doc.Add(qrLevelTable())
+	doc.Add(caption("Payload: " + qrPayload))
+
+	// --- Code 128 ---
+	doc.Add(layout.NewHeading("Code 128 (ISO/IEC 15417)", layout.H2))
+	doc.Add(caption(
+		"A high-density 1D barcode for alphanumeric data such as SKUs and " +
+			"tracking identifiers.",
+	))
+	code128 := mustBarcode(barcode.NewCode128(code128Data))
+	doc.Add(layout.NewBarcodeElement(code128, 300).
+		SetHeight(64).
+		SetAlign(layout.AlignLeft).
+		SetAltText("Code 128 barcode encoding " + code128Data))
+	doc.Add(caption("Encoded value: " + code128Data))
+
+	// --- EAN-13 ---
+	doc.Add(layout.NewHeading("EAN-13 (GS1 General Specifications)", layout.H2))
+	doc.Add(caption(
+		"The 13-digit retail product barcode. The thirteenth digit is a checksum " +
+			"over the first twelve.",
+	))
+	ean13 := mustBarcode(barcode.NewEAN13(ean13Data))
+	doc.Add(layout.NewBarcodeElement(ean13, 240).
+		SetHeight(96).
+		SetAlign(layout.AlignLeft).
+		SetAltText("EAN-13 barcode encoding " + ean13Data))
+	doc.Add(caption("Encoded value: " + ean13Data))
+
+	return doc
+}
+
+// qrLevelTable lays out one QR symbol per error-correction level in a row,
+// each captioned with its level letter and approximate recovery capacity.
+func qrLevelTable() *layout.Table {
+	levels := []struct {
+		name     string
+		recovery string
+		level    barcode.ECCLevel
+	}{
+		{"Level L", "~7%", barcode.ECCLevelL},
+		{"Level M", "~15%", barcode.ECCLevelM},
+		{"Level Q", "~25%", barcode.ECCLevelQ},
+		{"Level H", "~30%", barcode.ECCLevelH},
+	}
+
+	tbl := layout.NewTable().
+		SetColumnUnitWidths([]layout.UnitValue{
+			layout.Pct(25), layout.Pct(25), layout.Pct(25), layout.Pct(25),
+		})
+
+	noBorder := layout.CellBorders{}
+
+	symbols := tbl.AddRow()
+	for _, lv := range levels {
+		bc := mustBarcode(barcode.NewQRWithECC(qrPayload, lv.level))
+		el := layout.NewBarcodeElement(bc, 96).
+			SetAlign(layout.AlignCenter).
+			SetAltText(lv.name + " QR code encoding " + qrPayload)
+		symbols.AddCellElement(el).
+			SetBorders(noBorder).
+			SetVAlign(layout.VAlignMiddle).
+			SetPadding(8)
+	}
+
+	labels := tbl.AddRow()
+	for _, lv := range levels {
+		labels.AddCellElement(
+			layout.NewStyledParagraph(
+				layout.NewRun(lv.name, font.HelveticaBold, 9),
+				layout.NewRun("  "+lv.recovery, font.Helvetica, 9).
+					WithColor(layout.RGB(captionColor, captionColor, captionColor)),
+			).SetAlign(layout.AlignCenter),
+		).SetBorders(noBorder).SetPadding(4)
+	}
+
+	return tbl
+}
+
+func caption(text string) *layout.Paragraph {
+	return layout.NewStyledParagraph(
+		layout.NewRun(text, font.Helvetica, 9).
+			WithColor(layout.RGB(captionColor, captionColor, captionColor)),
+	).SetLeading(1.4).SetSpaceAfter(8)
+}
+
+func mustBarcode(bc *barcode.Barcode, err error) *barcode.Barcode {
+	if err != nil {
+		panic(err)
+	}
+	return bc
+}

--- a/examples/barcodes/main_test.go
+++ b/examples/barcodes/main_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	var buf bytes.Buffer
+	if _, err := buildDocument().WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+func TestBarcodesExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 1000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >1 KB", len(pdf))
+	}
+}
+
+func TestBarcodesExampleSinglePage(t *testing.T) {
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got != 1 {
+		t.Errorf("PageCount = %d, want 1", got)
+	}
+}
+
+func TestBarcodesExampleMetadata(t *testing.T) {
+	r := examplePDFReader(t)
+	title, author, _, _, _ := r.Info()
+	if title != "Barcodes" {
+		t.Errorf("/Info Title = %q, want %q", title, "Barcodes")
+	}
+	if author != "Folio" {
+		t.Errorf("/Info Author = %q, want %q", author, "Folio")
+	}
+}
+
+// TestBarcodesExampleContent asserts the headings and payload captions the
+// example emits appear in the rendered page text.
+func TestBarcodesExampleContent(t *testing.T) {
+	r := examplePDFReader(t)
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	for _, want := range []string{
+		"Barcodes",
+		"QR Code",
+		"Code 128",
+		"EAN-13",
+		qrPayload,
+		code128Data,
+		ean13Data,
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("page text missing %q; extracted:\n%s", want, text)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

barcode.NewQR produced QR codes that looked valid but were not scannable (#341). Four independent defects in the QR encoder each corrupted the symbol.

1. Reed-Solomon generator order. rsGeneratorPoly produced the generator polynomial constant-term first, but rsEncode performs synthetic division assuming the leading coefficient comes first. Every block's error-correction codewords were invalid. This alone makes all QR codes unscannable.
2. Format information copy 1. The first of the two format-information copies was written with its 15 bits reversed, so the redundant copies disagreed.
3. Version information. The 18 version-information bits (version 7 and up) were written in reversed order.
4. ECC codeword table. qrECCPerBlock used the wrong error-correction count in the H column for versions 21-40.

## Tests

Added barcode/qr_decode_test.go, which decodes generated symbols back independently of the encoder:

- an independently-constructed GF(256) confirms every Reed-Solomon block is a valid codeword;
- the data and ECC codeword tables are cross-checked against each version's known total capacity;
- the format and version information are read back from the standard module positions.

Each test was confirmed to fail when its corresponding fix is reverted. The encoder was additionally validated end to end across all 40 versions, all four ECC levels, and all three encoding modes.

## Example

Added examples/barcodes, which renders QR Code at all four error-correction levels, Code 128, and EAN-13 into a single PDF for visual and scanner verification.

Fixes #341
