### PR TITLE
font: parse descriptor metrics at face construction

### DIFF
--- a/font/truetype.go
+++ b/font/truetype.go
@@ -25,6 +25,14 @@ type sfntFace struct {
 	pf      *parsedFont
 	rawData []byte
 
+	// Descriptor metrics decoded once at construction (immutable after
+	// ParseTTF): italicAngle and fixedPitch from the raw post table,
+	// stemV and serif from the raw OS/2 table.
+	italicAngle float64
+	stemV       int
+	fixedPitch  bool
+	serif       bool
+
 	// Cached GSUB substitution tables. gsubOnce guards the single parse,
 	// covering both "parsed and empty" (gsubResult nil) and populated.
 	gsubResult *GSUBSubstitutions
@@ -58,10 +66,59 @@ func ParseTTF(data []byte) (Face, error) {
 	if err != nil {
 		return nil, fmt.Errorf("font: parse font: %w", err)
 	}
+	post := pf.rawTables["post"]
+	os2 := pf.rawTables["OS/2"]
 	return &sfntFace{
-		pf:      pf,
-		rawData: data,
+		pf:          pf,
+		rawData:     data,
+		italicAngle: postItalicAngle(post),
+		stemV:       os2StemV(os2),
+		fixedPitch:  postIsFixedPitch(post),
+		serif:       os2IsSerif(os2),
 	}, nil
+}
+
+// postItalicAngle parses the post table's Fixed 16.16 italic angle
+// field at offset 4. Returns 0 if post is missing or too short.
+func postItalicAngle(post []byte) float64 {
+	if len(post) < 8 {
+		return 0
+	}
+	raw := binary.BigEndian.Uint32(post[4:8])
+	intPart := int16(raw >> 16)
+	fracPart := float64(raw&0xFFFF) / 65536.0
+	return float64(intPart) + fracPart
+}
+
+// postIsFixedPitch checks the post table isFixedPitch field (offset 12).
+func postIsFixedPitch(post []byte) bool {
+	if len(post) < 16 {
+		return false
+	}
+	return binary.BigEndian.Uint32(post[12:16]) != 0
+}
+
+// os2StemV derives the dominant vertical stem width from the OS/2
+// usWeightClass using the formula 10 + 220*(weightClass-50)/900,
+// clamped to a minimum of 10. Returns 80 as a fallback if OS/2 is
+// missing.
+func os2StemV(os2 []byte) int {
+	if len(os2) < 6 {
+		return 80
+	}
+	weightClass := int(binary.BigEndian.Uint16(os2[4:6]))
+	stemV := int(math.Round(10 + 220*float64(weightClass-50)/900))
+	return max(stemV, 10)
+}
+
+// os2IsSerif checks the OS/2 sFamilyClass field (offset 30-31).
+// Family classes 1-5 and 7 indicate serif fonts.
+func os2IsSerif(os2 []byte) bool {
+	if len(os2) < 32 {
+		return false
+	}
+	class := int(int16(binary.BigEndian.Uint16(os2[30:32]))) >> 8 // high byte is class ID
+	return class >= 1 && class <= 5 || class == 7
 }
 
 // LoadTTF reads and parses a TrueType font file from disk.
@@ -149,18 +206,11 @@ func (f *sfntFace) BBox() [4]int {
 	}
 }
 
-// ItalicAngle returns the italic angle by parsing the post table's
-// Fixed 16.16 field at offset 4. Returns 0 if the post table is
-// missing or too short.
+// ItalicAngle returns the italic angle, decoded at construction from
+// the post table's Fixed 16.16 field at offset 4 (0 if post was
+// missing or too short).
 func (f *sfntFace) ItalicAngle() float64 {
-	post, ok := f.pf.rawTables["post"]
-	if !ok || len(post) < 8 {
-		return 0
-	}
-	raw := binary.BigEndian.Uint32(post[4:8])
-	intPart := int16(raw >> 16)
-	fracPart := float64(raw&0xFFFF) / 65536.0
-	return float64(intPart) + fracPart
+	return f.italicAngle
 }
 
 // CapHeight returns the cap height from the OS/2 table. Requires
@@ -172,18 +222,12 @@ func (f *sfntFace) CapHeight() int {
 	return int(f.pf.os2.sCapHeight)
 }
 
-// StemV derives the dominant vertical stem width from the OS/2
-// usWeightClass using the formula 10 + 220*(weightClass-50)/900,
-// clamped to a minimum of 10. Returns 80 as a fallback if the OS/2
-// table is missing.
+// StemV returns the dominant vertical stem width, decoded at
+// construction from the OS/2 usWeightClass using the formula
+// 10 + 220*(weightClass-50)/900, clamped to a minimum of 10 (80 as a
+// fallback if OS/2 was missing).
 func (f *sfntFace) StemV() int {
-	os2, ok := f.pf.rawTables["OS/2"]
-	if !ok || len(os2) < 6 {
-		return 80
-	}
-	weightClass := int(binary.BigEndian.Uint16(os2[4:6]))
-	stemV := int(math.Round(10 + 220*float64(weightClass-50)/900))
-	return max(stemV, 10)
+	return f.stemV
 }
 
 // Kern returns the kerning adjustment between two glyphs. GPOS
