### PR TITLE
layout: implement table rowspan geometry (#357)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ examples/
 ├── merge/          # parse, merge, and extract text from PDFs
 ├── redact/         # permanently remove sensitive text (SSNs, emails, PII)
 ├── report/         # multi-page report with layout API (tables, lists, columns)
+├── table-rowspan/  # table cells spanning multiple rows and columns
 ├── sign/           # PAdES digital signature with self-signed certificate
 ├── zugferd/        # PDF/A-3B invoice with Factur-X XML attachment
 └── README.md

--- a/examples/table-rowspan/main.go
+++ b/examples/table-rowspan/main.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Table-rowspan creates a one-page PDF demonstrating cells that span
+// multiple rows (rowspan) alongside multi-column spans (colspan).
+//
+// Usage:
+//
+//	go run ./examples/table-rowspan
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+)
+
+func main() {
+	if err := buildDocument().Save("table-rowspan.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created table-rowspan.pdf")
+}
+
+// buildDocument assembles a page with two tables: the minimal rowspan
+// case from issue #357, and a richer schedule grid where a cell spans
+// three rows. Extracted from main() so the example test can build the
+// same document against an in-memory buffer.
+func buildDocument() *document.Document {
+	doc := document.NewDocument(document.PageSizeA4)
+	doc.Info.Title = "Table Rowspan"
+	doc.Info.Author = "Folio"
+
+	doc.Add(layout.NewHeading("Rowspan", layout.H1))
+	doc.Add(layout.NewParagraph(
+		"The first column spans both rows; the second column has one cell per row.",
+		font.Helvetica, 11,
+	))
+
+	basic := layout.NewTable()
+	r1 := basic.AddRow()
+	r1.AddCell("Span", font.HelveticaBold, 10).SetRowspan(2).SetVAlign(layout.VAlignMiddle)
+	r1.AddCell("B1", font.Helvetica, 10)
+	r2 := basic.AddRow()
+	r2.AddCell("B2", font.Helvetica, 10)
+	doc.Add(basic)
+
+	doc.Add(layout.NewHeading("Schedule grid", layout.H2))
+	doc.Add(layout.NewParagraph(
+		"\"Morning\" spans three time slots; \"All day\" spans the whole column.",
+		font.Helvetica, 11,
+	))
+
+	sched := layout.NewTable()
+	sched.SetColumnWidths([]float64{90, 160, 160})
+
+	h := sched.AddHeaderRow()
+	h.AddCell("Block", font.HelveticaBold, 10)
+	h.AddCell("Track A", font.HelveticaBold, 10)
+	h.AddCell("Track B", font.HelveticaBold, 10)
+
+	row1 := sched.AddRow()
+	row1.AddCell("Morning", font.HelveticaBold, 10).SetRowspan(3).SetVAlign(layout.VAlignMiddle)
+	row1.AddCell("Registration", font.Helvetica, 10)
+	row1.AddCell("All day: help desk", font.Helvetica, 10).SetRowspan(3).SetVAlign(layout.VAlignMiddle)
+
+	row2 := sched.AddRow()
+	row2.AddCell("Keynote", font.Helvetica, 10)
+
+	row3 := sched.AddRow()
+	row3.AddCell("Workshop intro", font.Helvetica, 10)
+
+	doc.Add(sched)
+
+	return doc
+}

--- a/examples/table-rowspan/main_test.go
+++ b/examples/table-rowspan/main_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	var buf bytes.Buffer
+	if _, err := buildDocument().WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+func TestRowspanExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 1000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >1 KB", len(pdf))
+	}
+}
+
+func TestRowspanExampleSinglePage(t *testing.T) {
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got != 1 {
+		t.Errorf("PageCount = %d, want 1", got)
+	}
+}
+
+// TestRowspanExampleContent confirms every cell — including the cells
+// in rows that sit beside a rowspanning cell — is emitted. Before the
+// rowspan geometry fix the spanning cells still rendered; the failure
+// mode was purely visual (drawn one row tall), so this guards content
+// rather than geometry. The geometry assertions live in the layout
+// package's TestTableRowspan* tests.
+func TestRowspanExampleContent(t *testing.T) {
+	r := examplePDFReader(t)
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	for _, want := range []string{
+		"Span", "B1", "B2",
+		"Morning", "Registration", "Keynote", "Workshop intro", "All day: help desk",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("page text missing %q; extracted:\n%s", want, text)
+		}
+	}
+}

