### PR TITLE
docs: use AddConvertResult in html-to-pdf example and skill

### DIFF
--- a/.claude/skills/using-folio/SKILL.md
+++ b/.claude/skills/using-folio/SKILL.md
@@ -48,45 +48,24 @@ headers/footers, or every `position: fixed`/`absolute` element — with no error
 This is the single most common folio mistake.
 
 **Only reach for `ConvertFull` when you genuinely need the raw result** (e.g.
-to inspect or post-process elements before they reach the document). If you do,
-you must forward *all* of it. Page size is fixed at `NewDocument`, so resolve
-`@page` geometry first:
+to inspect or adjust elements before they reach the document). When you do, add
+it back with `Document.AddConvertResult` — never wire `result.Elements` by hand:
 
 ```go
 result, err := html.ConvertFull(htmlString, nil)
 if err != nil { return err }
 
-// Resolve @page geometry BEFORE NewDocument (page size cannot change after).
-ps := document.PageSizeA4
-if pc := result.PageConfig; pc != nil {
-    w, h, _ := pc.Resolve(ps.Width, ps.Height)
-    ps = document.PageSize{Width: w, Height: h}
-}
-doc := document.NewDocument(ps)
+// ... inspect or modify result here ...
 
-if pc := result.PageConfig; pc != nil && pc.HasMargins {
-    doc.SetMargins(layout.Margins{Top: pc.MarginTop, Right: pc.MarginRight,
-        Bottom: pc.MarginBottom, Left: pc.MarginLeft})
-}
-if result.MarginBoxes != nil      { doc.SetMarginBoxes(result.MarginBoxes) }
-if result.FirstMarginBoxes != nil { doc.SetFirstMarginBoxes(result.FirstMarginBoxes) }
-if result.LeftMarginBoxes != nil  { doc.SetLeftMarginBoxes(result.LeftMarginBoxes) }
-if result.RightMarginBoxes != nil { doc.SetRightMarginBoxes(result.RightMarginBoxes) }
-
-for _, e := range result.Elements { doc.Add(e) }
-
-// EASY TO FORGET: absolutely/fixed-positioned elements live in a separate
-// slice and must be forwarded too, or position:fixed/absolute content (page
-// watermarks, pinned footers) silently vanishes.
-for _, a := range result.Absolutes {
-    doc.AddAbsoluteWithOpts(a.Element, a.X, a.Y, a.Width, layout.AbsoluteOpts{
-        RightAligned: a.RightAligned, ZIndex: a.ZIndex, Fixed: a.Fixed, PageIndex: -1,
-    })
-}
+doc := document.NewDocument(document.PageSizeA4)
+if err := doc.AddConvertResult(result); err != nil { return err }
 ```
 
-If you find yourself replicating the block above, switch to `AddHTML` — it does
-exactly this, kept in sync with the converter.
+`AddConvertResult` forwards everything (elements, absolutes, `@page`
+geometry/margins, margin boxes, metadata) and sets the page size from any
+`@page` rule, so you don't pre-resolve geometry. `AddHTML` is exactly
+`ConvertFull` + `AddConvertResult`. Use `SetPageSize`/`PageSize()` if you need
+to read or override the size afterward.
 
 ## Options worth knowing (`*html.Options`)
 

