### PR TITLE
html: generate anonymous table-row for bare display:table-cell children (#367)

### DIFF
--- a/html/converter_table.go
+++ b/html/converter_table.go
@@ -152,65 +152,36 @@ func (c *converter) convertCSSTable(n *html.Node, style computedStyle) []layout.
 		tbl.SetMinWidthUnit(cssLengthToUnitValue(style.Width, c.containerWidth, style.FontSize))
 	}
 
+	// anonRow accumulates consecutive bare table-cell children into a
+	// single CSS anonymous table-row box. Reset to nil on any non-cell
+	// child so only consecutive cells share a row (per CSS table fixup).
+	var anonRow *layout.Row
 	for child := n.FirstChild; child != nil; child = child.NextSibling {
 		if child.Type != html.ElementNode {
 			continue
 		}
 		childStyle := c.computeElementStyle(child, style)
 
-		if childStyle.Display == "table-row" {
+		switch childStyle.Display {
+		case "table-row":
+			anonRow = nil
 			row := tbl.AddRow()
 			for cell := child.FirstChild; cell != nil; cell = cell.NextSibling {
 				if cell.Type != html.ElementNode {
 					continue
 				}
 				cellStyle := c.computeElementStyle(cell, childStyle)
-				cellElems := c.walkChildren(cell, cellStyle)
-
-				var layoutCell *layout.Cell
-				if len(cellElems) == 0 {
-					f := resolveFont(cellStyle)
-					layoutCell = row.AddCell(" ", f, cellStyle.FontSize)
-				} else if len(cellElems) == 1 {
-					layoutCell = row.AddCellElement(cellElems[0])
-				} else {
-					div := layout.NewDiv()
-					for _, e := range cellElems {
-						div.Add(e)
-					}
-					layoutCell = row.AddCellElement(div)
-				}
-				layoutCell.SetAlign(resolveTextAlign(cellStyle))
-				if cellStyle.hasPadding() {
-					layoutCell.SetPaddingSides(layout.Padding{
-						Top:    cellStyle.PaddingTopAt(c.containerWidth),
-						Right:  cellStyle.PaddingRightAt(c.containerWidth),
-						Bottom: cellStyle.PaddingBottomAt(c.containerWidth),
-						Left:   cellStyle.PaddingLeftAt(c.containerWidth),
-					})
-				}
-				if cellStyle.BackgroundColor != nil {
-					layoutCell.SetBackground(*cellStyle.BackgroundColor)
-					// The cell owns and draws the rounded box fill; clear the
-					// same block-level background on its content Paragraph(s)
-					// to avoid a square-cornered overdraw (issue #329).
-					clearCellParagraphBackground(layoutCell, *cellStyle.BackgroundColor)
-				}
-				if cellStyle.hasBorder() {
-					layoutCell.SetBorders(buildCellBorders(cellStyle))
-				}
-				if !tbl.BorderCollapse() {
-					if cellStyle.BorderRadiusTL > 0 || cellStyle.BorderRadiusTR > 0 ||
-						cellStyle.BorderRadiusBR > 0 || cellStyle.BorderRadiusBL > 0 {
-						layoutCell.SetBorderRadiusPerCorner(
-							cellStyle.BorderRadiusTL, cellStyle.BorderRadiusTR,
-							cellStyle.BorderRadiusBR, cellStyle.BorderRadiusBL)
-					} else if cellStyle.BorderRadius > 0 {
-						layoutCell.SetBorderRadius(cellStyle.BorderRadius)
-					}
-				}
+				c.addCSSTableCell(tbl, row, cell, cellStyle)
 			}
-		} else {
+		case "table-cell":
+			// Bare table-cell with no table-row parent: wrap consecutive
+			// cells in an anonymous table-row box (CSS table fixup).
+			if anonRow == nil {
+				anonRow = tbl.AddRow()
+			}
+			c.addCSSTableCell(tbl, anonRow, child, childStyle)
+		default:
+			anonRow = nil
 			// Non-row children — treat as a single-cell row.
 			childElems := c.convertNode(child, style)
 			if len(childElems) > 0 {
@@ -240,6 +211,55 @@ func (c *converter) convertCSSTable(n *html.Node, style computedStyle) []layout.
 	}
 
 	return []layout.Element{tbl}
+}
+
+// addCSSTableCell builds a single display:table-cell into row, applying the
+// cell's content, alignment, padding, background, borders, and border-radius.
+func (c *converter) addCSSTableCell(tbl *layout.Table, row *layout.Row, cell *html.Node, cellStyle computedStyle) {
+	cellElems := c.walkChildren(cell, cellStyle)
+
+	var layoutCell *layout.Cell
+	if len(cellElems) == 0 {
+		f := resolveFont(cellStyle)
+		layoutCell = row.AddCell(" ", f, cellStyle.FontSize)
+	} else if len(cellElems) == 1 {
+		layoutCell = row.AddCellElement(cellElems[0])
+	} else {
+		div := layout.NewDiv()
+		for _, e := range cellElems {
+			div.Add(e)
+		}
+		layoutCell = row.AddCellElement(div)
+	}
+	layoutCell.SetAlign(resolveTextAlign(cellStyle))
+	if cellStyle.hasPadding() {
+		layoutCell.SetPaddingSides(layout.Padding{
+			Top:    cellStyle.PaddingTopAt(c.containerWidth),
+			Right:  cellStyle.PaddingRightAt(c.containerWidth),
+			Bottom: cellStyle.PaddingBottomAt(c.containerWidth),
+			Left:   cellStyle.PaddingLeftAt(c.containerWidth),
+		})
+	}
+	if cellStyle.BackgroundColor != nil {
+		layoutCell.SetBackground(*cellStyle.BackgroundColor)
+		// The cell owns and draws the rounded box fill; clear the
+		// same block-level background on its content Paragraph(s)
+		// to avoid a square-cornered overdraw (issue #329).
+		clearCellParagraphBackground(layoutCell, *cellStyle.BackgroundColor)
+	}
+	if cellStyle.hasBorder() {
+		layoutCell.SetBorders(buildCellBorders(cellStyle))
+	}
+	if !tbl.BorderCollapse() {
+		if cellStyle.BorderRadiusTL > 0 || cellStyle.BorderRadiusTR > 0 ||
+			cellStyle.BorderRadiusBR > 0 || cellStyle.BorderRadiusBL > 0 {
+			layoutCell.SetBorderRadiusPerCorner(
+				cellStyle.BorderRadiusTL, cellStyle.BorderRadiusTR,
+				cellStyle.BorderRadiusBR, cellStyle.BorderRadiusBL)
+		} else if cellStyle.BorderRadius > 0 {
+			layoutCell.SetBorderRadius(cellStyle.BorderRadius)
+		}
+	}
 }
 
 // parseColWidth extracts the width from a <col> element, respecting the span attribute.

--- a/html/css_table_anonymous_row_test.go
+++ b/html/css_table_anonymous_row_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"math"
+	"testing"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// TestCSSTableAnonymousRow verifies that consecutive bare display:table-cell
+// children of a display:table element (with no display:table-row wrapper) are
+// grouped into a single CSS anonymous table-row box and laid out side by side,
+// rather than each becoming its own one-cell row and stacking vertically.
+func TestCSSTableAnonymousRow(t *testing.T) {
+	src := `<div style="display:table; width:100%;">
+  <div style="display:table-cell; width:50%;"><h2>Left column</h2><p>Left line one.</p><p>Left line two.</p></div>
+  <div style="display:table-cell; width:50%;"><h2>Right column</h2><p>Right line one.</p></div>
+</div>`
+
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected at least one element")
+	}
+
+	// The table may be elems[0] directly, or wrapped in a Div if margins were
+	// applied. PlanLayout on whichever element we get resolves both cases.
+	el := elems[0]
+	plan := el.PlanLayout(layout.LayoutArea{Width: 500, Height: 1e9})
+	if plan.Status != layout.LayoutFull {
+		t.Fatalf("unexpected plan status %v", plan.Status)
+	}
+	if len(plan.Blocks) == 0 {
+		t.Fatal("expected at least one placed block")
+	}
+
+	// Primary, metric-independent assertion: the two consecutive bare cells must
+	// form exactly ONE anonymous table-row. The bug produced one row PER cell
+	// (two TR blocks here), which stacked them vertically.
+	if rows := countTaggedBlocks(plan.Blocks, "TR"); rows != 1 {
+		t.Fatalf("expected 1 anonymous table-row for two bare table-cell children, got %d; "+
+			"consecutive cells should share a single row", rows)
+	}
+
+	// Geometric corroboration: a single row is about as tall as the taller cell,
+	// never the sum of both. Measure each cell at the ~250pt column width it gets
+	// in the real 50/50 layout so the baseline matches (full-width baselines would
+	// under-measure, since narrower columns reflow taller).
+	const colW = 250.0
+	leftH := measureCellHeight(t, `<div style="display:table; width:100%;">
+  <div style="display:table-cell; width:100%;"><h2>Left column</h2><p>Left line one.</p><p>Left line two.</p></div>
+</div>`, colW)
+	rightH := measureCellHeight(t, `<div style="display:table; width:100%;">
+  <div style="display:table-cell; width:100%;"><h2>Right column</h2><p>Right line one.</p></div>
+</div>`, colW)
+
+	taller := math.Max(leftH, rightH)
+	stackedSum := leftH + rightH
+	if plan.Consumed >= stackedSum-0.5 {
+		t.Fatalf("cells appear stacked: Consumed=%.2f >= stackedSum=%.2f (leftH=%.2f rightH=%.2f)",
+			plan.Consumed, stackedSum, leftH, rightH)
+	}
+	if math.Abs(plan.Consumed-taller) > 0.5*taller+2 {
+		t.Fatalf("Consumed=%.2f not close to a single row height (taller cell=%.2f)", plan.Consumed, taller)
+	}
+}
+
+// countTaggedBlocks counts blocks (recursively) whose Tag equals tag.
+func countTaggedBlocks(blocks []layout.PlacedBlock, tag string) int {
+	n := 0
+	for _, b := range blocks {
+		if b.Tag == tag {
+			n++
+		}
+		n += countTaggedBlocks(b.Children, tag)
+	}
+	return n
+}
+
+// measureCellHeight lays out a single-cell display:table at the given column
+// width and returns its consumed height, used as the per-cell baseline for the
+// side-by-side check.
+func measureCellHeight(t *testing.T, src string, width float64) float64 {
+	t.Helper()
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected at least one element")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: width, Height: 1e9})
+	return plan.Consumed
+}


### PR DESCRIPTION
## Summary

Tier 1 of addressing #367 (some old CSS layout techniques unsupported). This PR fixes the `display:table` / `display:table-cell` column case.

A `display:table` element whose direct children are `display:table-cell` boxes — with no `display:table-row` wrapper — treated each bare cell as its own single-cell row, so the cells stacked vertically instead of forming a horizontal row. CSS table fixup (CSS 2.1 §17.2.1) requires wrapping consecutive misparented cells in an anonymous `table-row` box.

`convertCSSTable` now groups consecutive `table-cell` children into one anonymous `layout.Row`. The per-cell build logic is extracted into `addCSSTableCell`, reused unchanged by the explicit `table-row` path so existing behavior is preserved. The accumulator resets on any non-cell child, so only consecutive cells share a row.

## Repro (pdftotext -layout of the reporter's table-columns case)

Before — cells stacked vertically:
```
Left column
Left line one.
Left line two.
Right column
Right line one.
Content after the row
This must appear BELOW both columns.
```

After — cells side by side, following content below:
```
Left column                            Right column
Left line one.                         Right line one.
Left line two.
Content after the row
This must appear BELOW both columns.
```

## Tests

Adds `TestCSSTableAnonymousRow`: asserts exactly one anonymous table-row (`Tag == "TR"`) is produced for two bare cells (the bug produced two), with a geometric corroboration that the consumed height is a single row, not the sum of both. Verified red (old code: "got 2") / green (fixed). Full `go test ./html/... ./layout/...` passes.

## Scope

Part of #367, not a full close. The float-based cases from the linked diagnostics (`float:right` columns, `clear:both`, float containment in an `overflow:hidden` BFC) are tracked as follow-up PRs.