--- a/layout/table.go
+++ b/layout/table.go
@@ -722,9 +722,10 @@ func cellIntrinsicWidths(cell *Cell, availWidth float64) (minW, maxW float64) {
 
 // gridCell is a cell positioned in the flat grid.
 type gridCell struct {
-	cell      *Cell
-	col       int     // starting column index
-	spanWidth float64 // total width across spanned columns
+	cell       *Cell
+	col        int     // starting column index
+	spanWidth  float64 // total width across spanned columns
+	spanHeight float64 // total height across spanned rows (0 = single row)
 }
 
 // gridRow is a row in the flat grid with computed height.
@@ -798,10 +799,15 @@ func (t *Table) buildGrid(colWidths []float64) []gridRow {
 			col++
 		}
 
-		// Compute row height: tallest cell content + padding.
+		// Compute row height: tallest cell content + padding. Rowspanning
+		// cells are excluded here so they don't inflate their starting row;
+		// their height is distributed across the spanned rows below.
 		maxH := 0.0
 		for i := range gr.cells {
 			h := t.cellContentHeight(&gr.cells[i])
+			if gr.cells[i].cell.rowspan > 1 {
+				continue
+			}
 			if h > maxH {
 				maxH = h
 			}
@@ -810,7 +816,56 @@ func (t *Table) buildGrid(colWidths []float64) []gridRow {
 		grid = append(grid, gr)
 	}
 
+	t.resolveRowspanHeights(grid)
 	return grid
+}
+
+// resolveRowspanHeights computes spanHeight for every rowspanning cell once
+// all natural row heights are known. If a spanning cell needs more height than
+// its spanned rows provide, the deficit grows the last spanned row; spanHeight
+// is then the total covered height (spanned row heights plus the spacing gaps
+// between them).
+//
+// Note: a rowspan that straddles a page break is not handled — PlanLayout
+// splits between rows without span awareness, so such a cell draws its full
+// height past the page bottom. Tracked as a known limitation (issue #357).
+func (t *Table) resolveRowspanHeights(grid []gridRow) {
+	sv := t.effectiveSpacingV()
+
+	// Pass 1: grow the last spanned row to cover any content deficit.
+	for r := range grid {
+		for i := range grid[r].cells {
+			gc := &grid[r].cells[i]
+			if gc.cell.rowspan <= 1 {
+				continue
+			}
+			end := min(r+gc.cell.rowspan, len(grid))
+			avail := float64(end-r-1) * sv
+			for k := r; k < end; k++ {
+				avail += grid[k].height
+			}
+			if need := t.cellContentHeight(gc); need > avail {
+				grid[end-1].height += need - avail
+			}
+		}
+	}
+
+	// Pass 2: record each spanning cell's total height from the final row
+	// heights (rows may have grown in pass 1).
+	for r := range grid {
+		for i := range grid[r].cells {
+			gc := &grid[r].cells[i]
+			if gc.cell.rowspan <= 1 {
+				continue
+			}
+			end := min(r+gc.cell.rowspan, len(grid))
+			h := float64(end-r-1) * sv
+			for k := r; k < end; k++ {
+				h += grid[k].height
+			}
+			gc.spanHeight = h
+		}
+	}
 }
 
 // cellContentHeight computes the height needed for a cell's content.
@@ -1357,31 +1412,37 @@ func drawTableRowDirect(ctx DrawContext, tbl *Table, grid []gridRow, rowIndex in
 				cellX += colWidths[c] + sh
 			}
 		}
-		cellBottomY := topY - gr.height
+		// Rowspanning cells extend below their starting row; spanHeight
+		// covers the full span (0 for single-row cells).
+		cellH := gr.height
+		if gc.spanHeight > 0 {
+			cellH = gc.spanHeight
+		}
+		cellBottomY := topY - cellH
 
 		// Background fill (with optional rounded corners).
 		r := gc.cell.borderRadius
 		hasRadius := r[0] > 0 || r[1] > 0 || r[2] > 0 || r[3] > 0
 		if gc.cell.bgColor != nil {
 			if hasRadius {
-				drawBackgroundRounded(ctx, *gc.cell.bgColor, cellX, cellBottomY, gc.spanWidth, gr.height, r)
+				drawBackgroundRounded(ctx, *gc.cell.bgColor, cellX, cellBottomY, gc.spanWidth, cellH, r)
 			} else {
-				drawBackground(ctx, *gc.cell.bgColor, cellX, topY, gc.spanWidth, gr.height)
+				drawBackground(ctx, *gc.cell.bgColor, cellX, topY, gc.spanWidth, cellH)
 			}
 		}
 
 		// Borders (with optional rounded corners).
 		if hasRadius {
-			drawCellBordersRounded(ctx.Stream, gc.cell.borders, cellX, cellBottomY, gc.spanWidth, gr.height, r)
+			drawCellBordersRounded(ctx.Stream, gc.cell.borders, cellX, cellBottomY, gc.spanWidth, cellH, r)
 		} else {
-			drawCellBorders(ctx.Stream, gc.cell.borders, cellX, cellBottomY, gc.spanWidth, gr.height)
+			drawCellBorders(ctx.Stream, gc.cell.borders, cellX, cellBottomY, gc.spanWidth, cellH)
 		}
 
 		// Cell content.
 		if gc.cell.content != nil {
-			drawCellElementDirect(ctx, gc, cellX, topY, gr.height)
+			drawCellElementDirect(ctx, gc, cellX, topY, cellH)
 		} else {
-			drawCellTextDirect(ctx, gc.cell, cellX, topY, gc.spanWidth, gr.height)
+			drawCellTextDirect(ctx, gc.cell, cellX, topY, gc.spanWidth, cellH)
 		}
 	}
 }

