### PR TITLE
html: native multi-level list numbering via CSS counters, ::marker content, and list-style-position (#356)

### DIFF
--- a/docs/CSS_SUPPORT.md
+++ b/docs/CSS_SUPPORT.md
@@ -37,10 +37,10 @@ but unknown CSS properties are always silent.
 | MultiColumn | 9 |
 | Tables | 2 |
 | Pagination | 5 |
-| Lists | 1 |
+| Lists | 2 |
 | Effects | 12 |
 | PDF | 6 |
-| **Total** | **138** |
+| **Total** | **139** |
 
 ## Value-form glossary
 
@@ -257,7 +257,8 @@ also takes effect on flex containers as the gap between items.
 
 | Property | Aliases | Accepted values | Notes |
 |---|---|---|---|
-| `list-style-type` | `list-style` | `disc`, `circle`, `square`, `decimal`, `lower-alpha`, `upper-alpha`, `lower-roman`, `upper-roman`, `none` | list-style is a shorthand; only the type is extracted. |
+| `list-style-position` | — | `inside`, `outside` | — |
+| `list-style-type` | `list-style` | `disc`, `circle`, `square`, `decimal`, `lower-alpha`, `upper-alpha`, `lower-roman`, `upper-roman`, `none` | list-style is a shorthand; type and position tokens are extracted. |
 
 ## Effects
 

--- a/examples/legal-numbering/main.go
+++ b/examples/legal-numbering/main.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Legal-numbering demonstrates multi-level clause numbering in a legal
+// agreement using native CSS counters — no markup workarounds:
+//
+//   - ol { counter-reset: item; list-style: none }
+//     li { counter-increment: item }
+//     li::marker { content: counters(item, ".") ". " }
+//
+// counters(item, ".") joins the whole counter stack, so nesting yields
+// "1.", "1.1.", "1.1.1.", "2." automatically. The marker sits in the left
+// gutter (list-style-position: outside, the default) so long clause bodies
+// wrap with a hanging indent under the clause text rather than under the
+// number.
+//
+// Usage:
+//
+//	go run ./examples/legal-numbering
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/carlos7ags/folio/document"
+	fhtml "github.com/carlos7ags/folio/html"
+)
+
+const legalHTML = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Master Services Agreement</title>
+  <style>
+    body { font-family: serif; font-size: 11pt; color: #111827; }
+    h1 { font-size: 16pt; margin: 0 0 12pt 0; text-align: center; }
+
+    /* Native multi-level legal numbering via counters() + ::marker. */
+    ol { counter-reset: item; list-style: none; }
+    li { counter-increment: item; margin-bottom: 6pt; }
+    li::marker { content: counters(item, ".") ". "; }
+
+    .clause-title { font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>Master Services Agreement</h1>
+
+  <ol>
+    <li>
+      <span class="clause-title">Definitions.</span>
+      <p>In this Agreement, the following terms have the meanings set out below,
+         and these definitions apply both to the singular and plural forms of
+         such terms and to every clause in which they appear throughout the body
+         of this Agreement.</p>
+      <ol>
+        <li>"Agreement" means this Master Services Agreement together with all
+            schedules, exhibits, and statements of work executed under it.</li>
+        <li>"Services" means the professional services described in each
+            statement of work agreed between the parties.
+          <ol>
+            <li>Each statement of work is incorporated into and governed by the
+                terms of this Agreement upon signature by both parties.</li>
+            <li>In the event of a conflict between a statement of work and this
+                Agreement, this Agreement controls except where the statement of
+                work expressly states otherwise.</li>
+          </ol>
+        </li>
+      </ol>
+    </li>
+    <li>
+      <span class="clause-title">Term and Termination.</span>
+      <p>This Agreement commences on the Effective Date and continues until
+         terminated in accordance with this clause.</p>
+      <ol>
+        <li>Either party may terminate this Agreement for convenience on thirty
+            (30) days' prior written notice to the other party.</li>
+        <li>Either party may terminate this Agreement immediately if the other
+            party commits a material breach that remains uncured for fifteen
+            (15) days after written notice describing the breach in reasonable
+            detail.</li>
+      </ol>
+    </li>
+    <li>
+      <span class="clause-title">Confidentiality.</span>
+      <p>Each party shall protect the other party's Confidential Information
+         using at least the same degree of care it uses to protect its own
+         confidential information of a similar nature.</p>
+    </li>
+  </ol>
+</body>
+</html>`
+
+func main() {
+	doc, err := buildDocument()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := doc.Save("legal-numbering.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created legal-numbering.pdf")
+}
+
+// buildDocument converts the demo HTML into a Document. Extracted from
+// main() so the example test can exercise the same construction against an
+// in-memory buffer.
+func buildDocument() (*document.Document, error) {
+	doc := document.NewDocument(document.PageSizeLetter)
+	doc.Info.Title = "Master Services Agreement"
+	doc.Info.Author = "Folio"
+	if err := doc.AddHTML(legalHTML, &fhtml.Options{}); err != nil {
+		return nil, fmt.Errorf("AddHTML: %w", err)
+	}
+	return doc, nil
+}

--- a/examples/legal-numbering/main_test.go
+++ b/examples/legal-numbering/main_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	doc, err := buildDocument()
+	if err != nil {
+		panic("buildDocument: " + err.Error())
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func TestLegalNumberingExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 1000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >1 KB", len(pdf))
+	}
+}
+
+// TestLegalNumberingExampleContent reads the page text and asserts the
+// multi-level ordinals produced by counters()/::marker (1., 1.1., 1.1.1., 2.)
+// and representative clause body text are present — proving the native
+// nested numbering rendered and no clause content was dropped.
+func TestLegalNumberingExampleContent(t *testing.T) {
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	// counters() joins the whole stack: top-level "1.", nested "1.1.", "1.2.",
+	// and the third level "1.2.1" (extracted as "1.2. 1." because the marker
+	// tokenizes around its trailing dot-space). "2." and "3." prove the
+	// outer increment fired across clauses.
+	for _, want := range []string{
+		"1.", "1.1.", "1.2.", "1.2. 1.", "2.", "2.1.", "3.",
+		"Definitions.", "Master Services Agreement",
+		"Term and Termination.", "Confidentiality.",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("page text missing %q; extracted:\n%s", want, text)
+		}
+	}
+}

--- a/html/converter_list.go
+++ b/html/converter_list.go
@@ -128,9 +128,22 @@ func (c *converter) populateList(n *html.Node, list *layout.List, style computed
 		hasBox := liHasBoxModel(liStyle)
 		nestedList := findNestedList(child)
 
+		// Apply the <li>'s own counters before its content is resolved so a
+		// counter-increment fires for each item and any counter-reset scopes
+		// the subtree. convertElement does this for the element path's block
+		// children, but the fast path and the li itself bypass it, so we mirror
+		// the reset-then-increment ordering here.
+		for _, cr := range liStyle.CounterReset {
+			c.resetCounter(cr.Name, cr.Value)
+		}
+		for _, ci := range liStyle.CounterIncrement {
+			c.incrementCounter(ci.Name, ci.Value)
+		}
+
 		// Fast path: plain inline item (optionally with a nested list as a
 		// sub-list) and no box-model styles. Preserves existing rendering
-		// and indentation for the common case.
+		// and indentation for the common case. Use if/else (not continue) so
+		// the shared counter pop below runs for both paths.
 		if !hasBox && !liHasBlockFlowChildren(c, child, liStyle) {
 			runs := c.collectListItemRuns(child, style)
 			if nestedList != nil {
@@ -141,17 +154,37 @@ func (c *converter) populateList(n *html.Node, list *layout.List, style computed
 				if nestedList.DataAtom == atom.Ol {
 					sub.SetStyle(layout.ListOrdered)
 				}
+				// The fast path bypasses convertElement for the nested
+				// list, so apply the nested list's own counter-reset and
+				// counter-increment around the recursion. The element path's
+				// nested list goes through convertElement, which already
+				// handles both.
+				nestedStyle := c.computeElementStyle(nestedList, style)
+				for _, cr := range nestedStyle.CounterReset {
+					c.resetCounter(cr.Name, cr.Value)
+				}
+				for _, ci := range nestedStyle.CounterIncrement {
+					c.incrementCounter(ci.Name, ci.Value)
+				}
 				c.populateList(nestedList, sub, style)
+				for _, cr := range nestedStyle.CounterReset {
+					c.popCounter(cr.Name)
+				}
 			} else if len(runs) > 0 {
 				list.AddItemRuns(runs)
 			}
-			continue
+		} else {
+			// Element path: convert the <li>'s children via the normal
+			// block-flow path so block elements, <br>, and nested lists lay
+			// out correctly. Apply the <li>'s own box styles when present.
+			c.addElementListItem(child, list, liStyle, hasBox)
 		}
 
-		// Element path: convert the <li>'s children via the normal
-		// block-flow path so block elements, <br>, and nested lists lay
-		// out correctly. Apply the <li>'s own box styles when present.
-		c.addElementListItem(child, list, liStyle, hasBox)
+		// Pop the li's own counter-reset after its subtree is processed so
+		// sibling items see the restored nesting (runs on both paths).
+		for _, cr := range liStyle.CounterReset {
+			c.popCounter(cr.Name)
+		}
 	}
 }
 

--- a/html/converter_list.go
+++ b/html/converter_list.go
@@ -97,6 +97,12 @@ func (c *converter) convertList(n *html.Node, style computedStyle, ordered bool)
 		list.SetDirection(style.Direction)
 	}
 
+	// list-style-position: inside flows the marker inline with the first
+	// content line; outside (the default) keeps it in the left gutter.
+	if style.ListStylePosition == "inside" {
+		list.SetMarkerInside(true)
+	}
+
 	c.populateList(n, list, style)
 
 	return []layout.Element{list}

--- a/html/converter_list.go
+++ b/html/converter_list.go
@@ -140,6 +140,12 @@ func (c *converter) populateList(n *html.Node, list *layout.List, style computed
 			c.incrementCounter(ci.Name, ci.Value)
 		}
 
+		// Resolve the li::marker { content } string now that this item's
+		// counters reflect counter-reset/increment, so counter()/counters() in
+		// the marker render the right values. Applied per path below once the
+		// item has been appended.
+		markerText, hasMarker := c.resolveMarkerContent(child)
+
 		// Fast path: plain inline item (optionally with a nested list as a
 		// sub-list) and no box-model styles. Preserves existing rendering
 		// and indentation for the common case. Use if/else (not continue) so
@@ -151,6 +157,9 @@ func (c *converter) populateList(n *html.Node, list *layout.List, style computed
 					runs = []layout.TextRun{{Text: " ", Font: font.Helvetica, FontSize: style.FontSize}}
 				}
 				sub := list.AddItemRunsWithSubList(runs)
+				if hasMarker {
+					list.SetLastItemMarker(markerText)
+				}
 				if nestedList.DataAtom == atom.Ol {
 					sub.SetStyle(layout.ListOrdered)
 				}
@@ -172,12 +181,18 @@ func (c *converter) populateList(n *html.Node, list *layout.List, style computed
 				}
 			} else if len(runs) > 0 {
 				list.AddItemRuns(runs)
+				if hasMarker {
+					list.SetLastItemMarker(markerText)
+				}
 			}
 		} else {
 			// Element path: convert the <li>'s children via the normal
 			// block-flow path so block elements, <br>, and nested lists lay
 			// out correctly. Apply the <li>'s own box styles when present.
 			c.addElementListItem(child, list, liStyle, hasBox)
+			if hasMarker {
+				list.SetLastItemMarker(markerText)
+			}
 		}
 
 		// Pop the li's own counter-reset after its subtree is processed so
@@ -186,6 +201,35 @@ func (c *converter) populateList(n *html.Node, list *layout.List, style computed
 			c.popCounter(cr.Name)
 		}
 	}
+}
+
+// resolveMarkerContent reads the li::marker { content } declaration for an
+// <li> and resolves it (counter()/counters()/strings). The bool reports whether
+// a content declaration exists at all: an explicit `content: none` (or empty)
+// returns ("", true) to suppress the marker, while the absence of any content
+// declaration returns ("", false) so the default style-derived marker stands.
+func (c *converter) resolveMarkerContent(li *html.Node) (string, bool) {
+	if c.sheet == nil {
+		return "", false
+	}
+	// matchingPseudoElementDeclarations sorts ascending by specificity (stable
+	// for ties), so the last matching `content` declaration is the cascade
+	// winner. Take it — matching the last-wins color/font-size handling in
+	// convertList rather than returning on the first (lowest-specificity) decl.
+	decls := c.sheet.matchingPseudoElementDeclarations(li, "marker")
+	text, found := "", false
+	for _, d := range decls {
+		if d.property != "content" {
+			continue
+		}
+		found = true
+		if val := strings.TrimSpace(d.value); val == "none" || val == "" {
+			text = ""
+		} else {
+			text = c.resolveContentValue(val)
+		}
+	}
+	return text, found
 }
 
 // addElementListItem converts an <li> with block-level children and/or

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -410,16 +410,23 @@ func (c *converter) resolveContentValue(val string) string {
 			closeIdx := strings.IndexByte(remaining, ')')
 			if closeIdx >= 0 {
 				inner := remaining[len("counters("):closeIdx]
-				parts := strings.SplitN(inner, ",", 2)
+				// Split on top-level commas only: the separator argument is a
+				// quoted string that may itself contain commas (e.g.
+				// counters(item, ", ")), so a naive split would corrupt it.
+				parts := splitCounterArgs(inner)
 				name := strings.TrimSpace(parts[0])
 				sep := "."
 				if len(parts) > 1 {
 					sep = strings.Trim(strings.TrimSpace(parts[1]), `"'`)
 				}
+				style := ""
+				if len(parts) > 2 {
+					style = strings.TrimSpace(parts[2])
+				}
 				stack := c.counters[name]
 				strs := make([]string, len(stack))
 				for i, v := range stack {
-					strs[i] = strconv.Itoa(v)
+					strs[i] = formatCounterValue(v, style)
 				}
 				result.WriteString(strings.Join(strs, sep))
 				remaining = remaining[closeIdx+1:]
@@ -448,7 +455,7 @@ func (c *converter) resolveContentValue(val string) string {
 				case "pages":
 					result.WriteString(layout.CounterPlaceholder("pages", style))
 				default:
-					result.WriteString(strconv.Itoa(c.getCounter(name)))
+					result.WriteString(formatCounterValue(c.getCounter(name), style))
 				}
 				remaining = remaining[closeIdx+1:]
 				continue
@@ -463,6 +470,63 @@ func (c *converter) resolveContentValue(val string) string {
 		}
 	}
 	return result.String()