--- a/document/addconvertresult_test.go
+++ b/document/addconvertresult_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import (
+	"reflect"
+	"testing"
+
+	foliohtml "github.com/carlos7ags/folio/html"
+	"github.com/carlos7ags/folio/layout"
+)
+
+// sampleHTML exercises the parts of a ConvertResult a naive ConvertFull+Add
+// pipeline drops: @page geometry/margins plus base, :first, :left, and :right
+// margin boxes, and a position:fixed element.
+const sampleHTML = `<!DOCTYPE html><html><head>
+<title>Sample</title>
+<meta name="author" content="Tester">
+<meta name="subject" content="Subj">
+<meta name="keywords" content="k1, k2">
+<meta name="generator" content="Gen">
+<style>
+  @page { size: A4; margin: 40px; @bottom-center { content: counter(page); } }
+  @page :first { margin: 20px; @top-center { content: "First"; } }
+  @page :left { margin-left: 60px; @bottom-left { content: "L"; color: red; } }
+  @page :right { margin-right: 60px; @bottom-right { content: "R"; color: blue; } }
+  .wm { position: fixed; top: 10px; left: 10px; }
+</style></head><body>
+<div class="wm">WATERMARK</div>
+<h1>Heading</h1>
+<p>Body paragraph.</p>
+</body></html>`
+
+// TestAddConvertResultMatchesAddHTML asserts AddHTML and
+// ConvertFull+AddConvertResult leave the document in the same state — the
+// contract that lets a caller use the raw result without losing anything.
+func TestAddConvertResultMatchesAddHTML(t *testing.T) {
+	viaAddHTML := NewDocument(PageSizeLetter)
+	if err := viaAddHTML.AddHTML(sampleHTML, nil); err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+
+	viaResult := NewDocument(PageSizeLetter)
+	result, err := foliohtml.ConvertFull(sampleHTML, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	if err := viaResult.AddConvertResult(result); err != nil {
+		t.Fatalf("AddConvertResult: %v", err)
+	}
+
+	if viaResult.pageSize != viaAddHTML.pageSize {
+		t.Errorf("pageSize: AddConvertResult=%v AddHTML=%v", viaResult.pageSize, viaAddHTML.pageSize)
+	}
+	if viaResult.margins != viaAddHTML.margins {
+		t.Errorf("margins: AddConvertResult=%v AddHTML=%v", viaResult.margins, viaAddHTML.margins)
+	}
+	assertMarginsEq(t, "firstMargins", viaResult.firstMargins, viaAddHTML.firstMargins)
+	assertMarginsEq(t, "leftMargins", viaResult.leftMargins, viaAddHTML.leftMargins)
+	assertMarginsEq(t, "rightMargins", viaResult.rightMargins, viaAddHTML.rightMargins)
+	if len(viaResult.elements) != len(viaAddHTML.elements) {
+		t.Errorf("elements: AddConvertResult=%d AddHTML=%d", len(viaResult.elements), len(viaAddHTML.elements))
+	}
+	if len(viaResult.absolutes) != len(viaAddHTML.absolutes) {
+		t.Errorf("absolutes: AddConvertResult=%d AddHTML=%d", len(viaResult.absolutes), len(viaAddHTML.absolutes))
+	}
+	for _, mb := range []struct {
+		name string
+		a, b map[string]layout.MarginBox
+	}{
+		{"marginBoxes", viaResult.marginBoxes, viaAddHTML.marginBoxes},
+		{"firstMarginBoxes", viaResult.firstMarginBoxes, viaAddHTML.firstMarginBoxes},
+		{"leftMarginBoxes", viaResult.leftMarginBoxes, viaAddHTML.leftMarginBoxes},
+		{"rightMarginBoxes", viaResult.rightMarginBoxes, viaAddHTML.rightMarginBoxes},
+	} {
+		if len(mb.a) == 0 {
+			t.Errorf("%s: fixture produced none; the :first/:left/:right path is unexercised", mb.name)
+		}
+		if !reflect.DeepEqual(mb.a, mb.b) {
+			t.Errorf("%s mismatch:\n AddConvertResult=%+v\n AddHTML=%+v", mb.name, mb.a, mb.b)
+		}
+	}
+	if viaResult.Info != viaAddHTML.Info {
+		t.Errorf("metadata mismatch:\n AddConvertResult=%+v\n AddHTML=%+v", viaResult.Info, viaAddHTML.Info)
+	}
+}
+
+func assertMarginsEq(t *testing.T, name string, a, b *layout.Margins) {
+	t.Helper()
+	if (a == nil) != (b == nil) {
+		t.Errorf("%s: presence differs AddConvertResult=%v AddHTML=%v", name, a, b)
+		return
+	}
+	if a != nil && *a != *b {
+		t.Errorf("%s: AddConvertResult=%v AddHTML=%v", name, *a, *b)
+	}
+}
+
+// TestAddConvertResultCarriesAbsolutesAndPageConfig is the motivating
+// regression: a position:fixed element and @page margin boxes must survive
+// (the naive Elements-only loop drops both).
+func TestAddConvertResultCarriesAbsolutesAndPageConfig(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	result, err := foliohtml.ConvertFull(sampleHTML, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	if len(result.Absolutes) == 0 {
+		t.Fatal("test fixture produced no absolutes; sampleHTML must contain a position:fixed element")
+	}
+	if err := doc.AddConvertResult(result); err != nil {
+		t.Fatalf("AddConvertResult: %v", err)
+	}
+	if len(doc.absolutes) != len(result.Absolutes) {
+		t.Errorf("fixed/absolute elements dropped: doc has %d, result had %d", len(doc.absolutes), len(result.Absolutes))
+	}
+	if len(doc.marginBoxes) == 0 {
+		t.Error("@page margin box (page numbering) was not applied")
+	}
+	// The @page { margin: 40px } overrides the 72pt default on all sides.
+	if doc.margins.Top == 72 {
+		t.Error("@page margins were not applied (still at the 72pt default)")
+	}
+	// The :left/:right reconstruction must preserve every field (notably the
+	// color set on those boxes), matching the converter's own LeftMarginBoxes
+	// /RightMarginBoxes. Dropping HasColor/Embedded would diverge here.
+	if !reflect.DeepEqual(doc.leftMarginBoxes, result.LeftMarginBoxes) {
+		t.Errorf("left margin boxes not faithfully reconstructed:\n doc=%+v\n result=%+v", doc.leftMarginBoxes, result.LeftMarginBoxes)
+	}
+	if !reflect.DeepEqual(doc.rightMarginBoxes, result.RightMarginBoxes) {
+		t.Errorf("right margin boxes not faithfully reconstructed:\n doc=%+v\n result=%+v", doc.rightMarginBoxes, result.RightMarginBoxes)
+	}
+}
+
+func TestAddConvertResultNil(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	if err := doc.AddConvertResult(nil); err == nil {
+		t.Error("AddConvertResult(nil) should return an error")
+	}
+}
+
+func TestSetAndGetPageSize(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	if got := doc.PageSize(); got != PageSizeLetter {
+		t.Errorf("PageSize() = %v, want %v (from NewDocument)", got, PageSizeLetter)
+	}
+	doc.SetPageSize(PageSizeA4)
+	if got := doc.PageSize(); got != PageSizeA4 {
+		t.Errorf("after SetPageSize: PageSize() = %v, want %v", got, PageSizeA4)
+	}
+}

--- a/document/document.go
+++ b/document/document.go
@@ -112,6 +112,19 @@ func NewDocument(ps PageSize) *Document {
 	}
 }
 
+// SetPageSize overrides the page dimensions set by NewDocument. AddHTML and
+// AddConvertResult also set this from @page rules, so call it after them to
+// force a size.
+func (d *Document) SetPageSize(ps PageSize) {
+	d.pageSize = ps
+}
+
+// PageSize returns the current page dimensions, including any size derived
+// from an @page rule.
+func (d *Document) PageSize() PageSize {
+	return d.pageSize
+}
+
 // SetTagged enables tagged PDF output (PDF/UA foundation).
 // When enabled, the document includes a structure tree with semantic tags
 // (P, H1-H6, Table, Figure, etc.) and marked content operators in the

--- a/document/html.go
+++ b/document/html.go
@@ -36,6 +36,19 @@ func (d *Document) AddHTMLWithContext(ctx context.Context, htmlStr string, opts 
 	if err != nil {
 		return err
 	}
+	return d.AddConvertResult(result)
+}
+
+// AddConvertResult feeds a raw [html.ConvertResult] into the document:
+// elements, absolutes, @page geometry/margins, margin boxes, and metadata
+// (existing non-empty Info fields are kept). AddHTML is exactly ConvertFull
+// followed by AddConvertResult; call this directly only to inspect or modify
+// the result first. Adding result.Elements by hand instead drops
+// result.Absolutes and the @page configuration.
+func (d *Document) AddConvertResult(result *foliohtml.ConvertResult) error {
+	if result == nil {
+		return fmt.Errorf("document: AddConvertResult: nil result")
+	}
 
 	// Apply metadata from <title> and <meta> tags.
 	m := result.Metadata
@@ -112,14 +125,14 @@ func (d *Document) AddHTMLWithContext(ctx context.Context, htmlStr string, opts 
 		if pc.Left != nil && len(pc.Left.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.Left.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
 			}
 			d.SetLeftMarginBoxes(boxes)
 		}
 		if pc.Right != nil && len(pc.Right.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.Right.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
 			}
 			d.SetRightMarginBoxes(boxes)
 		}

--- a/examples/html-to-pdf/main.go
+++ b/examples/html-to-pdf/main.go
@@ -1,8 +1,8 @@
 // Copyright 2026 Carlos Munoz and the Folio Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// HTML-to-PDF demonstrates converting a rich HTML document with CSS
-// into a polished, multi-page PDF using the html.ConvertFull API.
+// HTML-to-PDF demonstrates converting a rich HTML document with CSS into a
+// polished, multi-page PDF via html.ConvertFull + Document.AddConvertResult.
 //
 // CSS features exercised:
 //   - @page rules with custom margins
@@ -32,7 +32,6 @@ import (
 
 	"github.com/carlos7ags/folio/document"
 	"github.com/carlos7ags/folio/html"
-	"github.com/carlos7ags/folio/layout"
 )
 
 const reportHTML = `<!DOCTYPE html>
@@ -252,61 +251,15 @@ func buildDocument(htmlSource string) (*document.Document, error) {
 		return nil, fmt.Errorf("convert: %w", err)
 	}
 
-	// Resolve @page geometry + orientation-only swap + margin percentages /
-	// calc through the shared helper (before NewDocument, which fixes the
-	// page size) so this path matches AddHTML (B-1).
-	ps := document.PageSizeA4
-	if pc := result.PageConfig; pc != nil {
-		w, h, _ := pc.Resolve(ps.Width, ps.Height)
-		ps = document.PageSize{Width: w, Height: h}
-	}
-
-	doc := document.NewDocument(ps)
-	doc.SetMargins(layout.Margins{Top: 0, Right: 0, Bottom: 0, Left: 0})
-	doc.Info.Title = "Q4 2026 Quarterly Report"
-	doc.Info.Author = "Apex Capital Partners"
+	// ConvertFull hands back the raw result so it can be inspected or adjusted
+	// first; AddConvertResult then wires all of it — elements, absolutes,
+	// @page geometry/margins, margin boxes, and metadata — into the document.
+	// Adding result.Elements by hand instead would drop the absolutes and the
+	// @page configuration. (Document.AddHTML is exactly this pair.)
+	doc := document.NewDocument(document.PageSizeA4)
 	doc.SetAutoBookmarks(true)
-
-	// Apply @page margins (resolved above by pc.Resolve).
-	if pc := result.PageConfig; pc != nil {
-		if pc.HasMargins {
-			doc.SetMargins(layout.Margins{
-				Top: pc.MarginTop, Right: pc.MarginRight,
-				Bottom: pc.MarginBottom, Left: pc.MarginLeft,
-			})
-		}
-	}
-	if result.MarginBoxes != nil {
-		doc.SetMarginBoxes(result.MarginBoxes)
-	}
-	if result.FirstMarginBoxes != nil {
-		doc.SetFirstMarginBoxes(result.FirstMarginBoxes)
-	}
-
-	for _, e := range result.Elements {
-		doc.Add(e)
-	}
-
-	// Forward absolutely/fixed-positioned elements. These live in a separate
-	// slice from the normal flow, so a manual ConvertFull pipeline that only
-	// adds result.Elements silently drops every position:fixed/absolute box
-	// (page watermarks, pinned footers). Document.AddHTML does this for you;
-	// when wiring ConvertFull by hand, this loop is mandatory.
-	for _, a := range result.Absolutes {
-		doc.AddAbsoluteWithOpts(a.Element, a.X, a.Y, a.Width, layout.AbsoluteOpts{
-			RightAligned: a.RightAligned,
-			ZIndex:       a.ZIndex,
-			Fixed:        a.Fixed,
-			PageIndex:    -1,
-		})
-	}
-
-	// Apply metadata from <title> and <meta> tags.
-	if result.Metadata.Title != "" {
-		doc.Info.Title = result.Metadata.Title
-	}
-	if result.Metadata.Author != "" {
-		doc.Info.Author = result.Metadata.Author
+	if err := doc.AddConvertResult(result); err != nil {
+		return nil, fmt.Errorf("add: %w", err)
 	}
 	return doc, nil
 }

--- a/html/doc.go
+++ b/html/doc.go
@@ -92,4 +92,23 @@
 // @import (use inline <style> or Options.ExternalCSS). :has() selector.
 // CSS animations, transitions. clip-path, mask.
 // Vertical writing modes. ::first-line, ::first-letter pseudo-elements.
+//
+// # Loading local assets
+//
+// Local references (images, fonts, linked stylesheets, background-image url())
+// resolve through [Options.BaseFS] — an os.DirFS, embed.FS, or fstest.MapFS;
+// when nil, local references fail and assets must be inlined as data: URIs.
+// Set [Options.FallbackFontPath] for glyphs outside WinAnsiEncoding.
+//
+// A failed asset load is logged ([Options.Logger]) and skipped by default, so
+// broken paths silently degrade output. Set [Options.StrictAssets] to return
+// those failures as an error (with the partial result) — use it in dev and CI.
+//
+// # Feeding the result into a document
+//
+// Prefer [github.com/carlos7ags/folio/document.Document.AddHTML], which wires
+// the whole conversion into a document in one call. Use [ConvertFull] only to
+// inspect the raw [ConvertResult] first, then pass it to
+// [github.com/carlos7ags/folio/document.Document.AddConvertResult] — adding
+// result.Elements by hand drops result.Absolutes and the @page configuration.
 package html


### PR DESCRIPTION
## Summary

Follow-up to #352. Now that `Document.AddConvertResult` exists, the raw-result path no longer needs hand-wiring.

- **`examples/html-to-pdf`**: collapse the manual margin / margin-box / element / absolute forwarding in `buildDocument` into a single `doc.AddConvertResult(result)` call. Page size now comes from the `@page` rule via `AddConvertResult`, so the pre-`NewDocument` geometry resolve is gone too.
- **`using-folio` skill**: replace the long by-hand `ConvertFull` block with the `ConvertFull` + `AddConvertResult` pair, and mention `SetPageSize`/`PageSize()`.

## Stacking

This is **stacked on #352** (base branch = `feat/document-addconvertresult`), because the example won't compile without `AddConvertResult`. **Merge #352 first**, then this; I'll retarget the base to `main` once #352 lands.

Example builds, vets, and its `main_test.go` passes; full build green.