### PR TITLE
barcode: support Code 128 code sets A and C

### DIFF
--- a/barcode/barcode_test.go
+++ b/barcode/barcode_test.go
@@ -40,9 +40,11 @@ func TestCode128Empty(t *testing.T) {
 }
 
 func TestCode128InvalidChar(t *testing.T) {
-	_, err := NewCode128("Hello\x01World")
+	// Bytes above ASCII 127 are not encodable; control characters (handled by
+	// Code A) are.
+	_, err := NewCode128("Hello\xffWorld")
 	if err == nil {
-		t.Error("expected error for control character")
+		t.Error("expected error for non-ASCII byte")
 	}
 }
 

--- a/barcode/code128.go
+++ b/barcode/code128.go
@@ -5,45 +5,61 @@ package barcode
 
 import "fmt"
 
-// NewCode128 generates a Code 128 barcode from a string using Code B.
-// Code B covers ASCII 32-127; characters outside that range return an error.
+// Code 128 symbol values for the start codes and code-set switches. A switch
+// value selects the named code set from whichever set is currently active.
+const (
+	c128StartA  = 103
+	c128StartB  = 104
+	c128StartC  = 105
+	c128SwitchC = 99
+	c128SwitchB = 100
+	c128SwitchA = 101
+)
+
+// c128Set identifies a Code 128 code set.
+type c128Set int
+
+const (
+	c128None c128Set = iota
+	c128A
+	c128B
+	c128C
+)
+
+// NewCode128 generates a Code 128 barcode from a string. It encodes the full
+// ASCII range (0-127) by selecting code sets A, B, and C automatically, using
+// Code C for runs of digits. Bytes above 127 return an error.
 func NewCode128(data string) (*Barcode, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("barcode: empty data")
 	}
 
-	// Encode using Code B (ASCII 32-127).
-	values, err := encodeCode128B(data)
+	symbols, err := encodeCode128(data)
 	if err != nil {
 		return nil, err
 	}
 
-	// Build the module pattern.
 	var modules []bool
 
-	// Quiet zone (10 modules of white).
+	// Left quiet zone (10 modules).
 	for range 10 {
 		modules = append(modules, false)
 	}
 
