### PR TITLE
layout: fix ordered-list page-break numbering and content loss (#347)

### DIFF
--- a/html/converter_list.go
+++ b/html/converter_list.go
@@ -4,6 +4,9 @@
 package html
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/carlos7ags/folio/font"
 	"github.com/carlos7ags/folio/layout"
 
@@ -71,6 +74,20 @@ func (c *converter) convertList(n *html.Node, style computedStyle, ordered bool)
 	default:
 		if ordered {
 			list.SetStyle(layout.ListOrdered)
+		}
+	}
+
+	// Honor the <ol start="N"> attribute so ordered-list numbering begins at
+	// N (and, via List.overflowFrom, continues correctly across page breaks).
+	// SetStart clamps values below 1 to 1: zero/negative ordinals (which the
+	// HTML spec technically permits) are intentionally not rendered, since the
+	// alpha/roman marker styles have no representation for them.
+	// <reversed> is not yet supported.
+	if ordered {
+		if s := getAttr(n, "start"); s != "" {
+			if start, err := strconv.Atoi(strings.TrimSpace(s)); err == nil {
+				list.SetStart(start)
+			}
 		}
 	}
 

--- a/html/features_test.go
+++ b/html/features_test.go
@@ -540,6 +540,34 @@ func TestListStyleTypeAlpha(t *testing.T) {
 	}
 }
 
