### PR TITLE
font: bound WOFF table decompression before ReadAll

### DIFF
--- a/font/woff.go
+++ b/font/woff.go
@@ -22,6 +22,11 @@ const woffHeaderSize = 44
 // woffTableDirEntrySize is the size of each WOFF table directory entry.
 const woffTableDirEntrySize = 20
 
+// maxWOFFDecompressedSize caps the total declared uncompressed size of all
+// WOFF tables. Even large CJK fonts decompress to well under this; a file
+// declaring more is treated as corrupt to bound worst-case memory.
+const maxWOFFDecompressedSize = 256 << 20 // 256 MB
+
 // woffHeader represents the parsed WOFF1 file header.
 // Only the fields actually consumed by the decoder are kept;
 // length, reserved, and totalSfntSize are defined by the WOFF1 spec
@@ -78,6 +83,14 @@ func decodeWOFF(data []byte) ([]byte, error) {
 		}
 	}
 
+	var totalOrig uint64
+	for i := range entries {
+		totalOrig += uint64(entries[i].origLength)
+		if totalOrig > maxWOFFDecompressedSize {
+			return nil, fmt.Errorf("font: woff: declared table sizes exceed %d bytes: %w", maxWOFFDecompressedSize, ErrCorruptTable)
+		}
+	}
+
 	// Decompress each table.
 	tables := make([][]byte, len(entries))
 	for i, e := range entries {
@@ -92,7 +105,10 @@ func decodeWOFF(data []byte) ([]byte, error) {
 			if err != nil {
 				return nil, fmt.Errorf("font: woff: zlib init for table %d: %v: %w", i, err, ErrCorruptTable)
 			}
-			decompressed, err := io.ReadAll(r)
+			// Bound decompression to the declared size (+1 to detect a
+			// stream that expands past origLength). A decompression bomb
+			// stops here instead of materializing an unbounded buffer.
+			decompressed, err := io.ReadAll(io.LimitReader(r, int64(e.origLength)+1))
 			_ = r.Close()
 			if err != nil {
 				return nil, fmt.Errorf("font: woff: zlib decompress table %d: %v: %w", i, err, ErrCorruptTable)

--- a/font/woff_test.go
+++ b/font/woff_test.go
@@ -7,10 +7,17 @@ import (
 	"bytes"
 	"compress/zlib"
 	"encoding/binary"
+	"errors"
+	"io"
 	"os"
 	"sort"
 	"testing"
 )
+
+// zeroReader yields an endless stream of zero bytes without allocating.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) { return len(p), nil }
 
 // buildWOFF creates a WOFF1 file from raw TTF data for testing purposes.
 func buildWOFF(t *testing.T, ttfData []byte) []byte {
@@ -275,6 +282,54 @@ func TestDecodeWOFF_Errors(t *testing.T) {
 		_, err := decodeWOFF(data)
 		if err == nil {
 			t.Fatal("expected error for zero tables")
+		}
+	})
+
+	t.Run("decompression bomb rejected", func(t *testing.T) {
+		// A small zlib stream that expands far past its declared origLength.
+		var compressed bytes.Buffer
+		zw := zlib.NewWriter(&compressed)
+		if _, err := io.CopyN(zw, zeroReader{}, 10<<20); err != nil {
+			t.Fatal(err)
+		}
+		_ = zw.Close()
+		blob := compressed.Bytes()
+
+		// origLength just above compLength selects the compressed branch but
+		// stays far below the true expanded size, so the LimitReader stops
+		// the bomb long before 10 MB is materialized.
+		origLength := uint32(len(blob)) + 1024
+
+		tableOff := woffHeaderSize + woffTableDirEntrySize
+		data := make([]byte, tableOff+len(blob))
+		binary.BigEndian.PutUint32(data[0:4], woffMagic)
+		binary.BigEndian.PutUint32(data[4:8], 0x00010000) // flavor
+		binary.BigEndian.PutUint16(data[12:14], 1)        // numTables
+		entryOff := woffHeaderSize
+		binary.BigEndian.PutUint32(data[entryOff+4:entryOff+8], uint32(tableOff))   // offset
+		binary.BigEndian.PutUint32(data[entryOff+8:entryOff+12], uint32(len(blob))) // compLength
+		binary.BigEndian.PutUint32(data[entryOff+12:entryOff+16], origLength)       // origLength
+		copy(data[tableOff:], blob)
+
+		_, err := decodeWOFF(data)
+		if !errors.Is(err, ErrCorruptTable) {
+			t.Fatalf("expected ErrCorruptTable, got %v", err)
+		}
+	})
+
+	t.Run("oversized declared size rejected", func(t *testing.T) {
+		tableOff := woffHeaderSize + woffTableDirEntrySize
+		data := make([]byte, tableOff+4)
+		binary.BigEndian.PutUint32(data[0:4], woffMagic)
+		binary.BigEndian.PutUint32(data[4:8], 0x00010000) // flavor
+		binary.BigEndian.PutUint16(data[12:14], 1)        // numTables
+		entryOff := woffHeaderSize
+		binary.BigEndian.PutUint32(data[entryOff+4:entryOff+8], uint32(tableOff)) // offset
+		binary.BigEndian.PutUint32(data[entryOff+8:entryOff+12], 4)               // compLength
+		binary.BigEndian.PutUint32(data[entryOff+12:entryOff+16], 300<<20)        // origLength (> cap)
+		_, err := decodeWOFF(data)
+		if !errors.Is(err, ErrCorruptTable) {
+			t.Fatalf("expected ErrCorruptTable, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

WOFF table decompression called `io.ReadAll` on a zlib reader with no size bound, so a decompression bomb (small compressed table declaring a huge output) could allocate unbounded memory — an OOM DoS on untrusted font input.

## Change

- Wrap the zlib reader in `io.LimitReader(r, origLength+1)` so decompression stops at the declared size; the existing size-mismatch check rejects the bomb.
- Add a `maxWOFFDecompressedSize` (256 MiB) cap on the summed declared table sizes, rejected with `ErrCorruptTable`.

## Tests

Decompression-bomb rejection and oversized-declared-size rejection subtests, using an allocation-free reader so the test itself never materializes the bomb.