-	// Start code B.
-	modules = append(modules, code128Patterns[104]...)
-
-	// Data characters.
-	checksum := 104 // start code B value
-	for i, v := range values {
+	// Symbol values, accumulating the modulo-103 checksum (start code has
+	// weight 1, each following symbol weight 1, 2, 3, ...).
+	checksum := symbols[0]
+	modules = append(modules, code128Patterns[symbols[0]]...)
+	for k, v := range symbols[1:] {
 		modules = append(modules, code128Patterns[v]...)
-		checksum += v * (i + 1)
+		checksum += v * (k + 1)
 	}
-
-	// Checksum character.
-	checksum %= 103
-	modules = append(modules, code128Patterns[checksum]...)
+	modules = append(modules, code128Patterns[checksum%103]...)
 
 	// Stop pattern (13 modules: 2331112).
 	modules = append(modules, code128Stop...)
 
-	// Quiet zone.
+	// Right quiet zone (10 modules).
 	for range 10 {
 		modules = append(modules, false)
 	}
@@ -51,16 +67,110 @@ func NewCode128(data string) (*Barcode, error) {
 	return new1D(modules, 50), nil
 }
 
-// encodeCode128B converts ASCII text to Code 128 Code B values.
-func encodeCode128B(data string) ([]int, error) {
-	values := make([]int, len(data))
-	for i, ch := range data {
-		if ch < 32 || ch > 127 {
-			return nil, fmt.Errorf("barcode: Code 128B does not support character %d at position %d", ch, i)
-		}
-		values[i] = int(ch) - 32
+// isDigit128 reports whether b is an ASCII digit.
+func isDigit128(b byte) bool { return b >= '0' && b <= '9' }
+
+// digitRun128 returns the number of consecutive ASCII digits in data from i.
+func digitRun128(data string, i int) int {
+	n := 0
+	for i+n < len(data) && isDigit128(data[i+n]) {
+		n++
 	}
-	return values, nil
+	return n
+}
+
+// valueA returns the Code A value for an ASCII byte 0-95: 32-95 map to 0-63,
+// and the control characters 0-31 map to 64-95.
+func valueA(b byte) int {
+	if b < 32 {
+		return int(b) + 64
+	}
+	return int(b) - 32
+}
+
+// encodeCode128 converts data to Code 128 symbol values, beginning with a start
+// code and ending before the checksum. Code C is used for digit runs, Code A
+// for control characters, and Code B otherwise.
+func encodeCode128(data string) ([]int, error) {
+	for i := range len(data) {
+		if data[i] > 127 {
+			return nil, fmt.Errorf("barcode: Code 128 does not support byte %d at position %d", data[i], i)
+		}
+	}
+
+	n := len(data)
+	var symbols []int
+	set := c128None
+
+	for i := 0; i < n; {
+		if set == c128C {
+			// In Code C a value 0-99 is a digit pair. The encoder never
+			// switches C to C, so the value 99 is always the pair "99" and not
+			// the switch-to-C code.
+			if i+1 < n && isDigit128(data[i]) && isDigit128(data[i+1]) {
+				symbols = append(symbols, int(data[i]-'0')*10+int(data[i+1]-'0'))
+				i += 2
+				continue
+			}
+			// Leave Code C for the character at i.
+			if data[i] < 32 {
+				symbols = append(symbols, c128SwitchA)
+				set = c128A
+			} else {
+				symbols = append(symbols, c128SwitchB)
+				set = c128B
+			}
+			continue
+		}
+
+		run := digitRun128(data, i)
+		// Code C pays off for runs of four or more digits, or for an all-digit
+		// payload of even length.
+		wantC := run >= 4 || (run == n && run >= 2 && run%2 == 0)
+
+		if set == c128None {
+			switch {
+			case wantC:
+				symbols = append(symbols, c128StartC)
+				set = c128C
+			case data[i] < 32:
+				symbols = append(symbols, c128StartA)
+				set = c128A
+			default:
+				symbols = append(symbols, c128StartB)
+				set = c128B
+			}
+			continue
+		}
+
+		if run >= 4 {
+			symbols = append(symbols, c128SwitchC)
+			set = c128C
+			continue
+		}
+
+		c := data[i]
+		switch set {
+		case c128A:
+			if c <= 95 {
+				symbols = append(symbols, valueA(c))
+				i++
+			} else { // 96-127 needs Code B
+				symbols = append(symbols, c128SwitchB)
+				set = c128B
+			}
+		default: // c128B
+			if c >= 32 {
+				symbols = append(symbols, int(c)-32)
+				i++
+			} else { // control character needs Code A
+				symbols = append(symbols, c128SwitchA)
+				set = c128A
+			}
+		}
+	}
+
+	return symbols, nil
 }
 
 // code128Patterns contains the bar/space patterns for Code 128.

--- a/barcode/code128_decode_test.go
+++ b/barcode/code128_decode_test.go
@@ -64,8 +64,9 @@ func coreBits(bc *Barcode) string {
 
 // decodeCode128 reads a generated Code 128 symbol back to its text. It segments
 // the symbol into 11-module characters, recovers each value from the pattern
-// table, checks the start code, modulo-103 checksum, and stop pattern, and maps
-// the data values back to ASCII.
+// table, checks the start code, modulo-103 checksum, and stop pattern, then
+// interprets the values according to the active code set, following A/B/C
+// switches.
 func decodeCode128(t *testing.T, bc *Barcode) string {
 	t.Helper()
 	row := bc.modules[0]
@@ -73,7 +74,7 @@ func decodeCode128(t *testing.T, bc *Barcode) string {
 	hi := len(row) - trailingLight(row)
 	sym := row[lo:hi]
 
-	if len(sym) < 11*3+13 {
+	if len(sym) < 11*2+13 {
 		t.Fatalf("symbol too short: %d modules", len(sym))
 	}
 	if !bitsEqual(sym[len(sym)-13:], code128Stop) {
@@ -99,12 +100,9 @@ func decodeCode128(t *testing.T, bc *Barcode) string {
 		values = append(values, v)
 	}
 
-	if values[0] != 104 {
-		t.Fatalf("expected Start B (104), got %d", values[0])
-	}
 	data := values[1 : len(values)-1]
 	want := values[len(values)-1]
-	sum := 104
+	sum := values[0]
 	for k, v := range data {
 		sum += v * (k + 1)
 	}
@@ -112,22 +110,78 @@ func decodeCode128(t *testing.T, bc *Barcode) string {
 		t.Fatalf("checksum = %d, encoded %d", sum%103, want)
 	}
 
-	out := make([]byte, len(data))
-	for i, v := range data {
-		out[i] = byte(v + 32)
+	var set c128Set
+	switch values[0] {
+	case c128StartA:
+		set = c128A
+	case c128StartB:
+		set = c128B
+	case c128StartC:
+		set = c128C
+	default:
+		t.Fatalf("unexpected start code %d", values[0])
+	}
+
+	var out []byte
+	for _, v := range data {
+		switch set {
+		case c128C:
+			switch {
+			case v <= 99:
+				out = append(out, byte('0'+v/10), byte('0'+v%10))
+			case v == c128SwitchB:
+				set = c128B
+			case v == c128SwitchA:
+				set = c128A
+			default:
+				t.Fatalf("unexpected Code C symbol %d", v)
+			}
+		case c128B:
+			switch {
+			case v <= 95:
+				out = append(out, byte(v+32))
+			case v == c128SwitchC:
+				set = c128C
+			case v == c128SwitchA:
+				set = c128A
+			default:
+				t.Fatalf("unexpected Code B symbol %d", v)
+			}
+		default: // c128A
+			switch {
+			case v <= 63:
+				out = append(out, byte(v+32))
+			case v <= 95:
+				out = append(out, byte(v-64)) // control characters
+			case v == c128SwitchC:
+				set = c128C
+			case v == c128SwitchB:
+				set = c128B
+			default:
+				t.Fatalf("unexpected Code A symbol %d", v)
+			}
+		}
 	}
 	return string(out)
 }
 
 func TestCode128RoundTrip(t *testing.T) {
 	inputs := []string{
-		"FOLIO-2026",
-		"Hello, World!",
-		"1234567890",
-		"ABC abc 123",
-		" !\"#$%&'()*+,-./",
-		":;<=>?@[\\]^_`{|}~",
-		"\x7f", // DEL, the top of Code B
+		"FOLIO-2026",         // Code B then Code C
+		"Hello, World!",      // Code B
+		"1234567890",         // all digits, Code C
+		"12345",              // odd digit run
+		"AB12CD",             // short digit run stays in Code B
+		"ABCD1234567890WXYZ", // Code B, Code C, Code B
+		"ABC abc 123",        // mixed case and a short digit run
+		" !\"#$%&'()*+,-./",  // Code B symbols
+		":;<=>?@[\\]^_`{|}~", // Code B symbols
+		"\x7f",               // DEL, the top of Code B
+		"\x00\x01\x1f",       // Code A control characters
+		"line1\nline2\ttab",  // control characters mixed with Code B text
+		"\t\t007 agent",      // Code A then Code B
+		"\x011234",           // Code A then Code C
+		"1234\x01",           // Code C then Code A
 	}
 	for _, in := range inputs {
 		bc, err := NewCode128(in)
@@ -155,15 +209,22 @@ func TestCode128RoundTripAllPrintable(t *testing.T) {
 }
 
 // TestCode128GoldenPattern pins the core module pattern (between quiet zones)
-// for a known input, so a change to the pattern tables is caught.
+// for known inputs across code sets B, C, and A, so a change to the pattern
+// tables is caught.
 func TestCode128GoldenPattern(t *testing.T) {
-	const want = "1101001000010001100010100011101101000110111011000100010100011101101001101110011001110010100111011001100111001011001110100110100010001100011101011"
-	bc, err := NewCode128("FOLIO-2026")
-	if err != nil {
-		t.Fatal(err)
+	cases := map[string]string{
+		"FOLIO-2026": "11010010000100011000101000111011010001101110110001000101000111011010011011100101110111101100100111011100100110110000101001100011101011",
+		"1234567890": "110100111001011001110010001011000111000101101100001010011011110110100111100101100011101011",
+		"AB\x01CD":   "11010010000101000110001000101100011101011110100101100001000100011010110001000111001001101100011101011",
 	}
-	if got := coreBits(bc); got != want {
-		t.Errorf("core modules =\n%s\nwant\n%s", got, want)
+	for in, want := range cases {
+		bc, err := NewCode128(in)
+		if err != nil {
+			t.Fatalf("NewCode128(%q): %v", in, err)
+		}
+		if got := coreBits(bc); got != want {
+			t.Errorf("%q: core modules =\n%s\nwant\n%s", in, got, want)
+		}
 	}
 }
 

--- a/barcode/fuzz_test.go
+++ b/barcode/fuzz_test.go
@@ -20,10 +20,10 @@ func FuzzNewCode128(f *testing.F) {
 		"1234567890",
 		"SKU-12345",
 		"ISBN 978-0-596-00712-6",
-		string([]byte{0x00}), // NUL (out of Code B range)
+		string([]byte{0x00}), // NUL (Code A)
 		string([]byte{0xFF}), // high-byte (out of ASCII)
-		"\t\n\r",             // control whitespace (out of range)
-		"é",                  // UTF-8 multi-byte (out of range)
+		"\t\n\r",             // control whitespace (Code A)
+		"é",                  // UTF-8 multi-byte (out of ASCII)
 	}
 	for _, s := range seeds {
 		f.Add(s)


### PR DESCRIPTION
## Summary

Adds full Code 128 code-set support, the remaining encoder item from #346 (decode tests and the EAN-13 quiet-zone fix landed in #348).

The encoder previously emitted Code B only. It now selects code sets A, B, and C automatically:

- Code C encodes runs of digits as pairs, roughly halving the width of numeric payloads.
- Code A encodes the ASCII control characters (0-31).
- Code B covers the rest. Bytes above 127 return an error.

Switching uses full code-set switches (no Shift), which is always valid and at most one symbol longer in rare cases. The NewCode128 doc comment is updated accordingly.

## Tests

- The Code 128 decode test now follows A/B/C switches. Round-trip inputs cover Code B, Code C (even and odd digit runs), Code A (control characters), all printable ASCII, and every code-set transition (B-C, C-B, B-A, A-B, A-C, C-A).
- Golden module-pattern tests pin the assembled output for Code B+C and Code A inputs, catching a corrupted pattern-table entry that the table-symmetric round-trip cannot.
- The control-character rejection test now rejects a non-ASCII byte, since control characters are now encodable via Code A.

Code C and Code A output was confirmed to decode with an external reader.

Refs #346
