### PR TITLE
layout: float formatting context — multi-column floats, clear, containment (#367)

### DIFF
--- a/html/converter_block.go
+++ b/html/converter_block.go
@@ -149,10 +149,15 @@ func (c *converter) convertBlock(n *html.Node, style computedStyle) []layout.Ele
 	children := c.walkChildren(n, style)
 	restore()
 
+	// A clear-only div (e.g. <div style="clear:both">) must survive as a Div
+	// so it carries the Clearable behavior that pushes following content below
+	// the floats; otherwise the clearing element silently disappears.
+	hasClear := style.Clear != "" && style.Clear != "none"
+
 	// Allow empty divs that have visual properties (height, background, border).
 	hasVisualBox := style.Height != nil || style.BackgroundColor != nil ||
 		style.hasBorder() || style.hasPadding()
-	if len(children) == 0 && !hasVisualBox {
+	if len(children) == 0 && !hasVisualBox && !hasClear {
 		return nil
 	}
 
@@ -164,7 +169,7 @@ func (c *converter) convertBlock(n *html.Node, style computedStyle) []layout.Ele
 	hasOutline := style.OutlineWidth > 0
 	hasTransform := style.Transform != "" && strings.ToLower(strings.TrimSpace(style.Transform)) != "none"
 	hasBgImage := style.BackgroundImage != ""
-	if !style.hasPadding() && !style.hasBorder() && !style.hasMargin() && style.BackgroundColor == nil && !hasWidthConstraints && !hasHeightConstraints && !hasVisualEffects && !hasBoxShadow && !hasOutline && !hasTransform && !hasBgImage {
+	if !style.hasPadding() && !style.hasBorder() && !style.hasMargin() && style.BackgroundColor == nil && !hasWidthConstraints && !hasHeightConstraints && !hasVisualEffects && !hasBoxShadow && !hasOutline && !hasTransform && !hasBgImage && !hasClear {
 		return children
 	}
 

--- a/integration/float_columns_test.go
+++ b/integration/float_columns_test.go
@@ -1,0 +1,525 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/document"
+	foliohtml "github.com/carlos7ags/folio/html"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// TestFloatRightColumnPlacement renders a two-column float:left / float:right
+// 50/50 layout and asserts the right column lands in the right half of the
+// content box. The float:right column must resolve its 50% against the whole
+// containing block, not the ~50% left over beside the float:left column, and
+// must be positioned at the container's right edge.
+func TestFloatRightColumnPlacement(t *testing.T) {
+	const htmlStr = `<!DOCTYPE html><html><head><style>
+.col-left  { float: left;  width: 50%; }
+.col-right { float: right; width: 50%; }
+</style></head><body>
+<div class="col-left"><h2>Left column</h2><p>Left line one.</p></div>
+<div class="col-right"><h2>Right column</h2><p>Right line one.</p></div>
+</body></html>`
+
+	doc := document.NewDocument(document.PageSizeA4)
+	opts := &foliohtml.Options{
+		PageWidth:  document.PageSizeA4.Width,
+		PageHeight: document.PageSizeA4.Height,
+	}
+	if err := doc.AddHTML(htmlStr, opts); err != nil {
+		t.Fatal(err)
+	}
+	pdf, err := doc.ToBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := reader.Parse(pdf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := page.ContentStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spans := reader.NewContentProcessor(nil).Process(reader.ParseContentStream(data))
+	if len(spans) == 0 {
+		t.Fatal("no text spans extracted")
+	}
+
+	// Calibration: dump every span's text and horizontal position.
+	for _, s := range spans {
+		t.Logf("span: text=%q X=%.2f Y=%.2f W=%.2f", s.Text, s.X, s.Y, s.Width)
+	}
+
+	// Content box: A4 minus the document's default 72pt left/right margins.
+	const margin = 72.0
+	contentWidth := document.PageSizeA4.Width - 2*margin
+	midX := margin + contentWidth/2
+
+	leftX := math.Inf(1)
+	rightX := math.Inf(1)
+	for _, s := range spans {
+		if strings.Contains(s.Text, "Left") && s.X < leftX {
+			leftX = s.X
+		}
+		if strings.Contains(s.Text, "Right") && s.X < rightX {
+			rightX = s.X
+		}
+	}
+	if math.IsInf(leftX, 1) {
+		t.Fatalf("no span containing %q found", "Left")
+	}
+	if math.IsInf(rightX, 1) {
+		t.Fatalf("no span containing %q found", "Right")
+	}
+
+	t.Logf("leftX=%.2f rightX=%.2f contentWidth=%.2f midX=%.2f", leftX, rightX, contentWidth, midX)
+
+	// The right column must sit ~half the content width to the right of the
+	// left column (fix ≈ 0.5). The bug placed it ≈ 0.25 of the way; a 0.40
+	// threshold cleanly separates the two regimes.
+	delta := rightX - leftX
+	if delta < 0.40*contentWidth {
+		t.Errorf("right column not far enough right: rightX-leftX=%.2f, want >= %.2f (0.40*contentWidth, contentWidth=%.2f); leftX=%.2f rightX=%.2f",
+			delta, 0.40*contentWidth, contentWidth, leftX, rightX)
+	}
+
+	// The right column must genuinely be in the right half of the content
+	// box. Its content starts at the left edge of the right band, i.e. at the
+	// content midpoint; allow a 1pt epsilon for rounding. The bug placed it
+	// well left of the midpoint (≈ 0.25 of the content width).
+	const eps = 1.0
+	if rightX < midX-eps {
+		t.Errorf("right column not in right half: rightX=%.2f, midX=%.2f (contentWidth=%.2f); leftX=%.2f",
+			rightX, midX, contentWidth, leftX)
+	}
+}
+
+// TestFloatLeftRightContentBelow renders two 50% float columns (left + right
+// fill the whole width) followed by a normal in-flow block with NO clear. The
+// after block cannot fit beside the floats, so it must drop BELOW both columns
+// and render at full width — not squeeze into ~0 width beside them.
+func TestFloatLeftRightContentBelow(t *testing.T) {
+	const htmlStr = `<!DOCTYPE html><html><head><style>
+.col-left  { float: left;  width: 50%; }
+.col-right { float: right; width: 50%; }
+</style></head><body>
+<div class="col-left"><h2>Left column</h2><p>Left line one.</p></div>
+<div class="col-right"><h2>Right column</h2><p>Right line one.</p></div>
+<div class="after"><h2>Content after</h2><p>Should be below both columns.</p></div>
+</body></html>`
+
+	doc := document.NewDocument(document.PageSizeA4)
+	opts := &foliohtml.Options{
+		PageWidth:  document.PageSizeA4.Width,
+		PageHeight: document.PageSizeA4.Height,
+	}
+	if err := doc.AddHTML(htmlStr, opts); err != nil {
+		t.Fatal(err)
+	}
+	pdf, err := doc.ToBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := reader.Parse(pdf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := page.ContentStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spans := reader.NewContentProcessor(nil).Process(reader.ParseContentStream(data))
+	if len(spans) == 0 {
+		t.Fatal("no text spans extracted")
+	}
+
+	// Calibration: dump every span's text and position.
+	for _, s := range spans {
+		t.Logf("span: text=%q X=%.2f Y=%.2f W=%.2f", s.Text, s.X, s.Y, s.Width)
+	}
+
+	// colBottomY: the lowest (smallest-Y) text belonging to either column.
+	// afterTopY: the highest (largest-Y) text belonging to the after block,
+	// afterLeftX: the X of that topmost after-block span.
+	colBottomY := math.Inf(1)
+	afterTopY := math.Inf(-1)
+	afterLeftX := math.NaN()
+	for _, s := range spans {
+		isCol := strings.Contains(s.Text, "Left") || strings.Contains(s.Text, "Right") || strings.Contains(s.Text, "line")
+		isAfter := strings.Contains(s.Text, "Content") || strings.Contains(s.Text, "after") ||
+			strings.Contains(s.Text, "Should") || strings.Contains(s.Text, "below") ||
+			strings.Contains(s.Text, "columns")
+		if isCol && isAfter {
+			t.Fatalf("span %q classified as both column and after; classifier keywords overlap", s.Text)
+		}
+		if isCol && s.Y < colBottomY {
+			colBottomY = s.Y
+		}
+		if isAfter && s.Y > afterTopY {
+			afterTopY = s.Y
+			afterLeftX = s.X
+		}
+	}
+	if math.IsInf(colBottomY, 1) {
+		t.Fatal("no column spans found")
+	}
+	if math.IsInf(afterTopY, -1) {
+		t.Fatal("no after-block spans found")
+	}
+
+	t.Logf("colBottomY=%.2f afterTopY=%.2f afterLeftX=%.2f", colBottomY, afterTopY, afterLeftX)
+
+	// The after block must begin BELOW the lowest column text (smaller Y).
+	if afterTopY >= colBottomY {
+		t.Errorf("after block not below columns: afterTopY=%.2f, want < colBottomY=%.2f",
+			afterTopY, colBottomY)
+	}
+
+	// The after block must render at full width, not squeezed into a ~0-width
+	// vertical stack beside the floats. Its top line must start near the left
+	// margin (≈ 72pt), not pushed right toward the float band.
+	const margin = 72.0
+	const leftEps = 5.0
+	if afterLeftX > margin+leftEps {
+		t.Errorf("after block pushed right (squeezed beside floats): afterLeftX=%.2f, want <= %.2f",
+			afterLeftX, margin+leftEps)
+	}
+}
+
+// TestFloatColumnsInsideRowDiv renders a .row block container that holds a
+// float:left col, a float:right col, and an empty clear:both div, followed by
+// an .after block. The floats must lay out side by side INSIDE the row, the
+// row must grow to enclose them, and the .after block must paint BELOW the row
+// at full width — not overlap the columns.
+func TestFloatColumnsInsideRowDiv(t *testing.T) {
+	const htmlStr = `<!DOCTYPE html><html><head><style>
+.row{width:100%;} .col-left{float:left;width:50%;} .col-right{float:right;width:50%;} .clear{clear:both;}
+</style></head><body>
+<div class="row">
+<div class="col-left"><h2>Left column</h2><p>Left line one.</p><p>Left line two.</p></div>
+<div class="col-right"><h2>Right column</h2><p>Right line one.</p></div>
+<div class="clear"></div>
+</div>
+<div class="after"><h2>Content after the row</h2><p>This must appear BELOW both columns.</p></div>
+</body></html>`
+
+	spans := renderHTMLSpans(t, htmlStr)
+
+	for _, s := range spans {
+		t.Logf("span: text=%q X=%.2f Y=%.2f W=%.2f", s.Text, s.X, s.Y, s.Width)
+	}
+
+	// colBottomY: the lowest (smallest-Y) column text. "Left line two." is the
+	// lowest column line. afterTopY/afterLeftX: the highest after-block span.
+	// "Left"/"Right"/"line" appear only in the columns. The after block shares
+	// the words "column"/"columns"/"both", so those are deliberately excluded
+	// from the column classifier to avoid cross-contaminating colBottomY.
+	colBottomY := math.Inf(1)
+	afterTopY := math.Inf(-1)
+	afterLeftX := math.NaN()
+	for _, s := range spans {
+		isCol := strings.Contains(s.Text, "Left") || strings.Contains(s.Text, "Right") ||
+			strings.Contains(s.Text, "line")
+		isAfter := strings.Contains(s.Text, "Content") || strings.Contains(s.Text, "after") ||
+			strings.Contains(s.Text, "BELOW") || strings.Contains(s.Text, "must") ||
+			strings.Contains(s.Text, "appear")
+		if isCol && isAfter {
+			t.Fatalf("span %q classified as both column and after; classifier keywords overlap", s.Text)
+		}
+		if isCol && s.Y < colBottomY {
+			colBottomY = s.Y
+		}
+		if isAfter && s.Y > afterTopY {
+			afterTopY = s.Y
+			afterLeftX = s.X
+		}
+	}
+	if math.IsInf(colBottomY, 1) {
+		t.Fatal("no column spans found")
+	}
+	if math.IsInf(afterTopY, -1) {
+		t.Fatal("no after-block spans found")
+	}
+
+	t.Logf("colBottomY=%.2f afterTopY=%.2f afterLeftX=%.2f", colBottomY, afterTopY, afterLeftX)
+
+	// The after block must begin BELOW the lowest column text (smaller Y).
+	if afterTopY >= colBottomY {
+		t.Errorf("after block not below row: afterTopY=%.2f, want < colBottomY=%.2f",
+			afterTopY, colBottomY)
+	}
+
+	// The after block must render full-width: its top line starts near the
+	// left margin (≈ 72pt), not pushed right toward the float band.
+	const margin = 72.0
+	const leftEps = 5.0
+	if afterLeftX > margin+leftEps {
+		t.Errorf("after block pushed right: afterLeftX=%.2f, want <= %.2f",
+			afterLeftX, margin+leftEps)
+	}
+}
+
+// TestFloatInsideBFCContainer renders an overflow:hidden .container that wraps
+// two floated columns, followed by an .after block. The container must GROW to
+// enclose both floats so they are NOT clipped away (this is the core bug), and
+// the after block must paint below them.
+func TestFloatInsideBFCContainer(t *testing.T) {
+	const htmlStr = `<!DOCTYPE html><html><head><style>
+.container{overflow:hidden;} .col-left{float:left;width:50%;} .col-right{float:right;width:50%;}
+</style></head><body>
+<div class="container">
+<div class="col-left"><h2>Left column</h2><p>Left line one.</p></div>
+<div class="col-right"><h2>Right column</h2><p>Right line one.</p></div>
+</div>
+<div class="after"><h2>Content after</h2><p>Should be below both columns.</p></div>
+</body></html>`
+
+	spans := renderHTMLSpans(t, htmlStr)
+
+	for _, s := range spans {
+		t.Logf("span: text=%q X=%.2f Y=%.2f W=%.2f", s.Text, s.X, s.Y, s.Width)
+	}
+
+	const margin = 72.0
+	contentWidth := document.PageSizeA4.Width - 2*margin
+	midX := margin + contentWidth/2
+
+	// Core assertion: both columns' text survives (not clipped by the
+	// collapsed overflow:hidden box). Track their positions too.
+	var haveLeft, haveRight bool
+	leftColX := math.Inf(1)
+	rightColX := math.Inf(1)
+	colBottomY := math.Inf(1)
+	afterTopY := math.Inf(-1)
+	for _, s := range spans {
+		if strings.Contains(s.Text, "Left") {
+			haveLeft = true
+			if s.X < leftColX {
+				leftColX = s.X
+			}
+		}
+		if strings.Contains(s.Text, "Right") {
+			haveRight = true
+			if s.X < rightColX {
+				rightColX = s.X
+			}
+		}
+		isCol := strings.Contains(s.Text, "Left") || strings.Contains(s.Text, "Right") ||
+			strings.Contains(s.Text, "line")
+		isAfter := strings.Contains(s.Text, "Content") || strings.Contains(s.Text, "after") ||
+			strings.Contains(s.Text, "Should")
+		if isCol && isAfter {
+			t.Fatalf("span %q classified as both column and after; classifier keywords overlap", s.Text)
+		}
+		if isCol && s.Y < colBottomY {
+			colBottomY = s.Y
+		}
+		if isAfter && s.Y > afterTopY {
+			afterTopY = s.Y
+		}
+	}
+
+	if !haveLeft {
+		t.Errorf("left column text missing — clipped away by collapsed container")
+	}
+	if !haveRight {
+		t.Errorf("right column text missing — clipped away by collapsed container")
+	}
+	if math.IsInf(colBottomY, 1) {
+		t.Fatal("no column spans found")
+	}
+	if math.IsInf(afterTopY, -1) {
+		t.Fatal("no after-block spans found")
+	}
+
+	t.Logf("leftColX=%.2f rightColX=%.2f midX=%.2f colBottomY=%.2f afterTopY=%.2f",
+		leftColX, rightColX, midX, colBottomY, afterTopY)
+
+	// The right column must sit in the right half of the content box.
+	const eps = 1.0
+	if !math.IsInf(rightColX, 1) && rightColX < midX-eps {
+		t.Errorf("right column not in right half: rightColX=%.2f, want >= %.2f (midX)",
+			rightColX, midX)
+	}
+
+	// The after block must paint below both columns.
+	if afterTopY >= colBottomY {
+		t.Errorf("after block not below columns: afterTopY=%.2f, want < colBottomY=%.2f",
+			afterTopY, colBottomY)
+	}
+}
+
+// TestParagraphWrapsBesideFloatInDiv renders an overflow:hidden box holding a
+// float:left side box and an in-flow paragraph. The paragraph must wrap in the
+// reduced space to the RIGHT of the float (beside it, not under it), the box
+// must grow to enclose the float, and the .after block must paint below.
+func TestParagraphWrapsBesideFloatInDiv(t *testing.T) {
+	const htmlStr = `<!DOCTYPE html><html><head><style>
+.box{overflow:hidden;}
+.side{float:left;width:120px;}
+</style></head><body>
+<div class="box">
+<div class="side"><h2>Side</h2><p>Float text.</p></div>
+<p>This paragraph should wrap in the reduced space to the right of the floated box, starting to the right of the float rather than under it, and the overflow:hidden container should grow to enclose the float.</p>
+</div>
+<div class="after"><h2>After</h2><p>Below the box.</p></div>
+</body></html>`
+
+	spans := renderHTMLSpans(t, htmlStr)
+
+	for _, s := range spans {
+		t.Logf("span: text=%q X=%.2f Y=%.2f W=%.2f", s.Text, s.X, s.Y, s.Width)
+	}
+
+	const margin = 72.0
+
+	// floatX/floatBottomY: the leftmost X and lowest Y of the floated side box
+	// content ("Side", "Float text."). besideTopY: the Y of the topmost
+	// wrapping-paragraph line; besideX is the leftmost X on that line (its true
+	// left edge), so it reflects where the paragraph actually starts. The
+	// paragraph shares no words with the float or after block. afterTopY: the
+	// highest after-block span.
+	floatX := math.Inf(1)
+	floatBottomY := math.Inf(1)
+	var haveFloat bool
+	besideTopY := math.Inf(-1)
+	var haveBeside bool
+	afterTopY := math.Inf(-1)
+	var haveAfter bool
+	classifyBeside := func(text string) bool {
+		return strings.Contains(text, "paragraph") || strings.Contains(text, "wrap") ||
+			strings.Contains(text, "reduced") || strings.Contains(text, "right") ||
+			strings.Contains(text, "floated")
+	}
+	for _, s := range spans {
+		isFloat := strings.Contains(s.Text, "Side") || strings.Contains(s.Text, "Float")
+		isBeside := classifyBeside(s.Text)
+		isAfter := strings.Contains(s.Text, "After") || strings.Contains(s.Text, "Below")
+		if isFloat {
+			haveFloat = true
+			if s.X < floatX {
+				floatX = s.X
+			}
+			if s.Y < floatBottomY {
+				floatBottomY = s.Y
+			}
+		}
+		if isBeside {
+			haveBeside = true
+			if s.Y > besideTopY {
+				besideTopY = s.Y
+			}
+		}
+		if isAfter {
+			haveAfter = true
+			if s.Y > afterTopY {
+				afterTopY = s.Y
+			}
+		}
+	}
+
+	// besideX: the leftmost X among ALL spans on the topmost beside-line, not
+	// just keyword-matching ones, so it captures the line's true left edge.
+	besideX := math.Inf(1)
+	for _, s := range spans {
+		if math.Abs(s.Y-besideTopY) < 0.5 && s.X < besideX {
+			besideX = s.X
+		}
+	}
+
+	if !haveFloat {
+		t.Fatal("floated side box text missing — clipped away by collapsed container")
+	}
+	if !haveBeside {
+		t.Fatal("no wrapping-paragraph spans found")
+	}
+	if !haveAfter {
+		t.Fatal("no after-block spans found")
+	}
+
+	t.Logf("floatX=%.2f floatBottomY=%.2f besideX=%.2f besideTopY=%.2f afterTopY=%.2f",
+		floatX, floatBottomY, besideX, besideTopY, afterTopY)
+
+	// The float must sit near the left margin (small X).
+	const leftEps = 5.0
+	if floatX > margin+leftEps {
+		t.Errorf("floated box not near left margin: floatX=%.2f, want <= %.2f", floatX, margin+leftEps)
+	}
+
+	// The wrapping paragraph must start to the RIGHT of the float, past the
+	// float band. The 120px float is 120*0.75=90pt wide (96dpi→72dpi), so its
+	// right edge sits at margin+90 ≈ 162pt. The paragraph must start at or past
+	// that, i.e. beside the float, not under it at the left margin.
+	const floatBandRight = margin + 120.0*0.75
+	if besideX < floatBandRight {
+		t.Errorf("paragraph not beside float (under it instead): besideX=%.2f, want >= %.2f (margin+float width); floatX=%.2f",
+			besideX, floatBandRight, floatX)
+	}
+	// Robust relative guard: the paragraph must be clearly right of the float,
+	// by well over half the float band (90pt), not merely nudged right.
+	if besideX-floatX < 80.0 {
+		t.Errorf("paragraph not clearly right of float: besideX-floatX=%.2f, want >= 80; besideX=%.2f floatX=%.2f",
+			besideX-floatX, besideX, floatX)
+	}
+
+	// The after block must paint below the float's content and below the
+	// beside-text (smaller Y than both).
+	if afterTopY >= floatBottomY {
+		t.Errorf("after block not below float: afterTopY=%.2f, want < floatBottomY=%.2f", afterTopY, floatBottomY)
+	}
+	if afterTopY >= besideTopY {
+		t.Errorf("after block not below beside-text: afterTopY=%.2f, want < besideTopY=%.2f", afterTopY, besideTopY)
+	}
+}
+
+// renderHTMLSpans renders an HTML string to a single-page A4 PDF and returns
+// the extracted text spans.
+func renderHTMLSpans(t *testing.T, htmlStr string) []reader.TextSpan {
+	t.Helper()
+	doc := document.NewDocument(document.PageSizeA4)
+	opts := &foliohtml.Options{
+		PageWidth:  document.PageSizeA4.Width,
+		PageHeight: document.PageSizeA4.Height,
+	}
+	if err := doc.AddHTML(htmlStr, opts); err != nil {
+		t.Fatal(err)
+	}
+	pdf, err := doc.ToBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := reader.Parse(pdf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := page.ContentStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spans := reader.NewContentProcessor(nil).Process(reader.ParseContentStream(data))
+	if len(spans) == 0 {
+		t.Fatal("no text spans extracted")
+	}
+	return spans
+}

--- a/layout/div.go
+++ b/layout/div.go
@@ -648,15 +648,116 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 		}
 	}
 
+	// Detect floats among the children up front. The float-free path (the
+	// vast majority of containers) MUST behave exactly as before, so every
+	// float-aware operation below is gated behind hasFloat.
+	hasFloat := false
+	for _, e := range d.elements {
+		if _, ok := e.(*Float); ok {
+			hasFloat = true
+			break
+		}
+	}
+
 	// Lay out children within the inner area.
 	var fittedBlocks []PlacedBlock
 	var overflowElements []Element
 	curY := d.padding.Top
 	remaining := innerHeight
 
+	// fc tracks floats placed inside this container (content coordinates,
+	// origin at content-box top-left). Only used when hasFloat is true.
+	var fc floatContext
+
 	allFit := true
 	overflowStartIdx := -1
 	for idx, elem := range d.elements {
+		// Float child: place it beside same-side floats (stacking shift),
+		// register its extent, and consume no in-flow height.
+		if hasFloat {
+			if _, isFloat := elem.(*Float); isFloat {
+				plan := elem.PlanLayout(LayoutArea{Width: innerWidth, Height: remaining})
+				for bi := range plan.Blocks {
+					block := plan.Blocks[bi]
+					if block.floatInfo == nil {
+						continue
+					}
+					fi := block.floatInfo
+					shift := fc.place(fi.side, fi.floatWidth, fi.height, curY)
+					if fi.side == FloatLeft {
+						block.X += d.padding.Left + shift
+					} else {
+						block.X -= shift
+						block.X += d.padding.Left
+					}
+					block.Y += curY
+					fittedBlocks = append(fittedBlocks, block)
+				}
+				continue
+			}
+		}
+
+		// In-flow child.
+		if hasFloat {
+			// CSS clear: advance past matching active floats first.
+			if cl, ok := elem.(Clearable); ok {
+				cv := cl.ClearValue()
+				if cv == "left" || cv == "right" || cv == "both" {
+					if ny := fc.clear(cv, curY); ny > curY {
+						remaining -= ny - curY
+						curY = ny
+					}
+				}
+			}
+
+			avail, leftOff := fc.available(innerWidth, curY)
+
+			// A block whose minimum width exceeds the space beside the floats
+			// cannot sit there: drop it below all active floats.
+			if m, ok := elem.(Measurable); ok && m.MinWidth() > avail+0.01 {
+				if ny := fc.dropBelowAll(curY); ny > curY {
+					remaining -= ny - curY
+					curY = ny
+					avail, leftOff = fc.available(innerWidth, curY)
+				}
+			}
+
+			plan := elem.PlanLayout(LayoutArea{Width: avail, Height: remaining})
+			xOff := d.padding.Left + leftOff
+			switch plan.Status {
+			case LayoutFull:
+				for _, block := range plan.Blocks {
+					block.X += xOff
+					block.Y += curY
+					fittedBlocks = append(fittedBlocks, block)
+				}
+				curY += plan.Consumed
+				remaining -= plan.Consumed
+
+			case LayoutPartial:
+				for _, block := range plan.Blocks {
+					block.X += xOff
+					block.Y += curY
+					fittedBlocks = append(fittedBlocks, block)
+				}
+				allFit = false
+				overflowStartIdx = idx
+				if plan.Overflow != nil {
+					overflowElements = append(overflowElements, plan.Overflow)
+				}
+
+			case LayoutNothing:
+				allFit = false
+				overflowStartIdx = idx
+				overflowElements = append(overflowElements, elem)
+			}
+
+			if !allFit {
+				break
+			}
+			continue
+		}
+
 		plan := elem.PlanLayout(LayoutArea{Width: innerWidth, Height: remaining})
 
 		switch plan.Status {
@@ -697,7 +798,17 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 		overflowElements = append(overflowElements, d.elements[overflowStartIdx+1:]...)
 	}
 
-	totalH := curY + d.padding.Bottom
+	// Grow the container to enclose its floats (display:flow-root model): the
+	// reported height includes the floats so following siblings sit below the
+	// container and overflow:hidden clips to the grown box.
+	contentBottom := curY
+	if hasFloat {
+		if b := fc.lowestBottom(); b > contentBottom {
+			contentBottom = b
+		}
+	}
+
+	totalH := contentBottom + d.padding.Bottom
 
 	// Apply explicit height if set (CSS height property).
 	if d.heightUnit != nil {

--- a/layout/float_context.go
+++ b/layout/float_context.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+// floatContext tracks floats placed within a single block container's content
+// coordinate space (Y increases downward, origin at the content-box top-left).
+// It mirrors the body-flow float bookkeeping in render_plans.go (activeFloat /
+// effectiveWidth / consumeFloatHeight) but records each float's absolute
+// vertical extent [top, bottom] instead of a remaining height, so queries can
+// be answered at any Y. This lets a Div lay out in-flow children beside its own
+// floats and grow to enclose them (a pragmatic display:flow-root model).
+type floatContext struct {
+	floats []placedFloat
+}
+
+// placedFloat is one float occupying [top, bottom] on a given side.
+type placedFloat struct {
+	side   FloatSide
+	width  float64
+	top    float64
+	bottom float64
+}
+
+// place registers a float of the given side/width/height starting at atY and
+// returns the horizontal shift needed so same-side floats stack instead of
+// overlap (left floats accumulate from the left, right floats from the right).
+// The shift is the total width of same-side floats still occupying atY.
+func (fc *floatContext) place(side FloatSide, width, height, atY float64) float64 {
+	shift := fc.sameSideWidth(side, atY)
+	fc.floats = append(fc.floats, placedFloat{
+		side:   side,
+		width:  width,
+		top:    atY,
+		bottom: atY + height,
+	})
+	return shift
+}
+
+// sameSideWidth returns the combined width of floats on the given side that
+// still occupy atY (bottom > atY). Used for the stacking shift.
+func (fc *floatContext) sameSideWidth(side FloatSide, atY float64) float64 {
+	w := 0.0
+	for _, f := range fc.floats {
+		if f.side == side && f.bottom > atY {
+			w += f.width
+		}
+	}
+	return w
+}
+
+// available returns the width remaining for in-flow content at vertical
+// position atY, accounting only for floats still occupying space there
+// (bottom > atY), plus the total width of such LEFT floats as leftOffset. When
+// no float occupies atY it returns (containerWidth, 0).
+func (fc *floatContext) available(containerWidth, atY float64) (width, leftOffset float64) {
+	w := containerWidth
+	off := 0.0
+	for _, f := range fc.floats {
+		if f.bottom <= atY {
+			continue
+		}
+		w -= f.width
+		if f.side == FloatLeft {
+			off += f.width
+		}
+	}
+	if w < 0 {
+		w = 0
+	}
+	// Clamp leftOffset so it never pushes content past the container's right
+	// edge when left floats are wider than the container.
+	if off > containerWidth {
+		off = containerWidth
+	}
+	return w, off
+}
+
+// clear returns the Y below the matching floats still active at atY for a CSS
+// clear value ("left", "right", "both"); the max bottom of those floats, or
+// atY when none match.
+func (fc *floatContext) clear(value string, atY float64) float64 {
+	newY := atY
+	for _, f := range fc.floats {
+		if f.bottom <= atY {
+			continue
+		}
+		match := value == "both" ||
+			(value == "left" && f.side == FloatLeft) ||
+			(value == "right" && f.side == FloatRight)
+		if match && f.bottom > newY {
+			newY = f.bottom
+		}
+	}
+	return newY
+}
+
+// dropBelowAll returns the Y below ALL floats active at atY (max bottom), or
+// atY when none are active. Used when an in-flow block cannot fit beside the
+// floats.
+func (fc *floatContext) dropBelowAll(atY float64) float64 {
+	newY := atY
+	for _, f := range fc.floats {
+		if f.bottom <= atY {
+			continue
+		}
+		if f.bottom > newY {
+			newY = f.bottom
+		}
+	}
+	return newY
+}
+
+// lowestBottom returns the maximum bottom across ALL placed floats, or 0 when
+// empty. Used to grow the container to enclose its floats.
+func (fc *floatContext) lowestBottom() float64 {
+	low := 0.0
+	for _, f := range fc.floats {
+		if f.bottom > low {
+			low = f.bottom
+		}
+	}
+	return low
+}

--- a/layout/float_context_test.go
+++ b/layout/float_context_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import "testing"
+
+const fcEps = 0.001
+
+// fcEq compares two floats within the float-context test tolerance.
+func fcEq(a, b float64) bool { return approxEq(a, b, fcEps) }
+
+// TestFloatContextSingleLeft: one left float reduces available width and sets
+// leftOffset to its width while it is active; returns full width below it.
+func TestFloatContextSingleLeft(t *testing.T) {
+	var fc floatContext
+	shift := fc.place(FloatLeft, 100, 50, 0)
+	if !fcEq(shift, 0) {
+		t.Errorf("first float shift = %.3f, want 0", shift)
+	}
+
+	// At Y=0 (inside the float's extent [0,50]): width reduced, leftOffset=100.
+	w, off := fc.available(300, 0)
+	if !fcEq(w, 200) {
+		t.Errorf("available width at Y=0 = %.3f, want 200", w)
+	}
+	if !fcEq(off, 100) {
+		t.Errorf("leftOffset at Y=0 = %.3f, want 100", off)
+	}
+
+	// At Y=49 (still inside): same reduction.
+	w, off = fc.available(300, 49)
+	if !fcEq(w, 200) || !fcEq(off, 100) {
+		t.Errorf("available at Y=49 = (%.3f,%.3f), want (200,100)", w, off)
+	}
+
+	// At Y=50 (bottom, exclusive): float no longer occupies — full width.
+	w, off = fc.available(300, 50)
+	if !fcEq(w, 300) || !fcEq(off, 0) {
+		t.Errorf("available at Y=50 = (%.3f,%.3f), want (300,0)", w, off)
+	}
+
+	if lb := fc.lowestBottom(); !fcEq(lb, 50) {
+		t.Errorf("lowestBottom = %.3f, want 50", lb)
+	}
+}
+
+// TestFloatContextSingleRight: one right float reduces width but leftOffset
+// stays 0 (right floats do not push in-flow content rightward).
+func TestFloatContextSingleRight(t *testing.T) {
+	var fc floatContext
+	fc.place(FloatRight, 120, 40, 0)
+
+	w, off := fc.available(300, 0)
+	if !fcEq(w, 180) {
+		t.Errorf("available width = %.3f, want 180", w)
+	}
+	if !fcEq(off, 0) {
+		t.Errorf("leftOffset = %.3f, want 0 (right float)", off)
+	}
+
+	// Below the float: full width again.
+	w, off = fc.available(300, 40)
+	if !fcEq(w, 300) || !fcEq(off, 0) {
+		t.Errorf("available below right float = (%.3f,%.3f), want (300,0)", w, off)
+	}
+}
+
+// TestFloatContextTwoSameSideStack: two left floats stack — the second's shift
+// equals the first's width, and combined they reduce available width by both.
+func TestFloatContextTwoSameSideStack(t *testing.T) {
+	var fc floatContext
+	s1 := fc.place(FloatLeft, 100, 60, 0)
+	if !fcEq(s1, 0) {
+		t.Errorf("first left shift = %.3f, want 0", s1)
+	}
+	s2 := fc.place(FloatLeft, 80, 60, 0)
+	if !fcEq(s2, 100) {
+		t.Errorf("second left shift = %.3f, want 100 (stacks past first)", s2)
+	}
+
+	w, off := fc.available(400, 0)
+	if !fcEq(w, 220) {
+		t.Errorf("available with two left floats = %.3f, want 220", w)
+	}
+	if !fcEq(off, 180) {
+		t.Errorf("leftOffset with two left floats = %.3f, want 180", off)
+	}
+
+	// sameSideWidth reflects both.
+	if ssw := fc.sameSideWidth(FloatLeft, 0); !fcEq(ssw, 180) {
+		t.Errorf("sameSideWidth(left,0) = %.3f, want 180", ssw)
+	}
+	if ssw := fc.sameSideWidth(FloatRight, 0); !fcEq(ssw, 0) {
+		t.Errorf("sameSideWidth(right,0) = %.3f, want 0", ssw)
+	}
+}
+
+// TestFloatContextTwoSameSideStackStaggered: a same-side float whose start Y is
+// below an earlier float's bottom does not stack against the expired one.
+func TestFloatContextStackStaggered(t *testing.T) {
+	var fc floatContext
+	fc.place(FloatLeft, 100, 30, 0) // occupies [0,30]
+	// At Y=40 the first float is expired; the new one starts fresh at shift 0.
+	s := fc.place(FloatLeft, 90, 30, 40)
+	if !fcEq(s, 0) {
+		t.Errorf("staggered left shift = %.3f, want 0 (first float expired)", s)
+	}
+}
+
+// TestFloatContextOppositeSides: left + right floats reduce width by both, but
+// leftOffset only counts the left float.
+func TestFloatContextOppositeSides(t *testing.T) {
+	var fc floatContext
+	fc.place(FloatLeft, 100, 50, 0)
+	rs := fc.place(FloatRight, 120, 50, 0)
+	if !fcEq(rs, 0) {
+		t.Errorf("right shift with a left float present = %.3f, want 0 (opposite side)", rs)
+	}
+
+	w, off := fc.available(400, 0)
+	if !fcEq(w, 180) {
+		t.Errorf("available with L+R floats = %.3f, want 180", w)
+	}
+	if !fcEq(off, 100) {
+		t.Errorf("leftOffset with L+R floats = %.3f, want 100", off)
+	}
+}
+
+// TestFloatContextClear: clear advances to the bottom of the matching active
+// floats only.
+func TestFloatContextClear(t *testing.T) {
+	var fc floatContext
+	fc.place(FloatLeft, 100, 50, 0)  // [0,50]
+	fc.place(FloatRight, 120, 80, 0) // [0,80]
+
+	if y := fc.clear("left", 0); !fcEq(y, 50) {
+		t.Errorf("clear(left,0) = %.3f, want 50", y)
+	}
+	if y := fc.clear("right", 0); !fcEq(y, 80) {
+		t.Errorf("clear(right,0) = %.3f, want 80", y)
+	}
+	if y := fc.clear("both", 0); !fcEq(y, 80) {
+		t.Errorf("clear(both,0) = %.3f, want 80 (max of both)", y)
+	}
+
+	// Clearing at a Y past all floats is a no-op.
+	if y := fc.clear("both", 90); !fcEq(y, 90) {
+		t.Errorf("clear(both,90) = %.3f, want 90 (no active floats)", y)
+	}
+
+	// clear at a Y where only the right float is still active.
+	if y := fc.clear("left", 60); !fcEq(y, 60) {
+		t.Errorf("clear(left,60) = %.3f, want 60 (left float expired)", y)
+	}
+	if y := fc.clear("both", 60); !fcEq(y, 80) {
+		t.Errorf("clear(both,60) = %.3f, want 80", y)
+	}
+}
+
+// TestFloatContextDropBelowAll: dropBelowAll returns the max bottom of active
+// floats; no-op when none are active.
+func TestFloatContextDropBelowAll(t *testing.T) {
+	var fc floatContext
+	fc.place(FloatLeft, 100, 50, 0)  // [0,50]
+	fc.place(FloatRight, 120, 90, 0) // [0,90]
+
+	if y := fc.dropBelowAll(0); !fcEq(y, 90) {
+		t.Errorf("dropBelowAll(0) = %.3f, want 90", y)
+	}
+	// At Y=60 only the right float is active.
+	if y := fc.dropBelowAll(60); !fcEq(y, 90) {
+		t.Errorf("dropBelowAll(60) = %.3f, want 90", y)
+	}
+	// Past all floats: no-op.
+	if y := fc.dropBelowAll(100); !fcEq(y, 100) {
+		t.Errorf("dropBelowAll(100) = %.3f, want 100", y)
+	}
+}
+
+// TestFloatContextLowestBottom: max bottom across all placed floats; 0 when
+// empty; ignores expiry (it spans all floats ever placed).
+func TestFloatContextLowestBottom(t *testing.T) {
+	var fc floatContext
+	if lb := fc.lowestBottom(); !fcEq(lb, 0) {
+		t.Errorf("empty lowestBottom = %.3f, want 0", lb)
+	}
+	fc.place(FloatLeft, 100, 50, 0)   // [0,50]
+	fc.place(FloatRight, 120, 30, 40) // [40,70]
+	if lb := fc.lowestBottom(); !fcEq(lb, 70) {
+		t.Errorf("lowestBottom = %.3f, want 70", lb)
+	}
+}
+
+// TestFloatContextEmptyAvailable: with no floats, available returns the full
+// container width and zero offset at any Y.
+func TestFloatContextEmptyAvailable(t *testing.T) {
+	var fc floatContext
+	w, off := fc.available(250, 0)
+	if !fcEq(w, 250) || !fcEq(off, 0) {
+		t.Errorf("empty available = (%.3f,%.3f), want (250,0)", w, off)
+	}
+	w, off = fc.available(250, 999)
+	if !fcEq(w, 250) || !fcEq(off, 0) {
+		t.Errorf("empty available at high Y = (%.3f,%.3f), want (250,0)", w, off)
+	}
+}
+
+// TestFloatContextWidthClampsAtZero: floats wider than the container clamp the
+// available width at zero rather than going negative.
+func TestFloatContextWidthClampsAtZero(t *testing.T) {
+	var fc floatContext
+	fc.place(FloatLeft, 200, 50, 0)
+	fc.place(FloatRight, 200, 50, 0)
+	w, _ := fc.available(300, 0)
+	if !fcEq(w, 0) {
+		t.Errorf("available clamped = %.3f, want 0", w)
+	}
+}
+
+// TestFloatContextLeftOffsetClampsAtContainer: a left float wider than the
+// container clamps both the available width at zero and the leftOffset at the
+// container width, so content is never pushed past the right edge.
+func TestFloatContextLeftOffsetClampsAtContainer(t *testing.T) {
+	var fc floatContext
+	fc.place(FloatLeft, 140, 50, 0)
+	w, off := fc.available(100, 0)
+	if !fcEq(w, 0) {
+		t.Errorf("available width = %.3f, want 0 (left float wider than container)", w)
+	}
+	if off > 100 {
+		t.Errorf("leftOffset = %.3f, want <= 100 (container width)", off)
+	}
+}

--- a/layout/render_plans.go
+++ b/layout/render_plans.go
@@ -173,27 +173,72 @@ func (r *Renderer) renderWithPlans() []PageResult {
 		}
 
 		availWidth, leftOffset := effectiveWidth()
+
+		// A float resolves its width against the containing block, not the
+		// space remaining beside sibling floats (CSS 2.1 10.3.5). In-flow
+		// content uses the float-reduced width.
+		_, isFloatElem := elem.(*Float)
+
+		// No room beside the active floats: drop this in-flow block below
+		// them (same mechanics as clear:both). A block whose minimum content
+		// width exceeds the space left by the floats cannot sit beside them.
+		if !isFloatElem && len(floats) > 0 {
+			if m, ok := elem.(Measurable); ok && m.MinWidth() > availWidth+0.01 {
+				maxRemain := 0.0
+				for _, f := range floats {
+					if f.remainHeight > maxRemain {
+						maxRemain = f.remainHeight
+					}
+				}
+				if maxRemain > 0 {
+					curY += maxRemain
+					remainingHeight -= maxRemain
+					consumeFloatHeight(maxRemain)
+					availWidth, leftOffset = effectiveWidth()
+				}
+			}
+		}
+
+		planWidth := availWidth
+		if isFloatElem {
+			planWidth = maxWidth
+		}
 		area := LayoutArea{
-			Width:  availWidth,
+			Width:  planWidth,
 			Height: remainingHeight,
 		}
 
 		plan := elem.PlanLayout(area)
 
-		// Check if this element is a float.
+		// If this element is a float, place it beside any floats already
+		// active on the same side so multiple floats stack instead of
+		// overlapping (left floats from the left edge, right from the right).
 		isFloat := false
-		for _, b := range plan.Blocks {
-			if b.floatInfo != nil {
-				isFloat = true
-				floats = append(floats, activeFloat{
-					side:         b.floatInfo.side,
-					width:        b.floatInfo.floatWidth,
-					remainHeight: b.floatInfo.height,
-				})
+		for bi := range plan.Blocks {
+			b := &plan.Blocks[bi]
+			if b.floatInfo == nil {
+				continue
 			}
+			isFloat = true
+			var sameSide float64
+			for _, f := range floats {
+				if f.side == b.floatInfo.side {
+					sameSide += f.width
+				}
+			}
+			if b.floatInfo.side == FloatLeft {
+				b.X += sameSide
+			} else {
+				b.X -= sameSide
+			}
+			floats = append(floats, activeFloat{
+				side:         b.floatInfo.side,
+				width:        b.floatInfo.floatWidth,
+				remainHeight: b.floatInfo.height,
+			})
 		}
 
-		// Offset blocks by float left margin.
+		// Offset in-flow blocks past active left floats.
 		if leftOffset > 0 && !isFloat {
 			for i := range plan.Blocks {
 				plan.Blocks[i].X += leftOffset


### PR DESCRIPTION
## Summary

Closes out the float-based layouts from #367 (the `table-columns` case shipped in #370). Floats previously worked only as a single-float width reduction at the top of the page flow; multiple floats, `float:right` placement, clearing inside a container, and float containment were unsupported.

### Body flow (`layout/render_plans.go`)
- A float now resolves its width against the **full containing block**, not the space left by sibling floats — so percentage-width columns no longer collapse and `float:right` lands at the right edge.
- Multiple same-side floats **stack** instead of overlapping.
- An in-flow block that cannot fit beside the floats (its `MinWidth` exceeds the available width) **drops below** them, reusing the existing `clear:both` mechanics.

### Block containers (`layout/div.go` + `layout/float_context.go`)
- A new reusable `floatContext` lays out floats inside a `Div`: placement, width reduction for in-flow children, `clear` among children, and growing the container to **enclose** its floats (a `display:flow-root` model — a deliberate, pragmatic simplification of CSS BFC rules).
- Gated behind a `hasFloat` check, so containers with no float children are byte-for-byte unchanged. Migrating the body flow to share `floatContext` is a sensible follow-up.

### Converter (`html/converter_block.go`)
- Preserve empty `clear:both` divs so the clear survives conversion.

## Cases fixed (reporter's diagnostics, `pdftotext -layout`)

`float-left-right` and `float-in-bfc` — before / after:
```
BEFORE: right column packed mid-page; "Content after" beside the columns at the top
AFTER:  Left column          Right column
        Left line one.       Right line one.
        Content after
        Should be below both columns.
```
`float-in-bfc` specifically: the `overflow:hidden` container previously collapsed and clipped the floats away; it now grows to enclose them.

## Tests

- `layout/float_context_test.go` — 11 unit tests for the `floatContext` arithmetic (placement/stacking, available width at a Y, clear, drop-below, enclose, width/offset clamping).
- `integration/float_columns_test.go` — 5 PDF-span tests: column placement, content-below, `clear:both` inside a row div, `overflow:hidden` BFC containment, and text wrapping beside a float inside a div. Each was red/green-verified against the pre-fix code.
- Full `go test ./...` passes (incl. `-race` on the float/div tests); independent review APPROVE with no blockers.

## Known limitations (follow-ups)
- The body flow and `Div` don't yet share one float implementation (`floatContext` is used by `Div`; `render_plans.go` keeps its equivalent inline logic).
- Same-side floats exceeding 100% width overflow rather than wrapping to a new line.
- Float interaction with mid-container pagination is not specially handled.