+}
+
+// splitCounterArgs splits a counters() argument list on top-level commas,
+// ignoring commas inside single- or double-quoted strings so a quoted
+// separator like ", " is preserved intact.
+func splitCounterArgs(inner string) []string {
+	var args []string
+	var buf strings.Builder
+	var quote byte
+	for i := 0; i < len(inner); i++ {
+		ch := inner[i]
+		switch {
+		case quote != 0:
+			if ch == quote {
+				quote = 0
+			}
+			buf.WriteByte(ch)
+		case ch == '"' || ch == '\'':
+			quote = ch
+			buf.WriteByte(ch)
+		case ch == ',':
+			args = append(args, buf.String())
+			buf.Reset()
+		default:
+			buf.WriteByte(ch)
+		}
+	}
+	args = append(args, buf.String())
+	return args
+}
+
+// formatCounterValue renders a counter value using a CSS list-style keyword.
+// The style is matched case-insensitively; unknown keywords fall back to
+// decimal. Roman/alpha conversion is shared with the layout package so list
+// markers and counter() output stay consistent.
+func formatCounterValue(n int, style string) string {
+	switch strings.ToLower(strings.TrimSpace(style)) {
+	case "", "decimal":
+		return strconv.Itoa(n)
+	case "decimal-leading-zero":
+		if n >= 0 && n < 10 {
+			return "0" + strconv.Itoa(n)
+		}
+		return strconv.Itoa(n)
+	case "lower-roman":
+		return layout.ToRoman(n, false)
+	case "upper-roman":
+		return layout.ToRoman(n, true)
+	case "lower-alpha", "lower-latin":
+		return layout.ToAlpha(n, 'a')
+	case "upper-alpha", "upper-latin":
+		return layout.ToAlpha(n, 'A')
+	case "none":
+		return ""
+	default:
+		return strconv.Itoa(n)
+	}
 }
 
 // parseCounterEntries parses a counter-reset or counter-increment value.

