### PR TITLE
export: return a caller-owned copy from folio_last_error (fix UAF window)

### DIFF
--- a/export/cabi.go
+++ b/export/cabi.go
@@ -97,32 +97,25 @@ func (t *handleTable) count() int {
 	return len(t.handles)
 }
 
-// lastError stores the most recent error message per-thread (approximated
-// via a single global since cgo serializes calls through a single OS thread
-// by default). The returned C string is valid until the next C ABI call.
+// lastError stores the most recent error message. folio_last_error returns
+// a fresh caller-owned copy, so no C pointer is retained here.
 var (
 	lastErrorMu  sync.Mutex
-	lastErrorMsg *C.char
+	lastErrorMsg string
 )
 
 // setLastError stores an error message retrievable via folio_last_error.
 func setLastError(msg string) {
 	lastErrorMu.Lock()
 	defer lastErrorMu.Unlock()
-	if lastErrorMsg != nil {
-		C.free(unsafe.Pointer(lastErrorMsg))
-	}
-	lastErrorMsg = C.CString(msg)
+	lastErrorMsg = msg
 }
 
 // clearLastError clears any previous error.
 func clearLastError() {
 	lastErrorMu.Lock()
 	defer lastErrorMu.Unlock()
-	if lastErrorMsg != nil {
-		C.free(unsafe.Pointer(lastErrorMsg))
-		lastErrorMsg = nil
-	}
+	lastErrorMsg = ""
 }
 
 // setErr sets the last error from an error value and returns the error code.
@@ -158,13 +151,27 @@ func folio_version() *C.char {
 	return versionCStr
 }
 
-// folio_last_error returns the most recent error message, or nil if none.
+// folio_last_error returns the most recent error message as a fresh copy the
+// caller must release with folio_string_free, or nil if no error is set.
 //
 //export folio_last_error
 func folio_last_error() *C.char {
 	lastErrorMu.Lock()
 	defer lastErrorMu.Unlock()
-	return lastErrorMsg
+	if lastErrorMsg == "" {
+		return nil
+	}
+	return C.CString(lastErrorMsg)
+}
+
+// folio_string_free releases a string returned by folio_last_error.
+// Passing NULL is a no-op. Do NOT pass folio_version's return value.
+//
+//export folio_string_free
+func folio_string_free(s *C.char) {
+	if s != nil {
+		C.free(unsafe.Pointer(s))
+	}
 }
 
 func main() {}

--- a/export/folio.h
+++ b/export/folio.h
@@ -13,7 +13,8 @@
  *
  * 3. Strings returned FROM the library:
  *    - folio_version(): persistent pointer, do NOT free.
- *    - folio_last_error(): library-owned, valid until the next C ABI call.
+ *    - folio_last_error(): returns a fresh copy owned by the CALLER; release
+ *      it with folio_string_free(). Returns NULL when no error is set.
  *    - All other string data is returned as buffer handles (see below).
  *
  * 4. Buffer handles (folio_buffer_data / folio_buffer_len / folio_buffer_free):
@@ -159,6 +160,7 @@ typedef void (*folio_page_decorator_fn)(
 
 const char *folio_version(void);
 const char *folio_last_error(void);
+void        folio_string_free(const char *s);
 
 /* ── Buffer ────────────────────────────────────────────────────────── */
 

--- a/export/testdata/test_cabi.c
+++ b/export/testdata/test_cabi.c
@@ -16,7 +16,7 @@
     if (!(cond)) { \
         fprintf(stderr, "FAIL: %s (line %d)\n", msg, __LINE__); \
         const char* err = folio_last_error(); \
-        if (err) fprintf(stderr, "  last_error: %s\n", err); \
+        if (err) { fprintf(stderr, "  last_error: %s\n", err); folio_string_free(err); } \
         failures++; \
     } else { \
         passes++; \
@@ -97,7 +97,9 @@ int main(void) {
     /* Test 4: Invalid handle */
     rc = folio_document_set_title(99999, "bad");
     ASSERT(rc != 0, "invalid handle returns error");
-    ASSERT(folio_last_error() != NULL, "last_error set for invalid handle");
+    const char* e0 = folio_last_error();
+    ASSERT(e0 != NULL, "last_error set for invalid handle");
+    folio_string_free(e0);
 
     /* Test 5: Font lookup by name */
     uint64_t courier = folio_font_standard("Courier");
@@ -1815,7 +1817,9 @@ int main(void) {
     /* count above the 1<<20 cap: rejected, not a crash */
     rc = folio_table_set_column_widths(tblBounds, widthsBounds, (1 << 20) + 1);
     ASSERT(rc != 0, "oversized count rejected");
-    ASSERT(folio_last_error() != NULL, "last_error set for oversized count");
+    const char* eBounds = folio_last_error();
+    ASSERT(eBounds != NULL, "last_error set for oversized count");
+    folio_string_free(eBounds);
 
     /* NULL pointer with count > 0: rejected */
     rc = folio_table_set_column_widths(tblBounds, NULL, 3);
@@ -1834,6 +1838,30 @@ int main(void) {
     const char* boundsPaths[1] = {"nonexistent.pdf"};
     uint64_t mBounds = folio_merge_files((char**)boundsPaths, (1 << 20) + 1);
     ASSERT(mBounds == 0, "merge_files oversized count returns 0 handle");
+
+    /* ===== Stage 41: last_error copies are stable across subsequent errors ===== */
+    {
+        /* trigger error 1: invalid handle */
+        folio_document_set_title(0xDEAD, "x");
+        const char* e1 = folio_last_error();
+        ASSERT(e1 != NULL, "first error captured");
+        char first[256];
+        snprintf(first, sizeof first, "%s", e1 ? e1 : "");
+
+        /* trigger error 2: another invalid handle call replaces the stored message */
+        folio_document_add_page(0xBEEF);
+        const char* e2 = folio_last_error();
+        ASSERT(e2 != NULL, "second error captured");
+
+        /* e1 must still be a valid, unchanged C string (was freed under the
+           old contract; under ASan/valgrind this read would flag a UAF) */
+        ASSERT(strcmp(e1, first) == 0, "first error string still intact after second error");
+        ASSERT(e1 != e2, "each call returns a distinct allocation");
+
+        folio_string_free(e1);
+        folio_string_free(e2);
+        folio_string_free(NULL); /* NULL is a documented no-op */
+    }
 
     /* Summary */
     printf("\n%d passed, %d failed\n", passes, failures);


### PR DESCRIPTION
## Summary

`folio_last_error()` returned a pointer into a `*C.char` that `setLastError`/`clearLastError` could `C.free` on a later call — a use-after-free window: a caller holding a previously returned error string could see it invalidated (or freed) by a subsequent erroring call from another thread.

## Change

- Back the last error with a Go `string` (no retained `*C.char`, no `C.free` on update).
- `folio_last_error()` allocates a fresh `C.CString` copy under the lock on every call (or `NULL` if unset).
- New exported `folio_string_free(char*)` (NULL-safe) frees a returned copy.

## C ABI contract change

`folio_last_error()` now returns a **caller-owned** string that must be released with `folio_string_free`. Callers that previously treated it as borrowed will leak one short string per retrieval (no crash) until they adopt `folio_string_free`. `folio.h` documents the new ownership rule; the header/exports audit stays in sync.

## Tests

New C-ABI Stage 41: the first error string survives a second erroring call byte-for-byte, two retrievals are distinct allocations, and `folio_string_free(NULL)` is a no-op. Harness: 422 checks pass.