### PR TITLE
layout: indent nested list markers per level (#358)

### DIFF
--- a/layout/list.go
+++ b/layout/list.go
@@ -703,6 +703,11 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 			capturedHeight := lineHeight
 			capturedMaxW := area.Width
 			capturedIndent := totalIndent
+			// Indent the marker by the accumulated parent indent so each
+			// nesting level's marker steps right under its parent's content
+			// rather than stacking at the container's left edge (issue #358).
+			// (RTL already steps via its depth-dependent x term below.)
+			capturedBase := baseIndent
 			capturedIsLast := j == len(wordLines)-1
 			capturedRTL := l.direction == DirectionRTL
 			capturedInside := inside
@@ -740,7 +745,7 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 						drawTextLine(ctx, capturedWords, contentX+capturedMarkerW, baselineY, capturedMaxW-capturedIndent-capturedMarkerW, AlignLeft, capturedIsLast)
 					default:
 						if len(capturedMarker) > 0 {
-							drawTextLine(ctx, capturedMarker, absX, baselineY, capturedIndent, AlignLeft, true)
+							drawTextLine(ctx, capturedMarker, absX+capturedBase, baselineY, capturedIndent-capturedBase, AlignLeft, true)
 						}
 						drawTextLine(ctx, capturedWords, absX+capturedIndent, baselineY, capturedMaxW-capturedIndent, AlignLeft, capturedIsLast)
 					}
@@ -908,6 +913,10 @@ func (l *List) planElementItem(item listItem, index int, area LayoutArea, totalI
 		capturedMaxW := area.Width
 		capturedBaseline := markerBaseline
 		capturedRTL := l.direction == DirectionRTL
+		// Indent the marker by the accumulated parent indent so nested element
+		// items step right under their parent's content, matching the text-item
+		// path in planAt (issue #358).
+		capturedBase := totalIndent - l.effectiveIndent()
 
 		// The marker is drawn relative to its block's top, which sits at the
 		// element's top (curY). markerBaseline is measured from that top.
@@ -919,7 +928,7 @@ func (l *List) planElementItem(item listItem, index int, area LayoutArea, totalI
 				if capturedRTL {
 					drawTextLine(ctx, capturedMarker, absX+capturedMaxW-capturedIndent, baselineY, capturedIndent, AlignRight, true)
 				} else {
-					drawTextLine(ctx, capturedMarker, absX, baselineY, capturedIndent, AlignLeft, true)
+					drawTextLine(ctx, capturedMarker, absX+capturedBase, baselineY, capturedIndent-capturedBase, AlignLeft, true)
 				}
 			},
 		}

--- a/layout/list_position_test.go
+++ b/layout/list_position_test.go
@@ -196,3 +196,77 @@ func TestListGutterAutoSizeWideMarker(t *testing.T) {
 		t.Errorf("short-marker text x = %v, want 18", x)
 	}
 }
+
+// TestNestedMarkerIndentsPerLevel verifies that nested-list markers step right
+// per nesting level (each level's marker aligns under its parent's content
+// edge) rather than all stacking at the container's left margin (issue #358).
+// With short markers the gutter stays at the default 18pt, so successive
+// levels indent by 18pt: 0, 18, 36.
+func TestNestedMarkerIndentsPerLevel(t *testing.T) {
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	a := l.AddItemWithSubList("Level one")
+	a.SetStyle(ListOrdered)
+	b := a.AddItemWithSubList("Level two")
+	b.SetStyle(ListOrdered)
+	b.AddItem("Level three")
+
+	plan := l.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	lines := drawnLines(t, plan)
+
+	// The first token of each list line is its marker; in document order the
+	// three "1." markers are level 1, 2, 3.
+	var markerX []float64
+	for _, ln := range lines {
+		if len(ln) > 0 && ln[0].text == "1." {
+			markerX = append(markerX, ln[0].x)
+		}
+	}
+	if len(markerX) != 3 {
+		t.Fatalf("expected 3 nested '1.' markers, got %d: %+v", len(markerX), markerX)
+	}
+	want := []float64{0, 18, 36}
+	for i, x := range markerX {
+		if !approxEqual(x, want[i], 0.01) {
+			t.Errorf("level %d marker x = %v, want %v (markers must indent per level)", i+1, x, want[i])
+		}
+	}
+	// Guard against regressing to the old behavior (all markers at x=0).
+	if markerX[1] == 0 || markerX[2] == 0 {
+		t.Errorf("nested markers stacked at the left margin: %+v", markerX)
+	}
+}
+
+// TestNestedElementMarkerIndentsPerLevel covers the element-item path
+// (planElementItem, used for <li> with block children): its marker must also
+// indent per nesting level, matching the text-item path.
+func TestNestedElementMarkerIndentsPerLevel(t *testing.T) {
+	mkDiv := func(s string) Element {
+		d := NewDiv()
+		d.Add(NewParagraph(s, font.Helvetica, 12))
+		return d
+	}
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	a := l.AddItemElementWithSubList(mkDiv("Level one"))
+	a.SetStyle(ListOrdered)
+	b := a.AddItemElementWithSubList(mkDiv("Level two"))
+	b.SetStyle(ListOrdered)
+	b.AddItemElement(mkDiv("Level three"))
+
+	plan := l.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+	lines := drawnLines(t, plan)
+
+	var markerX []float64
+	for _, ln := range lines {
+		if len(ln) == 1 && ln[0].text == "1." { // element marker draws alone
+			markerX = append(markerX, ln[0].x)
+		}
+	}
+	if len(markerX) != 3 {
+		t.Fatalf("expected 3 element-item '1.' markers, got %d: %+v", len(markerX), markerX)
+	}
+	for i, want := range []float64{0, 18, 36} {
+		if !approxEqual(markerX[i], want, 0.01) {
+			t.Errorf("element level %d marker x = %v, want %v", i+1, markerX[i], want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #358.

Nested list markers were drawn at the container's left margin regardless of
nesting depth — only the item body text indented — so multi-level numbering
put every sub-number in the same left column instead of stepping under its
parent's content:

```
before                      after
1.  Definitions.            1.  Definitions.
1.1.  "Agreement" ...         1.1.  "Agreement" ...
1.2.  "Services" ...          1.2.  "Services" ...
1.2.1.  Each statement ...        1.2.1.  Each statement ...
```

### Change
`layout/list.go` draws each level's marker indented by the accumulated parent
indent (`planAt` text items and `planElementItem` block-child items, LTR
path), so a nested marker steps right under its parent's content edge.

- RTL is unchanged: it already stepped per level via its depth-dependent x
  term (the marker draws from `absX + maxWidth - totalIndent`, which moves with
  depth). `drawTextLine` ignores the width arg for non-justified alignment, so
  no RTL edit was needed.
- `list-style-position: inside` is unchanged: it already draws relative to the
  content edge, which is depth-correct.
- Single-level lists are byte-identical (baseIndent is 0).

### Tests
`TestNestedMarkerIndentsPerLevel` (text items) and
`TestNestedElementMarkerIndentsPerLevel` (block-child items) assert marker x =
{0, 18, 36} across three levels on the real PlanLayout/draw path; both fail if
the marker reverts to the container left edge. Existing nested-list and
single-level tests are unaffected; full module suite passes.