--- a/html/counter_style_test.go
+++ b/html/counter_style_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// formatCounterValue: table-driven coverage of every style keyword,
+// including none and the unknown fallback to decimal.
+func TestFormatCounterValue(t *testing.T) {
+	tests := []struct {
+		n     int
+		style string
+		want  string
+	}{
+		{4, "", "4"},
+		{4, "decimal", "4"},
+		{4, "DECIMAL", "4"}, // case-insensitive
+		{1, "decimal-leading-zero", "01"},
+		{9, "decimal-leading-zero", "09"},
+		{10, "decimal-leading-zero", "10"},
+		{0, "decimal-leading-zero", "00"},
+		{4, "lower-roman", "iv"},
+		{4, "upper-roman", "IV"},
+		{1, "lower-alpha", "a"},
+		{2, "lower-latin", "b"},
+		{1, "upper-alpha", "A"},
+		{27, "upper-latin", "AA"},
+		{5, "none", ""},
+		{5, "  Upper-Roman  ", "V"}, // trimmed + lowercased
+		{7, "bogus-style", "7"},     // unknown -> decimal fallback
+	}
+	for _, tt := range tests {
+		if got := formatCounterValue(tt.n, tt.style); got != tt.want {
+			t.Errorf("formatCounterValue(%d, %q) = %q, want %q", tt.n, tt.style, got, tt.want)
+		}
+	}
+}
+
+// counter() honors the optional list-style argument for regular counters.
+func TestResolveContentValueCounterStyle(t *testing.T) {
+	c := &converter{counters: make(map[string][]int)}
+	c.resetCounter("c", 0)
+	c.incrementCounter("c", 4) // c == 4
+
+	cases := []struct {
+		expr string
+		want string
+	}{
+		{`counter(c, upper-roman)`, "IV"},
+		{`counter(c, lower-roman)`, "iv"},
+		{`counter(c, lower-alpha)`, "d"},
+		{`counter(c, upper-alpha)`, "D"},
+		{`counter(c, decimal-leading-zero)`, "04"},
+		{`counter(c, decimal)`, "4"},
+		{`counter(c)`, "4"}, // default unchanged
+		{`counter(c, none)`, ""},
+	}
+	for _, tc := range cases {
+		if got := c.resolveContentValue(tc.expr); got != tc.want {
+			t.Errorf("resolveContentValue(%q) = %q, want %q", tc.expr, got, tc.want)
+		}
+	}
+}
+
+// counters() accepts an optional 3rd style argument, and without it the
+// output is identical to the prior decimal behavior.
+func TestResolveContentValueCountersStyle(t *testing.T) {
+	c := &converter{counters: make(map[string][]int)}
+	c.resetCounter("item", 0)
+	c.incrementCounter("item", 1) // 1
+	c.resetCounter("item", 0)     // nested
+	c.incrementCounter("item", 2) // 2
+
+	// With upper-alpha style: 1 -> A, 2 -> B.
+	if got := c.resolveContentValue(`counters(item, ".", upper-alpha)`); got != "A.B" {
+		t.Errorf("counters with upper-alpha = %q, want %q", got, "A.B")
+	}
+	// Custom separator with style.
+	if got := c.resolveContentValue(`counters(item, " > ", lower-roman)`); got != "i > ii" {
+		t.Errorf("counters with lower-roman = %q, want %q", got, "i > ii")
+	}
+	// No style: behavior identical to before (dotted decimals).
+	if got := c.resolveContentValue(`counters(item, ".")`); got != "1.2" {
+		t.Errorf("counters no style = %q, want %q", got, "1.2")
+	}
+	// Separator that itself contains a comma must be preserved intact
+	// (top-level comma splitting ignores commas inside quotes).
+	if got := c.resolveContentValue(`counters(item, ", ")`); got != "1, 2" {
+		t.Errorf("counters comma separator = %q, want %q", got, "1, 2")
+	}
+	// Comma-containing separator together with a style argument.
+	if got := c.resolveContentValue(`counters(item, ", ", upper-roman)`); got != "I, II" {
+		t.Errorf("counters comma separator + style = %q, want %q", got, "I, II")
+	}
+}
+
+// renderStreamText renders the elements through the full pipeline and returns
+// the first page's content stream as a string. Standard (Helvetica) text is
+// emitted as literal "(...) Tj" strings, so counter output is greppable.
+func renderStreamText(t *testing.T, elems []layout.Element) string {
+	t.Helper()
+	r := layout.NewRenderer(612, 792, layout.Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	for _, e := range elems {
+		r.Add(e)
+	}
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("expected at least one rendered page")
+	}
+	return string(pages[0].Stream.Bytes())
+}
+
+// List-walk wiring: li counter-increment must fire for each item during the
+// list walk, and a nested ol's reset + nested li increment must produce
+// correctly scoped counters() values. Each li has a <p> block child so it
+// takes the element path, whose walkChildren resolves the p::before content.
+func TestListWalkCounterIncrement(t *testing.T) {
+	htmlStr := `<style>
+		ol { counter-reset: item }
+		li { counter-increment: item }
+		li p::before { content: counters(item, ".") " " }
+	</style>
+	<ol><li><p>First</p><ol><li><p>Inner</p></li></ol></li><li><p>Second</p></li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	// The counters() prefix is rendered as its own Tj string immediately
+	// before the paragraph text. "1" before First, "1.1" before Inner (nested
+	// reset + nested increment), "2" before Second (outer increment fired).
+	for _, want := range []string{"(1) Tj", "(1.1) Tj", "(2) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+	// Sanity: the body text is present so we know we read the right content.
+	for _, want := range []string{"(First) Tj", "(Inner) Tj", "(Second) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing body text %q", want)
+		}
+	}
+}
+
+// A counter-reset declared on each <li> must be scoped per item: the push
+// is popped after the item's subtree, so a sibling sees a fresh single-level
+// reset rather than an accumulating stack. counters() (which joins the whole
+// stack) makes an unbalanced pop observable: without the pop the second item
+// would render "2:41-41" instead of "2:41".
+func TestListItemCounterResetScoped(t *testing.T) {
+	htmlStr := `<style>
+		ol { counter-reset: item }
+		li { counter-increment: item; counter-reset: note 41 }
+		li p::before { content: counter(item) ":" counters(note, "-") " " }
+	</style>
+	<ol><li><p>A</p></li><li><p>B</p></li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+	for _, want := range []string{"(1:41) Tj", "(2:41) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+	if strings.Contains(stream, "41-41") {
+		t.Errorf("counter-reset stack leaked across siblings (found 41-41)\nstream:\n%s", stream)
+	}
+}
+
+// Regression: a plain ordered list with no counter CSS still renders the
+// default decimal markers "1." / "2." unchanged by the counter wiring.
+func TestPlainOrderedListMarkersUnchanged(t *testing.T) {
+	elems, err := Convert(`<ol><li>a</li><li>b</li></ol>`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+	for _, want := range []string{"(1.) Tj", "(2.) Tj", "(a) Tj", "(b) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("plain ordered list missing %q\nstream:\n%s", want, stream)
+		}
+	}
+}