+// TestOrderedListStartAttribute verifies that <ol start="N"> is honored: the
+// converted list renders and carries the start offset. Cross-page numbering
+// continuation for a started list is covered at the layout level by
+// TestOrderedListMultiPageRespectsStart.
+func TestOrderedListStartAttribute(t *testing.T) {
+	html := `<ol start="5"><li>First</li><li>Second</li><li>Third</li></ol>`
+	elems, err := Convert(html, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected list elements")
+	}
+	list, ok := elems[0].(*layout.List)
+	if !ok {
+		t.Fatalf("expected first element to be *layout.List, got %T", elems[0])
+	}
+	// The wiring must carry the start="5" through to the list so the first
+	// marker is numbered 5 rather than restarting at 1.
+	if got := list.Start(); got != 5 {
+		t.Errorf("ordered list start = %d, want 5 (from <ol start=\"5\">)", got)
+	}
+	plan := list.PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if plan.Consumed <= 0 {
+		t.Error("ordered list with start should render")
+	}
+}
+
 // --- display: inline-block ---
 
 func TestDisplayInlineBlock(t *testing.T) {

--- a/layout/list.go
+++ b/layout/list.go
@@ -34,6 +34,14 @@ type List struct {
 	direction      Direction // text direction for list items
 	markerColor    *Color    // optional override color for markers
 	markerFontSize float64   // optional override font size for markers (0 = use list fontSize)
+
+	// start is the ordinal offset for marker numbering. The marker for the
+	// item at slice index i is numbered (i + 1 + start). It defaults to 0 so
+	// numbering begins at 1. SetStart adjusts it for <ol start="N">, and
+	// overflowFrom threads the count of items already emitted on prior pages
+	// into the continuation List so numbering continues across page breaks
+	// instead of restarting at 1.
+	start int
 }
 
 // listItem is a single entry in a list, optionally containing a nested sub-list.
@@ -49,9 +57,17 @@ type listItem struct {
 	subList *List     // optional nested list
 
 	// suppressMarker is set on a continuation fragment produced when an
-	// element item splits across pages. The marker (bullet/number) is drawn
-	// only on the first fragment, so continuation fragments suppress it.
+	// element item (or a plain runs item, see contPara) splits across pages.
+	// The marker (bullet/number) is drawn only on the first fragment, so
+	// continuation fragments suppress it.
 	suppressMarker bool
+
+	// contPara holds a pre-wrapped continuation paragraph for a plain
+	// (text/runs) item that was split across a page break. When non-nil it is
+	// used verbatim as the item's paragraph (overriding text/runs) so the tail
+	// lines that did not fit on the prior page render on the next one without
+	// re-deriving them from text.
+	contPara *Paragraph
 }
 
 // listLayoutRef carries list-specific rendering info on a Line.
@@ -91,6 +107,24 @@ func NewListEmbedded(ef *font.EmbeddedFont, fontSize float64) *List {
 func (l *List) SetStyle(s ListStyle) *List {
 	l.style = s
 	return l
+}
+
+// SetStart sets the ordinal of the first item's marker for ordered lists,
+// matching the HTML <ol start="N"> attribute. The first item is numbered n,
+// the second n+1, and so on. Values below 1 are clamped to 1.
+func (l *List) SetStart(n int) *List {
+	if n < 1 {
+		n = 1
+	}
+	l.start = n - 1
+	return l
+}
+
+// Start returns the ordinal of the first item's marker for ordered lists,
+// i.e. the value set via SetStart (or the HTML <ol start="N"> attribute).
+// It defaults to 1 when no start was configured.
+func (l *List) Start() int {
+	return l.start + 1
 }
 
 // SetIndent sets the left indent for item text (default 18pt).
@@ -366,6 +400,9 @@ func (l *List) MaxWidth() float64 {
 // itemParagraph creates a Paragraph for a list item's text content.
 // Uses styled runs when available, falling back to plain text.
 func (l *List) itemParagraph(item listItem) *Paragraph {
+	if item.contPara != nil {
+		return item.contPara
+	}
 	if len(item.runs) > 0 {
 		return NewStyledParagraph(item.runs...)
 	}
@@ -527,8 +564,13 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 			continue
 		}
 
-		markerPara := l.markerParagraph(i)
-		markerWords, _ := markerPara.measureWords(l.indent)
+		// Continuation fragments (a runs item split from a prior page)
+		// suppress the marker so the bullet/number is drawn only once.
+		var markerWords []Word
+		if !item.suppressMarker {
+			markerPara := l.markerParagraph(i)
+			markerWords, _ = markerPara.measureWords(l.indent)
+		}
 
 		// Measure and wrap item text directly.
 		textPara := l.itemParagraph(item)
@@ -540,12 +582,16 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 		lineHeight := maxFS * l.leading
 		wordLines := textPara.wrapWords(textWords, itemWidth)
 
-		// Build PlacedBlocks for each text line.
+		// Build PlacedBlocks for each text line. fitCount tracks how many of
+		// this item's lines fit on the current page; if not all fit, the item
+		// is split (or deferred whole) so it is never dropped.
+		fitCount := 0
 		for j, wl := range wordLines {
 			if curY+lineHeight > area.Height && len(blocks) > 0 {
 				allFit = false
 				break
 			}
+			fitCount = j + 1
 
 			capturedWords := wl
 			capturedHeight := lineHeight
@@ -588,8 +634,19 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 		}
 
 		if !allFit {
-			// Build overflow with remaining items.
-			overflowList := l.overflowFrom(i + 1)
+			// The item at i did not fully fit. Never skip it: if none of its
+			// lines fit, defer the whole item to the next page (overflow starts
+			// at i, marker intact). If some lines fit, split the item — emit the
+			// fitting head here and continue the tail on the next page with the
+			// marker suppressed. Either way the continuation List continues the
+			// ordinal sequence (overflowFrom threads the start offset).
+			var overflowList *List
+			if fitCount == 0 {
+				overflowList = l.overflowFrom(i)
+			} else {
+				_, tail := textPara.SplitAfterLine(fitCount, itemWidth)
+				overflowList = l.overflowSplitting(i, tail)
+			}
 			return LayoutPlan{
 				Status: LayoutPartial, Consumed: curY,
 				Blocks: wrapListBlocks(blocks, area.Width, curY), Overflow: overflowList,
@@ -613,10 +670,38 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 	return LayoutPlan{Status: LayoutFull, Consumed: curY, Blocks: wrapListBlocks(blocks, area.Width, curY)}
 }
 
-// overflowFrom builds a List carrying the items from index start onward,
+// overflowFrom builds a List carrying the items from index from onward,
 // preserving the list's rendering attributes for page-break continuation.
-func (l *List) overflowFrom(start int) *List {
-	return l.cloneWithItems(l.items[start:])
+// The continuation's start offset is advanced by from so ordered-list markers
+// continue the sequence across the page break instead of restarting at 1: the
+// item now at continuation slice index 0 was originally at index from, so its
+// marker (0 + 1 + cont.start) equals (from + 1 + l.start), its true ordinal.
+func (l *List) overflowFrom(from int) *List {
+	cont := l.cloneWithItems(l.items[from:])
+	cont.start = l.start + from
+	return cont
+}
+
+// overflowSplitting builds the continuation List for a plain (text/runs) item
+// at index i that was split across a page break. The item at i is replaced by a
+// continuation carrying the tail paragraph (the lines that did not fit) with the
+// marker suppressed; remaining items i+1... follow unchanged. The start offset
+// is advanced by i so the suppressed item still "occupies" its ordinal and the
+// following items continue numbering correctly.
+func (l *List) overflowSplitting(i int, tail *Paragraph) *List {
+	cont := l.items[i]
+	cont.contPara = tail
+	cont.suppressMarker = true
+	cont.text = ""
+	cont.runs = nil
+
+	items := make([]listItem, 0, len(l.items)-i)
+	items = append(items, cont)
+	items = append(items, l.items[i+1:]...)
+
+	out := l.cloneWithItems(items)
+	out.start = l.start + i
+	return out
 }
 
 // overflowContinuingElement builds the continuation List for a partially-laid-out
@@ -633,7 +718,9 @@ func (l *List) overflowContinuingElement(i int, elemOverflow Element) *List {
 	items := make([]listItem, 0, len(l.items)-i)
 	items = append(items, cont)
 	items = append(items, l.items[i+1:]...)
-	return l.cloneWithItems(items)
+	out := l.cloneWithItems(items)
+	out.start = l.start + i
+	return out
 }
 
 // cloneWithItems returns a List with the supplied items and this list's
@@ -743,7 +830,7 @@ func wrapListBlocks(blocks []PlacedBlock, width, height float64) []PlacedBlock {
 
 // marker returns the marker string (bullet, number, letter) for the item at index.
 func (l *List) marker(index int) string {
-	n := index + 1
+	n := index + 1 + l.start
 	switch l.style {
 	case ListNone:
 		return ""

--- a/layout/list_pagination_test.go
+++ b/layout/list_pagination_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// walkOrderedListPages walks the page chain of a List via PlanLayout, returning
+// the total number of content (non-marker) line blocks emitted across all pages
+// and the first-item marker ordinal observed on each page. The marker ordinal
+// for a page is derived from the List that produced it: marker index 0 with the
+// list's start offset applied (this is exactly the number drawn for the first
+// item rendered on that page).
+func walkOrderedListPages(t *testing.T, l *List, pageH float64) (totalContent int, firstMarkers []string, pages int) {
+	t.Helper()
+	indent := l.Indent()
+	var cur Element = l
+	curList := l
+	for cur != nil {
+		plan := cur.PlanLayout(LayoutArea{Width: 400, Height: pageH})
+		pages++
+		totalContent += contentLineCount(plan.Blocks, indent)
+		// Record the marker of the first item on this page. A continuation
+		// fragment that suppresses its marker contributes the empty string.
+		if curList.items[0].suppressMarker {
+			firstMarkers = append(firstMarkers, "")
+		} else {
+			firstMarkers = append(firstMarkers, curList.marker(0))
+		}
+
+		if plan.Status == LayoutFull {
+			break
+		}
+		next, ok := plan.Overflow.(*List)
+		if !ok {
+			t.Fatalf("page %d: overflow is not a *List", pages)
+		}
+		cur = plan.Overflow
+		curList = next
+		if pages > len(l.items)+10 {
+			t.Fatal("did not converge: too many pages (possible infinite loop)")
+		}
+	}
+	return totalContent, firstMarkers, pages
+}
+
+// TestOrderedListMultiPageNumberingContinues is the #347 regression: a long
+// ordered list of plain items that spans multiple pages must (a) render every
+// item with no content loss across the page boundary, and (b) continue the
+// ordinal sequence on later pages instead of restarting at 1.
+//
+// Fail-before: on main, the boundary item is dropped (totalContent == 59) and
+// page 2's first marker is "1." instead of its true ordinal.
+func TestOrderedListMultiPageNumberingContinues(t *testing.T) {
+	const n = 60
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	for i := 1; i <= n; i++ {
+		l.AddItem(fmt.Sprintf("Entry number %d in the ordered list", i))
+	}
+
+	// Page height chosen so each single-line item is ~14.4pt and a page holds
+	// well under all 60 items, forcing at least two pages.
+	const pageH = 200.0
+	totalContent, firstMarkers, pages := walkOrderedListPages(t, l, pageH)
+
+	if pages < 2 {
+		t.Fatalf("expected the list to span >=2 pages, got %d", pages)
+	}
+	if totalContent != n {
+		t.Errorf("content lost: expected %d item lines across pages, got %d", n, totalContent)
+	}
+
+	// Page 1's first marker is "1.". Every later page's first item must be the
+	// continuation of the sequence, never "1." again.
+	if firstMarkers[0] != "1." {
+		t.Errorf("page 1 first marker = %q, want %q", firstMarkers[0], "1.")
+	}
+	for p := 1; p < len(firstMarkers); p++ {
+		if firstMarkers[p] == "1." {
+			t.Errorf("page %d first marker restarted at %q (numbering did not continue)", p+1, firstMarkers[p])
+		}
+	}
+
+	// Reconstruct the full marker sequence per page and assert it is strictly
+	// the contiguous range 1..60 with no gaps and no resets. We do this by
+	// recomputing the ordinal of the first item on each page from the running
+	// item count, which must match the marker the List would draw.
+	emitted := 0
+	var cur Element = l
+	curList := l
+	for cur != nil {
+		plan := cur.PlanLayout(LayoutArea{Width: 400, Height: pageH})
+		pageItems := contentLineCount(plan.Blocks, indentOf(l))
+		if !curList.items[0].suppressMarker {
+			want := fmt.Sprintf("%d.", emitted+1)
+			if got := curList.marker(0); got != want {
+				t.Errorf("first item on a page: marker = %q, want %q", got, want)
+			}
+		}
+		emitted += pageItems
+		if plan.Status == LayoutFull {
+			break
+		}
+		next := plan.Overflow.(*List)
+		cur = plan.Overflow
+		curList = next
+	}
+	if emitted != n {
+		t.Errorf("emitted %d items total, want %d", emitted, n)
+	}
+}
+
+func indentOf(l *List) float64 { return l.Indent() }
+
+// TestListSetStartClamps verifies SetStart clamps values below 1 to 1 so a
+// stray <ol start="0"> or negative attribute can never produce a zero/negative
+// or restart-breaking ordinal.
+func TestListSetStartClamps(t *testing.T) {
+	cases := []struct {
+		set  int
+		want int
+	}{
+		{set: 0, want: 1},
+		{set: -5, want: 1},
+		{set: 1, want: 1},
+		{set: 5, want: 5},
+	}
+	for _, c := range cases {
+		l := NewList(font.Helvetica, 12).SetStyle(ListOrdered).SetStart(c.set)
+		if got := l.Start(); got != c.want {
+			t.Errorf("SetStart(%d): Start() = %d, want %d", c.set, got, c.want)
+		}
+		l.AddItem("only item")
+		if got := l.marker(0); got != fmt.Sprintf("%d.", c.want) {
+			t.Errorf("SetStart(%d): first marker = %q, want %q", c.set, got, fmt.Sprintf("%d.", c.want))
+		}
+	}
+}
+
+// TestOrderedListMultiPageRespectsStart verifies that <ol start="N"> numbering
+// continues correctly across a page break: page 1 starts at N and later pages
+// continue from where the prior page left off (never resetting to N or to 1).
+func TestOrderedListMultiPageRespectsStart(t *testing.T) {
+	const n = 60
+	const startAt = 100
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered).SetStart(startAt)
+	for i := 1; i <= n; i++ {
+		l.AddItem(fmt.Sprintf("Entry number %d", i))
+	}
+
+	const pageH = 200.0
+	totalContent, firstMarkers, pages := walkOrderedListPages(t, l, pageH)
+
+	if pages < 2 {
+		t.Fatalf("expected >=2 pages, got %d", pages)
+	}
+	if totalContent != n {
+		t.Errorf("content lost: expected %d item lines, got %d", n, totalContent)
+	}
+	want := fmt.Sprintf("%d.", startAt)
+	if firstMarkers[0] != want {
+		t.Errorf("page 1 first marker = %q, want %q", firstMarkers[0], want)
+	}
+	// Page 2's first marker must be startAt + (items on page 1), strictly
+	// greater than the page-1 start and never the page-1 value again.
+	if firstMarkers[1] == want {
+		t.Errorf("page 2 first marker reset to start value %q", want)
+	}
+}
+
+// TestUnorderedListMultiPageNoContentLoss verifies the boundary-item-drop fix
+// applies to bullet lists too: every item renders across the page break (there
+// is no number to continue for <ul>).
+//
+// Fail-before: the straddling item was dropped (totalContent == n-1).
+func TestUnorderedListMultiPageNoContentLoss(t *testing.T) {
+	const n = 60
+	l := NewList(font.Helvetica, 12).SetStyle(ListUnordered)
+	for i := 1; i <= n; i++ {
+		l.AddItem(fmt.Sprintf("Bullet entry number %d", i))
+	}
+
+	const pageH = 200.0
+	totalContent, _, pages := walkOrderedListPages(t, l, pageH)
+	if pages < 2 {
+		t.Fatalf("expected >=2 pages, got %d", pages)
+	}
+	if totalContent != n {
+		t.Errorf("content lost: expected %d bullet lines, got %d", n, totalContent)
+	}
+}
+
+// TestListPlainItemTallerThanPageSplits verifies that a single plain item whose
+// wrapped text is taller than the available page height is split across pages
+// without losing any of its lines, and the marker is drawn only on the first
+// fragment.
+//
+// Fail-before: on main the non-fitting item's tail lines were dropped at the
+// page boundary.
+func TestListPlainItemTallerThanPageSplits(t *testing.T) {
+	// One very long item that wraps to many lines.
+	var long string
+	for i := 0; i < 80; i++ {
+		long += fmt.Sprintf("word%d ", i)
+	}
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	l.AddItem(long)
+
+	// Tiny page so the single item must split across several pages.
+	const pageH = 60.0
+	const width = 200.0
+	indent := l.Indent()
+
+	// Count total content lines across the page chain and track how many
+	// fragments carry the marker. In the plain-runs path the marker is drawn
+	// inline with the first text line (not as its own block), so it is detected
+	// via the producing List's suppressMarker flag: only the first fragment
+	// renders the marker; every continuation suppresses it.
+	totalContent := 0
+	markerFragments := 0
+	pages := 0
+	var cur Element = l
+	curList := l
+	for cur != nil {
+		plan := cur.PlanLayout(LayoutArea{Width: width, Height: pageH})
+		pages++
+		totalContent += contentLineCount(plan.Blocks, indent)
+		if !curList.items[0].suppressMarker {
+			markerFragments++
+		}
+		if plan.Status == LayoutFull {
+			break
+		}
+		next := plan.Overflow.(*List)
+		cur = plan.Overflow
+		curList = next
+		if pages > 50 {
+			t.Fatal("did not converge: possible infinite loop")
+		}
+	}
+
+	// Compare against the unpaginated line count: nothing may be lost.
+	wantLines := len(l.Layout(width))
+	if pages < 2 {
+		t.Fatalf("expected the tall item to split across >=2 pages, got %d", pages)
+	}
+	if totalContent != wantLines {
+		t.Errorf("content lost: expected %d lines across fragments, got %d", wantLines, totalContent)
+	}
+	if markerFragments != 1 {
+		t.Errorf("marker rendered on %d fragments, want exactly 1 (first fragment only)", markerFragments)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses #347. An ordered list that spans a page break restarted its numbering at `1.` on the second page **and** silently dropped the item straddling the boundary.

This does not auto-close #347 — leaving it open for the reporter to validate.

## Root causes

- `overflowFrom(i + 1)` at the page boundary skipped the straddling item `i`, losing its content entirely.
- The continuation `List` had no notion of how many items preceded it, so its markers always began at 1.

## Fix

- Add a `start` ordinal offset to `List` (`SetStart`/`Start`), wired from the HTML `<ol start="N">` attribute. The marker for slice index `i` is `(i + 1 + start)`.
- Thread the prior-page item count into the continuation `List` via `overflowFrom`/`overflowSplitting`/`overflowContinuingElement` so numbering continues across breaks instead of restarting.
- Split a plain (text/runs) item that straddles the boundary: emit the fitting head lines and carry the tail in `listItem.contPara` with the marker suppressed, so no lines are lost.

## Before / after

60-item ordered list rendered to a 2-page Letter PDF:

| | Page 1 ends | Page 2 starts | Items present |
|---|---|---|---|
| Before | `55. Entry 55` | `1. Entry 57` (restart + Entry 56 dropped) | 59/60 |
| After | `55. Entry 55` | `56. Entry 56` | 60/60 |

## Tests

- `layout/list_pagination_test.go`: multi-page numbering continuity, `<ol start>` continuation across a break, unordered no-content-loss, a single item taller than a page, and `SetStart` clamping.
- `html/features_test.go`: `TestOrderedListStartAttribute` asserts the `<ol start="N">` wiring reaches the list (`Start() == 5`).

All new tests fail on the pre-fix code. Full suite green; rebased on current `main`.

## API

Additive only: new `List.SetStart(n int)` / `List.Start() int`. Non-numeric `start` attributes are ignored; zero/negative ordinals are clamped to 1 (intentional divergence from the HTML spec, since alpha/roman markers have no representation for them).