### PR TITLE
html/layout: inline-block/width <li> hugs content; clear box overpaint (follow-up to #343)

### DIFF
--- a/document/border_radius_render_test.go
+++ b/document/border_radius_render_test.go
@@ -142,6 +142,47 @@ func TestBorderRadiusNoSquareOverpaint(t *testing.T) {
 	}
 }
 
+// TestLiBorderRadiusNoSquareOverpaint guards the #343 fix: a styled <li> routed
+// through the element path builds a Div that paints a rounded (or circular) fill,
+// but the <li>'s background also propagated onto the inner content paragraph and
+// its text runs. Without clearing those, they re-draw a square `re` fill over the
+// rounded fill, squaring off the corners. This mirrors TestBorderRadiusNoSquareOverpaint
+// for the list-item path and FAILS before the fix (the badge emitted a full-box
+// and a run-highlight indigo square).
+func TestLiBorderRadiusNoSquareOverpaint(t *testing.T) {
+	// #4F46E5 -> 0.309804 0.27451 0.898039
+	const indigo = "0.309804 0.27451 0.898039"
+
+	cases := []struct {
+		name  string
+		html  string
+		color string
+	}{
+		{
+			name:  "InlineBlockCircleBadge",
+			html:  `<ul><li style="display:inline-block;background:#4F46E5;color:#fff;border-radius:50%;width:28px;height:28px;text-align:center">4</li></ul>`,
+			color: indigo,
+		},
+		{
+			name:  "RoundedSingleLine",
+			html:  `<ul><li style="border-radius:12px;background:#4F46E5;color:#fff;padding:4px 10px">Rounded item</li></ul>`,
+			color: indigo,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := renderHTMLStream(t, tc.html)
+			if !hasRoundedFillInColor(cs, tc.color) {
+				t.Errorf("expected a rounded fill (curve ops) in color %s; stream:\n%s", tc.color, cs)
+			}
+			if sq := squareFillsInColor(cs, tc.color); len(sq) > 0 {
+				t.Errorf("found square `re` fill(s) in box color %s (square overpaint over rounded <li> fill): %v\nstream:\n%s", tc.color, sq, cs)
+			}
+		})
+	}
+}
+
 // grayFillStripeInColor reports whether the stream fills a ` re` rectangle
 // stripe while the current non-stroking color is gray (0.6 0.6 0.6) — the
 // signature of the inner accent fill. It also returns the matching ` re` line.

--- a/examples/list-styling/main.go
+++ b/examples/list-styling/main.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// List-styling demonstrates rich <li> content and styled list-item
+// boxes in HTML→PDF conversion:
+//
+//   - Block-level children of an <li> (<div>, <p>, <br>) lay out as
+//     blocks, with the list marker on the first line (issue #342).
+//   - An <li> carries its own box: background, border, border-radius,
+//     and padding (issue #339).
+//   - An inline-block or explicit-width <li> shrinks to fit its
+//     content — e.g. a "number in a coloured circle" badge — while a
+//     block <li> fills the content column.
+//
+// Usage:
+//
+//	go run ./examples/list-styling
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/carlos7ags/folio/document"
+	fhtml "github.com/carlos7ags/folio/html"
+)
+
+const listHTML = `<!DOCTYPE html>
+<html>
+<head>
+  <title>List styling</title>
+  <style>
+    body { font-family: sans-serif; font-size: 11pt; color: #1f2937; }
+    h2 { font-size: 13pt; margin: 14pt 0 6pt 0; }
+    .step-title { font-weight: bold; }
+
+    /* A list item with block-level children (#342). */
+    ol.steps > li { margin-bottom: 8pt; }
+
+    /* A list item rendered as a rounded card (#339). */
+    ul.cards > li {
+      background: #EEF2FF;
+      border: 1pt solid #C7D2FE;
+      border-radius: 8pt;
+      padding: 8pt 12pt;
+      margin-bottom: 6pt;
+    }
+
+    /* Badges: a number in a coloured circle (inline-block + width). */
+    ul.badges > li {
+      display: inline-block;
+      width: 26pt;
+      height: 26pt;
+      line-height: 26pt;
+      text-align: center;
+      border-radius: 50%;
+      color: #fff;
+      font-weight: bold;
+    }
+    ul.badges > li.a { background: #4F46E5; }
+    ul.badges > li.b { background: #16A34A; }
+    ul.badges > li.c { background: #DC2626; }
+  </style>
+</head>
+<body>
+  <h2>1. Block children inside &lt;li&gt; (#342)</h2>
+  <ol class="steps">
+    <li>
+      <span class="step-title">Prepare the document.</span>
+      <div>Gather the source files and assets.</div>
+      <div>Confirm the page size and margins.</div>
+    </li>
+    <li>
+      <span class="step-title">Render and verify.</span>
+      <div>Convert to PDF.</div>
+      <div>Check the output against the spec.</div>
+    </li>
+  </ol>
+
+  <h2>2. List items as rounded cards (#339)</h2>
+  <ul class="cards">
+    <li>A list item with its own background, border, and rounded corners.</li>
+    <li>Each card hugs the content column and keeps its bullet alongside.</li>
+  </ul>
+
+  <h2>3. Badges — a number in a coloured circle</h2>
+  <ul class="badges">
+    <li class="a">1</li>
+    <li class="b">2</li>
+    <li class="c">3</li>
+  </ul>
+</body>
+</html>`
+
+func main() {
+	doc, err := buildDocument()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := doc.Save("list-styling.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created list-styling.pdf")
+}
+
+// buildDocument converts the demo HTML into a Document. Extracted from
+// main() so the example test can exercise the same construction against
+// an in-memory buffer.
+func buildDocument() (*document.Document, error) {
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.Info.Title = "List styling"
+	doc.Info.Author = "Folio"
+	if err := doc.AddHTML(listHTML, &fhtml.Options{}); err != nil {
+		return nil, fmt.Errorf("AddHTML: %w", err)
+	}
+	return doc, nil
+}