--- a/html/css_props.go
+++ b/html/css_props.go
@@ -652,11 +652,34 @@ var cssProperties = []cssProperty{
 	{
 		Name: "list-style-type", Aliases: []string{"list-style"}, Category: "Lists",
 		Values: []string{"disc", "circle", "square", "decimal", "lower-alpha", "upper-alpha", "lower-roman", "upper-roman", "none"},
-		Notes:  "list-style is a shorthand; only the type is extracted.",
+		Notes:  "list-style is a shorthand; type and position tokens are extracted.",
 		Apply: func(s *computedStyle, value string) {
 			v := strings.TrimSpace(strings.ToLower(value))
-			if parts := strings.Fields(v); len(parts) > 0 {
-				s.ListStyleType = parts[0]
+			parts := strings.Fields(v)
+			typeSet := false
+			for _, p := range parts {
+				switch p {
+				case "inside", "outside":
+					s.ListStylePosition = p
+				default:
+					// First non-position, non-url token is the marker type.
+					// A url(...) token is a marker image, not a type keyword.
+					if !typeSet && !strings.HasPrefix(p, "url(") {
+						s.ListStyleType = p
+						typeSet = true
+					}
+				}
+			}
+		},
+	},
+	{
+		Name: "list-style-position", Category: "Lists",
+		Values: []string{"inside", "outside"},
+		Apply: func(s *computedStyle, value string) {
+			v := strings.TrimSpace(strings.ToLower(value))
+			switch v {
+			case "inside", "outside":
+				s.ListStylePosition = v
 			}
 		},
 	},

--- a/html/list_position_test.go
+++ b/html/list_position_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"strings"
+	"testing"
+)
+
+// list-style-position parsing, standalone and via the list-style shorthand.
+func TestListStylePositionParsing(t *testing.T) {
+	c := &converter{}
+	cases := []struct {
+		prop, val string
+		wantPos   string
+		wantType  string // "" = leave type unasserted
+		checkType bool
+	}{
+		{"list-style-position", "inside", "inside", "", false},
+		{"list-style-position", "INSIDE", "inside", "", false},
+		{"list-style-position", "outside", "outside", "", false},
+		{"list-style-position", "bogus", "", "", false}, // invalid ignored
+		// Shorthand carries both type and position.
+		{"list-style", "disc inside", "inside", "disc", true},
+		{"list-style", "inside decimal", "inside", "decimal", true},
+		// Shorthand with only a type leaves position at the default (outside).
+		{"list-style", "decimal", "", "decimal", true},
+		// A bare none still sets the type to none.
+		{"list-style", "none", "", "none", true},
+		// A marker image url() is not mistaken for the type keyword.
+		{"list-style", "url(dot.png) square inside", "inside", "square", true},
+	}
+	for _, tc := range cases {
+		var s computedStyle
+		c.applyProperty(tc.prop, tc.val, &s)
+		if s.ListStylePosition != tc.wantPos {
+			t.Errorf("%s: %q → ListStylePosition=%q, want %q", tc.prop, tc.val, s.ListStylePosition, tc.wantPos)
+		}
+		if tc.checkType && s.ListStyleType != tc.wantType {
+			t.Errorf("%s: %q → ListStyleType=%q, want %q", tc.prop, tc.val, s.ListStyleType, tc.wantType)
+		}
+	}
+}
+
+// End-to-end: list-style-position: inside renders the marker inline with the
+// first content line and a wrapped continuation aligns under the marker. The
+// stream must contain both the marker and the item text (no content dropped).
+func TestListStylePositionInsideRenders(t *testing.T) {
+	htmlStr := `<style>
+		ol { list-style-position: inside; }
+	</style>
+	<ol><li>Wrapping clause body that is long enough to span two lines.</li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+	if !strings.Contains(stream, "(1.) Tj") {
+		t.Errorf("inside list: marker (1.) Tj missing\nstream:\n%s", stream)
+	}
+	// The first word renders as a kerned TJ array; assert a later literal word.
+	if !strings.Contains(stream, "(clause) Tj") {
+		t.Errorf("inside list: body word (clause) Tj missing\nstream:\n%s", stream)
+	}
+}

--- a/html/marker_content_test.go
+++ b/html/marker_content_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"strings"
+	"testing"
+)
+
+// End-to-end: li::marker { content: counters(item, ".") ". " } on the FAST
+// (inline) path drives native multi-level numbering through the counter stack.
+// This also exercises Phase 1's fast-path nested counter wiring.
+//
+// Tokenization note: a marker like "1.1. " is emitted as two text words —
+// "1.1" then "." (the trailing ". " starts a new word), so the stream contains
+// (1.1) Tj followed by (.) Tj rather than a single (1.1.) Tj. The top-level
+// "1." has no internal space and renders as one (1.) Tj. Assertions match the
+// real tokens while still proving the marker came from content.
+func TestMarkerContentNestedCounters(t *testing.T) {
+	htmlStr := `<style>
+		ol { counter-reset: item; list-style: none }
+		li { counter-increment: item }
+		li::marker { content: counters(item, ".") ". " }
+	</style>
+	<ol><li>Alpha<ol><li>Beta</li><li>Gamma</li></ol></li><li>Delta</li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	for _, want := range []string{"(1.) Tj", "(1.1) Tj", "(1.2) Tj", "(2.) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing marker %q\nstream:\n%s", want, stream)
+		}
+	}
+	for _, want := range []string{"(Alpha) Tj", "(Beta) Tj", "(Gamma) Tj", "(Delta) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing body %q", want)
+		}
+	}
+	// list-style: none would normally suppress all markers; the only reason
+	// numbers appear is the ::marker content, and no default bullet leaks in.
+	if strings.Contains(stream, "•") {
+		t.Errorf("unexpected default bullet glyph in content-driven markers")
+	}
+}
+
+// counter() with an explicit style argument inside ::marker content.
+func TestMarkerContentCounterStyle(t *testing.T) {
+	htmlStr := `<style>
+		ol { counter-reset: c; list-style: none }
+		li { counter-increment: c }
+		li::marker { content: counter(c, upper-roman) ". " }
+	</style>
+	<ol><li>One</li><li>Two</li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+	// "Two" is emitted with kerning as a TJ array, so only "One" is asserted
+	// as a literal Tj for body presence; the markers are the load-bearing part.
+	for _, want := range []string{"(I.) Tj", "(II.) Tj", "(One) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+}
+
+// content: none on ::marker suppresses the marker entirely while item text
+// still renders; the default decimal "1." must be absent.
+func TestMarkerContentNoneSuppresses(t *testing.T) {
+	htmlStr := `<style>
+		ol { counter-reset: item }
+		li { counter-increment: item }
+		li::marker { content: none }
+	</style>
+	<ol><li>X</li><li>Y</li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+	for _, want := range []string{"(X) Tj", "(Y) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing body %q\nstream:\n%s", want, stream)
+		}
+	}
+	if strings.Contains(stream, "(1.) Tj") {
+		t.Errorf("content:none did not suppress the default marker (found (1.) Tj)\nstream:\n%s", stream)
+	}
+}
+
+// Cascade: when multiple ::marker { content } rules match, the highest
+// specificity wins. "ol li::marker" outranks "li::marker", so the counter
+// marker must win over the literal "LO " (a first-wins bug would pick "LO").
+func TestMarkerContentCascadeSpecificity(t *testing.T) {
+	htmlStr := `<style>
+		ol { counter-reset: item; list-style: none }
+		li { counter-increment: item }
+		li::marker { content: "LO " }
+		ol li::marker { content: counter(item) ". " }
+	</style>
+	<ol><li>A</li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+	if !strings.Contains(stream, "(1.) Tj") {
+		t.Errorf("higher-specificity marker did not win\nstream:\n%s", stream)
+	}
+	if strings.Contains(stream, "(LO) Tj") {
+		t.Errorf("lower-specificity marker leaked (first-wins bug)\nstream:\n%s", stream)
+	}
+}
+
+// Element-path li (block child) with a custom ::marker content. The marker is
+// drawn before the element. counter(item) ") " renders ") " with the close
+// paren escaped per PDF string rules, so the token is (1\)) Tj.
+func TestMarkerContentElementPath(t *testing.T) {
+	htmlStr := `<style>
+		ol { counter-reset: item }
+		li { counter-increment: item }
+		li::marker { content: counter(item) ") " }
+	</style>
+	<ol><li><p>Body</p></li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+	if !strings.Contains(stream, `(1\)) Tj`) {
+		t.Errorf("element-path marker missing (1\\)) Tj\nstream:\n%s", stream)
+	}
+	if !strings.Contains(stream, "(Body) Tj") {
+		t.Errorf("element-path body missing (Body) Tj\nstream:\n%s", stream)
+	}
+}

