### PR TITLE
html/layout: optional flush (outline) list-marker alignment

### DIFF
--- a/html/converter.go
+++ b/html/converter.go
@@ -83,6 +83,13 @@ type Options struct {
 	// loop instead of letting them silently degrade the output.
 	StrictAssets bool
 
+	// FlushListMarkers draws every nested ordered/unordered list marker in the
+	// container's left column (all numbers share one left edge) instead of
+	// indenting each level's marker under its parent's content. Body text still
+	// cascades per level. This is the "outline" style common in legal
+	// documents. Default false (markers indent per nesting level).
+	FlushListMarkers bool
+
 	// MaxElements caps the number of HTML nodes converted into layout
 	// elements. 0 (the default) means unlimited. It guards against
 	// resource exhaustion from very large or programmatically-expanded
@@ -126,6 +133,7 @@ func (o *Options) defaults() Options {
 	out.Client = o.Client
 	out.Logger = o.Logger
 	out.StrictAssets = o.StrictAssets
+	out.FlushListMarkers = o.FlushListMarkers
 	out.MaxElements = o.MaxElements
 	out.MaxDepth = o.MaxDepth
 	return out

--- a/html/converter_list.go
+++ b/html/converter_list.go
@@ -103,6 +103,13 @@ func (c *converter) convertList(n *html.Node, style computedStyle, ordered bool)
 		list.SetMarkerInside(true)
 	}
 
+	// FlushListMarkers (document-wide option) draws all nested markers in one
+	// left column instead of indenting per level. Sub-lists inherit it via the
+	// AddItem*WithSubList constructors.
+	if c.opts.FlushListMarkers {
+		list.SetMarkerFlush(true)
+	}
+
 	c.populateList(n, list, style)
 
 	return []layout.Element{list}

--- a/html/flush_markers_test.go
+++ b/html/flush_markers_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFlushListMarkersOption verifies the document-wide Options.FlushListMarkers
+// toggle reaches the layout: it changes how a nested ordered list renders while
+// leaving the numbering intact. The precise flush geometry (all markers in one
+// left column) is asserted at the layout level in TestNestedMarkerFlush; here
+// we only confirm the option is wired through Convert.
+func TestFlushListMarkersOption(t *testing.T) {
+	const doc = `<ol><li>One<ol><li>Inner</li></ol></li><li>Two</li></ol>`
+
+	nested, err := Convert(doc, &Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	flush, err := Convert(doc, &Options{FlushListMarkers: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nStream := renderStreamText(t, nested)
+	fStream := renderStreamText(t, flush)
+
+	// Numbering renders in both modes (top-level 1./2., nested 1.).
+	for _, want := range []string{"(1.) Tj", "(2.) Tj"} {
+		if !strings.Contains(nStream, want) {
+			t.Errorf("default render missing marker %q", want)
+		}
+		if !strings.Contains(fStream, want) {
+			t.Errorf("flush render missing marker %q", want)
+		}
+	}
+
+	// The option must change the layout (the nested marker moves from its
+	// indented column to the container's left column); otherwise it is not
+	// wired through Options.
+	if nStream == fStream {
+		t.Error("FlushListMarkers had no effect on the rendered stream — option not wired")
+	}
+}

--- a/layout/list.go
+++ b/layout/list.go
@@ -35,6 +35,7 @@ type List struct {
 	markerColor    *Color    // optional override color for markers
 	markerFontSize float64   // optional override font size for markers (0 = use list fontSize)
 	markerInside   bool      // CSS list-style-position: inside (marker flows inline)
+	markerFlush    bool      // draw every nested marker in the container's left column instead of indenting per level
 
 	// start is the ordinal offset for marker numbering. The marker for the
 	// item at slice index i is numbered (i + 1 + start). It defaults to 0 so
@@ -184,6 +185,18 @@ func (l *List) SetMarkerInside(inside bool) *List {
 	return l
 }
 
+// SetMarkerFlush controls how nested-list markers align. When flush is true,
+// every level's marker is drawn in the container's left column (all numbers
+// share one left edge) while the body text still cascades per level — the
+// "outline" style common in legal documents. The default (false) indents each
+// level's marker under its parent's content. Applies to the left-to-right
+// outside path; it is inherited by sub-lists. Sub-lists created later inherit
+// the value set on the parent at creation time.
+func (l *List) SetMarkerFlush(flush bool) *List {
+	l.markerFlush = flush
+	return l
+}
+
 // AddItem adds a text item to the list.
 func (l *List) AddItem(text string) *List {
 	l.items = append(l.items, listItem{text: normalizeText(text)})
@@ -209,12 +222,13 @@ func (l *List) AddItemRuns(runs []TextRun) *List {
 // not mutated and List measurement sees canonical text.
 func (l *List) AddItemRunsWithSubList(runs []TextRun) *List {
 	sub := &List{
-		style:    ListUnordered,
-		font:     l.font,
-		embedded: l.embedded,
-		fontSize: l.fontSize,
-		indent:   l.indent,
-		leading:  l.leading,
+		style:       ListUnordered,
+		font:        l.font,
+		embedded:    l.embedded,
+		fontSize:    l.fontSize,
+		indent:      l.indent,
+		leading:     l.leading,
+		markerFlush: l.markerFlush,
 	}
 	l.items = append(l.items, listItem{runs: normalizeRuns(runs), subList: sub})
 	return sub
@@ -234,12 +248,13 @@ func (l *List) AddItemElement(elem Element) *List {
 // sub-list under it. The sub-list inherits the parent's font and font size.
 func (l *List) AddItemElementWithSubList(elem Element) *List {
 	sub := &List{
-		style:    ListUnordered,
-		font:     l.font,
-		embedded: l.embedded,
-		fontSize: l.fontSize,
-		indent:   l.indent,
-		leading:  l.leading,
+		style:       ListUnordered,
+		font:        l.font,
+		embedded:    l.embedded,
+		fontSize:    l.fontSize,
+		indent:      l.indent,
+		leading:     l.leading,
+		markerFlush: l.markerFlush,
 	}
 	l.items = append(l.items, listItem{element: elem, subList: sub})
 	return sub
@@ -249,12 +264,13 @@ func (l *List) AddItemElementWithSubList(elem Element) *List {
 // under that item. The sub-list inherits the parent's font and font size.
 func (l *List) AddItemWithSubList(text string) *List {
 	sub := &List{
-		style:    ListUnordered,
-		font:     l.font,
-		embedded: l.embedded,
-		fontSize: l.fontSize,
-		indent:   l.indent,
-		leading:  l.leading,
+		style:       ListUnordered,
+		font:        l.font,
+		embedded:    l.embedded,
+		fontSize:    l.fontSize,
+		indent:      l.indent,
+		leading:     l.leading,
+		markerFlush: l.markerFlush,
 	}
 	l.items = append(l.items, listItem{text: normalizeText(text), subList: sub})
 	return sub
@@ -706,8 +722,12 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 			// Indent the marker by the accumulated parent indent so each
 			// nesting level's marker steps right under its parent's content
 			// rather than stacking at the container's left edge (issue #358).
-			// (RTL already steps via its depth-dependent x term below.)
+			// markerFlush keeps every level's marker in the container's left
+			// column (outline style). RTL steps via its depth-dependent x term.
 			capturedBase := baseIndent
+			if l.markerFlush {
+				capturedBase = 0
+			}
 			capturedIsLast := j == len(wordLines)-1
 			capturedRTL := l.direction == DirectionRTL
 			capturedInside := inside
@@ -866,6 +886,7 @@ func (l *List) cloneWithItems(items []listItem) *List {
 		markerColor:    l.markerColor,
 		markerFontSize: l.markerFontSize,
 		markerInside:   l.markerInside,
+		markerFlush:    l.markerFlush,
 	}
 }
 
@@ -915,8 +936,11 @@ func (l *List) planElementItem(item listItem, index int, area LayoutArea, totalI
 		capturedRTL := l.direction == DirectionRTL
 		// Indent the marker by the accumulated parent indent so nested element
 		// items step right under their parent's content, matching the text-item
-		// path in planAt (issue #358).
+		// path in planAt (issue #358). markerFlush keeps it in the left column.
 		capturedBase := totalIndent - l.effectiveIndent()
+		if l.markerFlush {
+			capturedBase = 0
+		}
 
 		// The marker is drawn relative to its block's top, which sits at the
 		// element's top (curY). markerBaseline is measured from that top.

--- a/layout/list_position_test.go
+++ b/layout/list_position_test.go
@@ -270,3 +270,36 @@ func TestNestedElementMarkerIndentsPerLevel(t *testing.T) {
 		}
 	}
 }
+
+// TestNestedMarkerFlush verifies SetMarkerFlush keeps every nesting level's
+// marker in the container's left column (x=0) while body text still cascades,
+// the inverse of the per-level indent default (#358 follow-up).
+func TestNestedMarkerFlush(t *testing.T) {
+	l := NewList(font.Helvetica, 12).SetStyle(ListOrdered)
+	l.SetMarkerFlush(true)
+	a := l.AddItemWithSubList("Level one")
+	a.SetStyle(ListOrdered)
+	b := a.AddItemWithSubList("Level two")
+	b.SetStyle(ListOrdered)
+	b.AddItem("Level three")
+
+	plan := l.PlanLayout(LayoutArea{Width: 400, Height: 1000})
+
+	// Collect every marker token (the leading "1." of each level). In flush
+	// mode all three must share the container's left column (x=0), whereas the
+	// nested default (TestNestedMarkerIndentsPerLevel) puts them at 0/18/36.
+	var markerX []float64
+	for _, ln := range drawnLines(t, plan) {
+		if len(ln) > 0 && ln[0].text == "1." {
+			markerX = append(markerX, ln[0].x)
+		}
+	}
+	if len(markerX) != 3 {
+		t.Fatalf("expected 3 '1.' markers, got %d: %+v", len(markerX), markerX)
+	}
+	for i, x := range markerX {
+		if !approxEqual(x, 0, 0.01) {
+			t.Errorf("flush: level %d marker x = %v, want 0 (all markers share the left column)", i+1, x)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #358/#360. Adds an opt-in mode that draws every nested list
marker in the container's left column (all numbers share one left edge) while
the body text still cascades per level — the "outline" style common in legal
documents — as an alternative to the per-level marker indent that is now the
default.

### Comparison
Same Master Services Agreement (`examples/legal-numbering`), rendered both ways:

```
Nested (default)                 Flush (FlushListMarkers: true)
1.   Definitions.                1.   Definitions.
  1.1.  "Agreement" ...            1.1.  "Agreement" ...
  1.2.  "Services" ...             1.2.  "Services" ...
    1.2.1.  Each statement ...       1.2.1.    Each statement ...
    1.2.2.  In the event ...         1.2.2.    In the event ...
2.   Term and Termination.       2.   Term and Termination.
```

In nested, `1.2.1.`/`1.2.2.` indent under "Services"; in flush they stay in the
left column and the clause bodies hang. Reproduce locally by rendering the
`legal-numbering` example HTML with `&fhtml.Options{FlushListMarkers: true}`.

### API
Document-wide, off by default:

```go
doc.AddHTML(html, &fhtml.Options{FlushListMarkers: true})
```

Underneath, `layout.List.SetMarkerFlush(bool)` toggles it; sub-lists inherit
the value. Only the left-to-right outside path is affected; RTL and
`list-style-position: inside` are unchanged. Default (nested) output is
byte-identical.

### Scope
Kept intentionally minimal: a single document-wide option, no new CSS
property. If per-`<ol>` control within one document is needed later, a
(non-standard) CSS property can layer on top of the same `SetMarkerFlush`
plumbing.

### Tests
`TestNestedMarkerFlush` (layout: all markers share x=0 while bodies cascade) and
`TestFlushListMarkersOption` (the Options toggle reaches the layout and changes
the render while numbering stays intact). Full module suite passes.