### PR TITLE
export: bound C array arguments with unsafe.Slice and a count cap

### DIFF
--- a/export/cabi.go
+++ b/export/cabi.go
@@ -17,6 +17,7 @@ package main
 */
 import "C"
 import (
+	"fmt"
 	"sync"
 	"unsafe"
 )
@@ -130,6 +131,24 @@ func setErr(code C.int32_t, err error) C.int32_t {
 		setLastError(err.Error())
 	}
 	return code
+}
+
+// maxCArrayCount caps (pointer, count) array arguments accepted across the
+// C ABI. Counts above this are rejected instead of risking a crash.
+const maxCArrayCount = 1 << 20
+
+// checkCArray validates a (pointer, count) argument pair. On failure it sets
+// the last error and returns false.
+func checkCArray(ptr unsafe.Pointer, n int) bool {
+	if n < 0 || n > maxCArrayCount {
+		setLastError(fmt.Sprintf("array count %d out of range [0, %d]", n, maxCArrayCount))
+		return false
+	}
+	if n > 0 && ptr == nil {
+		setLastError("nil array pointer with non-zero count")
+		return false
+	}
+	return true
 }
 
 // folio_version returns the library version as a C string.

--- a/export/cabi_columns.go
+++ b/export/cabi_columns.go
@@ -42,8 +42,11 @@ func folio_columns_set_widths(colsH C.uint64_t, widths *C.double, count C.int32_
 		return errCode
 	}
 	n := int(count)
+	if !checkCArray(unsafe.Pointer(widths), n) {
+		return errInvalidArg
+	}
 	goWidths := make([]float64, n)
-	cWidths := (*[1 << 20]C.double)(unsafe.Pointer(widths))[:n:n]
+	cWidths := unsafe.Slice(widths, n)
 	for i := 0; i < n; i++ {
 		goWidths[i] = float64(cWidths[i])
 	}

--- a/export/cabi_forms.go
+++ b/export/cabi_forms.go
@@ -61,9 +61,13 @@ func folio_form_add_dropdown(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.do
 	}
 	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
 	n := int(optCount)