--- a/examples/list-styling/main_test.go
+++ b/examples/list-styling/main_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	doc, err := buildDocument()
+	if err != nil {
+		panic("buildDocument: " + err.Error())
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func TestListStylingExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 1000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >1 KB", len(pdf))
+	}
+}
+
+// TestListStylingExampleContent reads the page text and asserts the
+// step content (block children) and badge digits all rendered — if the
+// <li> layout regressed to flattening or dropping content, this catches it.
+func TestListStylingExampleContent(t *testing.T) {
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	for _, want := range []string{
+		"Prepare the document.", "Gather the source files",
+		"Confirm the page size", "rounded corners", "1", "2", "3",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("page text missing %q; extracted:\n%s", want, text)
+		}
+	}
+}

--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -227,6 +227,27 @@ func clearMatchingParagraphBackgrounds(elems []layout.Element, bg layout.Color) 
 	}
 }
 
+// clearMatchingBackgroundsRecursive is clearMatchingParagraphBackgrounds applied
+// at every depth: it clears matching paragraph/run backgrounds on direct child
+// Paragraphs and descends into any child Div to reach paragraphs nested inside
+// inner wrapper Divs (e.g. an <li> whose block-flow children are wrapped). It
+// does NOT clear a nested Div's own background — that Div owns and draws its own
+// (possibly rounded) fill, so only redundant paragraph/run overpaints are
+// removed.
+func clearMatchingBackgroundsRecursive(elems []layout.Element, bg layout.Color) {
+	for _, e := range elems {
+		switch v := e.(type) {
+		case *layout.Paragraph:
+			if pbg := v.Background(); pbg != nil && *pbg == bg {
+				v.ClearBackground()
+			}
+			v.ClearMatchingRunBackgrounds(bg)
+		case *layout.Div:
+			clearMatchingBackgroundsRecursive(v.Children(), bg)
+		}
+	}
+}
+
 // hasBorderRadius reports whether the computed style declares any border-radius,
 // absolute or percentage, on any corner.
 func (s computedStyle) hasBorderRadius() bool {

--- a/html/converter_list.go
+++ b/html/converter_list.go
@@ -160,6 +160,26 @@ func (c *converter) addElementListItem(li *html.Node, list *layout.List, liStyle
 			contentWidth = 0
 		}
 		applyDivStyles(div, liStyle, contentWidth)
+
+		// The Div now owns and draws the box background (honoring border-radius).
+		// Clear the redundant block-level/run background that the <li>'s
+		// background propagated onto the inner content paragraph and its text
+		// runs, so it does not re-draw a square fill over the rounded corners
+		// (same double-paint #340 fixed for convertBlock/blockquote/cells). The
+		// content may sit directly in the Div (a badge's single Paragraph) or
+		// nested inside an inner wrapper Div (block children), so clear at every
+		// depth. The children are cleared before being added below.
+		if liStyle.BackgroundColor != nil {
+			clearMatchingBackgroundsRecursive(children, *liStyle.BackgroundColor)
+		}
+	}
+	// An inline-block <li> (e.g. a badge "circle around a number") should HUG
+	// its content rather than fill the content column. Enable shrink-to-fit
+	// (CSS fit-content); an explicit CSS width still wins, since
+	// Div.PlanLayout resolves the width unit before applying shrink-to-fit
+	// (and applyDivStyles already set the width unit from liStyle.Width).
+	if liStyle.Display == "inline-block" {
+		div.SetShrinkToFit(true)
 	}
 	for _, e := range children {
 		div.Add(e)

--- a/html/li_block_box_test.go
+++ b/html/li_block_box_test.go
@@ -271,6 +271,143 @@ func TestLiPercentPaddingResolvesAgainstContentColumn(t *testing.T) {
 	}
 }
 