@@ -240,24 +284,16 @@ func (f *sfntFace) Flags() uint32 {
 	return flags
 }
 
-// isFixedPitch checks the post table isFixedPitch field (offset 12).
+// isFixedPitch reports the post table isFixedPitch field, decoded at
+// construction.
 func (f *sfntFace) isFixedPitch() bool {
-	post, ok := f.pf.rawTables["post"]
-	if !ok || len(post) < 16 {
-		return false
-	}
-	return binary.BigEndian.Uint32(post[12:16]) != 0
+	return f.fixedPitch
 }
 
-// isSerif checks the OS/2 sFamilyClass field (offset 30-31).
-// Family classes 1-5 and 7 indicate serif fonts.
+// isSerif reports the OS/2 sFamilyClass classification, decoded at
+// construction.
 func (f *sfntFace) isSerif() bool {
-	os2, ok := f.pf.rawTables["OS/2"]
-	if !ok || len(os2) < 32 {
-		return false
-	}
-	class := int(int16(binary.BigEndian.Uint16(os2[30:32]))) >> 8 // high byte is class ID
-	return class >= 1 && class <= 5 || class == 7
+	return f.serif
 }
 
 // isItalicFromOS2 checks OS/2 fsSelection bit 0 (Italic).

--- a/font/truetype_test.go
+++ b/font/truetype_test.go
@@ -226,6 +226,94 @@ func TestStemV(t *testing.T) {
 	}
 }
 
+func TestPostItalicAngle(t *testing.T) {
+	tests := []struct {
+		name string
+		post []byte
+		want float64
+	}{
+		{"nil", nil, 0},
+		{"too short", make([]byte, 7), 0},
+		{"zero angle", make([]byte, 8), 0},
+		{"-12.5 degrees", []byte{0, 0, 0, 0, 0xFF, 0xF3, 0x80, 0x00}, -12.5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := postItalicAngle(tt.post); got != tt.want {
+				t.Errorf("postItalicAngle(%v) = %f, want %f", tt.post, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostIsFixedPitch(t *testing.T) {
+	nonZero := make([]byte, 16)
+	nonZero[12] = 1
+	tests := []struct {
+		name string
+		post []byte
+		want bool
+	}{
+		{"nil", nil, false},
+		{"zero", make([]byte, 16), false},
+		{"nonzero", nonZero, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := postIsFixedPitch(tt.post); got != tt.want {
+				t.Errorf("postIsFixedPitch(%v) = %v, want %v", tt.post, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOS2StemV(t *testing.T) {
+	tests := []struct {
+		name string
+		os2  []byte
+		want int
+	}{
+		{"nil", nil, 80},
+		{"too short", make([]byte, 5), 80},
+		{"weight 400", []byte{0, 0, 0, 0, 0x01, 0x90}, 96},
+		{"weight 0 clamps to 10", make([]byte, 6), 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := os2StemV(tt.os2); got != tt.want {
+				t.Errorf("os2StemV(%v) = %d, want %d", tt.os2, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOS2IsSerif(t *testing.T) {
+	classBytes := func(class byte) []byte {
+		b := make([]byte, 32)
+		b[30] = class
+		return b
+	}
+	tests := []struct {
+		name string
+		os2  []byte
+		want bool
+	}{
+		{"nil", nil, false},
+		{"class 1", classBytes(1), true},
+		{"class 5", classBytes(5), true},
+		{"class 7", classBytes(7), true},
+		{"class 8", classBytes(8), false},
+		{"class 0", classBytes(0), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := os2IsSerif(tt.os2); got != tt.want {
+				t.Errorf("os2IsSerif(%v) = %v, want %v", tt.os2, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFaceInterface(t *testing.T) {
 	// Verify sfntFace implements Face at compile time
 	face := loadTestFace(t)


### PR DESCRIPTION
## Summary

`ItalicAngle`, `StemV`, `isFixedPitch`, and `isSerif` re-parsed the raw `post`/`OS/2` tables on every call. This decodes them once when the face is constructed.

## Change

Add four fields to `sfntFace` decoded once in `ParseTTF` via free functions that are byte-for-byte copies of the previous method bodies (all bounds checks and fallbacks preserved). The four accessors become single field reads. No new lazy state is introduced (it composes with the existing `sync.Once` cache synchronization).

## Correctness

Existing metric tests report identical values (e.g. StemV 96); a full `go test ./... -race` run confirms byte-identical PDF output across the repo. New table-driven tests cover the extracted decoders' nil/short/edge cases.