--- a/layout/table_test.go
+++ b/layout/table_test.go
@@ -401,6 +401,74 @@ func TestTableRowspan(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
+
+	// The spanning cell must cover both rows, not just its starting row.
+	grid := tbl.buildGrid(tbl.resolveColWidths(400))
+	span := grid[0].cells[0]
+	if span.cell.text != "Span" {
+		t.Fatalf("expected first cell to be the span cell, got %q", span.cell.text)
+	}
+	want := grid[0].height + grid[1].height // sv == 0 by default
+	if span.spanHeight != want {
+		t.Errorf("span height: got %g, want %g (row0 %g + row1 %g)",
+			span.spanHeight, want, grid[0].height, grid[1].height)
+	}
+	if span.spanHeight <= grid[0].height {
+		t.Errorf("span height %g should exceed a single row height %g",
+			span.spanHeight, grid[0].height)
+	}
+	// Single-row cells carry no spanHeight.
+	if b1 := grid[0].cells[1]; b1.spanHeight != 0 {
+		t.Errorf("non-spanning cell B1: spanHeight got %g, want 0", b1.spanHeight)
+	}
+}
+
+func TestTableRowspanIncludesVerticalSpacing(t *testing.T) {
+	tbl := NewTable()
+	tbl.SetCellSpacing(0, 6) // 6pt vertical gap between rows
+
+	r1 := tbl.AddRow()
+	r1.AddCell("Span", font.Helvetica, 10).SetRowspan(2)
+	r1.AddCell("B1", font.Helvetica, 10)
+	r2 := tbl.AddRow()
+	r2.AddCell("B2", font.Helvetica, 10)
+
+	grid := tbl.buildGrid(tbl.resolveColWidths(400))
+	span := grid[0].cells[0]
+	// Span reaches the bottom of row 1, so it must include the gap between rows.
+	want := grid[0].height + grid[1].height + 6
+	if span.spanHeight != want {
+		t.Errorf("span height with spacing: got %g, want %g", span.spanHeight, want)
+	}
+}
+
+func TestTableRowspanDeficitGrowsLastRow(t *testing.T) {
+	// A tall rowspan cell whose content needs more height than its spanned
+	// rows naturally provide must grow the last spanned row, and its
+	// spanHeight must cover the grown rows.
+	tbl := NewTable()
+	tbl.SetColumnWidths([]float64{60, 200})
+
+	r1 := tbl.AddRow()
+	// Narrow column forces the span cell's text to wrap into many lines.
+	r1.AddCell("one two three four five six seven eight nine ten", font.Helvetica, 10).SetRowspan(2)
+	r1.AddCell("B1", font.Helvetica, 10)
+	r2 := tbl.AddRow()
+	r2.AddCell("B2", font.Helvetica, 10)
+
+	grid := tbl.buildGrid(tbl.resolveColWidths(400))
+	span := grid[0].cells[0]
+
+	// spanHeight equals the (possibly grown) two rows plus their gap (sv == 0).
+	wantSpan := grid[0].height + grid[1].height
+	if span.spanHeight != wantSpan {
+		t.Errorf("span height: got %g, want %g", span.spanHeight, wantSpan)
+	}
+	// The cell's full content must fit within the span.
+	need := tbl.cellContentHeight(&grid[0].cells[0])
+	if span.spanHeight+0.01 < need {
+		t.Errorf("span height %g does not cover content height %g", span.spanHeight, need)
+	}
 }
 
 func TestTableDefaultBorder(t *testing.T) {
@@ -417,6 +485,56 @@ func TestTableAllBorders(t *testing.T) {
 	b := AllBorders(SolidBorder(1, ColorRed))
 	if b.Top.Width != 1 || b.Right.Width != 1 || b.Bottom.Width != 1 || b.Left.Width != 1 {
 		t.Error("all borders should have width 1")
+	}
+}
+
+func TestTableRowspanThreeRows(t *testing.T) {
+	// A cell spanning three rows must cover all three (plus the two gaps
+	// between them), not just the first.
+	tbl := NewTable()
+	tbl.SetColumnWidths([]float64{100, 100})
+	tbl.SetCellSpacing(0, 5)
+
+	r1 := tbl.AddRow()
+	r1.AddCell("Span3", font.Helvetica, 10).SetRowspan(3)
+	r1.AddCell("B1", font.Helvetica, 10)
+	r2 := tbl.AddRow()
+	r2.AddCell("B2", font.Helvetica, 10)
+	r3 := tbl.AddRow()
+	r3.AddCell("B3", font.Helvetica, 10)
+
+	grid := tbl.buildGrid(tbl.resolveColWidths(400))
+	span := grid[0].cells[0]
+	want := grid[0].height + grid[1].height + grid[2].height + 2*5 // two inter-row gaps
+	if span.spanHeight != want {
+		t.Errorf("3-row span height: got %g, want %g", span.spanHeight, want)
+	}
+}
+
+func TestTableColspanAndRowspanCombined(t *testing.T) {
+	// A cell with both colspan=2 and rowspan=2: width spans two columns,
+	// height spans two rows, and the following row's cell lands past the
+	// spanned columns.
+	tbl := NewTable()
+	tbl.SetColumnWidths([]float64{50, 50, 50})
+
+	r1 := tbl.AddRow()
+	r1.AddCell("Big", font.Helvetica, 10).SetColspan(2).SetRowspan(2)
+	r1.AddCell("C1", font.Helvetica, 10)
+	r2 := tbl.AddRow()
+	// Cols 0-1 occupied by the rowspan; this cell goes to col 2.
+	r2.AddCell("C2", font.Helvetica, 10)
+
+	grid := tbl.buildGrid(tbl.resolveColWidths(400))
+	big := grid[0].cells[0]
+	if big.spanWidth != 100 {
+		t.Errorf("colspan width: got %g, want 100", big.spanWidth)
+	}
+	if want := grid[0].height + grid[1].height; big.spanHeight != want {
+		t.Errorf("rowspan height: got %g, want %g", big.spanHeight, want)
+	}
+	if c2 := grid[1].cells[0]; c2.col != 2 {
+		t.Errorf("row 2 cell should start at col 2, got %d", c2.col)
 	}
 }
 


### PR DESCRIPTION
Fixes #357.

## Problem

`rowspan` was stored and used only to reserve grid occupancy so following rows skipped the spanned columns. The vertical geometry was never implemented: a spanning cell contributed height to its starting row only and was always drawn one row tall, so it appeared as a single row.

## Fix

- Add `spanHeight` to `gridCell` (the vertical analogue of `spanWidth`).
- In `buildGrid`, exclude rowspanning cells from their starting row's natural height, then resolve span heights in a second pass: sum the spanned rows' heights plus the inter-row spacing gaps, growing the last spanned row when the cell's content needs more room.
- `drawTableRowDirect` draws spanning cells at `spanHeight`. Vertical alignment already keys off the height argument, so content centers across the full span.

## Preview

The new `examples/table-rowspan` demo (issue's minimal case + a 3-row schedule grid):

![rowspan preview](https://raw.githubusercontent.com/carlos7ags/folio/assets-screenshots/screenshots/rowspan-357.png)

## Tests

- `TestTableRowspan` — span covers both rows; non-spanning sibling has `spanHeight == 0`.
- `TestTableRowspanIncludesVerticalSpacing` — span includes the inter-row gap.
- `TestTableRowspanDeficitGrowsLastRow` — tall content grows the last spanned row.
- `TestTableRowspanThreeRows` — 3-row span covers all rows plus both gaps.
- `TestTableColspanAndRowspanCombined` — width and height span independently.
- Example smoke test plus existing layout/colspan suites pass.

## Known limitation

A rowspan that straddles a page break is not yet handled — `PlanLayout`'s split logic is span-unaware, so such a cell draws its full height past the page bottom. Documented in a code comment; tracked in #362.