### PR TITLE
test: escape U+200D as \u200d in emoji test literals (fix red CI on main)

### DIFF
--- a/font/metrics_characterization_test.go
+++ b/font/metrics_characterization_test.go
@@ -109,7 +109,7 @@ var characterizationCorpus = []string{
 	"éf",
 	"काख",
 	"\U0001F1FA\U0001F1F8\U0001F1E9\U0001F1EA",
-	"\U0001F469‍\U0001F4BB",
+	"\U0001F469\u200d\U0001F4BB",
 	"؀٢",
 	"ﺍﻠ",
 }

--- a/unicode/grapheme/grapheme_differential_test.go
+++ b/unicode/grapheme/grapheme_differential_test.go
@@ -21,7 +21,7 @@ func TestNextBreakMatchesBreaks(t *testing.T) {
 		"éf",
 		"काख",
 		"\U0001F1FA\U0001F1F8\U0001F1E9\U0001F1EA",
-		"\U0001F469‍\U0001F4BB",
+		"\U0001F469\u200d\U0001F4BB",
 		"؀٢",
 		"ﺍﻠ",
 		strings.Repeat("x", 65), // cross the ASCII fast path in Breaks


### PR DESCRIPTION
## Summary

`main` CI is red: staticcheck **ST1018** flags raw `U+200D` (zero-width joiner) characters embedded in the emoji test-string literals added in #396:

- `font/metrics_characterization_test.go:112`
- `unicode/grapheme/grapheme_differential_test.go:24`

`make check` does not run golangci-lint, so this passed local gating and CI only failed after merge.

## Change

Replace the raw ZWJ with the `‍` escape. The string value is byte-for-byte identical, so the tests are unchanged; golangci-lint is now clean and both packages' tests pass.

**Merge this first** to green `main`; the other open PRs need to be brought up to date afterward.