### PR TITLE
docs: add using-folio skill; fix html-to-pdf example dropping absolutes

### DIFF
--- a/.claude/skills/using-folio/SKILL.md
+++ b/.claude/skills/using-folio/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: using-folio
+description: How to generate PDFs with the folio Go library (HTML to PDF). Use when writing Go code that calls github.com/carlos7ags/folio to render HTML/CSS into a PDF, configure pages/fonts/PDF-A, or when a generated PDF is missing content (page numbers, headers/footers, fixed/absolute elements). Teaches the canonical AddHTML path and how to verify output.
+---
+
+# Using folio
+
+folio is a pure-Go HTML-to-PDF library. This skill captures the stable usage
+patterns that are easy to get wrong. It deliberately avoids enumerating which
+CSS properties are supported (that list changes release to release) — for the
+current feature surface, read `examples/` in the repo and the package docs.
+
+## The one rule: use `Document.AddHTML`, not `html.ConvertFull`
+
+`AddHTML` is the canonical entry point. It wires *everything* the converter
+produces into the document:
+
+- normal-flow elements
+- **absolutely/fixed-positioned elements** (`position: absolute` / `fixed`)
+- page geometry and margins from `@page` rules
+- margin boxes for the base, `:first`, `:left`, and `:right` page slots
+  (e.g. `@bottom-center { content: counter(page) }` page numbers)
+- document metadata from `<title>` and `<meta>`
+
+```go
+import "github.com/carlos7ags/folio/document"
+
+doc := document.NewDocument(document.PageSizeA4)
+if err := doc.AddHTML(htmlString, nil); err != nil {
+    return err
+}
+if err := doc.Save("out.pdf"); err != nil {
+    return err
+}
+```
+
+`opts` may be nil. `AddHTMLWithContext` is the deadline-aware variant.
+`AddHTMLTemplate(tmpl, data, opts)` runs an `html/template` first (invoices,
+reports).
+
+### Why this matters
+
+`html.ConvertFull(html, opts)` returns a raw `*ConvertResult`. If you feed it
+into a document by hand, it is very easy to forward only `result.Elements` and
+silently drop `result.Absolutes`, `result.PageConfig`, and the margin-box maps.
+The symptom is a PDF that renders fine but is missing page numbers,
+headers/footers, or every `position: fixed`/`absolute` element — with no error.
+This is the single most common folio mistake.
+
+**Only reach for `ConvertFull` when you genuinely need the raw result** (e.g.
+to inspect or post-process elements before they reach the document). If you do,
+you must forward *all* of it. Page size is fixed at `NewDocument`, so resolve
+`@page` geometry first:
+
+```go
+result, err := html.ConvertFull(htmlString, nil)
+if err != nil { return err }
+
+// Resolve @page geometry BEFORE NewDocument (page size cannot change after).
+ps := document.PageSizeA4
+if pc := result.PageConfig; pc != nil {
+    w, h, _ := pc.Resolve(ps.Width, ps.Height)
+    ps = document.PageSize{Width: w, Height: h}
+}
+doc := document.NewDocument(ps)
+
+if pc := result.PageConfig; pc != nil && pc.HasMargins {
+    doc.SetMargins(layout.Margins{Top: pc.MarginTop, Right: pc.MarginRight,
+        Bottom: pc.MarginBottom, Left: pc.MarginLeft})
+}
+if result.MarginBoxes != nil      { doc.SetMarginBoxes(result.MarginBoxes) }
+if result.FirstMarginBoxes != nil { doc.SetFirstMarginBoxes(result.FirstMarginBoxes) }
+if result.LeftMarginBoxes != nil  { doc.SetLeftMarginBoxes(result.LeftMarginBoxes) }
+if result.RightMarginBoxes != nil { doc.SetRightMarginBoxes(result.RightMarginBoxes) }
+
+for _, e := range result.Elements { doc.Add(e) }
+
+// EASY TO FORGET: absolutely/fixed-positioned elements live in a separate
+// slice and must be forwarded too, or position:fixed/absolute content (page
+// watermarks, pinned footers) silently vanishes.
+for _, a := range result.Absolutes {
+    doc.AddAbsoluteWithOpts(a.Element, a.X, a.Y, a.Width, layout.AbsoluteOpts{
+        RightAligned: a.RightAligned, ZIndex: a.ZIndex, Fixed: a.Fixed, PageIndex: -1,
+    })
+}
+```
+
+If you find yourself replicating the block above, switch to `AddHTML` — it does
+exactly this, kept in sync with the converter.
+
+## Options worth knowing (`*html.Options`)
+
+All optional; the zero value (nil) is "sensible defaults, all local assets must
+be inlined as data: URIs".
+
+- `BaseFS fs.FS` — resolves every local path (images, fonts, linked CSS,
+  `background-image: url(...)`). Use `os.DirFS(dir)`, `embed.FS`, or
+  `fstest.MapFS`. Without it, any local-asset reference fails.
+- `FallbackFontPath string` — a Unicode TTF/OTF for glyphs outside
+  WinAnsiEncoding (CJK, emoji, many accented scripts). Resolved via `BaseFS`
+  when set.
+- `StrictAssets bool` — turn asset-load failures (missing fonts, broken image
+  paths, unreadable stylesheets) into a returned error instead of warn-and-
+  continue. Turn it **on in dev/CI** to catch broken paths; leave off in prod.
+- `Logger *slog.Logger` — receives warn events for failed assets when
+  `StrictAssets` is off.
+- `PageWidth` / `PageHeight`, `DefaultFontSize`, `URLPolicy`, `Client`,
+  `MaxElements`.
+
+## Fonts
+
+- The standard PDF fonts (Helvetica, Times, Courier) need no setup but only
+  cover WinAnsi. Anything else needs an embedded font.
+- Embed via CSS `@font-face { font-family: 'X'; src: url('fonts/X.ttf') }` with
+  `BaseFS` pointing at the asset root, then use `font-family: 'X'`.
+- For stray out-of-range characters in otherwise-Latin text, set
+  `Options.FallbackFontPath` rather than restyling everything.
+- See `examples/fonts`, `examples/cjk`, `examples/indic`, `examples/rtl`.
+
+## PDF/A (archival)
+
+Set a config before saving; folio adds the XMP metadata, output intent, and
+`/ID`, and validates conformance at write time:
+
+```go
+doc.SetPdfA(document.PdfAConfig{Level: document.PdfA2B})
+```
+
+Levels include `PdfA1B`, `PdfA2B`/`PdfA2U`/`PdfA2A`, `PdfA3B` (only level that
+permits file attachments), and the `PdfA4*` family. **PDF/A requires all fonts
+embedded** — the standard-14 fonts do not satisfy it, so supply real fonts via
+`@font-face`/`FallbackFontPath`. For ZUGFeRD/Factur-X invoices (PDF/A-3B +
+attachment + XMP schema), see `examples/zugferd`.
+
+## Verifying output
+
+A folio PDF that "renders" can still be wrong (dropped content, square corners
+where rounding was intended, restarted list numbering, missing page numbers).
+Verify with Poppler tools rather than trusting that no error means correct:
+
+```sh
+pdfinfo out.pdf                       # page count, size
+pdftotext -layout out.pdf -           # text + positions; grep for expected content
+pdftotext -layout -f 2 -l 2 out.pdf - # just page 2 — catch content lost at a page break
+pdftoppm -png -r 200 out.pdf page     # rasterize to inspect visually (bump -r for detail)
+```
+
+To distinguish a *rounded* corner (Bézier `c` operators) from a *square* one
+(`re` rectangle) that overpaints it, decompress the content stream and inspect
+the operators:
+
+```sh
+python3 -c "import sys,zlib,re; d=open('out.pdf','rb').read(); \
+print('\n'.join(s.decode('latin1') for s in re.findall(rb'stream\r?\n(.*?)\r?\nendstream', d, re.S) \
+for s in [zlib.decompress(s)] ))" | grep -E ' re$| c$' | sort | uniq -c
+```
+
+When fixing a rendering bug, render **before** (current `main`) and **after**
+(your branch) of the same minimal HTML and diff the two — structural unit tests
+alone miss visual regressions.
+
+## Pointers
+
+- `examples/` — runnable demos: `hello`, `html-to-pdf`, `invoice`, `report`,
+  `template`, `forms`, `links`, `merge`, `redact`, `optimize`, plus the font/
+  script examples above. Each is `go run ./examples/<name>`.
+- Page sizes: `document.PageSizeLetter`, `PageSizeA4`, `PageSizeLegal`,
+  `PageSizeTabloid`, …; `.Landscape()` swaps width/height.
+- Output: `doc.Save(path)`, `doc.WriteTo(w)`, and the `*WithOptions` variants
+  for compression/linearization settings.

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,9 @@ node_modules/
 *~
 
 # Local Claude Code state (worktrees, session artifacts)
