### PR TITLE
reader: parse array-form bfrange destinations in ToUnicode CMaps

### DIFF
--- a/reader/cmap.go
+++ b/reader/cmap.go
@@ -156,7 +156,8 @@ func (cm *CMap) parseBfChars(s string) {
 	}
 }
 
-// parseBfRanges extracts beginbfrange...endbfrange blocks.
+// parseBfRanges extracts beginbfrange...endbfrange blocks. Both destination
+// forms are handled; array-form entries populate bfChars.
 func (cm *CMap) parseBfRanges(s string) {
 	for {
 		idx := strings.Index(s, "beginbfrange")
@@ -171,14 +172,30 @@ func (cm *CMap) parseBfRanges(s string) {
 		block := s[:end]
 		s = s[end:]
 
-		tokens := extractHexTokens(block)
+		tokens := extractBfTokens(block)
 		for i := 0; i+2 < len(tokens); i += 3 {
-			low, _ := decodeHexCode(tokens[i])
-			high, _ := decodeHexCode(tokens[i+1])
-			dst := decodeUnicodeHex(tokens[i+2])
-			cm.bfRanges = append(cm.bfRanges, bfRange{
-				low: low, high: high, dst: dst,
-			})
+			lowTok, highTok, dstTok := tokens[i], tokens[i+1], tokens[i+2]
+			if lowTok.isArr || highTok.isArr {
+				// Malformed: low/high must be plain hex codes.
+				break
+			}
+			low, _ := decodeHexCode(lowTok.hex)
+			high, _ := decodeHexCode(highTok.hex)
+			if low > high {
+				continue
+			}
+			if !dstTok.isArr {
+				cm.bfRanges = append(cm.bfRanges, bfRange{
+					low: low, high: high, dst: decodeUnicodeHex(dstTok.hex),
+				})
+				continue
+			}
+			for k, h := range dstTok.arr {
+				if uint32(k) > high-low {
+					break
+				}
+				cm.bfChars[low+uint32(k)] = decodeUnicodeHex(h)
+			}
 		}
 	}
 }
@@ -224,6 +241,52 @@ func extractHexTokens(block string) []string {
 		tokens = append(tokens, block[:end])
 		block = block[end+1:]
 	}
+}
+
+// bfToken is one operand in a bfrange block: either a hex string or a
+// bracketed group of hex strings.
+type bfToken struct {
+	hex   string   // set when isArr is false
+	arr   []string // set when isArr is true
+	isArr bool
+}
+
+// extractBfTokens tokenizes a bfrange block into hex tokens and bracketed
+// groups, preserving array structure that extractHexTokens discards. Content
+// between tokens (whitespace, stray bytes) is skipped, matching
+// extractHexTokens' tolerance.
+func extractBfTokens(block string) []bfToken {
+	var tokens []bfToken
+	for len(block) > 0 {
+		lt := strings.IndexByte(block, '<')
+		lb := strings.IndexByte(block, '[')
+		if lt < 0 && lb < 0 {
+			return tokens
+		}
+		if lb >= 0 && (lt < 0 || lb < lt) {
+			// Array: collect hex tokens up to the matching ']'.
+			block = block[lb+1:]
+			closeIdx := strings.IndexByte(block, ']')
+			var group string
+			if closeIdx < 0 {
+				group = block
+				block = ""
+			} else {
+				group = block[:closeIdx]
+				block = block[closeIdx+1:]
+			}
+			tokens = append(tokens, bfToken{arr: extractHexTokens(group), isArr: true})
+			continue
+		}
+		block = block[lt+1:]
+		end := strings.IndexByte(block, '>')
+		if end < 0 {
+			return tokens
+		}
+		tokens = append(tokens, bfToken{hex: block[:end]})
+		block = block[end+1:]
+	}
+	return tokens
 }
 
 // decodeHexCode decodes a hex string like "0041" into a uint32 code and byte count.

--- a/reader/cmap_test.go
+++ b/reader/cmap_test.go
@@ -252,6 +252,181 @@ func TestCMapNilDecode(t *testing.T) {
 	}
 }
 
