### PR TITLE
html: bucket CSS rules by rightmost simple selector

### DIFF
--- a/document/bench_html_test.go
+++ b/document/bench_html_test.go
@@ -246,3 +246,47 @@ func BenchmarkHTMLReport(b *testing.B) {
 		_, _ = doc.WriteTo(io.Discard)
 	}
 }
+
+// buildLargeStylesheetHTML produces a document with nRules CSS rules of
+// mixed shapes (class, tag, id, descendant, attribute) and nElems elements
+// spread across those classes, stressing per-node rule matching.
+func buildLargeStylesheetHTML(nRules, nElems int) string {
+	var sb strings.Builder
+	sb.WriteString(`<!DOCTYPE html><html><head><style>`)
+	sb.WriteString(`body { font-family: Helvetica; font-size: 9pt; }`)
+	for i := 0; i < nRules; i++ {
+		switch i % 5 {
+		case 0:
+			fmt.Fprintf(&sb, ".c%d { color: #333; padding: 1px; }", i)
+		case 1:
+			fmt.Fprintf(&sb, "div .c%d { margin-bottom: 2px; }", i)
+		case 2:
+			fmt.Fprintf(&sb, "#id%d { font-weight: bold; }", i)
+		case 3:
+			fmt.Fprintf(&sb, "p.c%d span { color: #666; }", i)
+		case 4:
+			fmt.Fprintf(&sb, "[data-k%d] { font-size: 8pt; }", i)
+		}
+	}
+	sb.WriteString(`</style></head><body>`)
+	for i := 0; i < nElems; i++ {
+		fmt.Fprintf(&sb, `<div class="c%d"><p class="c%d">Row %d <span>detail</span></p></div>`,
+			i%nRules, (i*7)%nRules, i)
+	}
+	sb.WriteString(`</body></html>`)
+	return sb.String()
+}
+
+func BenchmarkHTMLLargeStylesheet(b *testing.B) {
+	src := buildLargeStylesheetHTML(300, 600)
+	opts := &html.Options{
+		PageWidth:  PageSizeLetter.Width,
+		PageHeight: PageSizeLetter.Height,
+	}
+	b.ResetTimer()
+	for range b.N {
+		doc := NewDocument(PageSizeLetter)
+		_ = doc.AddHTML(src, opts)
+		_, _ = doc.WriteTo(io.Discard)
+	}
+}

