### PR TITLE
reader: reject negative or oversized /W widths in xref streams

### DIFF
--- a/reader/fuzz_test.go
+++ b/reader/fuzz_test.go
@@ -57,6 +57,8 @@ func FuzzParse(f *testing.F) {
 func FuzzParsePDF(f *testing.F) {
 	// Minimal valid PDF.
 	f.Add([]byte("%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \ntrailer<</Size 4/Root 1 0 R>>\nstartxref\n190\n%%EOF"))
+	// Xref stream with a negative /W field width — regression seed.
+	f.Add(buildPDFWithXrefStreamW("[-5 3 1]"))
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Must not panic — errors are expected on random input.

--- a/reader/reader_malformed_test.go
+++ b/reader/reader_malformed_test.go
@@ -4,6 +4,7 @@
 package reader
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -372,4 +373,32 @@ func intToStr(n int) string {
 		n /= 10
 	}
 	return string(buf)
+}
+
+// buildPDFWithXrefStreamW returns a minimal PDF whose xref stream declares
+// the given /W array literal, e.g. "[-5 3 1]".
+func buildPDFWithXrefStreamW(w string) []byte {
+	// 8 bytes of entry data; content is irrelevant because parsing must
+	// fail on /W validation before entries are read.
+	entries := "\x01\x00\x09\x00\x01\x00\x00\x00"
+	obj := "1 0 obj\n<</Type/XRef/W" + w + "/Size 2/Length 8/Root 2 0 R>>\nstream\n" +
+		entries + "\nendstream\nendobj\n"
+	header := "%PDF-1.5\n"
+	body := header + obj
+	startxref := len(header)
+	return []byte(body + "startxref\n" + strconv.Itoa(startxref) + "\n%%EOF")
+}
+
+func TestMalformedXrefStreamNegativeW(t *testing.T) {
+	noPanic(t, "negative /W width", func() error {
+		_, err := Parse(buildPDFWithXrefStreamW("[-5 3 1]"))
+		return err
+	})
+}
+
+func TestMalformedXrefStreamHugeW(t *testing.T) {
+	noPanic(t, "huge /W width", func() error {
+		_, err := Parse(buildPDFWithXrefStreamW("[1000000000 3 1]"))
+		return err
+	})
 }

--- a/reader/xref.go
+++ b/reader/xref.go
@@ -174,9 +174,14 @@ func parseXrefStream(data []byte, offset int, table *xrefTable) (*core.PdfDictio
 		pdfIntValue(wArr.At(1)),
 		pdfIntValue(wArr.At(2)),
 	}
+	for _, width := range w {
+		if width < 0 || width > 8 {
+			return nil, -1, fmt.Errorf("reader: xref stream /W width %d out of range [0,8]", width)
+		}
+	}
 	entrySize := w[0] + w[1] + w[2]
-	if entrySize == 0 {
-		return nil, -1, fmt.Errorf("reader: xref stream entry size is 0")
+	if entrySize <= 0 {
+		return nil, -1, fmt.Errorf("reader: xref stream entry size %d invalid", entrySize)
 	}
 
 	// Get /Size.


### PR DESCRIPTION
## Summary

`parseXrefStream` read the three `/W` field widths from an xref-stream dictionary without validating sign or size. A crafted `/W [-5 3 1]` yields `entrySize = -1`, passes the old `entrySize == 0` guard, and then slices `streamData` with a negative index — a runtime panic on untrusted input (import/merge/redact paths). A huge positive width silently reads garbage.

## Change

- Reject any `/W` element outside `[0,8]` (8 bytes is the widest big-endian integer the reader can form; real PDFs use 1–8).
- Tighten the entry-size guard from `== 0` to `<= 0`.

## Tests

- `TestMalformedXrefStreamNegativeW` — the exact panic reproducer; now returns an error.
- `TestMalformedXrefStreamHugeW` — oversized width rejected.
- New `FuzzParsePDF` seed with the hostile `/W`.

The pre-fix panic was confirmed against the reproducer before applying the fix. Well-formed xref streams (including the library's own writer output) still parse.