+func TestParseCMapBfRangeArrayForm(t *testing.T) {
+	cmap := `
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+1 beginbfrange
+<0041> <0043> [<0061> <0062> <0063>]
+endbfrange
+`
+	cm := ParseCMap([]byte(cmap))
+
+	tests := []struct {
+		code uint32
+		want string
+	}{
+		{0x0041, "a"},
+		{0x0042, "b"},
+		{0x0043, "c"},
+	}
+	for _, tc := range tests {
+		s, ok := cm.lookupCode(tc.code)
+		if !ok || s != tc.want {
+			t.Errorf("code 0x%04X = %q, want %q", tc.code, s, tc.want)
+		}
+	}
+}
+
+func TestParseCMapBfRangeArrayFormMisalignment(t *testing.T) {
+	// Regression: an array-form entry used to be flattened by
+	// extractHexTokens, misaligning every entry that followed it in the
+	// block.
+	cmap := `
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+2 beginbfrange
+<0041> <0043> [<0061> <0062> <0063>]
+<0050> <0051> <0070>
+endbfrange
+`
+	cm := ParseCMap([]byte(cmap))
+
+	tests := []struct {
+		code uint32
+		want string
+	}{
+		{0x0041, "a"},
+		{0x0042, "b"},
+		{0x0043, "c"},
+		{0x0050, "p"},
+		{0x0051, "q"},
+	}
+	for _, tc := range tests {
+		s, ok := cm.lookupCode(tc.code)
+		if !ok || s != tc.want {
+			t.Errorf("code 0x%04X = %q, want %q", tc.code, s, tc.want)
+		}
+	}
+}
+
+func TestParseCMapBfRangeArrayFormLigature(t *testing.T) {
+	// Multi-rune destination inside an array (fi ligature).
+	cmap := `
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+1 beginbfrange
+<FB01> <FB01> [<00660069>]
+endbfrange
+`
+	cm := ParseCMap([]byte(cmap))
+	s, ok := cm.lookupCode(0xFB01)
+	if !ok || s != "fi" {
+		t.Errorf("code 0xFB01 = %q, want %q", s, "fi")
+	}
+}
+
+func TestParseCMapBfRangeArrayFormSurrogatePair(t *testing.T) {
+	// Surrogate-pair destination inside an array: D835 DC00 → U+1D400
+	// (MATHEMATICAL BOLD CAPITAL A).
+	cmap := `
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+1 beginbfrange
+<0001> <0001> [<D835DC00>]
+endbfrange
+`
+	cm := ParseCMap([]byte(cmap))
+	s, ok := cm.lookupCode(0x0001)
+	if !ok || s != "\U0001D400" {
+		t.Errorf("code 0x0001 = %q (%U), want U+1D400", s, []rune(s))
+	}
+}
+
+func TestParseCMapBfRangeArrayShorterThanRange(t *testing.T) {
+	cmap := `
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+1 beginbfrange
+<0041> <0045> [<0061> <0062>]
+endbfrange
+`
+	cm := ParseCMap([]byte(cmap))
+
+	if s, ok := cm.lookupCode(0x0041); !ok || s != "a" {
+		t.Errorf("code 0x41 = %q, want %q", s, "a")
+	}
+	if s, ok := cm.lookupCode(0x0042); !ok || s != "b" {
+		t.Errorf("code 0x42 = %q, want %q", s, "b")
+	}
+	// Codes past the array's length are unmapped; Decode falls back to
+	// the raw rune.
+	for _, code := range []uint32{0x0043, 0x0044, 0x0045} {
+		if _, ok := cm.lookupCode(code); ok {
+			t.Errorf("code 0x%04X should be unmapped", code)
+		}
+	}
+	got := cm.Decode([]byte{0x00, 0x43, 0x00, 0x44, 0x00, 0x45})
+	want := "CDE"
+	if got != want {
+		t.Errorf("Decode = %q, want %q", got, want)
+	}
+}
+
+func TestParseCMapBfRangeArrayLongerThanRange(t *testing.T) {
+	cmap := `
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+2 beginbfrange
+<0041> <0041> [<0061> <0062>]
+<0050> <0051> <0070>
+endbfrange
+`
+	cm := ParseCMap([]byte(cmap))
+
+	if s, ok := cm.lookupCode(0x0041); !ok || s != "a" {
+		t.Errorf("code 0x41 = %q, want %q", s, "a")
+	}
+	if _, ok := cm.lookupCode(0x0042); ok {
+		t.Error("code 0x42 should be unmapped; extra array destination must not leak")
+	}
+	// The extra destination must not shift the following entry.
+	if s, ok := cm.lookupCode(0x0050); !ok || s != "p" {
+		t.Errorf("code 0x50 = %q, want %q", s, "p")
+	}
+	if s, ok := cm.lookupCode(0x0051); !ok || s != "q" {
+		t.Errorf("code 0x51 = %q, want %q", s, "q")
+	}
+}
+
+func TestParseCMapBfRangeArrayUnterminated(t *testing.T) {
+	// Malformed: unterminated array at end of block. Must not panic, and
+	// entries before it are unaffected.
+	cmap := `
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+2 beginbfrange
+<0050> <0051> <0070>
+<0041> <0042> [<0061>
+endbfrange
+`
+	cm := ParseCMap([]byte(cmap))
+
+	if s, ok := cm.lookupCode(0x0050); !ok || s != "p" {
+		t.Errorf("code 0x50 = %q, want %q", s, "p")
+	}
+	if s, ok := cm.lookupCode(0x0051); !ok || s != "q" {
+		t.Errorf("code 0x51 = %q, want %q", s, "q")
+	}
+}
+
 func TestExtractHexTokens(t *testing.T) {
 	tokens := extractHexTokens("<0041> <0042>")
 	if len(tokens) != 2 || tokens[0] != "0041" || tokens[1] != "0042" {


### PR DESCRIPTION
## Summary

`parseBfRanges` only handled the scalar destination form of a ToUnicode `bfrange` (`<lo> <hi> <dst>`). The array-destination form (`<lo> <hi> [<d0> <d1> ...]`), which maps each code in the range to an explicit destination, was mis-tokenized: the flat hex scanner flattened the `[...]` so subsequent entries in the block shifted, corrupting text extraction.

## Change

- Add a structure-preserving `extractBfTokens` scanner that keeps `[...]` arrays intact.
- Rewrite `parseBfRanges` to walk token triples: scalar `dst` keeps the existing `bfRange` path; array `dst` writes per-code destinations into `bfChars` (bounded by the range width); malformed entries stop block processing; `lo > hi` is skipped.

## Tests

Array form, the misalignment regression (array entry followed by a simple entry), ligature and surrogate-pair destinations, array shorter/longer than the range, and an unterminated-array case. The misalignment test is proven to fail against the old parser.