### PR TITLE
barcode: declare UTF-8 with an ECI segment in QR byte mode

### DIFF
--- a/barcode/qr.go
+++ b/barcode/qr.go
@@ -24,6 +24,22 @@ const (
 	qrModeByte         qrMode = 4 // 0100
 )
 
+// ECI (Extended Channel Interpretation) constants for byte mode.
+const (
+	eciUTF8 = 26 // ECI assignment number for UTF-8
+	eciBits = 12 // ECI segment size: 4-bit mode indicator + 8-bit assignment number
+)
+
+// isASCII reports whether data contains only bytes in the ASCII range (0-127).
+func isASCII(data string) bool {
+	for i := range len(data) {
+		if data[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
 // alphanumericValues maps characters to their alphanumeric mode values.
 var alphanumericValues = map[byte]int{
 	'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9,
@@ -92,11 +108,15 @@ func charCountBits(mode qrMode, version int) int {
 	}
 }
 
-// dataCapacity returns the number of characters that fit in the given version/level/mode.
-func dataCapacity(version int, level ECCLevel, mode qrMode) int {
+// dataCapacity returns the number of characters that fit in the given
+// version/level/mode. eci accounts for a leading ECI segment (12 bits).
+func dataCapacity(version int, level ECCLevel, mode qrMode, eci bool) int {
 	dataCW := qrDataCodewords[version][level]
 	countBits := charCountBits(mode, version)
 	totalDataBits := dataCW*8 - 4 - countBits // subtract mode indicator and count bits
+	if eci {
+		totalDataBits -= eciBits
+	}
 
 	switch mode {
 	case qrModeNumeric:
@@ -143,10 +163,14 @@ func NewQRWithECC(data string, level ECCLevel) (*Barcode, error) {
 
 	mode := detectMode(data)
 
+	// Byte-mode data that is not plain ASCII is declared UTF-8 with an ECI
+	// segment so readers do not have to guess the encoding.
+	eci := mode == qrModeByte && !isASCII(data)
+
 	// Find the smallest version that fits.
 	version := 0
 	for v := 1; v <= 40; v++ {
-		cap := dataCapacity(v, level, mode)
+		cap := dataCapacity(v, level, mode, eci)
 		if len(data) <= cap {
 			version = v
 			break
@@ -214,7 +238,7 @@ func NewQRWithECC(data string, level ECCLevel) (*Barcode, error) {
 	}
 
 	// Encode data.
-	bits := encodeQRData(data, version, level, mode)
+	bits := encodeQRData(data, version, level, mode, eci)
 
 	// Place data bits.
 	placeData(modules, reserved, bits, size)
@@ -629,9 +653,16 @@ func encodeAlphanumericData(data string, version int) []bool {
 	return bits
 }
 
-// encodeByteData encodes data in byte mode.
-func encodeByteData(data string, version int) []bool {
+// encodeByteData encodes data in byte mode, optionally preceded by a UTF-8 ECI
+// segment.
+func encodeByteData(data string, version int, eci bool) []bool {
 	var bits []bool
+
+	if eci {
+		// ECI mode indicator (0111) followed by the UTF-8 assignment number.
+		bits = append(bits, false, true, true, true)
+		bits = appendBitsN(bits, eciUTF8, 8)
+	}
 
 	// Mode indicator: byte mode = 0100.
 	bits = append(bits, false, true, false, false)
@@ -652,7 +683,7 @@ func encodeByteData(data string, version int) []bool {
 
 // encodeQRData encodes data with the specified ECC level and encoding mode,
 // returning the complete bitstream including interleaved error correction codewords.
-func encodeQRData(data string, version int, level ECCLevel, mode qrMode) []bool {
+func encodeQRData(data string, version int, level ECCLevel, mode qrMode, eci bool) []bool {
 	var bits []bool
 
 	switch mode {
@@ -661,7 +692,7 @@ func encodeQRData(data string, version int, level ECCLevel, mode qrMode) []bool 
 	case qrModeAlphanumeric:
 		bits = encodeAlphanumericData(data, version)
 	default:
-		bits = encodeByteData(data, version)
+		bits = encodeByteData(data, version, eci)
 	}
 
 	// Terminator (up to 4 zero bits).

--- a/barcode/qr_eci_test.go
+++ b/barcode/qr_eci_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package barcode
+
+import "testing"
+
+// qrDataBytes reconstructs the data codewords (before error correction) from a
+// symbol's de-interleaved blocks, in block order.
+func qrDataBytes(version int, level ECCLevel, blocks [][]byte) []byte {
+	bi := qrBlockTable[version][level]
+	var out []byte
+	b := 0
+	for ; b < bi.group1Blocks; b++ {
+		out = append(out, blocks[b][:bi.group1DataCW]...)
+	}
+	for k := range bi.group2Blocks {
+		out = append(out, blocks[b+k][:bi.group2DataCW]...)
+	}
+	return out
+}
+
+// decodeQRBytePayload reads a byte-mode symbol back to its text and the ECI
+// assignment number that preceded the byte segment (-1 if there was none).
+func decodeQRBytePayload(t *testing.T, bc *Barcode) (string, int) {
+	t.Helper()
+	size := bc.width
+	version := (size - 17) / 4
+
+	level, mask, ok := readFormat(bc.modules, size)
+	if !ok {
+		t.Fatalf("format info invalid")
+	}
+	reserved := qrFunctionMap(version, size)
+	stream := extractCodewordStream(bc.modules, reserved, size, mask)
+	blocks := deinterleaveBlocks(stream[:qrTotalCodewords[version]], version, level)
+	data := qrDataBytes(version, level, blocks)
+
+	bits := make([]bool, 0, len(data)*8)
+	for _, b := range data {
+		for i := 7; i >= 0; i-- {
+			bits = append(bits, (b>>i)&1 == 1)
+		}
+	}
+	pos := 0
+	read := func(n int) int {
+		v := 0
+		for range n {
+			v <<= 1
+			if bits[pos] {
+				v |= 1
+			}
+			pos++
+		}
+		return v
+	}
+
+	eciNum := -1
+	mode := read(4)
+	if mode == 7 { // ECI mode indicator
+		eciNum = read(8)
+		mode = read(4)
+	}
+	if mode != 4 { // byte mode indicator
+		t.Fatalf("expected byte mode, got mode %d", mode)
+	}
+	count := read(charCountBits(qrModeByte, version))
+	out := make([]byte, count)
+	for i := range count {
+		out[i] = byte(read(8))
+	}
+	return string(out), eciNum
+}
+
+func TestQRByteModeECI(t *testing.T) {
+	cases := []struct {
+		data    string
+		wantECI bool
+	}{
+		{"https://example.com/folio", false}, // ASCII byte mode, no ECI
+		{"Hello, World!", false},
+		{"Café", true}, // non-ASCII, declared UTF-8
+		{"naïve résumé", true},
+		{"日本語のテスト", true},
+		{"emoji and 日本語 mixed", true},
+	}
+	for _, level := range []ECCLevel{ECCLevelL, ECCLevelM, ECCLevelQ, ECCLevelH} {
+		for _, c := range cases {
+			bc, err := NewQRWithECC(c.data, level)
+			if err != nil {
+				t.Fatalf("NewQRWithECC(%q, %d): %v", c.data, level, err)
+			}
+			got, eciNum := decodeQRBytePayload(t, bc)
+			if got != c.data {
+				t.Errorf("%q L%d: decoded %q", c.data, level, got)
+			}
+			// Non-ASCII data must carry the UTF-8 ECI assignment number (26);
+			// ASCII data must carry none (-1).
+			wantNum := -1
+			if c.wantECI {
+				wantNum = 26
+			}
+			if eciNum != wantNum {
+				t.Errorf("%q L%d: ECI number = %d, want %d", c.data, level, eciNum, wantNum)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

QR byte mode emitted raw bytes with no encoding declaration, so non-ASCII content (for example UTF-8) relied on the reader guessing the encoding. This adds an ECI segment (assignment number 26, UTF-8) before the byte segment when the data is not plain ASCII. ASCII byte data is unchanged.

The byte-mode capacity subtracts the 12-bit ECI segment when selecting the version, so non-ASCII payloads near capacity still fit.

## Tests

Added barcode/qr_eci_test.go, which reads the byte-mode bitstream back from the generated matrix and asserts:

- non-ASCII data carries the UTF-8 ECI assignment number (26); ASCII data carries none;
- the payload round-trips across all four ECC levels.

UTF-8 output was also confirmed to decode as the correct string with an external reader.

Refs #346
