### PR TITLE
layout: consolidate measurer resolution into resolveMeasurer

### DIFF
--- a/layout/list.go
+++ b/layout/list.go
@@ -570,11 +570,9 @@ func (l *List) itemText(item listItem) string {
 }
 
 // measurer returns the text measurer for this list's font.
+// Fallback l.font preserves the historical typed-nil return when unset.
 func (l *List) measurer() font.TextMeasurer {
-	if l.embedded != nil {
-		return l.embedded
-	}
-	return l.font
+	return resolveMeasurer(l.embedded, l.font, l.font)
 }
 
 // PlanLayout implements Element. Lists split between items.

--- a/layout/measurer.go
+++ b/layout/measurer.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import "github.com/carlos7ags/folio/font"
+
+// resolveMeasurer returns the text measurer for an embedded/standard font
+// pair: embedded wins, else the standard font, else fallback.
+//
+// The fallback makes each caller's nil policy explicit. Callers that test
+// the result against nil must pass an untyped nil fallback; callers that
+// historically returned their possibly-nil *font.Standard field unchecked
+// pass that same field as the fallback, preserving the typed-nil interface
+// they returned before consolidation.
+func resolveMeasurer(embedded *font.EmbeddedFont, std *font.Standard, fallback font.TextMeasurer) font.TextMeasurer {
+	if embedded != nil {
+		return embedded
+	}
+	if std != nil {
+		return std
+	}
+	return fallback
+}

--- a/layout/measurer_test.go
+++ b/layout/measurer_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+func TestResolveMeasurer(t *testing.T) {
+	embedded := font.NewEmbeddedFont(newFakeFace('a'))
+	std := font.Helvetica
+
+	t.Run("embedded and std set returns embedded", func(t *testing.T) {
+		got := resolveMeasurer(embedded, std, nil)
+		if got != font.TextMeasurer(embedded) {
+			t.Errorf("got %v, want embedded", got)
+		}
+	})
+
+	t.Run("embedded set, std nil returns embedded", func(t *testing.T) {
+		got := resolveMeasurer(embedded, nil, nil)
+		if got != font.TextMeasurer(embedded) {
+			t.Errorf("got %v, want embedded", got)
+		}
+	})
+
+	t.Run("embedded nil, std set returns std", func(t *testing.T) {
+		got := resolveMeasurer(nil, std, nil)
+		if got != font.TextMeasurer(std) {
+			t.Errorf("got %v, want std", got)
+		}
+	})
+
+	t.Run("both nil falls back to Helvetica", func(t *testing.T) {
+		got := resolveMeasurer(nil, nil, font.Helvetica)
+		if got != font.TextMeasurer(font.Helvetica) {
+			t.Errorf("got %v, want font.Helvetica", got)
+		}
+	})
+
+	t.Run("both nil with untyped nil fallback is nil", func(t *testing.T) {
+		got := resolveMeasurer(nil, nil, nil)
+		if got != nil {
+			t.Errorf("got %v, want untyped nil", got)
+		}
+	})
+
+	t.Run("both nil with typed nil fallback is not nil", func(t *testing.T) {
+		var nilStd *font.Standard
+		got := resolveMeasurer(nil, nil, nilStd)
+		if got == nil {
+			t.Error("got untyped nil, want typed-nil interface (regression: nil-standard-field fallback)")
+		}
+	})
+}

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -548,16 +548,10 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 	return lines
 }
 
-// runMeasurer returns the text measurer for a run.
+// runMeasurer returns the text measurer for a run, defaulting to
+// Helvetica if no font is set (defensive).
 func runMeasurer(run TextRun) font.TextMeasurer {
-	if run.Embedded != nil {
-		return run.Embedded
-	}
-	if run.Font != nil {
-		return run.Font
-	}
-	// Fallback: use Helvetica if no font is set (defensive).
-	return font.Helvetica
+	return resolveMeasurer(run.Embedded, run.Font, font.Helvetica)
 }
 
 // shapeAndMeasureWord runs the appropriate per-script shaper over a
@@ -1683,11 +1677,9 @@ func isSpace(r rune) bool {
 }
 
 // wordMeasurer returns a TextMeasurer for the given word's font.
+// Fallback w.Font preserves the historical typed-nil return when unset.
 func wordMeasurer(w Word) font.TextMeasurer {
-	if w.Embedded != nil {
-		return w.Embedded
-	}
-	return w.Font
+	return resolveMeasurer(w.Embedded, w.Font, w.Font)
 }
 
 // wrapWords performs greedy word-wrapping, returning groups of words per line.

--- a/layout/tab.go
+++ b/layout/tab.go
@@ -231,11 +231,9 @@ func (tl *TabbedLine) measureSegment(text string, measurer font.TextMeasurer) []
 }
 
 // measurer returns the text measurer for this tabbed line's font.
+// Fallback tl.font preserves the historical typed-nil return when unset.
 func (tl *TabbedLine) measurer() font.TextMeasurer {
-	if tl.embedded != nil {
-		return tl.embedded
-	}
-	return tl.font
+	return resolveMeasurer(tl.embedded, tl.font, tl.font)
 }
 
 // MinWidth implements Measurable. Returns the rightmost tab stop position

--- a/layout/table.go
+++ b/layout/table.go
@@ -883,7 +883,7 @@ func (t *Table) cellContentHeight(gc *gridCell) float64 {
 		return measureConsumed(cell.content, innerWidth) + padH
 	}
 
-	measurer := t.cellMeasurer(cell)
+	measurer := cellTextMeasurer(cell)
 	if measurer == nil {
 		return padH
 	}
@@ -909,17 +909,6 @@ func (t *Table) cellContentHeight(gc *gridCell) float64 {
 	}
 
 	return float64(lines)*cell.fontSize*1.2 + padH
-}
-
-// cellMeasurer returns the text measurer for a cell's font, or nil if none is set.
-func (t *Table) cellMeasurer(cell *Cell) font.TextMeasurer {
-	if cell.embedded != nil {
-		return cell.embedded
-	}
-	if cell.font != nil {
-		return cell.font
-	}
-	return nil
 }
 
 // Layout implements the Element interface.
@@ -1369,13 +1358,7 @@ func drawStyledBorder(stream *content.Stream, b Border, x1, y1, x2, y2 float64) 
 
 // cellTextMeasurer returns the text measurer for a cell's font, or nil if none is set.
 func cellTextMeasurer(cell *Cell) font.TextMeasurer {
-	if cell.embedded != nil {
-		return cell.embedded
-	}
-	if cell.font != nil {
-		return cell.font
-	}
-	return nil
+	return resolveMeasurer(cell.embedded, cell.font, nil)
 }
 
 // IsTable reports whether a Line was produced by a Table element.


### PR DESCRIPTION
## Summary

Six near-identical measurer-resolution helpers (embedded-font vs standard-font fallback) were duplicated across paragraph, list, tab, and table layout. This consolidates them into a single `resolveMeasurer` in `layout/measurer.go`.

## Change (behavior-preserving refactor)

All six call sites delegate to `resolveMeasurer`, preserving each site's exact fallback — including the typed-nil vs untyped-nil distinction. The duplicate `(*Table).cellMeasurer` is removed in favor of `cellTextMeasurer`.

## Tests

`TestResolveMeasurer` covers all six cases including the typed-nil/untyped-nil regression guard. Existing layout/html/integration suites stay green (output unchanged).