-.claude/
+.claude/*
+# ...but track shared, version-controlled skills.
+!.claude/skills/
 
 # OS
 .DS_Store

--- a/examples/html-to-pdf/main.go
+++ b/examples/html-to-pdf/main.go
@@ -287,6 +287,20 @@ func buildDocument(htmlSource string) (*document.Document, error) {
 		doc.Add(e)
 	}
 
+	// Forward absolutely/fixed-positioned elements. These live in a separate
+	// slice from the normal flow, so a manual ConvertFull pipeline that only
+	// adds result.Elements silently drops every position:fixed/absolute box
+	// (page watermarks, pinned footers). Document.AddHTML does this for you;
+	// when wiring ConvertFull by hand, this loop is mandatory.
+	for _, a := range result.Absolutes {
+		doc.AddAbsoluteWithOpts(a.Element, a.X, a.Y, a.Width, layout.AbsoluteOpts{
+			RightAligned: a.RightAligned,
+			ZIndex:       a.ZIndex,
+			Fixed:        a.Fixed,
+			PageIndex:    -1,
+		})
+	}
+
 	// Apply metadata from <title> and <meta> tags.
 	if result.Metadata.Title != "" {
 		doc.Info.Title = result.Metadata.Title


### PR DESCRIPTION
## Summary

Two related changes:

1. **New skill** `.claude/skills/using-folio/SKILL.md` — a thin, version-controlled usage guide for the library. It captures the stable patterns that are easy to get wrong, chiefly **use `Document.AddHTML`, not `html.ConvertFull`**, plus the options that matter (`BaseFS`, `FallbackFontPath`, `StrictAssets`), font and PDF/A setup, and a verification cookbook (pdftoppm / pdftotext / content-stream inspection). It deliberately does **not** enumerate the supported-CSS surface, which changes release to release.

2. **Bug fix in `examples/html-to-pdf`** — the example wires the raw `ConvertFull` result by hand but forwarded only `result.Elements`, silently dropping `result.Absolutes`. Any `position: fixed`/`absolute` content (page watermarks, pinned footers) would vanish with no error. Added the forwarding loop via `AddAbsoluteWithOpts`. `Document.AddHTML` already does this internally; since the example demonstrates the by-hand path, it must too.

## Why the skill exists

The single most common folio mistake is feeding only `ConvertFull(...).Elements` into a document, which drops absolutes, `@page` geometry, and margin boxes (page numbers, headers/footers) — the symptom is a PDF that renders fine but is missing content, with no error. This example having the same latent bug is the proof. The skill encodes the canonical path and how to verify output.

## Notes

- `.gitignore` now tracks `.claude/skills/` while keeping the rest of `.claude/` ignored.
- Doc/example only plus one example bug fix; no library API change.
- All packages build; `examples/html-to-pdf` builds and vets clean.