### PR TITLE
layout, font: add text-layout benchmark baseline

### DIFF
--- a/font/bench_test.go
+++ b/font/bench_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import "testing"
+
+// BenchmarkMeasureStringStandard covers Standard.MeasureString, including
+// grapheme cluster iteration and kern-pair lookups.
+func BenchmarkMeasureStringStandard(b *testing.B) {
+	s := "AVAILABLE Together Watch AVATAR Toward Wavelength quick fox"
+	b.ResetTimer()
+	for range b.N {
+		Helvetica.MeasureString(s, 12)
+	}
+}
+
+// BenchmarkMeasureStringEmbedded covers EmbeddedFont.MeasureString on a
+// TrueType face, including glyph lookup and grapheme cluster iteration.
+func BenchmarkMeasureStringEmbedded(b *testing.B) {
+	face, err := LoadFont("testdata/synthetic_cjk.ttf")
+	if err != nil {
+		b.Fatalf("LoadFont: %v", err)
+	}
+	ef := NewEmbeddedFont(face)
+	s := "中华人民共和国是一个历史悠久的文明古国"
+	b.ResetTimer()
+	for range b.N {
+		ef.MeasureString(s, 12)
+	}
+}

--- a/layout/bench_test.go
+++ b/layout/bench_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// englishText is roughly 100 words / 700 bytes, repeated to give the
+// wrap loop enough lines to work through per call.
+var englishText = strings.Repeat(
+	"Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod "+
+		"tempor incididunt ut labore et dolore magna aliqua ut enim ad minim "+
+		"veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex "+
+		"ea commodo consequat ",
+	4,
+)
+
+// arabicText is ~30 repetitions of a short Arabic phrase, routed through
+// ShapeArabic during word measurement.
+var arabicText = strings.Repeat("السلام عليكم ", 30)
+
+// BenchmarkParagraphWrapPlain covers Paragraph.Layout's greedy word-wrap
+// loop with plain left-aligned English text (no hyphenation attempts).
+func BenchmarkParagraphWrapPlain(b *testing.B) {
+	p := NewParagraph(englishText, font.Helvetica, 12)
+	b.ResetTimer()
+	for range b.N {
+		lines := p.Layout(200)
+		if len(lines) == 0 {
+			b.Fatal("Layout returned no lines")
+		}
+	}
+}
+
+// BenchmarkParagraphWrapJustifyHyphens covers justified wrapping at a
+// narrow width, which drives hyphenateWord on most line breaks.
+func BenchmarkParagraphWrapJustifyHyphens(b *testing.B) {
+	p := NewParagraph(englishText, font.Helvetica, 12).
+		SetAlign(AlignJustify).
+		SetHyphens("auto")
+	b.ResetTimer()
+	for range b.N {
+		lines := p.Layout(150)
+		if len(lines) == 0 {
+			b.Fatal("Layout returned no lines")
+		}
+	}
+}
+
+// BenchmarkParagraphWrapArabic covers ShapeArabic plus Standard.MeasureString
+// per word, exercised through the normal paragraph wrap path.
+func BenchmarkParagraphWrapArabic(b *testing.B) {
+	p := NewParagraph(arabicText, font.Helvetica, 12)
+	b.ResetTimer()
+	for range b.N {
+		lines := p.Layout(200)
+		if len(lines) == 0 {
+			b.Fatal("Layout returned no lines")
+		}
+	}
+}
+
+// BenchmarkBreakLongWordsUnshaped drives the prefix re-measurement loop in
+// breakLongWords on a single long unbreakable ASCII token.
+func BenchmarkBreakLongWordsUnshaped(b *testing.B) {
+	text := strings.Repeat("abcdefghij", 40)
+	w := Word{
+		Text:     text,
+		Font:     font.Helvetica,
+		FontSize: 12,
+		Width:    font.Helvetica.MeasureString(text, 12),
+	}
+	b.ResetTimer()
+	for range b.N {
+		words := breakLongWords([]Word{w}, 100)
+		if len(words) == 0 {
+			b.Fatal("breakLongWords returned no words")
+		}
+	}
+}
+
+// BenchmarkBreakLongWordsIndic drives breakLongWords on a shaped Devanagari
+// word, where each chunk must carry re-shaped GIDs (see
+// TestBreakLongWordsPreservesIndicOriginalTextAndGIDs).
+func BenchmarkBreakLongWordsIndic(b *testing.B) {
+	face := newMockDevaFace()
+	face.substitutions = &font.GSUBSubstitutions{
+		Single: map[font.GSUBFeature]map[uint16]uint16{},
+	}
+	ef := font.NewEmbeddedFont(face)
+
+	const fontSize = 12
+	source := strings.Repeat("क", 30)
+
+	gids, ok := ShapeIndicWithEmbedded(source, ef, ScriptDevanagari)
+	if !ok {
+		b.Fatal("ShapeIndicWithEmbedded returned (_, false) for the benchmark source")
+	}
+	wholeWidth := ef.MeasureGIDs(gids, fontSize)
+	if wholeWidth == 0 {
+		b.Fatal("mock face produced zero-width word; benchmark cannot drive breakLongWords")
+	}
+
+	w := Word{
+		Text:         source,
+		OriginalText: source,
+		GIDs:         gids,
+		Width:        wholeWidth,
+		Embedded:     ef,
+		FontSize:     fontSize,
+	}
+	maxWidth := wholeWidth / 4
+
+	b.ResetTimer()
+	for range b.N {
+		chunks := breakLongWords([]Word{w}, maxWidth)
+		if len(chunks) == 0 {
+			b.Fatal("breakLongWords returned no chunks")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a benchmark baseline for the text-layout hot path so the two upcoming optimizations (MeasureString grapheme allocation, quadratic prefix re-measure in break/hyphenate) have a regression guard.

## Change (tests only)

- `layout/bench_test.go`: paragraph wrap (plain, justified+hyphenated, Arabic shaping), and `breakLongWords` on unshaped ASCII and shaped Devanagari.
- `font/bench_test.go`: `MeasureString` on the standard (Helvetica kern-pair) and embedded (TrueType glyph) paths.

No production code is touched. `MeasureString` currently shows nonzero allocs/op, which the follow-up optimization targets.