--- a/html/style.go
+++ b/html/style.go
@@ -135,6 +135,7 @@ type computedStyle struct {
 
 	// List
 	ListStyleType      string
+	ListStylePosition  string        // "inside" or "outside" (empty = outside default)
 	ListMarkerColor    *layout.Color // marker color from ::marker pseudo-element
 	ListMarkerFontSize float64       // marker font size from ::marker (0 = use default)
 

--- a/layout/list.go
+++ b/layout/list.go
@@ -68,6 +68,13 @@ type listItem struct {
 	// lines that did not fit on the prior page render on the next one without
 	// re-deriving them from text.
 	contPara *Paragraph
+
+	// markerText/markerSet hold a verbatim marker string supplied by CSS
+	// (li::marker { content: ... }). When markerSet is true the item's marker
+	// is exactly markerText, overriding the style-derived marker entirely —
+	// including ListNone — and an empty markerText suppresses the marker.
+	markerText string
+	markerSet  bool
 }
 
 // listLayoutRef carries list-specific rendering info on a Line.
@@ -243,6 +250,18 @@ func (l *List) AddItemWithSubList(text string) *List {
 	return sub
 }
 
+// SetLastItemMarker sets a verbatim CSS marker string on the most recently
+// appended item (from li::marker { content }), overriding the style-derived
+// marker. It is a no-op when the list has no items.
+func (l *List) SetLastItemMarker(text string) *List {
+	if len(l.items) == 0 {
+		return l
+	}
+	l.items[len(l.items)-1].markerText = text
+	l.items[len(l.items)-1].markerSet = true
+	return l
+}
+
 // Layout implements Element. Each item is rendered as a paragraph
 // with a bullet or number prefix, indented from the left margin.
 func (l *List) Layout(maxWidth float64) []Line {
@@ -268,7 +287,7 @@ func (l *List) layoutAt(maxWidth float64, baseIndent float64) []Line {
 		}
 
 		markerPara := l.markerParagraph(i)
-		markerLines := markerPara.Layout(l.indent)
+		markerLines := markerPara.Layout(l.markerLayoutWidth(i))
 
 		// Create a paragraph for the item text.
 		textPara := l.itemParagraph(item)
@@ -322,7 +341,7 @@ func (l *List) layoutElementItem(item listItem, index int, maxWidth, totalIndent
 	plan := item.element.PlanLayout(LayoutArea{Width: itemWidth, Height: 1e9})
 
 	markerPara := l.markerParagraph(index)
-	markerLines := markerPara.Layout(l.indent)
+	markerLines := markerPara.Layout(l.markerLayoutWidth(index))
 	var markerWords []Word
 	if len(markerLines) > 0 {
 		markerWords = markerLines[0].Words
@@ -410,6 +429,18 @@ func (l *List) itemParagraph(item listItem) *Paragraph {
 		return NewParagraphEmbedded(item.text, l.embedded, l.fontSize)
 	}
 	return NewParagraph(item.text, l.font, l.fontSize)
+}
+
+// markerLayoutWidth returns the width to lay the marker paragraph out at.
+// Default (style-derived) markers wrap at the indent gutter as before. A custom
+// CSS marker (markerSet) may legitimately exceed the gutter, so it is laid out
+// at a width wide enough to keep it on a single line; the gutter is unchanged in
+// this phase, so such a marker simply extends past it.
+func (l *List) markerLayoutWidth(index int) float64 {
+	if l.items[index].markerSet {
+		return 1e9
+	}
+	return l.indent
 }
 
 // markerParagraph builds the marker paragraph for the item at index,
@@ -830,6 +861,9 @@ func wrapListBlocks(blocks []PlacedBlock, width, height float64) []PlacedBlock {
 
 // marker returns the marker string (bullet, number, letter) for the item at index.
 func (l *List) marker(index int) string {
+	if l.items[index].markerSet {
+		return l.items[index].markerText
+	}
 	n := index + 1 + l.start
 	switch l.style {
 	case ListNone:

--- a/layout/list.go
+++ b/layout/list.go
@@ -34,6 +34,7 @@ type List struct {
 	direction      Direction // text direction for list items
 	markerColor    *Color    // optional override color for markers
 	markerFontSize float64   // optional override font size for markers (0 = use list fontSize)
+	markerInside   bool      // CSS list-style-position: inside (marker flows inline)
 
 	// start is the ordinal offset for marker numbering. The marker for the
 	// item at slice index i is numbered (i + 1 + start). It defaults to 0 so
@@ -174,6 +175,15 @@ func (l *List) SetMarkerFontSize(size float64) *List {
 	return l
 }
 
+// SetMarkerInside controls marker placement. When inside is true (CSS
+// list-style-position: inside) the marker flows inline with the first content
+// line and wrapped lines align under the marker. The default (false) is
+// outside: the marker sits in the left gutter with a hanging indent.
+func (l *List) SetMarkerInside(inside bool) *List {
+	l.markerInside = inside
+	return l
+}
+
 // AddItem adds a text item to the list.
 func (l *List) AddItem(text string) *List {
 	l.items = append(l.items, listItem{text: normalizeText(text)})
@@ -272,7 +282,8 @@ func (l *List) Layout(maxWidth float64) []Line {
 // from parent lists (for nesting).
 func (l *List) layoutAt(maxWidth float64, baseIndent float64) []Line {
 	var allLines []Line
-	totalIndent := baseIndent + l.indent
+	effIndent := l.effectiveIndent()
+	totalIndent := baseIndent + effIndent
 	itemWidth := maxWidth - totalIndent
 
 	for i, item := range l.items {
@@ -298,6 +309,8 @@ func (l *List) layoutAt(maxWidth float64, baseIndent float64) []Line {
 		textLines := textPara.Layout(itemWidth)
 
 		// Combine: the first line has both marker and text side by side.
+		// (This Layout path feeds measurement/Columns; the marker is drawn by
+		// the paginated planAt path, which carries inside/gutter placement.)
 		for j, tl := range textLines {
 			line := Line{
 				Words:  make([]Word, 0, len(tl.Words)),
@@ -309,14 +322,9 @@ func (l *List) layoutAt(maxWidth float64, baseIndent float64) []Line {
 			}
 
 			if j == 0 && len(markerLines) > 0 {
-				line.listRef = &listLayoutRef{
-					markerWords: markerLines[0].Words,
-					indent:      totalIndent,
-				}
+				line.listRef = &listLayoutRef{markerWords: markerLines[0].Words, indent: totalIndent}
 			} else {
-				line.listRef = &listLayoutRef{
-					indent: totalIndent,
-				}
+				line.listRef = &listLayoutRef{indent: totalIndent}
 			}
 
 			line.Words = append(line.Words, tl.Words...)
@@ -391,7 +399,7 @@ func (l *List) MinWidth() float64 {
 			}
 		}
 	}
-	return l.indent + maxW
+	return l.effectiveIndent() + maxW
 }
 
 // MaxWidth implements Measurable. Returns indent + widest item line.
@@ -413,7 +421,7 @@ func (l *List) MaxWidth() float64 {
 			maxW = ww
 		}
 	}
-	return l.indent + maxW
+	return l.effectiveIndent() + maxW
 }
 
 // itemParagraph creates a Paragraph for a list item's text content.
@@ -429,6 +437,61 @@ func (l *List) itemParagraph(item listItem) *Paragraph {
 		return NewParagraphEmbedded(item.text, l.embedded, l.fontSize)
 	}
 	return NewParagraph(item.text, l.font, l.fontSize)
+}
+
+// effectiveIndent returns the left indent that defines the marker gutter (for
+// outside) or content offset (for inside). For inside it is l.indent unchanged.
+// For outside it grows only when the widest marker would overflow the default
+// indent, so a long custom marker does not overlap the item text; short-marker
+// lists are unaffected and stay byte-identical to before.
+func (l *List) effectiveIndent() float64 {
+	if l.markerInside {
+		return l.indent
+	}
+	widest := 0.0
+	for i := range l.items {
+		if l.items[i].suppressMarker {
+			continue
+		}
+		if w := l.markerWidth(i); w > widest {
+			widest = w
+		}
+	}
+	// Only grow when a marker is wider than the gutter (i.e. it would overlap
+	// the item text). Markers that already fit leave the indent untouched, so
+	// short-marker lists stay byte-identical. When growing, add a space gap so
+	// the marker and text are visibly separated.
+	if widest > l.indent {
+		return widest + l.spaceWidth()
+	}
+	return l.indent
+}
+
+// markerWidth returns the unbroken width of the item's marker (its widest
+// single-line extent), used to size the outside gutter so a long marker does
+// not overlap the item text. Zero when the marker is empty/suppressed.
+func (l *List) markerWidth(index int) float64 {
+	words, _ := l.markerParagraph(index).measureWords(1e9)
+	return wordsWidth(words)
+}
+
+// wordsWidth sums word widths plus the inter-word SpaceAfter gaps (the trailing
+// word's SpaceAfter is excluded, matching the rendered content extent).
+func wordsWidth(words []Word) float64 {
+	w := 0.0
+	for i := range words {
+		w += words[i].Width
+		if i < len(words)-1 {
+			w += words[i].SpaceAfter
+		}
+	}
+	return w
+}
+
+// spaceWidth returns the width of a single space in the list font at the
+// list font size — the gap between an inline/gutter marker and the item text.
+func (l *List) spaceWidth() float64 {
+	return l.measurer().MeasureString(" ", l.fontSize)
 }
 
 // markerLayoutWidth returns the width to lay the marker paragraph out at.
@@ -528,7 +591,7 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 		return LayoutPlan{Status: LayoutNothing}
 	}
 
-	totalIndent := baseIndent + l.indent
+	totalIndent := baseIndent + l.effectiveIndent()
 	itemWidth := area.Width - totalIndent
 
 	var blocks []PlacedBlock
@@ -598,16 +661,28 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 		// Continuation fragments (a runs item split from a prior page)
 		// suppress the marker so the bullet/number is drawn only once.
 		var markerWords []Word
+		markerW := 0.0
 		if !item.suppressMarker {
 			markerPara := l.markerParagraph(i)
 			markerWords, _ = markerPara.measureWords(l.indent)
+			// markerW is the drawn marker's content width (sum of the same
+			// words), so inside text starts exactly where the marker ends.
+			markerW = wordsWidth(markerWords)
 		}
 
-		// Measure and wrap item text directly.
+		// inside places the marker inline as the leading content of the first
+		// line (RTL still uses the outside gutter path; see drawTextLine below).
+		inside := l.markerInside && l.direction != DirectionRTL
+
+		// Measure and wrap item text directly. For inside, the first line is
+		// narrowed by the marker width so wrapped lines align under the marker.
 		textPara := l.itemParagraph(item)
 		textPara.SetLeading(l.leading)
 		if l.direction != DirectionAuto {
 			textPara.SetDirection(l.direction)
+		}
+		if inside && markerW > 0 {
+			textPara.SetFirstLineIndent(markerW)
 		}
 		textWords, maxFS := textPara.measureWords(itemWidth)
 		lineHeight := maxFS * l.leading
@@ -630,9 +705,16 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 			capturedIndent := totalIndent
 			capturedIsLast := j == len(wordLines)-1
 			capturedRTL := l.direction == DirectionRTL
+			capturedInside := inside
+			// For inside, the marker leads the first line inline at the content
+			// edge; the text then starts markerW further right on that line.
+			capturedMarkerW := 0.0
 			var capturedMarker []Word
 			if j == 0 {
 				capturedMarker = markerWords
+				if capturedInside {
+					capturedMarkerW = markerW
+				}
 			}
 
 			block := PlacedBlock{
@@ -641,13 +723,22 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 				Links: linkSpans(wl),
 				Draw: func(ctx DrawContext, absX, absTopY float64) {
 					baselineY := absTopY - computeBaseline(capturedWords, capturedHeight)
-					if capturedRTL {
+					switch {
+					case capturedRTL:
 						// RTL: marker on the right, text indented from the right.
 						if len(capturedMarker) > 0 {
 							drawTextLine(ctx, capturedMarker, absX+capturedMaxW-capturedIndent, baselineY, capturedIndent, AlignRight, true)
 						}
 						drawTextLine(ctx, capturedWords, absX, baselineY, capturedMaxW-capturedIndent, AlignRight, capturedIsLast)
-					} else {
+					case capturedInside:
+						// Inside: marker is inline at the content edge; the first
+						// line's text follows it, wrapped lines align under it.
+						contentX := absX + capturedIndent
+						if len(capturedMarker) > 0 {
+							drawTextLine(ctx, capturedMarker, contentX, baselineY, capturedMarkerW, AlignLeft, true)
+						}
+						drawTextLine(ctx, capturedWords, contentX+capturedMarkerW, baselineY, capturedMaxW-capturedIndent-capturedMarkerW, AlignLeft, capturedIsLast)
+					default:
 						if len(capturedMarker) > 0 {
 							drawTextLine(ctx, capturedMarker, absX, baselineY, capturedIndent, AlignLeft, true)
 						}
@@ -655,10 +746,11 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 					}
 				},
 			}
-			// Offset link annotation x-coords by the indent since the
-			// text starts after the marker column.
+			// Offset link annotation x-coords. Text starts after the gutter
+			// (outside) or after the inline marker on the first line (inside).
+			linkBase := capturedIndent + capturedMarkerW
 			for k := range block.Links {
-				block.Links[k].X += capturedIndent
+				block.Links[k].X += linkBase
 			}
 			blocks = append(blocks, block)
 			curY += lineHeight
@@ -768,6 +860,7 @@ func (l *List) cloneWithItems(items []listItem) *List {
 		direction:      l.direction,
 		markerColor:    l.markerColor,
 		markerFontSize: l.markerFontSize,
+		markerInside:   l.markerInside,
 	}
 }
 
@@ -784,6 +877,8 @@ func (l *List) planElementItem(item listItem, index int, area LayoutArea, totalI
 		return nil, 0, LayoutNothing, nil
 	}
 
+	// inside is honored for text/runs items only; element items keep the
+	// gutter (outside) marker placement even when inside is requested.
 	var markerWords []Word
 	if !item.suppressMarker {
 		markerPara := l.markerParagraph(index)

--- a/layout/list.go
+++ b/layout/list.go
@@ -837,20 +837,21 @@ func (l *List) marker(index int) string {
 	case ListOrdered:
 		return fmt.Sprintf("%d.", n)
 	case ListOrderedRoman:
-		return toRoman(n, false) + "."
+		return ToRoman(n, false) + "."
 	case ListOrderedRomanUp:
-		return toRoman(n, true) + "."
+		return ToRoman(n, true) + "."
 	case ListOrderedAlpha:
-		return toAlpha(n, 'a') + "."
+		return ToAlpha(n, 'a') + "."
 	case ListOrderedAlphaUp:
-		return toAlpha(n, 'A') + "."
+		return ToAlpha(n, 'A') + "."
 	default:
 		return "\u2022" // bullet character •
 	}
 }
 
-// toRoman converts n to a Roman numeral string.
-func toRoman(n int, upper bool) string {
+// ToRoman converts n to a Roman numeral string (lower-case, or upper-case when
+// upper is true). Values outside 1..3999 fall back to decimal.
+func ToRoman(n int, upper bool) string {
 	if n <= 0 || n > 3999 {
 		return fmt.Sprintf("%d", n)
 	}
@@ -875,8 +876,9 @@ func toRoman(n int, upper bool) string {
 	return result
 }
 
-// toAlpha converts n to alphabetic numbering (1=a, 2=b, ..., 26=z, 27=aa).
-func toAlpha(n int, base byte) string {
+// ToAlpha converts n to alphabetic numbering using base as the first letter
+// ('a' or 'A'): 1=a, 2=b, ..., 26=z, 27=aa. Non-positive n falls back to decimal.
+func ToAlpha(n int, base byte) string {
 	if n <= 0 {
 		return fmt.Sprintf("%d", n)
 	}

--- a/layout/list_position_test.go
+++ b/layout/list_position_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/carlos7ags/folio/content"
+	"github.com/carlos7ags/folio/font"
+)
+
+// reTdShow matches a `x y Td` followed (after intervening ops) by a `(text) Tj`
+// on the next show. It is used to recover the draw x of a piece of text.
+var reTd = regexp.MustCompile(`(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+Td`)
+var reTj = regexp.MustCompile(`\((.*?)\) Tj`)
+
+// drawnText is one (x, text) draw recovered from a content stream.
+type drawnText struct {
+	x    float64
+	text string
+}
+
+// drawnLines renders the leaf text-line blocks of a list plan, one slice of
+// (x, text) pieces per block in document order. Each word is emitted as
+// `... x y Td (word) Tj` by drawTextLine, so we pair each Td with the next Tj.
+func drawnLines(t *testing.T, plan LayoutPlan) [][]drawnText {
+	t.Helper()
+	var leaves []PlacedBlock
+	var walk func(bs []PlacedBlock)
+	walk = func(bs []PlacedBlock) {
+		for _, b := range bs {
+			if len(b.Children) > 0 {
+				walk(b.Children)
+				continue
+			}
+			if b.Draw != nil {
+				leaves = append(leaves, b)
+			}
+		}
+	}
+	walk(plan.Blocks)
+
+	var out [][]drawnText
+	for _, b := range leaves {
+		s := content.NewStream()
+		ctx := DrawContext{Stream: s, Page: &PageResult{}}
+		b.Draw(ctx, b.X, b.Y+b.Height)
+		stream := string(s.Bytes())
+		var line []drawnText
+		tds := reTd.FindAllStringSubmatchIndex(stream, -1)
+		for _, td := range tds {
+			x, _ := strconv.ParseFloat(stream[td[2]:td[3]], 64)
+			rest := stream[td[1]:]
+			if m := reTj.FindStringSubmatch(rest); m != nil {
+				line = append(line, drawnText{x: x, text: m[1]})
+			}
+		}
+		if len(line) > 0 {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// TestListInsideVsOutsideGeometry asserts the defining geometric difference
+// between list-style-position inside and outside for a wrapping item:
+//
+//   - outside: the marker sits in the left gutter; the first text word and the
+//     wrapped continuation word both start at the same content edge (hanging).
+//   - inside: the marker leads the first line inline at the content edge, so the
+//     first text word starts to the RIGHT of the marker, while the wrapped
+//     continuation word aligns back at the content edge (under the marker).
+func TestListInsideVsOutsideGeometry(t *testing.T) {
+	const areaW = 120.0
+	const indent = 18.0
+	// Short words that wrap cleanly (no character-breaking) at the narrow width.
+	mk := func(inside bool) [][]drawnText {
+		l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+		l.SetMarkerInside(inside)
+		l.AddItem("one two ten six nine four ate")
+		plan := l.PlanLayout(LayoutArea{Width: areaW, Height: 1000})
+		if plan.Status != LayoutFull {
+			t.Fatalf("inside=%v: expected LayoutFull, got %v", inside, plan.Status)
+		}
+		lines := drawnLines(t, plan)
+		if len(lines) < 2 {
+			t.Fatalf("inside=%v: expected wrapping to >=2 lines, got %d: %v", inside, len(lines), lines)
+		}
+		return lines
+	}
+
+	outside := mk(false)
+	// Outside line 0: marker in the gutter at x=0, first text word at the indent.
+	if outside[0][0].text != "1." || outside[0][0].x != 0 {
+		t.Errorf("outside: expected marker '1.' at x=0, got %+v", outside[0][0])
+	}
+	outFirstText := outside[0][1]
+	if !approxEqual(outFirstText.x, indent, 0.01) {
+		t.Errorf("outside: first text word x = %v, want indent %v", outFirstText.x, indent)
+	}
+	// Outside hanging indent: continuation line also starts at the indent.
+	if !approxEqual(outside[1][0].x, indent, 0.01) {
+		t.Errorf("outside: continuation x = %v, want indent %v", outside[1][0].x, indent)
+	}
+
+	inside := mk(true)
+	// Inside line 0: marker leads inline at the content edge (the indent), and
+	// the first text word follows it shifted right by the marker width.
+	inMarker := inside[0][0]
+	if inMarker.text != "1." || !approxEqual(inMarker.x, indent, 0.01) {
+		t.Errorf("inside: expected marker '1.' at content edge %v, got %+v", indent, inMarker)
+	}
+	inFirstText := inside[0][1]
+	if inFirstText.x <= inMarker.x {
+		t.Errorf("inside: first text word x (%v) should be right of inline marker (%v)", inFirstText.x, inMarker.x)
+	}
+	// Inside continuation aligns back under the marker (the content edge).
+	if !approxEqual(inside[1][0].x, indent, 0.01) {
+		t.Errorf("inside: continuation x = %v, want content edge %v", inside[1][0].x, indent)
+	}
+	// Defining first-line difference: inside shifts the first text word right of
+	// where outside places it (by the marker width).
+	if inFirstText.x <= outFirstText.x+1 {
+		t.Errorf("inside first text x (%v) should be markerWidth right of outside (%v)", inFirstText.x, outFirstText.x)
+	}
+}
+
+// TestListGutterAutoSizeWideMarker verifies the outside gutter grows so a
+// marker wider than the default 18pt indent does not overlap the item text,
+// while a plain short-marker list keeps the 18pt indent (no regression).
+func TestListGutterAutoSizeWideMarker(t *testing.T) {
+	// Wide custom marker via ::marker content.
+	wide := NewList(font.Helvetica, 12)
+	wide.AddItem("Body text of the clause.")
+	wide.SetLastItemMarker("Section 12: ")
+
+	markerW := wide.markerWidth(0)
+	if markerW <= 18 {
+		t.Fatalf("test precondition: marker width %v should exceed default 18pt indent", markerW)
+	}
+	eff := wide.effectiveIndent()
+	if eff <= 18 {
+		t.Errorf("wide marker: effectiveIndent %v did not grow past 18", eff)
+	}
+
+	// Intrinsic widths must include the grown gutter, else a list nested in a
+	// table/flex would be under-sized and the marker would overlap the text.
+	if mn := wide.MinWidth(); mn < eff {
+		t.Errorf("wide marker: MinWidth %v < grown gutter %v", mn, eff)
+	}
+	if mx := wide.MaxWidth(); mx < eff {
+		t.Errorf("wide marker: MaxWidth %v < grown gutter %v", mx, eff)
+	}
+
+	plan := wide.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	lines := drawnLines(t, plan)
+	if len(lines) == 0 {
+		t.Fatal("wide marker: no lines drawn")
+	}
+	// Line 0 holds the gutter marker (at x=0) then the body text. The body must
+	// start at or beyond the indent so it never overlaps the marker.
+	first := lines[0]
+	markerX := first[0].x
+	if markerX != 0 {
+		t.Errorf("wide marker: marker should be at gutter x=0, got %v", markerX)
+	}
+	// The body text is the first piece whose x is at/after the content edge.
+	var bodyX float64 = -1
+	for _, p := range first {
+		if p.x >= eff-0.01 {
+			bodyX = p.x
+			break
+		}
+	}
+	if bodyX < 0 {
+		t.Fatalf("wide marker: no body text at/after content edge %v; line=%+v", eff, first)
+	}
+	if bodyX < markerX+markerW-0.01 {
+		t.Errorf("body text x (%v) overlaps marker [%v, %v]", bodyX, markerX, markerX+markerW)
+	}
+
+	// Regression: a plain short-marker list keeps the default 18pt indent.
+	short := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	short.AddItem("Item one")
+	if got := short.effectiveIndent(); got != 18 {
+		t.Errorf("short-marker list effectiveIndent = %v, want 18 (unchanged)", got)
+	}
+	sl := drawnLines(t, short.PlanLayout(LayoutArea{Width: 400, Height: 1000}))
+	if len(sl) == 0 || len(sl[0]) < 2 {
+		t.Fatalf("short-marker: expected marker+text on line 0, got %+v", sl)
+	}
+	if x := sl[0][1].x; !approxEqual(x, 18, 0.01) {
+		t.Errorf("short-marker text x = %v, want 18", x)
+	}
+}

--- a/layout/listnumbering_test.go
+++ b/layout/listnumbering_test.go
@@ -41,9 +41,9 @@ func TestToRoman(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := toRoman(tt.n, tt.upper)
+		got := ToRoman(tt.n, tt.upper)
 		if got != tt.want {
-			t.Errorf("toRoman(%d, %v) = %q, want %q", tt.n, tt.upper, got, tt.want)
+			t.Errorf("ToRoman(%d, %v) = %q, want %q", tt.n, tt.upper, got, tt.want)
 		}
 	}
 }
@@ -67,9 +67,9 @@ func TestToAlpha(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := toAlpha(tt.n, tt.base)
+		got := ToAlpha(tt.n, tt.base)
 		if got != tt.want {
-			t.Errorf("toAlpha(%d, %q) = %q, want %q", tt.n, string(tt.base), got, tt.want)
+			t.Errorf("ToAlpha(%d, %q) = %q, want %q", tt.n, string(tt.base), got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
Closes #356.

Adds native support for multi-level ("legal") ordered-list numbering and CSS
list-style-position, so documents like nested contracts render without markup
workarounds:

```css
ol { counter-reset: item; list-style: none; }
li { counter-increment: item; }
li::marker { content: counters(item, ".") ". "; }
```
renders `1.`, `1.1.`, `1.2.`, `1.2.1.`, `2.`, … with a hanging indent.

### What's added
- **CSS counters drive list markers.** The existing counter stack
  (`counter-reset`/`counter-increment`) is now maintained through the list
  walk, and `li::marker { content: ... }` defines the marker string,
  resolving `counter()` / `counters(name, sep)` against live counter state.
- **Counter style arguments.** `counter(name, <style>)` and
  `counters(name, sep, <style>)` honor decimal, decimal-leading-zero,
  lower/upper-roman, and lower/upper-alpha (+latin), sharing one numeral
  implementation with the layout markers. `counters()` separator parsing is
  quote-aware so `counters(item, ", ")` is preserved.
- **`list-style-position`.** `outside` (default, hanging indent) and `inside`
  (marker flows inline with the first content line; wrapped lines align under
  it). Folded into the `list-style` shorthand.
- **Gutter sizing.** The outside marker gutter grows only when the widest
  marker would exceed the default indent, so wide markers don't overlap the
  text; short-marker lists are byte-identical to before. Intrinsic
  width (`MinWidth`/`MaxWidth`) accounts for the grown gutter.
- **Example.** `examples/legal-numbering` renders a nested Master Services
  Agreement using the CSS above.

### Structure
Three commits, one per phase:
1. counter-engine groundwork (style args + list-walk wiring)
2. `::marker { content }` drives the marker
3. `list-style-position` + gutter sizing + example

### Tests
Counter style resolution (incl. comma separator and per-item reset scoping),
marker content end-to-end on both the inline and block `<li>` paths, cascade
specificity, `content: none` suppression, inside-vs-outside draw geometry
(asserted on real stream x-coordinates), gutter auto-grow + intrinsic width,
shorthand parsing, and the example's multi-level ordinals. Full module test
suite passes (race-clean on the touched packages).

### Known limitation (separate)
Nested list markers stack at the container's left margin rather than indenting
per level (pre-existing layout behavior, independent of this change). Tracked
in #358.