--- a/html/css.go
+++ b/html/css.go
@@ -4,6 +4,7 @@
 package html
 
 import (
+	"sort"
 	"strings"
 
 	"golang.org/x/net/html"
@@ -36,6 +37,7 @@ type styleSheet struct {
 	rules     []cssRule
 	fontFaces []fontFaceRule
 	pageRules []pageRule // @page declarations
+	index     *ruleIndex // lazily built selector index, see buildIndex
 }
 
 // cssRule is a single CSS rule: selector(s) + declarations.
@@ -61,6 +63,101 @@ type selectorPart struct {
 	pseudo        string // e.g. "first-child", "nth-child(2)"
 	pseudoElement string // e.g. "before", "after"
 	attrSelectors []attrSelector
+}
+
+// selectorRef locates one selector inside styleSheet.rules.
+type selectorRef struct {
+	ruleIdx int
+	selIdx  int
+}
+
+// ruleIndex buckets selectors by their rightmost simple selector so
+// matching a node probes only candidate rules instead of scanning all of
+// them. A bucket key is a necessary (not sufficient) condition for a
+// match: selectors whose last part has an id go in byID, else a class in
+// byClass (lowercased), else a concrete tag in byTag, else universal
+// (covers "*", pseudo-class-only, and attribute-only selectors).
+//
+// If a future selector feature relaxes matching of id/class/tag on the
+// last part (e.g. an attribute-flag case-insensitive id), buildIndex and
+// candidateRefs must be updated to match — see partMatches in
+// css_selectors.go for the ground truth these buckets approximate.
+type ruleIndex struct {
+	byID      map[string][]selectorRef
+	byClass   map[string][]selectorRef
+	byTag     map[string][]selectorRef
+	universal []selectorRef
+	ruleCount int // len(ss.rules) when built; rebuilt if rules were appended
+}
+
+// buildIndex populates ss.index from ss.rules. Not safe for concurrent use;
+// styleSheet matching is single-goroutine per conversion, same as the rest
+// of the converter.
+func (ss *styleSheet) buildIndex() {
+	idx := &ruleIndex{
+		byID:      map[string][]selectorRef{},
+		byClass:   map[string][]selectorRef{},
+		byTag:     map[string][]selectorRef{},
+		ruleCount: len(ss.rules),
+	}
+	for ri, rule := range ss.rules {
+		for si, sel := range rule.selectors {
+			ref := selectorRef{ruleIdx: ri, selIdx: si}
+			if len(sel.parts) == 0 {
+				idx.universal = append(idx.universal, ref)
+				continue
+			}
+			last := sel.parts[len(sel.parts)-1]
+			switch {
+			case last.id != "":
+				idx.byID[last.id] = append(idx.byID[last.id], ref)
+			case last.class != "":
+				key := strings.ToLower(last.class)
+				idx.byClass[key] = append(idx.byClass[key], ref)
+			case last.tag != "" && last.tag != "*":
+				idx.byTag[last.tag] = append(idx.byTag[last.tag], ref)
+			default:
+				idx.universal = append(idx.universal, ref)
+			}
+		}
+	}
+	ss.index = idx
+}
+
+// candidateRefs returns the selector refs whose bucket keys are consistent
+// with n, sorted by (ruleIdx, selIdx) with duplicates removed. Bucket keys
+// are necessary conditions for a match, so every selector that could match
+// n is included — filtering candidates with selectorMatches is equivalent
+// to scanning all rules.
+func (ss *styleSheet) candidateRefs(n *html.Node) []selectorRef {
+	if ss.index == nil || ss.index.ruleCount != len(ss.rules) {
+		ss.buildIndex()
+	}
+	idx := ss.index
+	var refs []selectorRef
+	if id := nodeAttr(n, "id"); id != "" {
+		refs = append(refs, idx.byID[id]...)
+	}
+	for _, cls := range nodeClasses(n) {
+		refs = append(refs, idx.byClass[strings.ToLower(cls)]...)
+	}
+	refs = append(refs, idx.byTag[strings.ToLower(n.Data)]...)
+	refs = append(refs, idx.universal...)
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].ruleIdx != refs[j].ruleIdx {
+			return refs[i].ruleIdx < refs[j].ruleIdx
+		}
+		return refs[i].selIdx < refs[j].selIdx
+	})
+	// Dedupe: duplicate node classes (class="a a") probe a bucket twice.
+	out := refs[:0]
+	for i, r := range refs {
+		if i > 0 && r == refs[i-1] {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // attrSelector represents a CSS attribute selector like [attr], [attr=value], etc.
@@ -758,22 +855,32 @@ func (ss *styleSheet) matchingDeclarations(n *html.Node) []cssDecl {
 	}
 	var matches []match
 
-	for _, rule := range ss.rules {
-		for _, sel := range rule.selectors {
-			// Skip selectors with pseudo-elements — those are for ::before/::after.
-			if len(sel.parts) > 0 && sel.parts[len(sel.parts)-1].pseudoElement != "" {
-				continue
-			}
-			if selectorMatches(sel, n) {
-				for _, d := range rule.declarations {
-					spec := sel.specificity
-					if d.important {
-						spec += 1000
-					}
-					matches = append(matches, match{specificity: spec, decl: d})
+	// candidateRefs are sorted by (ruleIdx, selIdx), i.e. document order,
+	// and include every selector that could possibly match n (bucket keys
+	// are necessary conditions). So the first matching candidate of a rule
+	// is the same selector a full linear scan would match first, and
+	// skipRule reproduces the original scan's "break on first match".
+	refs := ss.candidateRefs(n)
+	skipRule := -1
+	for _, ref := range refs {
+		if ref.ruleIdx == skipRule {
+			continue
+		}
+		rule := &ss.rules[ref.ruleIdx]
+		sel := rule.selectors[ref.selIdx]
+		// Skip selectors with pseudo-elements — those are for ::before/::after.
+		if len(sel.parts) > 0 && sel.parts[len(sel.parts)-1].pseudoElement != "" {
+			continue
+		}
+		if selectorMatches(sel, n) {
+			for _, d := range rule.declarations {
+				spec := sel.specificity
+				if d.important {
+					spec += 1000
 				}
-				break
+				matches = append(matches, match{specificity: spec, decl: d})
 			}
+			skipRule = ref.ruleIdx
 		}
 	}
 
@@ -809,26 +916,31 @@ func (ss *styleSheet) matchingPseudoElementDeclarations(n *html.Node, pseudo str
 	}
 	var matches []match
 
-	for _, rule := range ss.rules {
-		for _, sel := range rule.selectors {
-			if len(sel.parts) == 0 {
-				continue
-			}
-			last := sel.parts[len(sel.parts)-1]
-			if last.pseudoElement != pseudo {
-				continue
-			}
-			// Match the selector against the node (ignoring the pseudoElement field in partMatches).
-			if selectorMatches(sel, n) {
-				for _, d := range rule.declarations {
-					spec := sel.specificity
-					if d.important {
-						spec += 1000
-					}
-					matches = append(matches, match{specificity: spec, decl: d})
+	refs := ss.candidateRefs(n)
+	skipRule := -1
+	for _, ref := range refs {
+		if ref.ruleIdx == skipRule {
+			continue
+		}
+		rule := &ss.rules[ref.ruleIdx]
+		sel := rule.selectors[ref.selIdx]
+		if len(sel.parts) == 0 {
+			continue
+		}
+		last := sel.parts[len(sel.parts)-1]
+		if last.pseudoElement != pseudo {
+			continue
+		}
+		// Match the selector against the node (ignoring the pseudoElement field in partMatches).
+		if selectorMatches(sel, n) {
+			for _, d := range rule.declarations {
+				spec := sel.specificity
+				if d.important {
+					spec += 1000
 				}
-				break
+				matches = append(matches, match{specificity: spec, decl: d})
 			}
+			skipRule = ref.ruleIdx
 		}
 	}
 

--- a/html/css_index_test.go
+++ b/html/css_index_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	xhtml "golang.org/x/net/html"
+)
+
+// referenceMatchingDeclarations is a copy of matchingDeclarations' original
+// linear scan, kept as a reference to prove the indexed version produces
+// identical output for every node.
+func referenceMatchingDeclarations(ss *styleSheet, n *xhtml.Node) []cssDecl {
+	if ss == nil || len(ss.rules) == 0 {
+		return nil
+	}
+	type match struct {
+		specificity int
+		decl        cssDecl
+	}
+	var matches []match
+	for _, rule := range ss.rules {
+		for _, sel := range rule.selectors {
+			if len(sel.parts) > 0 && sel.parts[len(sel.parts)-1].pseudoElement != "" {
+				continue
+			}
+			if selectorMatches(sel, n) {
+				for _, d := range rule.declarations {
+					spec := sel.specificity
+					if d.important {
+						spec += 1000
+					}
+					matches = append(matches, match{specificity: spec, decl: d})
+				}
+				break
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	for i := 1; i < len(matches); i++ {
+		for j := i; j > 0 && matches[j].specificity < matches[j-1].specificity; j-- {
+			matches[j], matches[j-1] = matches[j-1], matches[j]
+		}
+	}
+	var result []cssDecl
+	for _, m := range matches {
+		result = append(result, m.decl)
+	}
+	return result
+}
+
+// referenceMatchingPseudoElementDeclarations mirrors
+// matchingPseudoElementDeclarations' original linear scan.
+func referenceMatchingPseudoElementDeclarations(ss *styleSheet, n *xhtml.Node, pseudo string) []cssDecl {
+	if ss == nil || len(ss.rules) == 0 {
+		return nil
+	}
+	type match struct {
+		specificity int
+		decl        cssDecl
+	}
+	var matches []match
+	for _, rule := range ss.rules {
+		for _, sel := range rule.selectors {
+			if len(sel.parts) == 0 {
+				continue
+			}
+			last := sel.parts[len(sel.parts)-1]
+			if last.pseudoElement != pseudo {
+				continue
+			}
+			if selectorMatches(sel, n) {
+				for _, d := range rule.declarations {
+					spec := sel.specificity
+					if d.important {
+						spec += 1000
+					}
+					matches = append(matches, match{specificity: spec, decl: d})
+				}
+				break
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	for i := 1; i < len(matches); i++ {
+		for j := i; j > 0 && matches[j].specificity < matches[j-1].specificity; j-- {
+			matches[j], matches[j-1] = matches[j-1], matches[j]
+		}
+	}
+	var result []cssDecl
+	for _, m := range matches {
+		result = append(result, m.decl)
+	}
+	return result
+}
+
+// walkElements calls fn for every element node in the tree.
+func walkElements(n *xhtml.Node, fn func(*xhtml.Node)) {
+	if n.Type == xhtml.ElementNode {
+		fn(n)
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		walkElements(c, fn)
+	}
+}
+
+// TestMatchingDeclarationsIndexEquivalence covers the selector shapes and
+// cascade edge cases the rightmost-selector index must not disturb: bucket
+// kinds (id/class/tag/universal), combinators, first-selector-wins within a
+// rule, document-order tie-breaks, !important, pseudo-elements, case
+// sensitivity, and duplicate node classes.
+func TestMatchingDeclarationsIndexEquivalence(t *testing.T) {
+	css := `
+		#title { color: red; }
+		.highlight { background: yellow; }
+		p { margin: 1px; }
+		* { box-sizing: border-box; }
+		p.note#x { padding: 2px; }
+		div p { color: green; }
+		div > p { color: blue; }
+		h1 + p { color: purple; }
+		h1 ~ p { color: orange; }
+		p, .highlight { font-weight: bold; }
+		span.second-only { color: pink; }
+		p.tie { border: 1px solid black; }
+		p.tie2 { border: 2px solid black; }
+		p.important-case { color: black !important; }
+		:first-child { text-decoration: underline; }
+		[data-x] { outline: 1px dotted; }
+		p::before { content: "before"; }
+		.a { color: cyan; }
+	`
+	docHTML := `<!DOCTYPE html><html><body>
+		<p id="title" class="note x">title</p>
+		<p id="x" class="note">note</p>
+		<div><p>nested</p></div>
+		<div><p class="direct">direct child</p></div>
+		<h1>heading</h1>
+		<p>after h1</p>
+		<p class="highlight">both selectors match</p>
+		<span class="second-only">second selector only</span>
+		<p class="tie tie2">tie break</p>
+		<P CLASS="Highlight" id="Title">case test</P>
+		<div id="empty"></div>
+		<p data-x="1">attr only</p>
+		<p class="a a">duplicate class</p>
+	</body></html>`
+
+	doc, err := xhtml.Parse(strings.NewReader(docHTML))
+	if err != nil {
+		t.Fatalf("parse doc: %v", err)
+	}
+
+	ss := &styleSheet{}
+	ss.parseCSS(css, "")
+
+	var checked int
+	walkElements(doc, func(n *xhtml.Node) {
+		checked++
+		got := ss.matchingDeclarations(n)
+		want := referenceMatchingDeclarations(ss, n)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("matchingDeclarations mismatch for <%s id=%q class=%q>:\n got:  %+v\n want: %+v",
+				n.Data, nodeAttr(n, "id"), nodeAttr(n, "class"), got, want)
+		}
+
+		for _, pseudo := range []string{"before", "after"} {
+			gotPE := ss.matchingPseudoElementDeclarations(n, pseudo)
+			wantPE := referenceMatchingPseudoElementDeclarations(ss, n, pseudo)
+			if !reflect.DeepEqual(gotPE, wantPE) {
+				t.Errorf("matchingPseudoElementDeclarations(%q) mismatch for <%s>:\n got:  %+v\n want: %+v",
+					pseudo, n.Data, gotPE, wantPE)
+			}
+		}
+	})
+	if checked == 0 {
+		t.Fatal("no element nodes walked")
+	}
+}
+
+// TestMatchingDeclarationsPseudoElementExcluded locks that a ::before rule
+// is excluded from matchingDeclarations and returned only by
+// matchingPseudoElementDeclarations(n, "before").
+func TestMatchingDeclarationsPseudoElementExcluded(t *testing.T) {
+	ss := &styleSheet{}
+	ss.parseCSS(`p::before { content: "x"; } p { color: red; }`, "")
+
+	doc, err := xhtml.Parse(strings.NewReader(`<p>text</p>`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var p *xhtml.Node
+	walkElements(doc, func(n *xhtml.Node) {
+		if n.Data == "p" {
+			p = n
+		}
+	})
+	if p == nil {
+		t.Fatal("no <p> found")
+	}
+
+	decls := ss.matchingDeclarations(p)
+	for _, d := range decls {
+		if d.property == "content" {
+			t.Errorf("matchingDeclarations must not include ::before declarations, got %+v", decls)
+		}
+	}
+
+	before := ss.matchingPseudoElementDeclarations(p, "before")
+	if len(before) != 1 || before[0].property != "content" {
+		t.Errorf("matchingPseudoElementDeclarations(before) = %+v, want [content]", before)
+	}
+}
+
+// TestMatchingDeclarationsFirstSelectorWins locks that within a single
+// rule, the first written selector that matches contributes the
+// declarations — the winning selector's own specificity is used even
+// though a later selector in the same rule would also match.
+func TestMatchingDeclarationsFirstSelectorWins(t *testing.T) {
+	ss := &styleSheet{}
+	ss.parseCSS(`p, .highlight { font-weight: bold; }`, "")
+	doc, err := xhtml.Parse(strings.NewReader(`<p class="highlight">x</p>`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var p *xhtml.Node
+	walkElements(doc, func(n *xhtml.Node) {
+		if n.Data == "p" {
+			p = n
+		}
+	})
+	got := ss.matchingDeclarations(p)
+	want := referenceMatchingDeclarations(ss, p)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 declaration (rule matched once), got %d: %+v", len(got), got)
+	}
+}
+
+// TestMatchingDeclarationsIndexRebuildsAfterAppend locks the lazy rebuild
+// guard: rules appended to ss.rules after a first query must be visible to
+// subsequent queries.
+func TestMatchingDeclarationsIndexRebuildsAfterAppend(t *testing.T) {
+	ss := &styleSheet{}
+	ss.parseCSS(`p { color: red; }`, "")
+
+	doc, err := xhtml.Parse(strings.NewReader(`<p>x</p>`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var p *xhtml.Node
+	walkElements(doc, func(n *xhtml.Node) {
+		if n.Data == "p" {
+			p = n
+		}
+	})
+
+	first := ss.matchingDeclarations(p)
+	if len(first) != 1 {
+		t.Fatalf("expected 1 declaration before append, got %d", len(first))
+	}
+
+	extra := &styleSheet{}
+	extra.parseCSS(`p { font-size: 12px; }`, "")
+	ss.rules = append(ss.rules, extra.rules...)
+
+	second := ss.matchingDeclarations(p)
+	if len(second) != 2 {
+		t.Fatalf("expected 2 declarations after append, got %d: %+v", len(second), second)
+	}
+}


### PR DESCRIPTION
## Summary

CSS matching scanned every rule for every element (O(rules × elements)). On large stylesheets this dominates conversion time.

## Change

Build an index bucketing rules by their rightmost simple selector (id / class / tag / universal); matching only visits candidate rules for an element. Both `matchingDeclarations` and `matchingPseudoElementDeclarations` iterate candidates, preserving the original first-selector-wins `break` and document-order tie-break semantics exactly.

## Equivalence

`css_index_test.go` keeps verbatim copies of the pre-change linear-scan functions and asserts `reflect.DeepEqual` between indexed and reference output at every node of a document, across all combinators, `!important`, pseudo-class/attribute/pseudo-element selectors, class case-insensitivity vs id case-sensitivity, and the lazy-rebuild-after-append guard. Existing golden byte-output tests are unchanged.

## Benchmark (300 rules / 600 elements)

~35.4ms → ~28.8ms/op (~19% faster), ~307k → ~187k allocs/op (~39% fewer).