### PR TITLE
image: enforce dimension limits from header before full decode

### DIFF
--- a/image/gif.go
+++ b/image/gif.go
@@ -14,6 +14,14 @@ import (
 // as a soft mask if present. Dimensions are validated against
 // [MaxDimension] and [MaxPixels] before the pixel buffer is allocated.
 func NewGIF(data []byte) (*Image, error) {
+	cfg, err := gif.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("image: gif: %w", err)
+	}
+	if err := checkDimensions(cfg.Width, cfg.Height); err != nil {
+		return nil, fmt.Errorf("image: gif: %w", err)
+	}
+
 	img, err := gif.Decode(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("image: gif: %w", err)

--- a/image/gif_test.go
+++ b/image/gif_test.go
@@ -5,6 +5,8 @@ package image
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
 	goimage "image"
 	"image/color"
 	"image/color/palette"
@@ -15,6 +17,25 @@ import (
 
 	"github.com/carlos7ags/folio/core"
 )
+
+// craftGIFHeader builds a GIF89a signature and logical screen descriptor
+// declaring the given canvas dimensions, with no global color table. This is
+// enough for DecodeConfig to report the size before any frame is decoded.
+func craftGIFHeader(w, h uint16) []byte {
+	b := append([]byte("GIF89a"), 0, 0, 0, 0, 0, 0, 0)
+	binary.LittleEndian.PutUint16(b[6:8], w)
+	binary.LittleEndian.PutUint16(b[8:10], h)
+	return b
+}
+
+// TestNewGIFOversizedHeader verifies the dimension limit is enforced from the
+// logical-screen descriptor, before the frame buffer is allocated.
+func TestNewGIFOversizedHeader(t *testing.T) {
+	_, err := NewGIF(craftGIFHeader(60000, 100))
+	if !errors.Is(err, ErrDimensionTooLarge) {
+		t.Fatalf("expected ErrDimensionTooLarge, got %v", err)
+	}
+}
 
 // createTestGIF generates a small GIF image in memory.
 func createTestGIF(t *testing.T, w, h int) []byte {

--- a/image/png.go
+++ b/image/png.go
@@ -16,6 +16,14 @@ import (
 // extracted into a separate soft mask. Dimensions are validated against
 // [MaxDimension] and [MaxPixels] before the pixel buffer is allocated.
 func NewPNG(data []byte) (*Image, error) {
+	cfg, err := png.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("image: png: %w", err)
+	}
+	if err := checkDimensions(cfg.Width, cfg.Height); err != nil {
+		return nil, fmt.Errorf("image: png: %w", err)
+	}
+
 	img, err := png.Decode(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("image: png: %w", err)

--- a/image/png_test.go
+++ b/image/png_test.go
@@ -5,6 +5,9 @@ package image
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
+	"hash/crc32"
 	goimage "image"
 	"image/color"
 	"image/png"
@@ -14,6 +17,45 @@ import (
 
 	"github.com/carlos7ags/folio/core"
 )
+
+// craftPNGHeader builds a valid 8-byte signature plus an IHDR chunk (with
+// correct CRC) declaring the given dimensions. No pixel data follows, so a
+// full decode would fail; the header alone is enough for DecodeConfig.
+func craftPNGHeader(w, h uint32) []byte {
+	sig := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], w)
+	binary.BigEndian.PutUint32(ihdr[4:8], h)
+	ihdr[8] = 8 // bit depth
+	ihdr[9] = 2 // color type: truecolor
+	// ihdr[10..12] = 0 (compression, filter, interlace)
+	chunk := append([]byte("IHDR"), ihdr...)
+	crc := crc32.ChecksumIEEE(chunk)
+	out := append([]byte{}, sig...)
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(ihdr)))
+	out = append(out, lenBuf...)
+	out = append(out, chunk...)
+	crcBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(crcBuf, crc)
+	return append(out, crcBuf...)
+}
+
+// TestNewPNGOversizedHeader verifies the pixel-count limit is enforced from
+// the header, before the full raster is decoded and allocated.
+func TestNewPNGOversizedHeader(t *testing.T) {
+	_, err := NewPNG(craftPNGHeader(16000, 16000))
+	if !errors.Is(err, ErrPixelCountTooLarge) {
+		t.Fatalf("expected ErrPixelCountTooLarge, got %v", err)
+	}
+}
+
+func TestNewPNGOversizedDimension(t *testing.T) {
+	_, err := NewPNG(craftPNGHeader(60000, 10))
+	if !errors.Is(err, ErrDimensionTooLarge) {
+		t.Fatalf("expected ErrDimensionTooLarge, got %v", err)
+	}
+}
 
 // createTestPNG generates a small PNG image in memory.
 func createTestPNG(t *testing.T, w, h int, withAlpha bool) []byte {

--- a/image/tiff.go
+++ b/image/tiff.go
@@ -16,6 +16,14 @@ import (
 // uncommon in PDF workflows. Dimensions are validated against
 // [MaxDimension] and [MaxPixels] before the pixel buffer is allocated.
 func NewTIFF(data []byte) (*Image, error) {
+	cfg, err := tiff.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("image: tiff: %w", err)
+	}
+	if err := checkDimensions(cfg.Width, cfg.Height); err != nil {
+		return nil, fmt.Errorf("image: tiff: %w", err)
+	}
+
 	img, err := tiff.Decode(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("image: tiff: %w", err)

--- a/image/tiff_test.go
+++ b/image/tiff_test.go
@@ -5,6 +5,8 @@ package image
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
 	goimage "image"
 	"image/color"
 	"os"
@@ -13,6 +15,50 @@ import (
 
 	"golang.org/x/image/tiff"
 )
+
+// craftTIFFHeader builds a minimal little-endian TIFF with a single IFD
+// declaring ImageWidth and ImageLength as LONG values. No strip data follows,
+// so a full decode would fail; the IFD alone lets DecodeConfig report the
+// dimensions before any raster is allocated.
+func craftTIFFHeader(w, h uint32) []byte {
+	var b bytes.Buffer
+	b.Write([]byte{'I', 'I'})     // little-endian byte order
+	b.Write([]byte{0x2A, 0x00})   // magic 42
+	writeU32LE(&b, 8)             // offset of first IFD
+	writeU16LE(&b, 2)             // entry count
+	writeTIFFEntry(&b, 256, 4, w) // ImageWidth (LONG)
+	writeTIFFEntry(&b, 257, 4, h) // ImageLength (LONG)
+	writeU32LE(&b, 0)             // next IFD offset (none)
+	return b.Bytes()
+}
+
+func writeU16LE(b *bytes.Buffer, v uint16) {
+	buf := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf, v)
+	b.Write(buf)
+}
+
+func writeU32LE(b *bytes.Buffer, v uint32) {
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, v)
+	b.Write(buf)
+}
+
+func writeTIFFEntry(b *bytes.Buffer, tag, typ uint16, value uint32) {
+	writeU16LE(b, tag)
+	writeU16LE(b, typ)
+	writeU32LE(b, 1) // count
+	writeU32LE(b, value)
+}
+
+// TestNewTIFFOversizedHeader verifies the pixel-count limit is enforced from
+// the IFD dimensions, before the raster is decoded.
+func TestNewTIFFOversizedHeader(t *testing.T) {
+	_, err := NewTIFF(craftTIFFHeader(16000, 16000))
+	if !errors.Is(err, ErrPixelCountTooLarge) {
+		t.Fatalf("expected ErrPixelCountTooLarge, got %v", err)
+	}
+}
 
 // createTestTIFF generates a small TIFF image in memory.
 func createTestTIFF(t *testing.T, w, h int) []byte {

--- a/image/webp.go
+++ b/image/webp.go
@@ -14,6 +14,14 @@ import (
 // soft mask if present. Dimensions are validated against [MaxDimension]
 // and [MaxPixels] before the pixel buffer is allocated.
 func NewWebP(data []byte) (*Image, error) {
+	cfg, err := webp.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("image: webp: %w", err)
+	}
+	if err := checkDimensions(cfg.Width, cfg.Height); err != nil {
+		return nil, fmt.Errorf("image: webp: %w", err)
+	}
+
 	img, err := webp.Decode(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("image: webp: %w", err)

--- a/image/webp_test.go
+++ b/image/webp_test.go
@@ -4,12 +4,53 @@
 package image
 
 import (
+	"encoding/binary"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/carlos7ags/folio/core"
 )
+
+// craftWebPHeader builds a RIFF container with a single VP8X chunk declaring
+// the given canvas dimensions. VP8X carries the canvas size in its header, so
+// DecodeConfig reports it without decoding any pixel data.
+func craftWebPHeader(w, h uint32) []byte {
+	vp8x := make([]byte, 10)
+	// vp8x[0] = feature flags (0: no alpha), vp8x[1:4] reserved.
+	wm := w - 1
+	hm := h - 1
+	vp8x[4] = byte(wm)
+	vp8x[5] = byte(wm >> 8)
+	vp8x[6] = byte(wm >> 16)
+	vp8x[7] = byte(hm)
+	vp8x[8] = byte(hm >> 8)
+	vp8x[9] = byte(hm >> 16)
+
+	body := []byte("WEBP")
+	body = append(body, 'V', 'P', '8', 'X')
+	lenBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(lenBuf, uint32(len(vp8x)))
+	body = append(body, lenBuf...)
+	body = append(body, vp8x...)
+
+	out := []byte("RIFF")
+	sizeBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sizeBuf, uint32(len(body)))
+	out = append(out, sizeBuf...)
+	return append(out, body...)
+}
+
+// TestNewWebPOversizedHeader verifies the dimension limit is enforced from the
+// VP8X canvas size, before the raster is decoded. A width past MaxDimension
+// with a product below WebP's own 2^31 cap isolates our check as the rejecter.
+func TestNewWebPOversizedHeader(t *testing.T) {
+	_, err := NewWebP(craftWebPHeader(60000, 1))
+	if !errors.Is(err, ErrDimensionTooLarge) {
+		t.Fatalf("expected ErrDimensionTooLarge, got %v", err)
+	}
+}
 
 // minimalWebP is a 1x1 green VP8L (lossless) WebP.
 // RIFF header (12) + VP8L chunk header (8) + VP8L bitstream.


### PR DESCRIPTION
## Summary

`NewPNG`/`NewGIF`/`NewTIFF`/`NewWebP` decoded the full image before checking dimensions, so a small file declaring enormous width/height could allocate a huge pixel buffer before the limit check fired — a memory-exhaustion vector on untrusted images.

## Change

Call `DecodeConfig` first and run `checkDimensions` on the declared width/height before the full `Decode`. The existing post-decode check is kept as a cheap defensive re-check.

## Tests

Crafted minimal headers (PNG/GIF/TIFF/WebP) declaring oversized dimensions/pixel-counts; each is rejected before decode with the appropriate `ErrDimensionTooLarge` / `ErrPixelCountTooLarge`. Existing positive-decode tests still pass.