+// elementBoxWidth returns the width of the styled-box container block for an
+// element list item: the widest block under the "L" wrapper that is not the
+// marker block (leaf "LI" at X==0 width==indent). This is the drawn width of
+// the <li>'s wrapping Div.
+func elementBoxWidth(blocks []layout.PlacedBlock) (float64, bool) {
+	best := 0.0
+	found := false
+	var walk func(bs []layout.PlacedBlock, offX float64)
+	walk = func(bs []layout.PlacedBlock, offX float64) {
+		for _, b := range bs {
+			// Skip the "L" structure wrapper (full-list width) and the marker
+			// leaf (X==0, width==indent), measuring the actual content box.
+			isWrapper := b.Tag == "L"
+			isMarker := b.Tag == "LI" && offX+b.X == 0 && b.Width == 18 && len(b.Children) == 0
+			if !isWrapper && !isMarker && b.Width > 0 {
+				if b.Width > best {
+					best = b.Width
+					found = true
+				}
+			}
+			walk(b.Children, offX+b.X)
+		}
+	}
+	walk(blocks, 0)
+	return best, found
+}
+
+// TestLiInlineBlockHugsVsBlockFills is the key behavioral contrast for #343:
+// the same styled <li> content hugs (narrow box) when display:inline-block and
+// fills the content column when block. The inline-block box must be strictly
+// narrower than the block box.
+func TestLiInlineBlockHugsVsBlockFills(t *testing.T) {
+	const pageW = 400.0
+	inlineHTML := `<ul><li style="display:inline-block;background:#eee;border-radius:6px;padding:3px 8px">chip</li></ul>`
+	blockHTML := `<ul><li style="display:block;background:#eee;border-radius:6px;padding:3px 8px">chip</li></ul>`
+
+	inlineElems, err := Convert(inlineHTML, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blockElems, err := Convert(blockHTML, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inlineW, ok := elementBoxWidth(inlineElems[0].PlanLayout(layout.LayoutArea{Width: pageW, Height: 1000}).Blocks)
+	if !ok {
+		t.Fatal("no inline-block element box found")
+	}
+	blockW, ok := elementBoxWidth(blockElems[0].PlanLayout(layout.LayoutArea{Width: pageW, Height: 1000}).Blocks)
+	if !ok {
+		t.Fatal("no block element box found")
+	}
+	if inlineW >= blockW {
+		t.Errorf("inline-block box width %.3f should be < block box width %.3f (it should hug)", inlineW, blockW)
+	}
+}
+
+// TestLiInlineBlockHugsContent confirms an inline-block <li> lays out narrower
+// than the full content column (it hugs its text), with the marker beside it.
+func TestLiInlineBlockHugsContent(t *testing.T) {
+	const pageW = 400.0
+	htmlStr := `<ul><li style="display:inline-block;background:#eee;border-radius:6px;padding:3px 8px">chip</li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: pageW, Height: 1000})
+
+	const indent = 18.0
+	contentCol := pageW - indent // 382
+	boxW, ok := elementBoxWidth(plan.Blocks)
+	if !ok {
+		t.Fatal("no element box found")
+	}
+	if boxW >= contentCol {
+		t.Errorf("inline-block <li> box width %.3f should be < content column %.0f (it should hug)", boxW, contentCol)
+	}
+	// The box must still draw a background (it went through the styled element path).
+	ops := drawPlanToStream(plan)
+	if !strings.Contains(ops, "0.933333 0.933333 0.933333 rg") {
+		t.Errorf("expected #eee background fill on hugging box, got:\n%s", ops)
+	}
+}
+
+// TestLiExplicitWidthBadgeRespectsWidth confirms a badge <li> with an explicit
+// CSS width lays the box out at that width (a ~28pt circle hugging the digit),
+// not the full content column (#343).
+func TestLiExplicitWidthBadgeRespectsWidth(t *testing.T) {
+	const pageW = 400.0
+	htmlStr := `<ul><li style="display:inline-block;background:#4F46E5;color:#fff;border-radius:50%;width:28px;height:28px;text-align:center">4</li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: pageW, Height: 1000})
+
+	boxW, ok := elementBoxWidth(plan.Blocks)
+	if !ok {
+		t.Fatal("no element box found")
+	}
+	// 28px resolves to 21pt (CSS px → PDF points at 0.75). The box must
+	// respect that explicit width, not fill the content column or shrink to
+	// the single digit.
+	if diff := boxW - 21.0; diff < -0.5 || diff > 0.5 {
+		t.Errorf("badge box width = %.3f, want ≈21 (explicit width 28px = 21pt)", boxW)
+	}
+	// Confirm the circle fill is painted.
+	ops := drawPlanToStream(plan)
+	if !strings.Contains(ops, "0.309804 0.27451 0.898039 rg") {
+		t.Errorf("expected indigo badge fill, got:\n%s", ops)
+	}
+}
+
+// TestLiBlockNoWidthFillsColumn is the regression guard: a normal block-flow
+// <li> (no inline-block, no width) still fills the content column.
+func TestLiBlockNoWidthFillsColumn(t *testing.T) {
+	const pageW = 400.0
+	// Block child (a <div>) forces the element path; background makes the box
+	// width observable. No display:inline-block and no explicit width.
+	htmlStr := `<ul><li style="background:#eee"><div>body</div></li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: pageW, Height: 1000})
+
+	const indent = 18.0
+	contentCol := pageW - indent // 382
+	boxW, ok := elementBoxWidth(plan.Blocks)
+	if !ok {
+		t.Fatal("no element box found")
+	}
+	if diff := boxW - contentCol; diff < -1 || diff > 1 {
+		t.Errorf("block <li> box width = %.3f, want ≈%.0f (full content column)", boxW, contentCol)
+	}
+}
+
 // TestLiStyledBoxIsElementItem confirms a styled <li> goes through the element
 // path (single multi-line-capable item) rather than the inline runs path.
 func TestLiStyledBoxIsElementItem(t *testing.T) {


### PR DESCRIPTION
Follow-up to #343 (which laid out `<li>` block children and gave the `<li>` a box). Two refinements for styled list items, surfaced while validating the badge use case from #339:

- An `<li>` with `display:inline-block` or an explicit `width` now **shrinks to fit** its content (e.g. a badge — a number in a coloured circle) instead of filling the content column. A block `<li>` still fills the column.
- The redundant block/run background on the item content is **cleared** so it no longer overpaints the rounded fill as a square — a styled inline-block `<li>` now renders as a proper rounded box / circle (this was a visual defect left in #343).

Also adds an **`examples/list-styling`** demo (with a test) covering block children in `<li>` (#342), styled `<li>` cards (#339), and badge circles.

## Example output
`go run ./examples/list-styling`:

<img width="520" src="https://raw.githubusercontent.com/carlos7ags/folio/assets/pr-327a-screenshots/pr-assets/li-followup/list_styling.png">

## Notes
- Related to #339 and #342; **not** marked to auto-close — leaving those for manual close after reporter validation.
- Render-level test asserts a styled rounded `<li>` emits no square fill over the rounded path; html tests assert inline-block/width `<li>` hugs (width < column) while a block `<li>` fills it. Full suite + vet + gofmt green.