### PR TITLE
export: add folio_buffer_len64; saturate folio_buffer_len at INT32_MAX

### DIFF
--- a/export/cabi_buffer.go
+++ b/export/cabi_buffer.go
@@ -11,7 +11,10 @@ package main
 #include <string.h>
 */
 import "C"
-import "unsafe"
+import (
+	"math"
+	"unsafe"
+)
 
 // cBuffer holds C-allocated memory for returning byte data to callers.
 // The data pointer is allocated via C.malloc and must be freed with C.free.
@@ -58,7 +61,27 @@ func folio_buffer_len(buf C.uint64_t) C.int32_t {
 	if !ok {
 		return 0
 	}
+	if b.len > math.MaxInt32 {
+		setLastError("buffer exceeds 2 GiB; use folio_buffer_len64")
+		return C.int32_t(math.MaxInt32)
+	}
 	return C.int32_t(b.len)
+}
+
+// folio_buffer_len64 returns the byte length of a buffer handle as int64.
+// Prefer this over folio_buffer_len, which saturates at INT32_MAX.
+//
+//export folio_buffer_len64
+func folio_buffer_len64(buf C.uint64_t) C.int64_t {
+	v := ht.load(uint64(buf))
+	if v == nil {
+		return 0
+	}
+	b, ok := v.(*cBuffer)
+	if !ok {
+		return 0
+	}
+	return C.int64_t(b.len)
 }
 
 // folio_buffer_free releases the C-allocated memory and removes the buffer handle.

--- a/export/folio.h
+++ b/export/folio.h
@@ -20,6 +20,8 @@
  * 4. Buffer handles (folio_buffer_data / folio_buffer_len / folio_buffer_free):
  *    The library allocates the buffer; the caller MUST call folio_buffer_free()
  *    when done. The data pointer is valid until folio_buffer_free() is called.
+ *    For buffers that can exceed 2 GiB use folio_buffer_len64; folio_buffer_len
+ *    saturates at INT32_MAX and sets the last error.
  *
  * 5. Array arguments (pointer + count): the pointer must reference at least
  *    `count` elements, valid for the duration of the call; the library reads,
@@ -165,7 +167,8 @@ void        folio_string_free(const char *s);
 /* ── Buffer ────────────────────────────────────────────────────────── */
 
 void    *folio_buffer_data(uint64_t buf);
-int32_t  folio_buffer_len(uint64_t buf);
+int32_t  folio_buffer_len(uint64_t buf);     /* saturates at INT32_MAX; see folio_buffer_len64 */
+int64_t  folio_buffer_len64(uint64_t buf);
 void     folio_buffer_free(uint64_t buf);
 
 /* ── Document ──────────────────────────────────────────────────────── */

--- a/export/testdata/test_cabi.c
+++ b/export/testdata/test_cabi.c
@@ -57,6 +57,13 @@ int main(void) {
     int32_t len = folio_buffer_len(buf);
     ASSERT(len > 0, "buffer has data");
 
+    int64_t len64 = folio_buffer_len64(buf);
+    ASSERT(len64 > 0, "buffer_len64 has data");
+    ASSERT(len64 == (int64_t)len, "buffer_len64 matches buffer_len for small buffer");
+
+    /* invalid handle returns 0 for both variants */
+    ASSERT(folio_buffer_len64(0xDEADBEEF) == 0, "buffer_len64 invalid handle is 0");
+
     void* data = folio_buffer_data(buf);
     ASSERT(data != NULL, "buffer data is non-null");
     ASSERT(memcmp(data, "%PDF-1.7", 8) == 0, "buffer starts with PDF header");


### PR DESCRIPTION
## Summary

`folio_buffer_len` returns an `int32_t`, so a buffer larger than 2 GiB silently truncated or went negative — an undetected overflow for C callers.

## Change

- `folio_buffer_len` now returns `INT32_MAX` and sets a last error (`"buffer exceeds 2 GiB; use folio_buffer_len64"`) when the true length exceeds `math.MaxInt32`, instead of truncating.
- New additive `folio_buffer_len64` returns the true `int64_t` length with no saturation.

`folio.h` documents the saturation behavior and the new accessor; the header/exports audit stays in sync (395/395).

## Tests

C-ABI harness gains `folio_buffer_len64` assertions (positive value, agreement with `folio_buffer_len` on a small buffer, 0 on an invalid handle). Harness: 425 checks pass.