+	if n < 0 || n > maxCArrayCount {
+		setLastError(fmt.Sprintf("array count %d out of range [0, %d]", n, maxCArrayCount))
+		return errInvalidArg
+	}
 	goOpts := make([]string, n)
 	if n > 0 && options != nil {
-		cArray := (*[1 << 20]*C.char)(unsafe.Pointer(options))[:n:n]
+		cArray := unsafe.Slice(options, n)
 		for i := 0; i < n; i++ {
 			goOpts[i] = C.GoString(cArray[i])
 		}

--- a/export/cabi_forms_ext.go
+++ b/export/cabi_forms_ext.go
@@ -48,9 +48,13 @@ func folio_form_add_listbox(formH C.uint64_t, name *C.char, x1, y1, x2, y2 C.dou
 	}
 	rect := [4]float64{float64(x1), float64(y1), float64(x2), float64(y2)}
 	n := int(optCount)
+	if n < 0 || n > maxCArrayCount {
+		setLastError(fmt.Sprintf("array count %d out of range [0, %d]", n, maxCArrayCount))
+		return errInvalidArg
+	}
 	goOpts := make([]string, n)
 	if n > 0 && options != nil {
-		cArray := (*[1 << 20]*C.char)(unsafe.Pointer(options))[:n:n]
+		cArray := unsafe.Slice(options, n)
 		for i := 0; i < n; i++ {
 			goOpts[i] = C.GoString(cArray[i])
 		}
@@ -71,9 +75,14 @@ func folio_form_add_radio_group(formH C.uint64_t, name *C.char,
 		setLastError("radio group requires at least one option")
 		return errInvalidArg
 	}
-	cValues := (*[1 << 20]*C.char)(unsafe.Pointer(values))[:n:n]
-	cRects := (*[1 << 20]C.double)(unsafe.Pointer(rects))[: n*4 : n*4]
-	cPages := (*[1 << 20]C.int32_t)(unsafe.Pointer(pageIndices))[:n:n]
+	if !checkCArray(unsafe.Pointer(values), n) ||
+		!checkCArray(unsafe.Pointer(rects), n*4) ||
+		!checkCArray(unsafe.Pointer(pageIndices), n) {
+		return errInvalidArg
+	}
+	cValues := unsafe.Slice(values, n)
+	cRects := unsafe.Slice(rects, n*4)
+	cPages := unsafe.Slice(pageIndices, n)
 
 	opts := make([]forms.RadioOption, n)
 	for i := 0; i < n; i++ {

--- a/export/cabi_grid.go
+++ b/export/cabi_grid.go
@@ -52,6 +52,9 @@ func folio_grid_set_template_columns(gridH C.uint64_t, types *C.int32_t, values 
 		return errCode
 	}
 	n := int(count)
+	if !checkCArray(unsafe.Pointer(types), n) || !checkCArray(unsafe.Pointer(values), n) {
+		return errInvalidArg
+	}
 	tracks := parseGridTracks(types, values, n)
 	g.SetTemplateColumns(tracks)
 	return errOK
@@ -64,6 +67,9 @@ func folio_grid_set_template_rows(gridH C.uint64_t, types *C.int32_t, values *C.
 		return errCode
 	}
 	n := int(count)
+	if !checkCArray(unsafe.Pointer(types), n) || !checkCArray(unsafe.Pointer(values), n) {
+		return errInvalidArg
+	}
 	tracks := parseGridTracks(types, values, n)
 	g.SetTemplateRows(tracks)
 	return errOK
@@ -76,6 +82,9 @@ func folio_grid_set_auto_rows(gridH C.uint64_t, types *C.int32_t, values *C.doub
 		return errCode
 	}
 	n := int(count)
+	if !checkCArray(unsafe.Pointer(types), n) || !checkCArray(unsafe.Pointer(values), n) {
+		return errInvalidArg
+	}
 	tracks := parseGridTracks(types, values, n)
 	g.SetAutoRows(tracks)
 	return errOK
@@ -192,8 +201,8 @@ func folio_grid_free(gridH C.uint64_t) {
 
 func parseGridTracks(types *C.int32_t, values *C.double, n int) []layout.GridTrack {
 	tracks := make([]layout.GridTrack, n)
-	cTypes := (*[1 << 20]C.int32_t)(unsafe.Pointer(types))[:n:n]
-	cValues := (*[1 << 20]C.double)(unsafe.Pointer(values))[:n:n]
+	cTypes := unsafe.Slice(types, n)
+	cValues := unsafe.Slice(values, n)
 	for i := 0; i < n; i++ {
 		tracks[i] = layout.GridTrack{
 			Type:  layout.GridTrackType(cTypes[i]),

--- a/export/cabi_merge.go
+++ b/export/cabi_merge.go
@@ -27,7 +27,10 @@ func folio_reader_merge(readers *C.uint64_t, count C.int32_t) C.uint64_t {
 		setLastError("merge requires at least one reader")
 		return 0
 	}
-	cHandles := (*[1 << 20]C.uint64_t)(unsafe.Pointer(readers))[:n:n]
+	if !checkCArray(unsafe.Pointer(readers), n) {
+		return 0
+	}
+	cHandles := unsafe.Slice(readers, n)
 	goReaders := make([]*reader.PdfReader, n)
 	for i := 0; i < n; i++ {
 		r, errCode := loadReader(C.uint64_t(cHandles[i]))
@@ -54,7 +57,10 @@ func folio_merge_files(paths **C.char, count C.int32_t) C.uint64_t {
 		setLastError("merge requires at least one path")
 		return 0
 	}
-	cPaths := (*[1 << 20]*C.char)(unsafe.Pointer(paths))[:n:n]
+	if !checkCArray(unsafe.Pointer(paths), n) {
+		return 0
+	}
+	cPaths := unsafe.Slice(paths, n)
 	goPaths := make([]string, n)
 	for i := 0; i < n; i++ {
 		goPaths[i] = C.GoString(cPaths[i])
@@ -201,7 +207,10 @@ func folio_merge_reorder_pages(mergedH C.uint64_t, order *C.int32_t, count C.int
 		return errCode
 	}
 	n := int(count)
-	cOrder := (*[1 << 20]C.int32_t)(unsafe.Pointer(order))[:n:n]
+	if !checkCArray(unsafe.Pointer(order), n) {
+		return errInvalidArg
+	}
+	cOrder := unsafe.Slice(order, n)
 	goOrder := make([]int, n)
 	for i := 0; i < n; i++ {
 		goOrder[i] = int(cOrder[i])

--- a/export/cabi_page_ext.go
+++ b/export/cabi_page_ext.go
@@ -10,6 +10,7 @@ package main
 */
 import "C"
 import (
+	"fmt"
 	"unsafe"
 
 	"github.com/carlos7ags/folio/document"
@@ -92,9 +93,13 @@ func pageTextMarkup(pageH C.uint64_t, markupType document.MarkupType,
 	color := [3]float64{float64(r), float64(g), float64(b)}
 
 	n := int(quadCount)
+	if n < 0 || n > maxCArrayCount {
+		setLastError(fmt.Sprintf("array count %d out of range [0, %d]", n, maxCArrayCount))
+		return errInvalidArg
+	}
 	var qp [][8]float64
 	if n > 0 && quadPoints != nil {
-		flat := (*[1 << 20]C.double)(quadPoints)[: n*8 : n*8]
+		flat := unsafe.Slice((*C.double)(quadPoints), n*8)
 		qp = make([][8]float64, n)
 		for i := 0; i < n; i++ {
 			for j := 0; j < 8; j++ {

--- a/export/cabi_redact.go
+++ b/export/cabi_redact.go
@@ -31,7 +31,10 @@ func folio_redact_text(rH C.uint64_t, targets **C.char, count C.int32_t, optsH C
 		setLastError("redact_text requires at least one target")
 		return 0
 	}
-	cTargets := (*[1 << 20]*C.char)(unsafe.Pointer(targets))[:n:n]
+	if !checkCArray(unsafe.Pointer(targets), n) {
+		return 0
+	}
+	cTargets := unsafe.Slice(targets, n)
 	goTargets := make([]string, n)
 	for i := 0; i < n; i++ {
 		goTargets[i] = C.GoString(cTargets[i])
@@ -83,11 +86,18 @@ func folio_redact_regions(rH C.uint64_t, pages *C.int32_t, x1s, y1s, x2s, y2s *C
 		setLastError("redact_regions requires at least one mark")
 		return 0
 	}
-	cPages := (*[1 << 20]C.int32_t)(unsafe.Pointer(pages))[:n:n]
-	cX1 := (*[1 << 20]C.double)(unsafe.Pointer(x1s))[:n:n]
-	cY1 := (*[1 << 20]C.double)(unsafe.Pointer(y1s))[:n:n]
-	cX2 := (*[1 << 20]C.double)(unsafe.Pointer(x2s))[:n:n]
-	cY2 := (*[1 << 20]C.double)(unsafe.Pointer(y2s))[:n:n]
+	if !checkCArray(unsafe.Pointer(pages), n) ||
+		!checkCArray(unsafe.Pointer(x1s), n) ||
+		!checkCArray(unsafe.Pointer(y1s), n) ||
+		!checkCArray(unsafe.Pointer(x2s), n) ||
+		!checkCArray(unsafe.Pointer(y2s), n) {
+		return 0
+	}
+	cPages := unsafe.Slice(pages, n)
+	cX1 := unsafe.Slice(x1s, n)
+	cY1 := unsafe.Slice(y1s, n)
+	cX2 := unsafe.Slice(x2s, n)
+	cY2 := unsafe.Slice(y2s, n)
 
 	marks := make([]reader.RedactionMark, n)
 	for i := 0; i < n; i++ {

--- a/export/cabi_tab.go
+++ b/export/cabi_tab.go
@@ -28,6 +28,11 @@ func folio_tabbed_line_new(fontH C.uint64_t, fontSize C.double,
 		return 0
 	}
 	n := int(count)
+	if !checkCArray(unsafe.Pointer(positions), n) ||
+		!checkCArray(unsafe.Pointer(aligns), n) ||
+		!checkCArray(unsafe.Pointer(leaders), n) {
+		return 0
+	}
 	stops := parseTabs(positions, aligns, leaders, n)
 	tl := layout.NewTabbedLine(f, float64(fontSize), stops...)
 	return C.uint64_t(ht.store(tl))
@@ -41,6 +46,11 @@ func folio_tabbed_line_new_embedded(fontH C.uint64_t, fontSize C.double,
 		return 0
 	}
 	n := int(count)
+	if !checkCArray(unsafe.Pointer(positions), n) ||
+		!checkCArray(unsafe.Pointer(aligns), n) ||
+		!checkCArray(unsafe.Pointer(leaders), n) {
+		return 0
+	}
 	stops := parseTabs(positions, aligns, leaders, n)
 	tl := layout.NewTabbedLineEmbedded(ef, float64(fontSize), stops...)
 	return C.uint64_t(ht.store(tl))
@@ -56,9 +66,13 @@ func folio_tabbed_line_set_segments(tlH C.uint64_t, segments **C.char, count C.i
 		return errCode
 	}
 	n := int(count)
+	if n < 0 || n > maxCArrayCount {
+		setLastError(fmt.Sprintf("array count %d out of range [0, %d]", n, maxCArrayCount))
+		return errInvalidArg
+	}
 	goSegs := make([]string, n)
 	if n > 0 && segments != nil {
-		cArray := (*[1 << 20]*C.char)(unsafe.Pointer(segments))[:n:n]
+		cArray := unsafe.Slice(segments, n)
 		for i := 0; i < n; i++ {
 			goSegs[i] = C.GoString(cArray[i])
 		}
@@ -94,9 +108,9 @@ func folio_tabbed_line_free(tlH C.uint64_t) {
 
 func parseTabs(positions *C.double, aligns *C.int32_t, leaders *C.int32_t, n int) []layout.TabStop {
 	stops := make([]layout.TabStop, n)
-	cPos := (*[1 << 20]C.double)(unsafe.Pointer(positions))[:n:n]
-	cAlign := (*[1 << 20]C.int32_t)(unsafe.Pointer(aligns))[:n:n]
-	cLeader := (*[1 << 20]C.int32_t)(unsafe.Pointer(leaders))[:n:n]
+	cPos := unsafe.Slice(positions, n)
+	cAlign := unsafe.Slice(aligns, n)
+	cLeader := unsafe.Slice(leaders, n)
 	for i := 0; i < n; i++ {
 		stops[i] = layout.TabStop{
 			Position: float64(cPos[i]),

--- a/export/cabi_table.go
+++ b/export/cabi_table.go
@@ -33,8 +33,11 @@ func folio_table_set_column_widths(tH C.uint64_t, widths *C.double, count C.int3
 		return errCode
 	}
 	n := int(count)
+	if !checkCArray(unsafe.Pointer(widths), n) {
+		return errInvalidArg
+	}
 	goWidths := make([]float64, n)
-	ptr := (*[1 << 20]C.double)(unsafe.Pointer(widths))[:n:n]
+	ptr := unsafe.Slice(widths, n)
 	for i := 0; i < n; i++ {
 		goWidths[i] = float64(ptr[i])
 	}

--- a/export/cabi_v062.go
+++ b/export/cabi_v062.go
@@ -219,12 +219,19 @@ func folio_grid_set_template_areas(gridH C.uint64_t, rows **C.char,
 		return errCode
 	}
 	n := int(rowCount)
+	if n < 0 || n > maxCArrayCount {
+		setLastError(fmt.Sprintf("array count %d out of range [0, %d]", n, maxCArrayCount))
+		return errInvalidArg
+	}
 	if n == 0 || rows == nil {
 		gr.SetTemplateAreas(nil)
 		return errOK
 	}
-	cRows := (*[1 << 20]*C.char)(unsafe.Pointer(rows))[:n:n]
-	cCols := (*[1 << 20]C.int32_t)(unsafe.Pointer(cols))[:n:n]
+	if !checkCArray(unsafe.Pointer(cols), n) {
+		return errInvalidArg
+	}
+	cRows := unsafe.Slice(rows, n)
+	cCols := unsafe.Slice(cols, n)
 	areas := make([][]string, n)
 	for i := 0; i < n; i++ {
 		// Each row is a space-separated string; split into cells.

--- a/export/folio.h
+++ b/export/folio.h
@@ -20,6 +20,12 @@
  *    The library allocates the buffer; the caller MUST call folio_buffer_free()
  *    when done. The data pointer is valid until folio_buffer_free() is called.
  *
+ * 5. Array arguments (pointer + count): the pointer must reference at least
+ *    `count` elements, valid for the duration of the call; the library reads,
+ *    never retains, them. count must be in [0, 1048576]; larger counts are
+ *    rejected with FOLIO_ERR_ARG (or a 0 handle) and set the last error.
+ *    A NULL pointer with count > 0 is rejected the same way.
+ *
  * ERROR CONVENTION
  * ----------------
  * Functions returning int32_t: 0 = success, negative = error.

--- a/export/testdata/test_cabi.c
+++ b/export/testdata/test_cabi.c
@@ -1805,6 +1805,36 @@ int main(void) {
      * matrix against synthetic TTCs. Here we cover only the C-boundary
      * argument handling. */
 
+    /* ===== Stage 40: array-bounds rejection at the C ABI ===== */
+    printf("Testing oversized/NULL/negative array-count rejection...\n");
+
+    uint64_t tblBounds = folio_table_new();
+    ASSERT(tblBounds != 0, "table_new returns handle");
+    double widthsBounds[2] = {100.0, 200.0};
+
+    /* count above the 1<<20 cap: rejected, not a crash */
+    rc = folio_table_set_column_widths(tblBounds, widthsBounds, (1 << 20) + 1);
+    ASSERT(rc != 0, "oversized count rejected");
+    ASSERT(folio_last_error() != NULL, "last_error set for oversized count");
+
+    /* NULL pointer with count > 0: rejected */
+    rc = folio_table_set_column_widths(tblBounds, NULL, 3);
+    ASSERT(rc != 0, "NULL array with count>0 rejected");
+
+    /* negative count: rejected */
+    rc = folio_table_set_column_widths(tblBounds, widthsBounds, -1);
+    ASSERT(rc != 0, "negative count rejected");
+
+    /* sane call still works */
+    rc = folio_table_set_column_widths(tblBounds, widthsBounds, 2);
+    ASSERT(rc == 0, "valid widths still accepted");
+    folio_table_free(tblBounds);
+
+    /* handle-returning path: oversized count returns a 0 handle, not a crash */
+    const char* boundsPaths[1] = {"nonexistent.pdf"};
+    uint64_t mBounds = folio_merge_files((char**)boundsPaths, (1 << 20) + 1);
+    ASSERT(mBounds == 0, "merge_files oversized count returns 0 handle");
+
     /* Summary */
     printf("\n%d passed, %d failed\n", passes, failures);
     return failures > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

The C ABI converted incoming C array pointers to Go slices by casting through a fixed-size array type (`(*[1<<20]T)(ptr)[:count:count]`). That pattern silently truncates or, with a hostile/oversized `count`, indexes out of the real allocation — undefined behavior reachable from any caller passing array arguments.

## Change

Replace all 25 fixed-array cast sites with `unsafe.Slice`, each preceded by a shared `checkCArray` guard: reject `count` outside `[0, maxCArrayCount]` (2^20) and nil-pointer-with-count. int32-returning functions return `errInvalidArg`; handle-returning functions return `0`. Sites that intentionally treat nil+count as empty keep that shape with the upper bound added. `folio.h` documents the array-argument contract.

## Tests

New C ABI stage exercising oversized, NULL, and negative array-count rejection; `test_cabi` passes (418 checks) and the header/exports audit stays in sync.