### PR TITLE
document: add AddConvertResult and SetPageSize/PageSize

### DIFF
--- a/document/addconvertresult_test.go
+++ b/document/addconvertresult_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"reflect"
+	"testing"
+
+	foliohtml "github.com/carlos7ags/folio/html"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// sampleHTML exercises the parts of a ConvertResult a naive ConvertFull+Add
+// pipeline drops: @page geometry/margins plus base, :first, :left, and :right
+// margin boxes, and a position:fixed element.
+const sampleHTML = `<!DOCTYPE html><html><head>
+<title>Sample</title>
+<meta name="author" content="Tester">
+<meta name="subject" content="Subj">
+<meta name="keywords" content="k1, k2">
+<meta name="generator" content="Gen">
+<style>
+  @page { size: A4; margin: 40px; @bottom-center { content: counter(page); } }
+  @page :first { margin: 20px; @top-center { content: "First"; } }
+  @page :left { margin-left: 60px; @bottom-left { content: "L"; color: red; } }
+  @page :right { margin-right: 60px; @bottom-right { content: "R"; color: blue; } }
+  .wm { position: fixed; top: 10px; left: 10px; }
+</style></head><body>
+<div class="wm">WATERMARK</div>
+<h1>Heading</h1>
+<p>Body paragraph.</p>
+</body></html>`
+
+// TestAddConvertResultMatchesAddHTML asserts AddHTML and
+// ConvertFull+AddConvertResult leave the document in the same state — the
+// contract that lets a caller use the raw result without losing anything.
+func TestAddConvertResultMatchesAddHTML(t *testing.T) {
+	viaAddHTML := NewDocument(PageSizeLetter)
+	if err := viaAddHTML.AddHTML(sampleHTML, nil); err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+
+	viaResult := NewDocument(PageSizeLetter)
+	result, err := foliohtml.ConvertFull(sampleHTML, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	if err := viaResult.AddConvertResult(result); err != nil {
+		t.Fatalf("AddConvertResult: %v", err)
+	}
+
+	if viaResult.pageSize != viaAddHTML.pageSize {
+		t.Errorf("pageSize: AddConvertResult=%v AddHTML=%v", viaResult.pageSize, viaAddHTML.pageSize)
+	}
+	if viaResult.margins != viaAddHTML.margins {
+		t.Errorf("margins: AddConvertResult=%v AddHTML=%v", viaResult.margins, viaAddHTML.margins)
+	}
+	assertMarginsEq(t, "firstMargins", viaResult.firstMargins, viaAddHTML.firstMargins)
+	assertMarginsEq(t, "leftMargins", viaResult.leftMargins, viaAddHTML.leftMargins)
+	assertMarginsEq(t, "rightMargins", viaResult.rightMargins, viaAddHTML.rightMargins)
+	if len(viaResult.elements) != len(viaAddHTML.elements) {
+		t.Errorf("elements: AddConvertResult=%d AddHTML=%d", len(viaResult.elements), len(viaAddHTML.elements))
+	}
+	if len(viaResult.absolutes) != len(viaAddHTML.absolutes) {
+		t.Errorf("absolutes: AddConvertResult=%d AddHTML=%d", len(viaResult.absolutes), len(viaAddHTML.absolutes))
+	}
+	for _, mb := range []struct {
+		name string
+		a, b map[string]layout.MarginBox
+	}{
+		{"marginBoxes", viaResult.marginBoxes, viaAddHTML.marginBoxes},
+		{"firstMarginBoxes", viaResult.firstMarginBoxes, viaAddHTML.firstMarginBoxes},
+		{"leftMarginBoxes", viaResult.leftMarginBoxes, viaAddHTML.leftMarginBoxes},
+		{"rightMarginBoxes", viaResult.rightMarginBoxes, viaAddHTML.rightMarginBoxes},
+	} {
+		if len(mb.a) == 0 {
+			t.Errorf("%s: fixture produced none; the :first/:left/:right path is unexercised", mb.name)
+		}
+		if !reflect.DeepEqual(mb.a, mb.b) {
+			t.Errorf("%s mismatch:\n AddConvertResult=%+v\n AddHTML=%+v", mb.name, mb.a, mb.b)
+		}
+	}
+	if viaResult.Info != viaAddHTML.Info {
+		t.Errorf("metadata mismatch:\n AddConvertResult=%+v\n AddHTML=%+v", viaResult.Info, viaAddHTML.Info)
+	}
+}
+
+func assertMarginsEq(t *testing.T, name string, a, b *layout.Margins) {
+	t.Helper()
+	if (a == nil) != (b == nil) {
+		t.Errorf("%s: presence differs AddConvertResult=%v AddHTML=%v", name, a, b)
+		return
+	}
+	if a != nil && *a != *b {
+		t.Errorf("%s: AddConvertResult=%v AddHTML=%v", name, *a, *b)
+	}
+}
+
+// TestAddConvertResultCarriesAbsolutesAndPageConfig is the motivating
+// regression: a position:fixed element and @page margin boxes must survive
+// (the naive Elements-only loop drops both).
+func TestAddConvertResultCarriesAbsolutesAndPageConfig(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	result, err := foliohtml.ConvertFull(sampleHTML, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	if len(result.Absolutes) == 0 {
+		t.Fatal("test fixture produced no absolutes; sampleHTML must contain a position:fixed element")
+	}
+	if err := doc.AddConvertResult(result); err != nil {
+		t.Fatalf("AddConvertResult: %v", err)
+	}
+	if len(doc.absolutes) != len(result.Absolutes) {
+		t.Errorf("fixed/absolute elements dropped: doc has %d, result had %d", len(doc.absolutes), len(result.Absolutes))
+	}
+	if len(doc.marginBoxes) == 0 {
+		t.Error("@page margin box (page numbering) was not applied")
+	}
+	// The @page { margin: 40px } overrides the 72pt default on all sides.
+	if doc.margins.Top == 72 {
+		t.Error("@page margins were not applied (still at the 72pt default)")
+	}
+	// The :left/:right reconstruction must preserve every field (notably the
+	// color set on those boxes), matching the converter's own LeftMarginBoxes
+	// /RightMarginBoxes. Dropping HasColor/Embedded would diverge here.
+	if !reflect.DeepEqual(doc.leftMarginBoxes, result.LeftMarginBoxes) {
+		t.Errorf("left margin boxes not faithfully reconstructed:\n doc=%+v\n result=%+v", doc.leftMarginBoxes, result.LeftMarginBoxes)
+	}
+	if !reflect.DeepEqual(doc.rightMarginBoxes, result.RightMarginBoxes) {
+		t.Errorf("right margin boxes not faithfully reconstructed:\n doc=%+v\n result=%+v", doc.rightMarginBoxes, result.RightMarginBoxes)
+	}
+}
+
+func TestAddConvertResultNil(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	if err := doc.AddConvertResult(nil); err == nil {
+		t.Error("AddConvertResult(nil) should return an error")
+	}
+}
+
+func TestSetAndGetPageSize(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	if got := doc.PageSize(); got != PageSizeLetter {
+		t.Errorf("PageSize() = %v, want %v (from NewDocument)", got, PageSizeLetter)
+	}
+	doc.SetPageSize(PageSizeA4)
+	if got := doc.PageSize(); got != PageSizeA4 {
+		t.Errorf("after SetPageSize: PageSize() = %v, want %v", got, PageSizeA4)
+	}
+}

--- a/document/document.go
+++ b/document/document.go
@@ -112,6 +112,19 @@ func NewDocument(ps PageSize) *Document {
 	}
 }
 
+// SetPageSize overrides the page dimensions set by NewDocument. AddHTML and
+// AddConvertResult also set this from @page rules, so call it after them to
+// force a size.
+func (d *Document) SetPageSize(ps PageSize) {
+	d.pageSize = ps
+}
+
+// PageSize returns the current page dimensions, including any size derived
+// from an @page rule.
+func (d *Document) PageSize() PageSize {
+	return d.pageSize
+}
+
 // SetTagged enables tagged PDF output (PDF/UA foundation).
 // When enabled, the document includes a structure tree with semantic tags
 // (P, H1-H6, Table, Figure, etc.) and marked content operators in the

--- a/document/html.go
+++ b/document/html.go
@@ -36,6 +36,19 @@ func (d *Document) AddHTMLWithContext(ctx context.Context, htmlStr string, opts 
 	if err != nil {
 		return err
 	}
+	return d.AddConvertResult(result)
+}
+
+// AddConvertResult feeds a raw [html.ConvertResult] into the document:
+// elements, absolutes, @page geometry/margins, margin boxes, and metadata
+// (existing non-empty Info fields are kept). AddHTML is exactly ConvertFull
+// followed by AddConvertResult; call this directly only to inspect or modify
+// the result first. Adding result.Elements by hand instead drops
+// result.Absolutes and the @page configuration.
+func (d *Document) AddConvertResult(result *foliohtml.ConvertResult) error {
+	if result == nil {
+		return fmt.Errorf("document: AddConvertResult: nil result")
+	}
 
 	// Apply metadata from <title> and <meta> tags.
 	m := result.Metadata
@@ -112,14 +125,14 @@ func (d *Document) AddHTMLWithContext(ctx context.Context, htmlStr string, opts 
 		if pc.Left != nil && len(pc.Left.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.Left.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
 			}
 			d.SetLeftMarginBoxes(boxes)
 		}
 		if pc.Right != nil && len(pc.Right.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.Right.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
 			}
 			d.SetRightMarginBoxes(boxes)
 		}

--- a/html/doc.go
+++ b/html/doc.go
@@ -92,4 +92,23 @@
 // @import (use inline <style> or Options.ExternalCSS). :has() selector.
 // CSS animations, transitions. clip-path, mask.
 // Vertical writing modes. ::first-line, ::first-letter pseudo-elements.
+//
+// # Loading local assets
+//
+// Local references (images, fonts, linked stylesheets, background-image url())
+// resolve through [Options.BaseFS] — an os.DirFS, embed.FS, or fstest.MapFS;
+// when nil, local references fail and assets must be inlined as data: URIs.
+// Set [Options.FallbackFontPath] for glyphs outside WinAnsiEncoding.
+//
+// A failed asset load is logged ([Options.Logger]) and skipped by default, so
+// broken paths silently degrade output. Set [Options.StrictAssets] to return
+// those failures as an error (with the partial result) — use it in dev and CI.
+//
+// # Feeding the result into a document
+//
+// Prefer [github.com/carlos7ags/folio/document.Document.AddHTML], which wires
+// the whole conversion into a document in one call. Use [ConvertFull] only to
+// inspect the raw [ConvertResult] first, then pass it to
+// [github.com/carlos7ags/folio/document.Document.AddConvertResult] — adding
+// result.Elements by hand drops result.Absolutes and the @page configuration.
 package html


### PR DESCRIPTION
## Summary

Adds two ergonomic, additive APIs to `document.Document` and fixes a latent margin-box bug found along the way.

### `AddConvertResult(*html.ConvertResult) error`

`AddHTML` was the only public way to render HTML. Callers who needed the raw `html.ConvertResult` — to inspect or post-process elements before they reach the document — had to wire it in by hand, and that path is **lossy**: forwarding `result.Elements` alone silently drops `result.Absolutes`, the `@page` geometry, and the margin boxes (page numbers, headers/footers). It renders fine and is missing content, with no error. This is the most common folio mistake; our own `examples/html-to-pdf` had the same latent bug (fixed separately in #350).

This extracts the wiring half of `AddHTML` into a public method. `AddHTML` is now exactly `ConvertFull` + `AddConvertResult`, so the two paths cannot diverge.

```go
result, err := html.ConvertFull(htmlString, nil)
// ... inspect / modify result ...
doc.AddConvertResult(result) // forwards everything, correctly
```

### `SetPageSize(PageSize)` / `PageSize() PageSize`

Page size was only settable at `NewDocument`, yet `AddHTML` mutates it internally from `@page` rules — with no public setter or getter. (PR #107 had to delete a `SetPageSize` line from the docs precisely because it didn't exist.) These add the missing door.

### Latent bug fix (margin boxes)

While extracting, the `@page :left` / `:right` margin-box reconstruction was dropping `HasColor` and the `Embedded` font — fields that `base`/`:first` already carried and that the converter's own `LeftMarginBoxes`/`RightMarginBoxes` retain. All four sets are now consistent. A regression test asserts the reconstruction matches the converter (fails before this fix, passes after).

## Tests

`document/addconvertresult_test.go`:
- `AddHTML` and `AddConvertResult` leave identical document state (page size, all margins incl. `:first/:left/:right`, all four margin-box sets, element/absolute counts, full metadata).
- Absolutes + `@page` config survive (the motivating regression).
- `:left/:right` field fidelity (the latent-bug regression).
- nil-result guard; `SetPageSize`/`PageSize` round-trip.

Full suite green; additive and non-breaking; no import-cycle (document already imports html). Also makes PR #107's intended `SetPageSize` usage valid.

## Doc

`html/doc.go` gains short sections on local-asset loading (`BaseFS`, `StrictAssets`) and on preferring `AddHTML`/`AddConvertResult` over hand-wiring.