### PR TITLE
font: bound cmap range expansion against hostile overlapping ranges

### DIFF
--- a/font/cmap.go
+++ b/font/cmap.go
@@ -18,6 +18,13 @@ import (
 // what sfnt exposed and keeps the diff focused.
 type cmapTable map[rune]uint16
 
+// cmapMaxMappedCodes bounds the total number of code points expanded
+// across all groups/segments of one subtable. Non-overlapping coverage
+// cannot exceed 0x110000 (~1.1M) codes; overlapping ranges are only
+// produced by hostile or broken fonts. 1<<22 (~4.2M) leaves ~4x
+// headroom over the theoretical legitimate maximum.
+const cmapMaxMappedCodes = 1 << 22
+
 // parseCmapTable decodes a font's `cmap` table, picks the best Unicode
 // subtable available, and returns the resolved mapping.
 //
@@ -220,6 +227,7 @@ func parseCmapFormat4(data []byte, subOff uint64) (cmapTable, error) {
 	}
 
 	out := make(cmapTable)
+	var totalCodes uint64
 	for i := uint64(0); i < segCount; i++ {
 		end := binary.BigEndian.Uint16(data[endOff+i*2 : endOff+i*2+2])
 		start := binary.BigEndian.Uint16(data[startOff+i*2 : startOff+i*2+2])
@@ -227,6 +235,10 @@ func parseCmapFormat4(data []byte, subOff uint64) (cmapTable, error) {
 		idRangeOffset := binary.BigEndian.Uint16(data[rangeOff+i*2 : rangeOff+i*2+2])
 		if start > end {
 			continue
+		}
+		totalCodes += uint64(end) - uint64(start) + 1
+		if totalCodes > cmapMaxMappedCodes {
+			return nil, fmt.Errorf("font: cmap fmt4: total mapped codes exceed %d: %w", cmapMaxMappedCodes, ErrCorruptTable)
 		}
 		// The terminating sentinel segment (0xFFFF, 0xFFFF, idDelta=1)
 		// processes naturally: the resulting glyph ID is 0 and the
@@ -311,6 +323,7 @@ func parseCmapFormat12(data []byte, subOff uint64) (cmapTable, error) {
 	}
 
 	out := make(cmapTable)
+	var totalCodes uint64
 	for i := uint64(0); i < numGroups; i++ {
 		off := subOff + 16 + i*12
 		startChar := binary.BigEndian.Uint32(data[off : off+4])
@@ -323,6 +336,10 @@ func parseCmapFormat12(data []byte, subOff uint64) (cmapTable, error) {
 		// hostile fonts declare endChar past 0x10FFFF.
 		if endChar > 0x10FFFF {
 			endChar = 0x10FFFF
+		}
+		totalCodes += uint64(endChar) - uint64(startChar) + 1
+		if totalCodes > cmapMaxMappedCodes {
+			return nil, fmt.Errorf("font: cmap fmt12: total mapped codes exceed %d: %w", cmapMaxMappedCodes, ErrCorruptTable)
 		}
 		for c := startChar; c <= endChar; c++ {
 			gid32 := startGID + (c - startChar)

--- a/font/cmap_test.go
+++ b/font/cmap_test.go
@@ -312,6 +312,76 @@ func TestParseCmapFormat12LargeGroupCount(t *testing.T) {
 	}
 }
 
+// TestParseCmapFormat12OverlappingRangesRejected pins the range-
+// expansion budget: 8 identical full-range groups charge
+// 8 x 1,114,112 = 8,912,896 mapped codes, well over cmapMaxMappedCodes
+// (1<<22). Overlapping declared ranges only arise from hostile or
+// broken fonts — legitimate coverage cannot exceed the Unicode range
+// once. The fixture is small enough that even unfixed code finishes
+// in well under a second, so a regression here fails on `err == nil`
+// rather than hanging CI.
+func TestParseCmapFormat12OverlappingRangesRejected(t *testing.T) {
+	groups := make([]struct{ startChar, endChar, startGID uint32 }, 8)
+	for i := range groups {
+		groups[i] = struct{ startChar, endChar, startGID uint32 }{0, 0x10FFFF, 1}
+	}
+	sub := buildFormat12Subtable(groups)
+	cmap := wrapCmap([]struct {
+		platformID, encodingID uint16
+		subtable               []byte
+	}{{platformID: 0, encodingID: 4, subtable: sub}})
+	_, err := parseCmapTable(cmap)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Fatalf("overlapping full-range groups: err = %v, want ErrCorruptTable", err)
+	}
+}
+
+// TestParseCmapFormat4OverlappingSegmentsRejected pins the same budget
+// for format 4: 70 segments each covering the full BMP charge
+// 70 x 65,535 = 4,587,450 mapped codes, over cmapMaxMappedCodes.
+func TestParseCmapFormat4OverlappingSegmentsRejected(t *testing.T) {
+	segments := make([]struct {
+		start, end uint16
+		delta      int16
+	}, 70)
+	for i := range segments {
+		segments[i] = struct {
+			start, end uint16
+			delta      int16
+		}{start: 0, end: 0xFFFE, delta: 1}
+	}
+	sub := buildFormat4Subtable(segments)
+	cmap := wrapCmap([]struct {
+		platformID, encodingID uint16
+		subtable               []byte
+	}{{platformID: 3, encodingID: 1, subtable: sub}})
+	_, err := parseCmapTable(cmap)
+	if !errors.Is(err, ErrCorruptTable) {
+		t.Fatalf("overlapping full-BMP segments: err = %v, want ErrCorruptTable", err)
+	}
+}
+
+// TestParseCmapFormat12SingleFullRangeAccepted pins that the budget
+// does not reject the largest legitimate shape: one group spanning
+// the entire Unicode range charges 1,114,112 codes, comfortably under
+// cmapMaxMappedCodes.
+func TestParseCmapFormat12SingleFullRangeAccepted(t *testing.T) {
+	sub := buildFormat12Subtable([]struct{ startChar, endChar, startGID uint32 }{
+		{startChar: 0, endChar: 0x10FFFF, startGID: 1},
+	})
+	cmap := wrapCmap([]struct {
+		platformID, encodingID uint16
+		subtable               []byte
+	}{{platformID: 0, encodingID: 4, subtable: sub}})
+	tab, err := parseCmapTable(cmap)
+	if err != nil {
+		t.Fatalf("single full-range group should stay under budget: %v", err)
+	}
+	if tab[0x41] != 0x42 {
+		t.Errorf("tab[0x41] = %d, want 0x42", tab[0x41])
+	}
+}
+
 // TestParseCmapAcceptsMicrosoftSymbol pins the symbol-font fallback
 // in scoreSubtable. Wingdings, Symbol, and dingbat fonts ship a
 // (platformID=3, encodingID=0) format-4 subtable mapping PUA


### PR DESCRIPTION
## Summary

`parseCmapFormat4` and `parseCmapFormat12` expanded every character-code range into individual mappings with no cap. A hostile font with many large, overlapping ranges could force hundreds of millions of iterations — a CPU-exhaustion DoS on untrusted font input.

## Change

Charge the range width against a `cmapMaxMappedCodes` (2^22) budget *before* entering the per-code inner loop, aborting with `ErrCorruptTable` once the running total exceeds it. Hostile input aborts in O(numGroups)/O(segCount) without ever expanding.

## Tests

Overlapping-range rejection for both formats, plus a single-full-range acceptance case to guard the bound isn't too tight.