### PR TITLE
html: make asset resolution safe by default (SSRF + arbitrary file read)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed (breaking)
+
+- **`html` no longer fetches remote or absolute-path assets by default** — a document's `http(s)` references (`<img>`, `background-image: url()`, linked stylesheets, `@font-face url()`) are only fetched when `Options.AllowRemoteFetch` is set, and absolute filesystem paths in document content are only read when `Options.AllowAbsolutePaths` is set (both default false). When remote fetch is enabled with no `Options.URLPolicy`, the built-in `html.DenyInternalHosts` policy blocks loopback, RFC1918, link-local, and non-http(s) targets and is re-checked on every redirect hop; absolute-path reads are size-capped like HTTP reads. Set `URLPolicy` to a function returning nil to allow every host. `Options.FallbackFontPath` and the built-in system-font search are unaffected.
+
+### Added
+
+- **`html.Options.AllowRemoteFetch`** — opt-in for fetching `http(s)` assets referenced by the document. Default false.
+- **`html.Options.AllowAbsolutePaths`** — opt-in for reading absolute filesystem paths named in document content when `BaseFS` is nil. Default false; reads are size-capped like the HTTP path.
+- **`html.DenyInternalHosts`** — a `URLPolicy` that blocks non-http(s) schemes and targets resolving to loopback, private (RFC1918 / ULA), link-local, unspecified, or multicast addresses (plus carrier-grade NAT, and IPv4-compatible / NAT64 IPv6 forms that embed such addresses). Applied by default when `AllowRemoteFetch` is true and `URLPolicy` is nil, and re-checked on every redirect hop.
+- **`html.Options.MaxTotalAssetBytes`** — caps the aggregate bytes read across every asset loaded during one conversion (images, fonts, stylesheets — remote, `BaseFS`-relative, and absolute alike). 0 selects a generous 512 MiB default; loads that cross the cap fail with `html.ErrAssetBudgetExceeded`.
+- **`html.ErrRemoteFetchDisabled`** — returned when a document references an `http(s)` asset but `AllowRemoteFetch` is false. Reported normally (logged, and surfaced under `StrictAssets`).
+- **`html.ErrAbsolutePathDenied`** — returned when a document references an absolute filesystem path but `AllowAbsolutePaths` is false. Reported normally.
+- **`html.ErrAssetBudgetExceeded`** — returned when a conversion's aggregate asset read size crosses `Options.MaxTotalAssetBytes`. Reported normally.
+
 ## [0.9.1] - 2026-06-10
 
 A rendering-correctness release across `border-radius` (#329), CSS paged media

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -193,6 +193,46 @@ same standardization touches ~130 internal helper errors across the
 tree; none are exported, so the impact is limited to test fixtures
 that string-matched against the previous messages.
 
+### Remote and absolute-path assets are now opt-in
+
+`html.Convert` / `html.ConvertFull` no longer fetch remote or
+absolute-path assets by default. A document's `http(s)` references
+(`<img>`, `background-image: url()`, linked stylesheets,
+`@font-face url()`) are fetched only when `Options.AllowRemoteFetch` is
+set, and absolute filesystem paths in document content are read only when
+`Options.AllowAbsolutePaths` is set. A blocked reference fails with
+`ErrRemoteFetchDisabled` or `ErrAbsolutePathDenied` — logged, and
+surfaced through the joined error under `StrictAssets`.
+
+When remote fetch is enabled with no `URLPolicy`, the built-in
+`DenyInternalHosts` policy blocks loopback, RFC1918, link-local, and
+non-http(s) targets and is re-checked on every redirect hop. Set
+`URLPolicy` to a function returning nil to allow every host.
+
+```go
+// before — remote images fetched with no filtering
+opts := &html.Options{}
+
+// after — enable remote fetch; internal hosts blocked by default
+opts := &html.Options{AllowRemoteFetch: true}
+
+// after — allow every host, including internal ones
+opts := &html.Options{
+    AllowRemoteFetch: true,
+    URLPolicy:        func(string) error { return nil },
+}
+```
+
+`Options.FallbackFontPath` and the built-in system-font search load
+absolute paths through a separate trusted code path and are unaffected.
+
+A conversion now also enforces an aggregate asset-size budget via the new
+`Options.MaxTotalAssetBytes` (default 512 MiB when 0), covering every
+asset it reads — images, fonts, and stylesheets alike. Documents within
+the default are unaffected; raise it for asset-heavy documents (many
+large embedded fonts) or lower it to tightly bound untrusted input. A
+crossed budget fails the offending load with `ErrAssetBudgetExceeded`.
+
 ### Visual changes
 
 Several v0.8.0 fixes change the visible output of affected documents.

--- a/document/issue328_test.go
+++ b/document/issue328_test.go
@@ -39,7 +39,7 @@ body { font-family: 'CJK'; font-size: 14px; }
 	doc := NewDocument(PageSizeLetter)
 	doc.Info.Title = "Issue 328"
 	doc.SetPdfA(PdfAConfig{Level: PdfA3B})
-	if err := doc.AddHTML(htmlStr, &foliohtml.Options{StrictAssets: true}); err != nil {
+	if err := doc.AddHTML(htmlStr, &foliohtml.Options{AllowAbsolutePaths: true, StrictAssets: true}); err != nil {
 		t.Fatalf("AddHTML: %v", err)
 	}
 

--- a/examples/cjk/main.go
+++ b/examples/cjk/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	htmlStr := buildHTML(fontPath)
 
-	result, err := html.ConvertFull(htmlStr, nil)
+	result, err := html.ConvertFull(htmlStr, &html.Options{AllowAbsolutePaths: true})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "convert: %v\n", err)
 		os.Exit(1)

--- a/examples/cjk/main_test.go
+++ b/examples/cjk/main_test.go
@@ -53,7 +53,7 @@ func TestCJKExampleProducesValidPDF(t *testing.T) {
 	}
 
 	htmlStr := buildHTML(ttcPath)
-	result, err := html.ConvertFull(htmlStr, nil)
+	result, err := html.ConvertFull(htmlStr, &html.Options{AllowAbsolutePaths: true})
 	if err != nil {
 		t.Fatalf("html.ConvertFull: %v", err)
 	}

--- a/html/converter.go
+++ b/html/converter.go
@@ -7,15 +7,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"math"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/carlos7ags/folio/font"
 	"github.com/carlos7ags/folio/layout"
@@ -49,10 +53,31 @@ type Options struct {
 	// converter searches common system font locations.
 	FallbackFontPath string
 	// URLPolicy is called before the converter fetches a remote URL
-	// (for <img src="http://...">, background-image: url(), etc.).
-	// Return nil to allow the fetch, or an error to block it.
-	// If nil, all URLs are allowed.
+	// (for <img src="http://...">, background-image: url(), etc.), and
+	// again for each redirect hop. Return nil to allow the fetch, or an
+	// error to block it. Only consulted when AllowRemoteFetch is true.
+	// If nil while AllowRemoteFetch is true, the built-in DenyInternalHosts
+	// policy is used; set URLPolicy to a function that always returns nil
+	// to allow every host.
 	URLPolicy URLPolicy
+	// AllowRemoteFetch enables fetching http(s) assets referenced by the
+	// document (<img src="http://...">, background-image: url(http://...),
+	// linked stylesheets, @font-face url(http://...)). Default false: no
+	// network request is made and such references fail with
+	// ErrRemoteFetchDisabled (logged, and surfaced under StrictAssets).
+	// When true, every fetch is filtered by URLPolicy; if URLPolicy is nil,
+	// the built-in DenyInternalHosts policy is applied, which blocks
+	// loopback, RFC1918, link-local, and non-http(s) targets and is
+	// re-checked on every redirect hop.
+	AllowRemoteFetch bool
+	// AllowAbsolutePaths enables reading absolute filesystem paths named in
+	// document content (<img src="/etc/..."> or @font-face url('/abs/...'))
+	// when BaseFS is nil. Default false: such references fail with
+	// ErrAbsolutePathDenied. When true, the read is capped at the same byte
+	// limit as the HTTP path. This does NOT affect Options.FallbackFontPath
+	// or the built-in system-font search, which load programmatic absolute
+	// paths through a separate trusted code path.
+	AllowAbsolutePaths bool
 	// Client is the HTTP client used to fetch remote images and stylesheets.
 	// If nil, http.DefaultClient is used.
 	Client *http.Client
@@ -98,6 +123,19 @@ type Options struct {
 	// goroutine stack) without bound. Exceeding it returns a *LimitError
 	// (Kind LimitDepth).
 	MaxDepth int
+
+	// MaxTotalAssetBytes caps the aggregate bytes read across every asset
+	// loaded during one conversion (images, fonts, linked stylesheets —
+	// remote, BaseFS-relative, and absolute alike). 0 selects a generous
+	// default (512 MiB) that comfortably fits realistic documents with
+	// several embedded fonts and images while bounding the worst case,
+	// where many references at the per-asset limit would otherwise
+	// multiply into unbounded memory. Once the running total is crossed,
+	// the offending and any later asset loads fail with
+	// ErrAssetBudgetExceeded (logged, and surfaced under StrictAssets).
+	// Set a large value to effectively disable, or a small one to tightly
+	// bound untrusted input.
+	MaxTotalAssetBytes int64
 }
 
 // URLPolicy controls whether the HTML converter may fetch a remote URL.
@@ -123,11 +161,14 @@ func (o *Options) defaults() Options {
 	out.BaseFS = o.BaseFS
 	out.FallbackFontPath = o.FallbackFontPath
 	out.URLPolicy = o.URLPolicy
+	out.AllowRemoteFetch = o.AllowRemoteFetch
+	out.AllowAbsolutePaths = o.AllowAbsolutePaths
 	out.Client = o.Client
 	out.Logger = o.Logger
 	out.StrictAssets = o.StrictAssets
 	out.MaxElements = o.MaxElements
 	out.MaxDepth = o.MaxDepth
+	out.MaxTotalAssetBytes = o.MaxTotalAssetBytes
 	return out
 }
 
@@ -186,21 +227,24 @@ func normaliseFSPath(p string) (string, error) {
 //
 // Resolution order:
 //
-//  1. src is an http/https URL — fetched via opts.Client subject to
-//     urlPolicy. A policy denial is wrapped with [ErrURLPolicyDenied].
+//  1. src is an http/https URL — fetched only when opts.AllowRemoteFetch
+//     is set (otherwise [ErrRemoteFetchDisabled]), filtered by urlPolicy
+//     (or [DenyInternalHosts] when nil), re-checked on every redirect hop.
+//     A policy denial is wrapped with [ErrURLPolicyDenied].
 //
 //  2. origin is an http/https URL, src is relative — resolved as a URL
-//     against origin's host/path and fetched.
+//     against origin's host/path and fetched under the same gate.
 //
-//  3. src is filepath.IsAbs and opts.BaseFS is nil — read directly from
-//     the OS via os.ReadFile. Typically a system font path like
-//     "/System/Library/Fonts/STHeiti Light.ttc" or
-//     `C:\Windows\Fonts\msyh.ttc` referenced from programmatically-built
-//     HTML where the caller chose not to configure a BaseFS. When
-//     opts.BaseFS is set, an absolute path is treated as web-style root
-//     of BaseFS instead — joinFSPath strips the leading slash and reads
-//     from the BaseFS root, matching how `<base href="/">` resolves in
-//     browsers.
+//  3. src is filepath.IsAbs and opts.BaseFS is nil — read from the OS
+//     only when opts.AllowAbsolutePaths is set (otherwise
+//     [ErrAbsolutePathDenied]), size-capped like the HTTP path. The read
+//     covers document-supplied absolute references such as
+//     `<img src="/abs">` or `@font-face url('/abs')`; the programmatic
+//     Options.FallbackFontPath and system-font search use a separate
+//     trusted path and are unaffected. When opts.BaseFS is set, an
+//     absolute path is treated as web-style root of BaseFS instead —
+//     joinFSPath strips the leading slash and reads from the BaseFS root,
+//     matching how `<base href="/">` resolves in browsers.
 //
 //  4. Otherwise — resolved via joinFSPath relative to origin's directory
 //     (or BaseFS root for inline contexts) and read through opts.BaseFS.
@@ -221,27 +265,88 @@ func normaliseFSPath(p string) (string, error) {
 // CSS fetch limit. The cap is ignored for filesystem reads — those are
 // bounded by the source data.
 //
+// budget bounds the aggregate bytes read across all assets in one
+// conversion; the returned bytes are charged against it. A nil budget
+// imposes no aggregate cap.
+//
 // data: URIs are NOT handled here; callers parse them inline because
 // each asset type has its own metadata-aware decoder (font.Face from
 // font/x-truetype, *image.Image from image/png, raw bytes for CSS).
-func resolveLocalAsset(opts Options, urlPolicy URLPolicy, origin, src string, maxBytes int64) ([]byte, error) {
+func resolveLocalAsset(opts Options, urlPolicy URLPolicy, budget *assetBudget, origin, src string, maxBytes int64) ([]byte, error) {
+	var data []byte
+	var err error
 	switch {
 	case isURL(src):
-		return fetchHTTPBytes(httpClientOrDefault(opts.Client), urlPolicy, src, maxBytes)
+		data, err = fetchRemote(opts, urlPolicy, src, maxBytes)
 	case isURL(origin):
-		return fetchHTTPBytes(httpClientOrDefault(opts.Client), urlPolicy, joinURL(origin, src), maxBytes)
+		data, err = fetchRemote(opts, urlPolicy, joinURL(origin, src), maxBytes)
 	case opts.BaseFS == nil && filepath.IsAbs(src):
-		return os.ReadFile(src)
+		if !opts.AllowAbsolutePaths {
+			return nil, fmt.Errorf("%w: %s", ErrAbsolutePathDenied, src)
+		}
+		data, err = readFileLimited(src, maxBytes)
 	default:
-		return readAsset(opts.BaseFS, joinFSPath(origin, src))
+		data, err = readAsset(opts.BaseFS, joinFSPath(origin, src))
 	}
+	if err != nil {
+		return nil, err
+	}
+	if err := budget.account(int64(len(data))); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// assetBudget bounds the total bytes read across every asset load in one
+// conversion, capping the aggregate memory that many references to the
+// per-asset limit could otherwise amplify. Safe for concurrent use.
+type assetBudget struct {
+	used  atomic.Int64
+	limit int64
+}
+
+// newAssetBudget returns a budget with the given limit, substituting the
+// generous default when limit is non-positive.
+func newAssetBudget(limit int64) *assetBudget {
+	if limit <= 0 {
+		limit = defaultMaxTotalAssetBytes
+	}
+	return &assetBudget{limit: limit}
+}
+
+// account charges n bytes against the budget, returning
+// ErrAssetBudgetExceeded once the running total crosses the cap. A nil
+// budget (or non-positive limit) never rejects.
+func (b *assetBudget) account(n int64) error {
+	if b == nil || b.limit <= 0 {
+		return nil
+	}
+	if b.used.Add(n) > b.limit {
+		return fmt.Errorf("%w: read exceeds %d bytes total", ErrAssetBudgetExceeded, b.limit)
+	}
+	return nil
+}
+
+// fetchRemote enforces the AllowRemoteFetch gate, selects the effective
+// URL policy (the caller's, or DenyInternalHosts when nil), and performs
+// the fetch with that policy applied pre-flight and on every redirect hop.
+func fetchRemote(opts Options, userPolicy URLPolicy, rawURL string, maxBytes int64) ([]byte, error) {
+	if !opts.AllowRemoteFetch {
+		return nil, fmt.Errorf("%w: %s", ErrRemoteFetchDisabled, rawURL)
+	}
+	policy := userPolicy
+	if policy == nil {
+		policy = DenyInternalHosts
+	}
+	return fetchHTTPBytes(httpClientOrDefault(opts.Client), policy, rawURL, maxBytes)
 }
 
 // fetchHTTPBytes consults urlPolicy first (wrapping denials with
 // ErrURLPolicyDenied so reportAssetError can distinguish caller intent
 // from genuine load failure), then performs the GET via httpGetBytes
-// with the supplied byte cap. A maxBytes value of 0 falls back to the
-// 50MB default, matching the historical fetchImage cap.
+// on a client copy whose CheckRedirect re-applies urlPolicy to every
+// redirect hop. A maxBytes value of 0 falls back to the 50MB default,
+// matching the historical fetchImage cap.
 func fetchHTTPBytes(client *http.Client, urlPolicy URLPolicy, url string, maxBytes int64) ([]byte, error) {
 	if urlPolicy != nil {
 		if err := urlPolicy(url); err != nil {
@@ -251,7 +356,138 @@ func fetchHTTPBytes(client *http.Client, urlPolicy URLPolicy, url string, maxByt
 	if maxBytes <= 0 {
 		maxBytes = 50 << 20
 	}
-	return httpGetBytes(client, url, maxBytes)
+	return httpGetBytes(clientWithRedirectPolicy(client, urlPolicy), url, maxBytes)
+}
+
+// clientWithRedirectPolicy returns a shallow copy of client whose
+// CheckRedirect re-applies policy to every redirect target (wrapping a
+// denial as ErrURLPolicyDenied) and caps the redirect chain at 10, so a
+// public first hop cannot bounce the request to an internal host. The
+// caller's client is never mutated. A nil policy yields the standard
+// redirect behavior with the 10-hop cap.
+func clientWithRedirectPolicy(client *http.Client, policy URLPolicy) *http.Client {
+	c := *client
+	c.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return fmt.Errorf("html: stopped after 10 redirects")
+		}
+		if policy != nil {
+			if err := policy(req.URL.String()); err != nil {
+				return fmt.Errorf("%w: %w", ErrURLPolicyDenied, err)
+			}
+		}
+		return nil
+	}
+	return &c
+}
+
+// DenyInternalHosts is a URLPolicy that blocks non-http(s) schemes and
+// targets that resolve to loopback, private (RFC1918 / ULA), link-local,
+// unspecified, or multicast addresses. It is the default policy applied
+// when AllowRemoteFetch is true and Options.URLPolicy is nil, and it is
+// re-checked on every redirect hop. Callers may also set it explicitly.
+//
+// For a DNS name, every resolved address is checked; the fetch is denied
+// if any resolves to an internal address. This leaves a narrow TOCTOU
+// window (the http client re-resolves at dial time); closing it fully
+// would require a dial-time guard, tracked as a follow-up.
+func DenyInternalHosts(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("html: parse url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("html: scheme %q not allowed", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("html: empty host")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if isInternalIP(ip) {
+			return fmt.Errorf("html: host %s resolves to internal address", host)
+		}
+		return nil
+	}
+	addrs, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("html: resolve %s: %w", host, err)
+	}
+	for _, ip := range addrs {
+		if isInternalIP(ip) {
+			return fmt.Errorf("html: host %s resolves to internal address %s", host, ip)
+		}
+	}
+	return nil
+}
+
+// isInternalIP reports whether ip is one an asset fetch must never reach.
+func isInternalIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+		return true
+	}
+	if v4 := ip.To4(); v4 != nil {
+		// Carrier-grade NAT 100.64.0.0/10 (RFC 6598) is not covered by
+		// IsPrivate; block it too.
+		return v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127
+	}
+	// IPv6 forms that embed an IPv4 address route to it, so classify the
+	// embedded address: IPv4-compatible "::a.b.c.d" and the NAT64
+	// well-known prefix 64:ff9b::/96 (last four bytes), either of which
+	// could otherwise smuggle e.g. 169.254.169.254.
+	if v16 := ip.To16(); v16 != nil {
+		if isNAT64(v16) || isIPv4Compatible(v16) {
+			return isInternalIP(net.IP(v16[12:16]))
+		}
+	}
+	return false
+}
+
+// isIPv4Compatible reports whether v16 is the deprecated "::a.b.c.d" form
+// (11 leading zero bytes, byte 11 zero) that maps directly to an IPv4.
+func isIPv4Compatible(v16 net.IP) bool {
+	for _, b := range v16[:12] {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// isNAT64 reports whether v16 carries the NAT64 well-known prefix
+// 64:ff9b::/96, whose last four bytes are an embedded IPv4.
+func isNAT64(v16 net.IP) bool {
+	prefix := []byte{0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0}
+	for i := 0; i < 12; i++ {
+		if v16[i] != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// readFileLimited reads path into memory, capping at maxBytes to bound
+// worst-case memory for absolute-path document assets (mirrors the HTTP
+// path's cap). maxBytes <= 0 falls back to the 50MB default used by the
+// HTTP path.
+func readFileLimited(path string, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		maxBytes = 50 << 20
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("html: file %s exceeds %d bytes", path, maxBytes)
+	}
+	return data, nil
 }
 
 // resolveLocalAsset is the converter-method wrapper around the package
@@ -259,7 +495,7 @@ func fetchHTTPBytes(client *http.Client, urlPolicy URLPolicy, url string, maxByt
 // pre-converter call sites (parseStyleBlocks) call the free function
 // directly with the already-built Options + URLPolicy values.
 func (c *converter) resolveLocalAsset(origin, src string, maxBytes int64) ([]byte, error) {
-	return resolveLocalAsset(c.opts, c.urlPolicy, origin, src, maxBytes)
+	return resolveLocalAsset(c.opts, c.urlPolicy, c.budget, origin, src, maxBytes)
 }
 
 // httpClientOrDefault returns the configured HTTP client or http.DefaultClient.
@@ -623,9 +859,10 @@ func ConvertFullWithContext(ctx context.Context, htmlStr string, opts *Options) 
 			stylesheetErrs = append(stylesheetErrs, formatAssetError("stylesheet", err, []any{"href", href}))
 		}
 	}
-	ss := parseStyleBlocks(doc, o, logStylesheetErr)
+	budget := newAssetBudget(o.MaxTotalAssetBytes)
+	ss := parseStyleBlocks(doc, o, budget, logStylesheetErr)
 
-	c := &converter{opts: o, logger: logger, rootFontSize: o.DefaultFontSize, sheet: ss, embeddedFonts: make(map[string]*font.EmbeddedFont), containerWidth: o.PageWidth, counters: make(map[string][]int), urlPolicy: o.URLPolicy, strictErrs: stylesheetErrs, ctx: ctx}
+	c := &converter{opts: o, logger: logger, rootFontSize: o.DefaultFontSize, sheet: ss, embeddedFonts: make(map[string]*font.EmbeddedFont), containerWidth: o.PageWidth, counters: make(map[string][]int), urlPolicy: o.URLPolicy, budget: budget, strictErrs: stylesheetErrs, ctx: ctx}
 
 	// Parse @page config early so containerWidth reflects the actual page size
 	// (e.g. landscape pages have a wider containerWidth).
@@ -717,9 +954,10 @@ func ConvertWithContext(ctx context.Context, htmlStr string, opts *Options) ([]l
 			stylesheetErrs = append(stylesheetErrs, formatAssetError("stylesheet", err, []any{"href", href}))
 		}
 	}
-	ss := parseStyleBlocks(doc, o, logStylesheetErr)
+	budget := newAssetBudget(o.MaxTotalAssetBytes)
+	ss := parseStyleBlocks(doc, o, budget, logStylesheetErr)
 
-	c := &converter{opts: o, logger: logger, rootFontSize: o.DefaultFontSize, sheet: ss, embeddedFonts: make(map[string]*font.EmbeddedFont), containerWidth: o.PageWidth, counters: make(map[string][]int), urlPolicy: o.URLPolicy, strictErrs: stylesheetErrs, ctx: ctx}
+	c := &converter{opts: o, logger: logger, rootFontSize: o.DefaultFontSize, sheet: ss, embeddedFonts: make(map[string]*font.EmbeddedFont), containerWidth: o.PageWidth, counters: make(map[string][]int), urlPolicy: o.URLPolicy, budget: budget, strictErrs: stylesheetErrs, ctx: ctx}
 
 	// Update containerWidth if @page specifies a different page size.
 	if len(ss.pageRules) > 0 {
@@ -773,6 +1011,11 @@ type converter struct {
 
 	// urlPolicy is called before fetching remote URLs. Nil means allow all.
 	urlPolicy URLPolicy
+
+	// budget bounds the aggregate asset bytes read across the conversion.
+	// Shared with the pre-converter stylesheet loads so every path counts
+	// against one total. Nil in unit tests that build a converter directly.
+	budget *assetBudget
 
 	// strictErrs accumulates asset-load failures when Options.StrictAssets
 	// is true. Convert / ConvertFull return errors.Join(strictErrs...) at
@@ -837,6 +1080,17 @@ type pendingOverlay struct {
 	zIndex       int
 }
 
+// maxFontBytes caps a single @font-face read. Larger than the image/CSS
+// cap because pan-CJK TTC collections (Noto CJK, STHeiti, etc.) routinely
+// run to tens or low hundreds of MB, yet the read must still be bounded.
+const maxFontBytes = 256 << 20
+
+// defaultMaxTotalAssetBytes is the aggregate per-conversion asset cap used
+// when Options.MaxTotalAssetBytes is 0. Generous enough for realistic
+// documents (several embedded fonts plus images) while bounding the
+// worst case where many maxFontBytes-sized reads would otherwise multiply.
+const defaultMaxTotalAssetBytes = 512 << 20
+
 // loadFontFaces loads @font-face fonts into the converter's embeddedFonts map.
 // data: URIs are decoded inline; every other src — http(s) URL, BaseFS-
 // relative path, and absolute filesystem path — flows through the unified
@@ -868,7 +1122,7 @@ func (c *converter) loadFontFaces(faces []fontFaceRule) {
 		if strings.HasPrefix(src, "data:") {
 			face, err = decodeFontDataURI(src)
 		} else {
-			data, err = c.resolveLocalAsset(ff.origin, src, 50<<20)
+			data, err = c.resolveLocalAsset(ff.origin, src, maxFontBytes)
 			if err == nil {
 				face, err = font.ParseFontForLanguage(data, lang)
 			}
@@ -1060,7 +1314,7 @@ func (c *converter) loadFallbackFont(p, lang string) (font.Face, error) {
 		return font.LoadFontForLanguage(p, lang)
 	}
 	if c.opts.BaseFS != nil {
-		data, baseErr := c.resolveLocalAsset("", p, 50<<20)
+		data, baseErr := c.resolveLocalAsset("", p, maxFontBytes)
 		if baseErr == nil {
 			return font.ParseFontForLanguage(data, lang)
 		}

--- a/html/converter_safe_asset_test.go
+++ b/html/converter_safe_asset_test.go
@@ -1,0 +1,415 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/fstest"
+
+	"github.com/carlos7ags/folio/layout"
+)
+
+// allowAllURLs is a URLPolicy that permits every host. Tests that hit a
+// loopback httptest server need it because the built-in DenyInternalHosts
+// default blocks 127.0.0.1.
+func allowAllURLs(string) error { return nil }
+
+// makePNGBytes returns a small encoded PNG for tests (no binary fixture).
+func makePNGBytes(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for y := 0; y < 4; y++ {
+		for x := 0; x < 4; x++ {
+			img.Set(x, y, color.RGBA{R: 10, G: 120, B: 220, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// errRoundTripper always errors without touching the network, and counts
+// its invocations so a test can prove no request was attempted.
+type errRoundTripper struct{ calls *int }
+
+func (rt errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	*rt.calls++
+	return nil, fmt.Errorf("transport should not be reached")
+}
+
+// capturingHandler records the "error" attr value of each log record so a
+// test can errors.Is against it (asset denials are logged, not escalated
+// under StrictAssets).
+type capturingHandler struct {
+	mu   sync.Mutex
+	errs []error
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "error" {
+			if err, ok := a.Value.Any().(error); ok {
+				h.mu.Lock()
+				h.errs = append(h.errs, err)
+				h.mu.Unlock()
+			}
+		}
+		return true
+	})
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *capturingHandler) has(target error) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, e := range h.errs {
+		if errors.Is(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDenyInternalHosts pins the default policy's allow/deny decisions
+// using IP literals only, so the table is deterministic (no DNS).
+func TestDenyInternalHosts(t *testing.T) {
+	cases := []struct {
+		url  string
+		deny bool
+	}{
+		{"http://93.184.216.34/x", false},                 // public IPv4 literal
+		{"http://127.0.0.1/x", true},                      // loopback
+		{"http://10.0.0.1/x", true},                       // RFC1918
+		{"http://192.168.1.1/x", true},                    // RFC1918
+		{"http://169.254.169.254/latest/meta-data", true}, // link-local (cloud metadata)
+		{"http://[::1]/x", true},                          // IPv6 loopback
+		{"http://[fe80::1]/x", true},                      // IPv6 link-local
+		{"http://0.0.0.0/x", true},                        // unspecified
+		{"http://100.64.0.1/x", true},                     // carrier-grade NAT
+		{"file:///etc/passwd", true},                      // non-http scheme
+		{"https://93.184.216.34/x", false},                // public over https
+		{"http://[::127.0.0.1]/x", true},                  // IPv4-compatible IPv6 loopback
+		{"http://[64:ff9b::a9fe:a9fe]/x", true},           // NAT64-embedded link-local (169.254.169.254)
+	}
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			err := DenyInternalHosts(tc.url)
+			if tc.deny && err == nil {
+				t.Errorf("DenyInternalHosts(%q) = nil, want denial", tc.url)
+			}
+			if !tc.deny && err != nil {
+				t.Errorf("DenyInternalHosts(%q) = %v, want allow", tc.url, err)
+			}
+		})
+	}
+}
+
+// TestRemoteFetchDisabledByDefault verifies that with no opt-in, an
+// http(s) reference is not fetched: the transport is never reached and,
+// under StrictAssets, ErrRemoteFetchDisabled is returned.
+func TestRemoteFetchDisabledByDefault(t *testing.T) {
+	calls := 0
+	client := &http.Client{Transport: errRoundTripper{calls: &calls}}
+
+	_, err := Convert(`<img src="http://127.0.0.1:1/x.png"/>`, &Options{
+		Client:       client,
+		StrictAssets: true,
+	})
+	if err == nil {
+		t.Fatal("expected ErrRemoteFetchDisabled under StrictAssets")
+	}
+	if !errors.Is(err, ErrRemoteFetchDisabled) {
+		t.Errorf("error = %v, want ErrRemoteFetchDisabled", err)
+	}
+	if calls != 0 {
+		t.Errorf("transport was reached %d times; no request should be made", calls)
+	}
+}
+
+// TestLoopbackBlockedByDefaultPolicy verifies that with AllowRemoteFetch
+// enabled but no URLPolicy, the built-in DenyInternalHosts blocks a
+// loopback httptest server. The denial is logged (not escalated under
+// StrictAssets), so we capture it through the Logger.
+func TestLoopbackBlockedByDefaultPolicy(t *testing.T) {
+	var hit atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hit.Store(true)
+		_, _ = w.Write(makePNGBytes(t))
+	}))
+	defer srv.Close()
+
+	h := &capturingHandler{}
+	src := fmt.Sprintf(`<img src="%s/x.png"/>`, srv.URL)
+	if _, err := Convert(src, &Options{
+		AllowRemoteFetch: true,
+		StrictAssets:     true,
+		Logger:           slog.New(h),
+	}); err != nil {
+		t.Fatalf("URLPolicy denial must not escalate under StrictAssets: %v", err)
+	}
+	if !h.has(ErrURLPolicyDenied) {
+		t.Error("expected a logged ErrURLPolicyDenied for the loopback target")
+	}
+	if hit.Load() {
+		t.Error("loopback server was reached despite the default deny policy")
+	}
+}
+
+// TestAllowAllOverrideFetches verifies that an explicit allow-all
+// URLPolicy lets a loopback fetch succeed and decode into an image.
+func TestAllowAllOverrideFetches(t *testing.T) {
+	pngBytes := makePNGBytes(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngBytes)
+	}))
+	defer srv.Close()
+
+	h := &capturingHandler{}
+	src := fmt.Sprintf(`<img src="%s/photo.png"/>`, srv.URL)
+	elems, err := Convert(src, &Options{
+		AllowRemoteFetch: true,
+		URLPolicy:        allowAllURLs,
+		Logger:           slog.New(h),
+	})
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected an element")
+	}
+	if _, ok := elems[0].(*layout.ImageElement); !ok {
+		t.Fatalf("expected ImageElement, got %T (fetch may have failed)", elems[0])
+	}
+	if len(h.errs) != 0 {
+		t.Errorf("expected no asset errors, got %v", h.errs)
+	}
+}
+
+// TestRedirectHopRechecked verifies that DenyInternalHosts-style per-hop
+// checking blocks a redirect from an allowed host to a denied one. Server
+// A allows through, redirects to B; the policy denies B. The denial is
+// logged (not escalated), so we capture it through the Logger.
+func TestRedirectHopRechecked(t *testing.T) {
+	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(makePNGBytes(t))
+	}))
+	defer srvB.Close()
+
+	srvA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srvB.URL+"/b.png", http.StatusFound)
+	}))
+	defer srvA.Close()
+
+	policy := func(u string) error {
+		if u == srvB.URL+"/b.png" {
+			return fmt.Errorf("host B denied")
+		}
+		return nil
+	}
+
+	h := &capturingHandler{}
+	src := fmt.Sprintf(`<img src="%s/a.png"/>`, srvA.URL)
+	if _, err := Convert(src, &Options{
+		AllowRemoteFetch: true,
+		StrictAssets:     true,
+		URLPolicy:        policy,
+		Logger:           slog.New(h),
+	}); err != nil {
+		t.Fatalf("URLPolicy denial must not escalate under StrictAssets: %v", err)
+	}
+	if !h.has(ErrURLPolicyDenied) {
+		t.Error("expected the redirect to B to be blocked and logged as ErrURLPolicyDenied")
+	}
+}
+
+// TestAbsolutePathDeniedByDefault verifies that an absolute filesystem
+// path in document content is denied when BaseFS is nil and
+// AllowAbsolutePaths is unset.
+func TestAbsolutePathDeniedByDefault(t *testing.T) {
+	dir := t.TempDir()
+	abs := filepath.Join(dir, "photo.png")
+	if err := os.WriteFile(abs, makePNGBytes(t), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Convert(fmt.Sprintf(`<img src="%s"/>`, abs), &Options{StrictAssets: true})
+	if err == nil {
+		t.Fatal("expected ErrAbsolutePathDenied under StrictAssets")
+	}
+	if !errors.Is(err, ErrAbsolutePathDenied) {
+		t.Errorf("error = %v, want ErrAbsolutePathDenied", err)
+	}
+}
+
+// TestAbsolutePathAllowedAndCapped verifies that with AllowAbsolutePaths
+// an absolute PNG loads, and that readFileLimited enforces the byte cap.
+func TestAbsolutePathAllowedAndCapped(t *testing.T) {
+	dir := t.TempDir()
+	abs := filepath.Join(dir, "photo.png")
+	if err := os.WriteFile(abs, makePNGBytes(t), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	elems, err := Convert(fmt.Sprintf(`<img src="%s"/>`, abs), &Options{
+		AllowAbsolutePaths: true,
+		StrictAssets:       true,
+	})
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if _, ok := elems[0].(*layout.ImageElement); !ok {
+		t.Fatalf("expected ImageElement, got %T", elems[0])
+	}
+
+	t.Run("readFileLimited", func(t *testing.T) {
+		big := filepath.Join(t.TempDir(), "big.bin")
+		if err := os.WriteFile(big, make([]byte, 100), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := readFileLimited(big, 10); err == nil {
+			t.Error("expected error when file exceeds cap")
+		}
+		data, err := readFileLimited(big, 1000)
+		if err != nil {
+			t.Fatalf("within-cap read failed: %v", err)
+		}
+		if len(data) != 100 {
+			t.Errorf("read %d bytes, want 100", len(data))
+		}
+	})
+}
+
+// TestSystemFontEscapeHatchUnaffected verifies that Options.FallbackFontPath
+// still loads an absolute font path even when AllowAbsolutePaths is false:
+// the programmatic font loader bypasses the gated resolver, so no
+// ErrAbsolutePathDenied is produced for the font.
+func TestSystemFontEscapeHatchUnaffected(t *testing.T) {
+	abs, err := filepath.Abs("../font/testdata/synthetic_cjk.ttf")
+	if err != nil {
+		t.Fatalf("resolve fixture path: %v", err)
+	}
+
+	h := &capturingHandler{}
+	// A non-WinAnsi character forces the fallback-font path to run.
+	_, err = Convert(`<p>日</p>`, &Options{
+		AllowAbsolutePaths: false,
+		FallbackFontPath:   abs,
+		StrictAssets:       true,
+		Logger:             slog.New(h),
+	})
+	if err != nil {
+		t.Fatalf("FallbackFontPath must load despite AllowAbsolutePaths=false: %v", err)
+	}
+	if h.has(ErrAbsolutePathDenied) {
+		t.Error("FallbackFontPath was wrongly routed through the gated resolver")
+	}
+}
+
+// TestAssetBudgetAccount unit-tests the aggregate counter directly.
+func TestAssetBudgetAccount(t *testing.T) {
+	if err := (*assetBudget)(nil).account(1 << 30); err != nil {
+		t.Errorf("nil budget must never reject: %v", err)
+	}
+	b := newAssetBudget(100)
+	if err := b.account(60); err != nil {
+		t.Errorf("first read within cap: %v", err)
+	}
+	if err := b.account(40); err != nil {
+		t.Errorf("read reaching the cap exactly must pass: %v", err)
+	}
+	if err := b.account(1); !errors.Is(err, ErrAssetBudgetExceeded) {
+		t.Errorf("crossing the cap = %v, want ErrAssetBudgetExceeded", err)
+	}
+}
+
+// TestAssetBudgetRejectsOnceExceeded verifies that several assets each
+// under the per-asset cap but together over the aggregate cap are
+// rejected once the running total crosses the budget.
+func TestAssetBudgetRejectsOnceExceeded(t *testing.T) {
+	pngBytes := makePNGBytes(t)
+	s := int64(len(pngBytes))
+	fsys := fstest.MapFS{
+		"a.png": {Data: pngBytes},
+		"b.png": {Data: pngBytes},
+		"c.png": {Data: pngBytes},
+	}
+
+	// Budget admits exactly two images; the third crosses it.
+	src := `<img src="a.png"/><img src="b.png"/><img src="c.png"/>`
+	elems, err := Convert(src, &Options{
+		BaseFS:             fsys,
+		MaxTotalAssetBytes: 2 * s,
+		StrictAssets:       true,
+	})
+	if err == nil {
+		t.Fatal("expected ErrAssetBudgetExceeded once the budget is crossed")
+	}
+	if !errors.Is(err, ErrAssetBudgetExceeded) {
+		t.Errorf("error = %v, want ErrAssetBudgetExceeded", err)
+	}
+	// The first two images fit and rendered; only the third was rejected.
+	imgs := 0
+	for _, e := range elems {
+		if _, ok := e.(*layout.ImageElement); ok {
+			imgs++
+		}
+	}
+	if imgs != 2 {
+		t.Errorf("rendered %d images, want 2 within budget", imgs)
+	}
+}
+
+// TestAssetBudgetUnaffectedUnderCap verifies a normal document under the
+// budget loads every asset without error.
+func TestAssetBudgetUnaffectedUnderCap(t *testing.T) {
+	pngBytes := makePNGBytes(t)
+	fsys := fstest.MapFS{
+		"a.png": {Data: pngBytes},
+		"b.png": {Data: pngBytes},
+	}
+	h := &capturingHandler{}
+	src := `<img src="a.png"/><img src="b.png"/>`
+	elems, err := Convert(src, &Options{
+		BaseFS:       fsys,
+		StrictAssets: true, // default budget applies (512 MiB)
+		Logger:       slog.New(h),
+	})
+	if err != nil {
+		t.Fatalf("Convert under budget: %v", err)
+	}
+	if h.has(ErrAssetBudgetExceeded) {
+		t.Error("budget rejected an asset under a normal document")
+	}
+	imgs := 0
+	for _, e := range elems {
+		if _, ok := e.(*layout.ImageElement); ok {
+			imgs++
+		}
+	}
+	if imgs != 2 {
+		t.Errorf("rendered %d images, want 2", imgs)
+	}
+}

--- a/html/converter_test.go
+++ b/html/converter_test.go
@@ -8592,7 +8592,7 @@ func TestBackgroundImageHTTPURL(t *testing.T) {
 		`<div style="background-image: url('%s/bg.png'); width: 100px; height: 100px;"><p>Hello</p></div>`,
 		srv.URL,
 	)
-	elems, err := Convert(htmlStr, nil)
+	elems, err := Convert(htmlStr, &Options{AllowRemoteFetch: true, URLPolicy: allowAllURLs})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/html/css.go
+++ b/html/css.go
@@ -84,7 +84,7 @@ type cssDecl struct {
 // (10MB HTTP cap matching the historical CSS fetch limit). onLoadError, if
 // non-nil, is invoked for stylesheet loads that fail (used to surface the
 // failure to Options.Logger without aborting the conversion).
-func parseStyleBlocks(doc *html.Node, opts Options, onLoadError func(href string, err error)) *styleSheet {
+func parseStyleBlocks(doc *html.Node, opts Options, budget *assetBudget, onLoadError func(href string, err error)) *styleSheet {
 	ss := &styleSheet{}
 
 	// First pass: collect <link rel="stylesheet"> elements and load them.
@@ -102,7 +102,7 @@ func parseStyleBlocks(doc *html.Node, opts Options, onLoadError func(href string
 				}
 			}
 			if rel == "stylesheet" && href != "" {
-				data, err := resolveLocalAsset(opts, opts.URLPolicy, "", href, 10<<20)
+				data, err := resolveLocalAsset(opts, opts.URLPolicy, budget, "", href, 10<<20)
 				if err == nil {
 					ss.parseCSS(string(data), href)
 				} else if onLoadError != nil {

--- a/html/errors.go
+++ b/html/errors.go
@@ -134,6 +134,26 @@ func formatAssetError(category string, err error, attrs []any) error {
 // Use with errors.Is to test the cause.
 var ErrURLPolicyDenied = errors.New("html: URL fetch blocked by URLPolicy")
 
+// ErrRemoteFetchDisabled is returned when the document references an
+// http(s) asset but Options.AllowRemoteFetch is false. Unlike an
+// ErrURLPolicyDenied, it is reported normally — logged via Options.Logger
+// and, under Options.StrictAssets, added to the joined return-error — so
+// callers discover why the asset did not load. Use with errors.Is.
+var ErrRemoteFetchDisabled = errors.New("html: remote fetch disabled (set Options.AllowRemoteFetch)")
+
+// ErrAbsolutePathDenied is returned when the document references an
+// absolute filesystem path but Options.AllowAbsolutePaths is false.
+// Programmatic paths (Options.FallbackFontPath, system-font search) are
+// not affected. Reported normally, like ErrRemoteFetchDisabled. Use with
+// errors.Is.
+var ErrAbsolutePathDenied = errors.New("html: absolute filesystem path denied (set Options.AllowAbsolutePaths)")
+
+// ErrAssetBudgetExceeded is returned when a conversion's aggregate asset
+// read size crosses Options.MaxTotalAssetBytes. The offending load and any
+// later ones fail with it. Reported normally (logged, and surfaced under
+// StrictAssets). Use with errors.Is.
+var ErrAssetBudgetExceeded = errors.New("html: total asset byte budget exceeded")
+
 // LimitKind identifies which resource ceiling a LimitError reports.
 type LimitKind int
 

--- a/html/issue229_test.go
+++ b/html/issue229_test.go
@@ -57,7 +57,7 @@ func TestResolverMatrixAbsolutePathNoBaseFS(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := Convert(tc.html, &Options{StrictAssets: true}); err != nil {
+			if _, err := Convert(tc.html, &Options{AllowAbsolutePaths: true, StrictAssets: true}); err != nil {
 				t.Errorf("absolute path with BaseFS=nil should resolve via OS: %v", err)
 			}
 		})
@@ -74,7 +74,7 @@ func TestResolverMatrixAbsolutePathNoBaseFS(t *testing.T) {
 		src := fmt.Sprintf(`<html><head><style>
 			@font-face { font-family: 'X'; src: url('%s'); }
 		</style></head><body><p>x</p></body></html>`, missing)
-		_, err := Convert(src, &Options{StrictAssets: true})
+		_, err := Convert(src, &Options{AllowAbsolutePaths: true, StrictAssets: true})
 		if err == nil {
 			t.Fatal("expected error for missing absolute font path")
 		}
@@ -132,7 +132,7 @@ func TestSVGImgSrcGoesThroughURLPolicy(t *testing.T) {
 	}
 
 	src := fmt.Sprintf(`<html><body><img src="%s/icon.svg"/></body></html>`, srv.URL)
-	if _, err := Convert(src, &Options{URLPolicy: deny}); err != nil {
+	if _, err := Convert(src, &Options{AllowRemoteFetch: true, URLPolicy: deny}); err != nil {
 		t.Fatalf("Convert: %v", err)
 	}
 
@@ -161,7 +161,7 @@ func TestImageFormatDetectionPrefersExtensionOverContentType(t *testing.T) {
 	defer srv.Close()
 
 	src := fmt.Sprintf(`<html><body><img src="%s/photo.jpg"/></body></html>`, srv.URL)
-	_, err := Convert(src, &Options{StrictAssets: true})
+	_, err := Convert(src, &Options{AllowRemoteFetch: true, URLPolicy: allowAllURLs, StrictAssets: true})
 	if err != nil {
 		t.Errorf("image with mismatched Content-Type but valid extension+bytes should decode: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestStrictAssetsRemoteFontHTTPFailureEscalatesNotPolicyTagged(t *testing.T)
 	src := fmt.Sprintf(`<html><head><style>
 		@font-face { font-family: 'X'; src: url('%s/font.ttf'); }
 	</style></head><body><p>hi</p></body></html>`, srv.URL)
-	_, err := Convert(src, &Options{StrictAssets: true})
+	_, err := Convert(src, &Options{AllowRemoteFetch: true, URLPolicy: allowAllURLs, StrictAssets: true})
 	if err == nil {
 		t.Fatal("expected error from HTTP 500")
 	}

--- a/html/issue232_test.go
+++ b/html/issue232_test.go
@@ -193,7 +193,7 @@ func TestStrictAssetsRemoteFontHTTPFailureEscalates(t *testing.T) {
 	src := `<html><head><style>
 		@font-face { font-family: 'X'; src: url('` + srv.URL + `/font.ttf'); }
 	</style></head><body><p>hi</p></body></html>`
-	_, err := Convert(src, &Options{StrictAssets: true})
+	_, err := Convert(src, &Options{AllowRemoteFetch: true, URLPolicy: allowAllURLs, StrictAssets: true})
 	if err == nil {
 		t.Fatal("expected HTTP 500 to escalate")
 	}
@@ -225,8 +225,9 @@ func TestStrictAssetsURLPolicyDenialNotEscalated(t *testing.T) {
 	</style></head><body><p>hi</p></body></html>`
 
 	_, err := Convert(src, &Options{
-		StrictAssets: true,
-		URLPolicy:    denyAll,
+		AllowRemoteFetch: true,
+		StrictAssets:     true,
+		URLPolicy:        denyAll,
 	})
 	if err != nil {
 		t.Fatalf("URLPolicy denial must not escalate under StrictAssets: %v", err)

--- a/html/lang_propagation_test.go
+++ b/html/lang_propagation_test.go
@@ -147,7 +147,7 @@ func TestLoadFontFacesUsesDocLangForTTC(t *testing.T) {
 
 	loadWith := func(lang string) []byte {
 		c := &converter{
-			opts:          (&Options{}).defaults(),
+			opts:          (&Options{AllowAbsolutePaths: true}).defaults(),
 			logger:        loggerOrDiscard(nil),
 			embeddedFonts: make(map[string]*font.EmbeddedFont),
 		}
@@ -206,7 +206,7 @@ func TestLangPropagationDoesNotBreakFontFaceLoad(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			html := buildSyntheticCJKHTML(abs, tc.lang)
-			result, err := ConvertFull(html, &Options{StrictAssets: true})
+			result, err := ConvertFull(html, &Options{AllowAbsolutePaths: true, StrictAssets: true})
 			if err != nil {
 				t.Fatalf("ConvertFull: %v", err)
 			}

--- a/html/marginbox_font_issue328_test.go
+++ b/html/marginbox_font_issue328_test.go
@@ -79,7 +79,7 @@ func TestIssue328MarginBoxResolvedFontEncodesRealGlyphs(t *testing.T) {
 	// 中华国 are codepoints the fixture covers → GIDs 1, 2, 7.
 	const content = "中华国"
 
-	result, err := ConvertFull(marginFontHTML(fontPath, content, content), &Options{StrictAssets: true})
+	result, err := ConvertFull(marginFontHTML(fontPath, content, content), &Options{AllowAbsolutePaths: true, StrictAssets: true})
 	if err != nil {
 		t.Fatalf("ConvertFull: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestIssue328MarginBoxResolvedFontEncodesRealGlyphs(t *testing.T) {
 func TestIssue328MarginBoxAsciiIsNotdefInCJKFixture(t *testing.T) {
 	fontPath := resolveCJKFixture(t)
 
-	result, err := ConvertFull(marginFontHTML(fontPath, "Page 1", "Page 1"), &Options{StrictAssets: true})
+	result, err := ConvertFull(marginFontHTML(fontPath, "Page 1", "Page 1"), &Options{AllowAbsolutePaths: true, StrictAssets: true})
 	if err != nil {
 		t.Fatalf("ConvertFull: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestIssue328MarginBoxAsciiIsNotdefInCJKFixture(t *testing.T) {
 // fresh/independent font (or Helvetica) would break this identity.
 func TestIssue328MarginBoxInheritsBodyFontInstance(t *testing.T) {
 	fontPath := resolveCJKFixture(t)
-	result, err := ConvertFull(marginFontHTML(fontPath, "中", "中"), &Options{StrictAssets: true})
+	result, err := ConvertFull(marginFontHTML(fontPath, "中", "中"), &Options{AllowAbsolutePaths: true, StrictAssets: true})
 	if err != nil {
 		t.Fatalf("ConvertFull: %v", err)
 	}
@@ -163,7 +163,7 @@ body { font-family: 'Synth'; font-size: 14px; }
 @page :first { @bottom-center { content: "中"; } }
 </style></head><body><p>中华人民共和国</p></body></html>`
 
-	result, err := ConvertFull(htmlStr, &Options{StrictAssets: true})
+	result, err := ConvertFull(htmlStr, &Options{AllowAbsolutePaths: true, StrictAssets: true})
 	if err != nil {
 		t.Fatalf("ConvertFull: %v", err)
 	}
@@ -194,7 +194,7 @@ body { font-family: 'Synth'; font-size: 14px; }
 // right-aligned footer against the right margin regardless of length.
 func TestIssue328MarginBoxEmbeddedMeasureNonZero(t *testing.T) {
 	fontPath := resolveCJKFixture(t)
-	result, err := ConvertFull(marginFontHTML(fontPath, "中", "中华国"), &Options{StrictAssets: true})
+	result, err := ConvertFull(marginFontHTML(fontPath, "中", "中华国"), &Options{AllowAbsolutePaths: true, StrictAssets: true})
 	if err != nil {
 		t.Fatalf("ConvertFull: %v", err)
 	}

--- a/html/options_fs_client_test.go
+++ b/html/options_fs_client_test.go
@@ -149,7 +149,9 @@ func TestClientUsedForImageFetch(t *testing.T) {
 	}
 
 	elems, err := Convert(fmt.Sprintf(`<img src="%s/photo.jpg"/>`, srv.URL), &Options{
-		Client: client,
+		AllowRemoteFetch: true,
+		URLPolicy:        allowAllURLs,
+		Client:           client,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -180,7 +182,7 @@ func TestClientUsedForStylesheetFetch(t *testing.T) {
 	}
 	html := fmt.Sprintf(`<html><head><link rel="stylesheet" href="%s/s.css"/></head><body><p>hi</p></body></html>`, srv.URL)
 
-	if _, err := ConvertFull(html, &Options{Client: client}); err != nil {
+	if _, err := ConvertFull(html, &Options{AllowRemoteFetch: true, URLPolicy: allowAllURLs, Client: client}); err != nil {
 		t.Fatal(err)
 	}
 	if seen == 0 {
@@ -196,8 +198,9 @@ func TestURLPolicyStillBlocksWithCustomClient(t *testing.T) {
 		Transport: &countingTransport{inner: http.DefaultTransport, counter: &seen},
 	}
 	_, err := Convert(`<img src="http://example.invalid/x.jpg"/>`, &Options{
-		Client:    client,
-		URLPolicy: func(string) error { return fmt.Errorf("denied") },
+		AllowRemoteFetch: true,
+		Client:           client,
+		URLPolicy:        func(string) error { return fmt.Errorf("denied") },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -350,7 +353,7 @@ func TestFontFaceRelativeToHTTPStylesheet(t *testing.T) {
 	defer srv.Close()
 
 	html := fmt.Sprintf(`<html><head><link rel="stylesheet" href="%s/css/site.css"/></head><body><p>hi</p></body></html>`, srv.URL)
-	if _, err := Convert(html, &Options{Client: srv.Client()}); err != nil {
+	if _, err := Convert(html, &Options{AllowRemoteFetch: true, URLPolicy: allowAllURLs, Client: srv.Client()}); err != nil {
 		t.Fatal(err)
 	}
 	mu.Lock()
@@ -707,7 +710,7 @@ func TestFontFaceRootAnchoredFromHTTPStylesheet(t *testing.T) {
 	defer srv.Close()
 
 	html := fmt.Sprintf(`<html><head><link rel="stylesheet" href="%s/css/site.css"/></head><body><p>hi</p></body></html>`, srv.URL)
-	if _, err := Convert(html, &Options{Client: srv.Client()}); err != nil {
+	if _, err := Convert(html, &Options{AllowRemoteFetch: true, URLPolicy: allowAllURLs, Client: srv.Client()}); err != nil {
 		t.Fatal(err)
 	}
 	mu.Lock()

--- a/html/url_policy_test.go
+++ b/html/url_policy_test.go
@@ -15,6 +15,7 @@ import (
 func TestURLPolicyBlocksImgSrc(t *testing.T) {
 	blocked := false
 	elems, err := Convert(`<img src="http://localhost/photo.jpg"/>`, &Options{
+		AllowRemoteFetch: true,
 		URLPolicy: func(url string) error {
 			blocked = true
 			return fmt.Errorf("blocked")
@@ -41,6 +42,7 @@ func TestURLPolicyBlocksBackgroundImage(t *testing.T) {
 	elems, err := Convert(
 		`<div style="width:100px; height:100px; background-image: url('http://localhost/bg.jpg')">text</div>`,
 		&Options{
+			AllowRemoteFetch: true,
 			URLPolicy: func(url string) error {
 				blocked = true
 				return fmt.Errorf("blocked")
@@ -73,6 +75,7 @@ func TestURLPolicyAllowsWhenNil(t *testing.T) {
 func TestURLPolicyConvertFull(t *testing.T) {
 	blocked := false
 	_, err := ConvertFull(`<img src="http://localhost/photo.jpg"/>`, &Options{
+		AllowRemoteFetch: true,
 		URLPolicy: func(url string) error {
 			blocked = true
 			return fmt.Errorf("blocked")

--- a/integration/cjk_drop_sfnt_roundtrip_test.go
+++ b/integration/cjk_drop_sfnt_roundtrip_test.go
@@ -55,7 +55,7 @@ func TestCJKDropSfntRoundTripsThroughPDFExtraction(t *testing.T) {
 body { font-family: 'CJK'; font-size: 14px; }
 </style></head><body><p>%s。</p></body></html>`, stHeiti, want)
 
-	result, err := html.ConvertFull(htmlStr, &html.Options{StrictAssets: true})
+	result, err := html.ConvertFull(htmlStr, &html.Options{AllowAbsolutePaths: true, StrictAssets: true})
 	if err != nil {
 		t.Fatalf("ConvertFull: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestCJKRoundTripWithSyntheticFixture(t *testing.T) {
 body { font-family: 'CJK'; font-size: 14px; }
 </style></head><body><p>%s。</p></body></html>`, fixturePath, want)
 
-	result, err := html.ConvertFull(htmlStr, &html.Options{StrictAssets: true})
+	result, err := html.ConvertFull(htmlStr, &html.Options{AllowAbsolutePaths: true, StrictAssets: true})
 	if err != nil {
 		t.Fatalf("ConvertFull: %v", err)
 	}


### PR DESCRIPTION
## Summary — BREAKING default change

Untrusted HTML/CSS could previously drive the converter to fetch arbitrary `http(s)` URLs (SSRF) and read arbitrary absolute local files. Asset resolution is now **deny-by-default**; callers opt in explicitly.

### Behavior change (see MIGRATING.md)

- **Remote fetch** (`http(s)` assets) is refused unless `Options.AllowRemoteFetch` is set (`ErrRemoteFetchDisabled`). No request is issued when disabled.
- **Absolute filesystem paths** are refused unless `Options.AllowAbsolutePaths` is set (`ErrAbsolutePathDenied`). `Options.FallbackFontPath` and the built-in system-font search are unaffected.
- When remote fetch is enabled, **internal/private hosts are denied by default** (`DenyInternalHosts`) unless the caller supplies a `URLPolicy`. The check covers loopback/private/link-local/CGNAT/`0.0.0.0`, IPv6 equivalents, IPv4-in-IPv6 (`::a.b.c.d`), and the NAT64 `64:ff9b::/96` prefix, and is re-checked on each redirect hop (10-hop cap).

### New knobs

- `Options.AllowRemoteFetch`, `Options.AllowAbsolutePaths`.
- `Options.MaxTotalAssetBytes` — aggregate asset-byte budget per conversion (default 512 MiB), rejecting with `ErrAssetBudgetExceeded` once exceeded, so many large `@font-face`/image references can't be amplified into unbounded memory.

## Tests

Default-deny is proven with zero network/FS I/O under zero-value `Options`; opt-in paths, `DenyInternalHosts` (including `::127.0.0.1` and NAT64 metadata), redirect-hop re-checking, `errors.Is` through wrapping, and the aggregate budget are all covered under `-race`.

## Known follow-up

`DenyInternalHosts` validates the hostname and relies on the stdlib transport to re-resolve at dial time, leaving a DNS-rebinding TOCTOU window (only reachable when a caller enables remote fetch and sets no `URLPolicy`; the default is unaffected). A dial-time IP re-check is tracked as a follow-up.