### PR TITLE
html, layout: add golden characterization corpus for style + paragraph geometry

### DIFF
--- a/html/style_golden_test.go
+++ b/html/style_golden_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+// checkGolden compares got against the committed golden file, or writes it
+// when UPDATE_GOLDEN is set. Regenerating goldens must never run in CI — a
+// stale-golden failure there is the safety net working as intended.
+func checkGolden(t *testing.T, name string, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", "style_golden", name+".golden")
+	if os.Getenv("UPDATE_GOLDEN") != "" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("missing golden %s — run UPDATE_GOLDEN=1 go test to create: %v", path, err)
+	}
+	if string(want) != got {
+		t.Errorf("golden mismatch for %s\n--- want\n%s\n--- got\n%s", name, want, got)
+	}
+}
+
+// f4 formats a float with fixed 4-decimal precision so goldens are stable
+// across architectures.
+func f4(v float64) string {
+	return strconv.FormatFloat(v, 'f', 4, 64)
+}
+
+// colorStr renders a layout.Color deterministically regardless of color
+// space.
+func colorStr(c layout.Color) string {
+	if c.Space == layout.ColorSpaceCMYK {
+		return fmt.Sprintf("cmyk(%s,%s,%s,%s)", f4(c.C), f4(c.M), f4(c.Y), f4(c.K))
+	}
+	return fmt.Sprintf("rgb(%s,%s,%s)", f4(c.R), f4(c.G), f4(c.B))
+}
+
+// newGoldenConverter builds a converter the same way ConvertFullWithContext
+// does (html/converter.go), minus font loading — the corpus uses no
+// @font-face — so computeElementStyle sees the exact same converter state
+// Convert would give it.
+func newGoldenConverter(t *testing.T, htmlStr string) (*converter, *html.Node, computedStyle) {
+	t.Helper()
+	var opts *Options
+	o := opts.defaults()
+
+	doc, err := html.Parse(strings.NewReader(htmlStr))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	budget := newAssetBudget(o.MaxTotalAssetBytes)
+	ss := parseStyleBlocks(doc, o, budget, func(string, error) {})
+
+	c := &converter{
+		opts:           o,
+		logger:         loggerOrDiscard(o.Logger),
+		rootFontSize:   o.DefaultFontSize,
+		sheet:          ss,
+		embeddedFonts:  make(map[string]*font.EmbeddedFont),
+		containerWidth: o.PageWidth,
+		counters:       make(map[string][]int),
+		budget:         budget,
+	}
+
+	root := defaultStyle()
+	root.FontSize = o.DefaultFontSize
+	return c, doc, root
+}
+
+// dumpStyles walks every element under <body>, threading each element's
+// computed style as its children's parent the same way walkChildren does,
+// and returns a deterministic text dump of the resolved styles.
+//
+// <html> and <body> are resolved (so a rule targeting them, or inheritance
+// through them, is honored) but not dumped — only their descendants are,
+// matching the corpus's focus on author content.
+func dumpStyles(t *testing.T, htmlStr string) string {
+	t.Helper()
+	c, doc, root := newGoldenConverter(t, htmlStr)
+
+	var htmlNode *html.Node
+	for n := doc.FirstChild; n != nil; n = n.NextSibling {
+		if n.Type == html.ElementNode && n.DataAtom == atom.Html {
+			htmlNode = n
+			break
+		}
+	}
+	if htmlNode == nil {
+		t.Fatal("no <html> element in parsed document")
+	}
+	htmlStyle := c.computeElementStyle(htmlNode, root)
+
+	body := findBodyNode(doc)
+	if body == nil {
+		t.Fatal("no <body> element in parsed document")
+	}
+	bodyStyle := c.computeElementStyle(body, htmlStyle)
+
+	var sb strings.Builder
+	var walk func(n *html.Node, parent computedStyle, depth int)
+	walk = func(n *html.Node, parent computedStyle, depth int) {
+		for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
+			if ch.Type != html.ElementNode {
+				continue
+			}
+			style := c.computeElementStyle(ch, parent)
+			writeStyleLine(t, &sb, ch.Data, style, depth)
+			walk(ch, style, depth+1)
+		}
+	}
+	walk(body, bodyStyle, 0)
+	return sb.String()
+}
+
+// writeStyleLine appends one deterministic dump line for style. Fields are
+// grouped and pipe-delimited so a diff pinpoints which subsystem changed.
+// A dumped value that is NaN/Inf, or a non-positive font size, is a product
+// bug this corpus exists to catch — fail loudly instead of pinning it.
+func writeStyleLine(t *testing.T, sb *strings.Builder, tag string, s computedStyle, depth int) {
+	t.Helper()
+	if s.FontSize <= 0 {
+		t.Fatalf("%s: non-positive font size %v", tag, s.FontSize)
+	}
+	for _, v := range []float64{s.FontSize, s.LineHeight, s.LetterSpacing, s.TextIndent} {
+		if v != v || v > 1e300 || v < -1e300 { // NaN or effectively Inf
+			t.Fatalf("%s: non-finite value in dumped style: %v", tag, v)
+		}
+	}
+
+	indent := strings.Repeat("  ", depth)
+	fmt.Fprintf(sb, "%s%s fontFamily=%s fontSize=%s weight=%d style=%s color=%s align=%d lineHeight=%s display=%s\n",
+		indent, tag, s.FontFamily, f4(s.FontSize), s.FontWeight, s.FontStyle, colorStr(s.Color), s.TextAlign, f4(s.LineHeight), s.Display)
+	fmt.Fprintf(sb, "%s  marginAt400=%s,%s,%s,%s paddingAt400=%s,%s,%s,%s borderW=%s,%s,%s,%s decoration=%d\n",
+		indent,
+		f4(s.MarginTopAt(400)), f4(s.MarginRightAt(400)), f4(s.MarginBottomAt(400)), f4(s.MarginLeftAt(400)),
+		f4(s.PaddingTopAt(400)), f4(s.PaddingRightAt(400)), f4(s.PaddingBottomAt(400)), f4(s.PaddingLeftAt(400)),
+		f4(s.BorderTopWidth), f4(s.BorderRightWidth), f4(s.BorderBottomWidth), f4(s.BorderLeftWidth),
+		s.TextDecoration)
+	fmt.Fprintf(sb, "%s  letterSpacing=%s textTransform=%s whiteSpace=%s textIndent=%s\n",
+		indent, f4(s.LetterSpacing), s.TextTransform, s.WhiteSpace, f4(s.TextIndent))
+	fmt.Fprintf(sb, "%s  flex: justify=%s alignItems=%s gap=%s\n",
+		indent, s.JustifyContent, s.AlignItems, f4(s.Gap))
+}
+
+// TestStyleGolden pins html/converter_style.go's end-to-end "HTML+CSS
+// snippet → computed style" behavior against a fixed corpus. This is the
+// behavior-preservation net for refactors of converter_style.go:
+// a golden diff here means observable style resolution changed.
+//
+// The At(400) columns pin the #269 lazy margin/padding resolution against
+// a fixed 400pt container width. As of Phase 4 (see html/style.go) the
+// legacy eagerly-resolved float fields no longer exist — only these
+// resolved-at-consumer-time values are dumped.
+func TestStyleGolden(t *testing.T) {
+	cases := []struct {
+		name string
+		html string
+	}{
+		{
+			name: "inline_style",
+			html: `<p style="color: #ff0000; font-size: 18px">x</p>`,
+		},
+		{
+			name: "class_selector",
+			html: `<style>.a { font-weight: bold }</style><p class="a">x</p>`,
+		},
+		{
+			name: "descendant_selector",
+			html: `<style>div p { color: blue }</style><div><p>x</p></div><p>y</p>`,
+		},
+		{
+			name: "specificity",
+			html: `<style>
+				p { color: green }
+				.b { color: blue }
+				#c { color: red }
+			</style><p id="c" class="b">x</p>`,
+		},
+		{
+			name: "inheritance",
+			html: `<style>.parent { font-size: 20px; color: #123456; margin: 10px }</style>` +
+				`<div class="parent"><p>child p</p><span>child span</span></div>`,
+		},
+		{
+			// Pins the #269 lazy-resolution mid-state: legacy float fields
+			// are gone, so the At(400) columns are the only observable
+			// resolution of %, em, rem and calc().
+			name: "relative_lengths",
+			html: `<div style="font-size: 20px">` +
+				`<p style="font-size: 2em; margin-left: 10%; padding-top: calc(10% + 5px)">x</p>` +
+				`<p style="font-size: 1.5rem">y</p>` +
+				`</div>`,
+		},
+		{
+			name: "shorthands",
+			html: `<p style="margin: 1px 2px 3px 4px; padding: 10px 20px; border: 1px solid red">x</p>`,
+		},
+		{
+			name: "css_variables",
+			html: `<style>:root { --c: green } p { color: var(--c) }</style><p>x</p>`,
+		},
+		{
+			name: "tag_defaults",
+			html: `<h1>a</h1><h2>b</h2><strong>c</strong><em>d</em><code>e</code>`,
+		},
+		{
+			name: "display_flex",
+			html: `<div style="display: flex; justify-content: space-between; align-items: center; gap: 8px">` +
+				`<span>a</span><span>b</span></div>`,
+		},
+		{
+			name: "text_properties",
+			html: `<p style="text-align: center; text-decoration: underline; letter-spacing: 2px; ` +
+				`text-transform: uppercase; white-space: pre">x</p>`,
+		},
+		{
+			// Two <style> blocks setting the same property — cascade order
+			// (not specificity) decides; the later declaration wins.
+			name: "conflicting_last_wins",
+			html: `<style>p { color: red }</style><style>p { color: blue }</style><p>x</p>`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dumpStyles(t, tc.html)
+			checkGolden(t, tc.name, got)
+		})
+	}
+}

--- a/html/testdata/style_golden/class_selector.golden
+++ b/html/testdata/style_golden/class_selector.golden
@@ -1,0 +1,4 @@
+p fontFamily=helvetica fontSize=12.0000 weight=700 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/conflicting_last_wins.golden
+++ b/html/testdata/style_golden/conflicting_last_wins.golden
@@ -1,0 +1,4 @@
+p fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,1.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/css_variables.golden
+++ b/html/testdata/style_golden/css_variables.golden
@@ -1,0 +1,4 @@
+p fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.5020,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/descendant_selector.golden
+++ b/html/testdata/style_golden/descendant_selector.golden
@@ -1,0 +1,12 @@
+div fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=0.0000,0.0000,0.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000
+  p fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,1.0000) align=0 lineHeight=1.2000 display=block
+    marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+    letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+    flex: justify=flex-start alignItems=stretch gap=0.0000
+p fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/display_flex.golden
+++ b/html/testdata/style_golden/display_flex.golden
@@ -1,0 +1,12 @@
+div fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=flex
+  marginAt400=0.0000,0.0000,0.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=space-between alignItems=center gap=6.0000
+  span fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=inline
+    marginAt400=0.0000,0.0000,0.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+    letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+    flex: justify=flex-start alignItems=stretch gap=0.0000
+  span fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=inline
+    marginAt400=0.0000,0.0000,0.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+    letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+    flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/inheritance.golden
+++ b/html/testdata/style_golden/inheritance.golden
@@ -1,0 +1,12 @@
+div fontFamily=helvetica fontSize=15.0000 weight=400 style=normal color=rgb(0.0706,0.2039,0.3373) align=0 lineHeight=1.2000 display=block
+  marginAt400=7.5000,7.5000,7.5000,7.5000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000
+  p fontFamily=helvetica fontSize=15.0000 weight=400 style=normal color=rgb(0.0706,0.2039,0.3373) align=0 lineHeight=1.2000 display=block
+    marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+    letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+    flex: justify=flex-start alignItems=stretch gap=0.0000
+  span fontFamily=helvetica fontSize=15.0000 weight=400 style=normal color=rgb(0.0706,0.2039,0.3373) align=0 lineHeight=1.2000 display=inline
+    marginAt400=0.0000,0.0000,0.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+    letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+    flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/inline_style.golden
+++ b/html/testdata/style_golden/inline_style.golden
@@ -1,0 +1,4 @@
+p fontFamily=helvetica fontSize=13.5000 weight=400 style=normal color=rgb(1.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/relative_lengths.golden
+++ b/html/testdata/style_golden/relative_lengths.golden
@@ -1,0 +1,12 @@
+div fontFamily=helvetica fontSize=15.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=0.0000,0.0000,0.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000
+  p fontFamily=helvetica fontSize=30.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+    marginAt400=12.0000,0.0000,12.0000,40.0000 paddingAt400=43.7500,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+    letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+    flex: justify=flex-start alignItems=stretch gap=0.0000
+  p fontFamily=helvetica fontSize=18.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+    marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+    letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+    flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/shorthands.golden
+++ b/html/testdata/style_golden/shorthands.golden
@@ -1,0 +1,4 @@
+p fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=0.7500,1.5000,2.2500,3.0000 paddingAt400=7.5000,15.0000,7.5000,15.0000 borderW=0.7500,0.7500,0.7500,0.7500 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/specificity.golden
+++ b/html/testdata/style_golden/specificity.golden
@@ -1,0 +1,4 @@
+p fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(1.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/tag_defaults.golden
+++ b/html/testdata/style_golden/tag_defaults.golden
@@ -1,0 +1,20 @@
+h1 fontFamily=helvetica fontSize=24.0000 weight=700 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=16.0800,0.0000,16.0800,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000
+h2 fontFamily=helvetica fontSize=18.0000 weight=700 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=block
+  marginAt400=14.9400,0.0000,14.9400,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000
+strong fontFamily=helvetica fontSize=12.0000 weight=700 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=inline
+  marginAt400=0.0000,0.0000,0.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000
+em fontFamily=helvetica fontSize=12.0000 weight=400 style=italic color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=inline
+  marginAt400=0.0000,0.0000,0.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000
+code fontFamily=courier fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=0 lineHeight=1.2000 display=inline
+  marginAt400=0.0000,0.0000,0.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=0
+  letterSpacing=0.0000 textTransform= whiteSpace= textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/html/testdata/style_golden/text_properties.golden
+++ b/html/testdata/style_golden/text_properties.golden
@@ -1,0 +1,4 @@
+p fontFamily=helvetica fontSize=12.0000 weight=400 style=normal color=rgb(0.0000,0.0000,0.0000) align=1 lineHeight=1.2000 display=block
+  marginAt400=12.0000,0.0000,12.0000,0.0000 paddingAt400=0.0000,0.0000,0.0000,0.0000 borderW=0.0000,0.0000,0.0000,0.0000 decoration=1
+  letterSpacing=1.5000 textTransform=uppercase whiteSpace=pre textIndent=0.0000
+  flex: justify=flex-start alignItems=stretch gap=0.0000

--- a/layout/paragraph_golden_test.go
+++ b/layout/paragraph_golden_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// checkGolden compares got against the committed golden file, or writes it
+// when UPDATE_GOLDEN is set. Regenerating goldens must never run in CI — a
+// stale-golden failure there is the safety net working as intended.
+func checkGolden(t *testing.T, name string, got string) {
+	t.Helper()
+	path := filepath.Join("testdata", "paragraph_golden", name+".golden")
+	if os.Getenv("UPDATE_GOLDEN") != "" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("missing golden %s — run UPDATE_GOLDEN=1 go test to create: %v", path, err)
+	}
+	if string(want) != got {
+		t.Errorf("golden mismatch for %s\n--- want\n%s\n--- got\n%s", name, want, got)
+	}
+}
+
+// f4 formats a float with fixed 4-decimal precision so goldens are stable
+// across architectures.
+func f4(v float64) string {
+	return strconv.FormatFloat(v, 'f', 4, 64)
+}
+
+// checkFinite fails the test if v is NaN/Inf — a dumped value like that is
+// a product bug this corpus exists to catch, not something to pin silently.
+func checkFinite(t *testing.T, label string, v float64) {
+	t.Helper()
+	if v != v || v > 1e300 || v < -1e300 {
+		t.Fatalf("%s: non-finite geometry value: %v", label, v)
+	}
+}
+
+// dumpLines renders the geometry of lines exactly as Layout produced them.
+func dumpLines(t *testing.T, sb *strings.Builder, lines []Line) {
+	t.Helper()
+	for i, line := range lines {
+		checkFinite(t, fmt.Sprintf("line %d width", i), line.Width)
+		checkFinite(t, fmt.Sprintf("line %d height", i), line.Height)
+		fmt.Fprintf(sb, "line %d: width=%s height=%s spaceW=%s isLast=%v align=%d spaceBefore=%s\n",
+			i, f4(line.Width), f4(line.Height), f4(line.SpaceW), line.IsLast, line.Align, f4(line.SpaceBefore))
+		for j, w := range line.Words {
+			checkFinite(t, fmt.Sprintf("line %d word %d width", i, j), w.Width)
+			if w.FontSize <= 0 {
+				t.Fatalf("line %d word %d: non-positive font size %v", i, j, w.FontSize)
+			}
+			fmt.Fprintf(sb, "  word %d: %q w=%s spaceAfter=%s fontSize=%s break=%v embedded=%v\n",
+				j, w.Text, f4(w.Width), f4(w.SpaceAfter), f4(w.FontSize), w.LineBreak, w.Embedded != nil)
+		}
+	}
+}
+
+// dumpParagraph lays out p at maxWidth and returns a deterministic
+// geometry dump: every line and word, followed by the width/height
+// summary trailer.
+func dumpParagraph(t *testing.T, p *Paragraph, maxWidth float64) string {
+	t.Helper()
+	var sb strings.Builder
+	lines := p.Layout(maxWidth)
+	dumpLines(t, &sb, lines)
+	fmt.Fprintf(&sb, "minWidth=%s maxWidth=%s measureHeight(W)=%s lines(W)=%d\n",
+		f4(p.MinWidth()), f4(p.MaxWidth()), f4(p.MeasureHeight(maxWidth)), p.MeasureLines(maxWidth))
+	return sb.String()
+}
+
+// TestParagraphGolden pins layout/paragraph.go's word-wrap and measurement
+// geometry against a fixed corpus of standard-font paragraphs. This is the
+// behavior-preservation net for refactors of paragraph.go: a
+// golden diff here means observable line-breaking or measurement changed.
+func TestParagraphGolden(t *testing.T) {
+	t.Run("simple_wrap", func(t *testing.T) {
+		p := NewParagraph("Hello World", font.Helvetica, 12)
+		checkGolden(t, "simple_wrap", dumpParagraph(t, p, 40))
+	})
+
+	t.Run("wide_single_line", func(t *testing.T) {
+		p := NewParagraph("Hello World", font.Helvetica, 12)
+		checkGolden(t, "wide_single_line", dumpParagraph(t, p, 500))
+	})
+
+	t.Run("justify", func(t *testing.T) {
+		p := NewParagraph("The quick brown fox jumps over the lazy dog. It runs fast.", font.Helvetica, 12)
+		p.SetAlign(AlignJustify)
+		checkGolden(t, "justify", dumpParagraph(t, p, 120))
+	})
+
+	t.Run("center_right", func(t *testing.T) {
+		// Width forces a two-line wrap so per-line Width differs between
+		// lines, not just the align tag.
+		const text = "The quick brown fox jumps"
+		var sb strings.Builder
+		fmt.Fprintln(&sb, "== AlignCenter ==")
+		center := NewParagraph(text, font.Helvetica, 12)
+		center.SetAlign(AlignCenter)
+		dumpLines(t, &sb, center.Layout(80))
+		fmt.Fprintln(&sb, "== AlignRight ==")
+		right := NewParagraph(text, font.Helvetica, 12)
+		right.SetAlign(AlignRight)
+		dumpLines(t, &sb, right.Layout(80))
+		checkGolden(t, "center_right", sb.String())
+	})
+
+	t.Run("long_word_break", func(t *testing.T) {
+		p := NewParagraph(strings.Repeat("x", 80), font.Helvetica, 12)
+		checkGolden(t, "long_word_break", dumpParagraph(t, p, 100))
+	})
+
+	t.Run("cjk_break", func(t *testing.T) {
+		// The only embeddable font fixture checked into the repo
+		// (font/testdata/synthetic_cjk.ttf) covers exactly ten CJK
+		// ideographs; see loadSyntheticCJKEmbedded's package comment in
+		// marginbox_embedded_glyph_issue328_test.go. Build the corpus
+		// string from that covered set so glyphs resolve to real GIDs
+		// instead of .notdef.
+		emb := loadSyntheticCJKEmbedded(t)
+		p := NewParagraphEmbedded("中华人民共和国是一个", emb, 12)
+		checkGolden(t, "cjk_break", dumpParagraph(t, p, 60))
+	})
+
+	t.Run("explicit_newlines", func(t *testing.T) {
+		p := NewParagraph("Line one\nLine two\nLine three", font.Helvetica, 12)
+		checkGolden(t, "explicit_newlines", dumpParagraph(t, p, 200))
+	})
+
+	t.Run("mixed_runs", func(t *testing.T) {
+		p := NewStyledParagraph(
+			TextRun{Text: "Big ", Font: font.TimesRoman, FontSize: 18},
+			TextRun{Text: "small text", Font: font.Courier, FontSize: 10},
+		)
+		checkGolden(t, "mixed_runs", dumpParagraph(t, p, 100))
+	})
+
+	t.Run("leading", func(t *testing.T) {
+		p := NewParagraph("Hello World", font.Helvetica, 12)
+		p.SetLeading(2.0)
+		checkGolden(t, "leading", dumpParagraph(t, p, 40))
+	})
+
+	t.Run("first_line_indent", func(t *testing.T) {
+		p := NewParagraph("The quick brown fox jumps over the lazy dog", font.Helvetica, 12)
+		p.SetFirstLineIndent(24)
+		checkGolden(t, "first_line_indent", dumpParagraph(t, p, 100))
+	})
+
+	t.Run("split_after_line", func(t *testing.T) {
+		p := NewParagraph("Hello World", font.Helvetica, 12)
+		head, tail := p.SplitAfterLine(1, 40)
+		var sb strings.Builder
+		fmt.Fprintln(&sb, "== head ==")
+		if head != nil {
+			dumpLines(t, &sb, head.Layout(40))
+		} else {
+			fmt.Fprintln(&sb, "<nil>")
+		}
+		fmt.Fprintln(&sb, "== tail ==")
+		if tail != nil {
+			dumpLines(t, &sb, tail.Layout(40))
+		} else {
+			fmt.Fprintln(&sb, "<nil>")
+		}
+		checkGolden(t, "split_after_line", sb.String())
+	})
+
+	t.Run("ellipsis", func(t *testing.T) {
+		p := NewParagraph("This text is far too long to fit on one line", font.Helvetica, 12)
+		p.SetEllipsis(true)
+		checkGolden(t, "ellipsis", dumpParagraph(t, p, 60))
+	})
+}

--- a/layout/testdata/paragraph_golden/center_right.golden
+++ b/layout/testdata/paragraph_golden/center_right.golden
@@ -1,0 +1,18 @@
+== AlignCenter ==
+line 0: width=51.7800 height=14.4000 spaceW=3.3360 isLast=false align=1 spaceBefore=0.0000
+  word 0: "The" w=20.6760 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "quick" w=27.7680 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 1: width=51.1200 height=14.4000 spaceW=3.3360 isLast=false align=1 spaceBefore=0.0000
+  word 0: "brown" w=32.4960 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "fox" w=15.2880 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 2: width=32.0040 height=14.4000 spaceW=3.3360 isLast=true align=1 spaceBefore=0.0000
+  word 0: "jumps" w=32.0040 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+== AlignRight ==
+line 0: width=51.7800 height=14.4000 spaceW=3.3360 isLast=false align=2 spaceBefore=0.0000
+  word 0: "The" w=20.6760 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "quick" w=27.7680 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 1: width=51.1200 height=14.4000 spaceW=3.3360 isLast=false align=2 spaceBefore=0.0000
+  word 0: "brown" w=32.4960 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "fox" w=15.2880 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 2: width=32.0040 height=14.4000 spaceW=3.3360 isLast=true align=2 spaceBefore=0.0000
+  word 0: "jumps" w=32.0040 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false

--- a/layout/testdata/paragraph_golden/cjk_break.golden
+++ b/layout/testdata/paragraph_golden/cjk_break.golden
@@ -1,0 +1,13 @@
+line 0: width=60.0000 height=14.4000 spaceW=0.0000 isLast=false align=0 spaceBefore=0.0000
+  word 0: "中" w=12.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=true
+  word 1: "华" w=12.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=true
+  word 2: "人" w=12.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=true
+  word 3: "民" w=12.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=true
+  word 4: "共" w=12.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=true
+line 1: width=60.0000 height=14.4000 spaceW=0.0000 isLast=true align=0 spaceBefore=0.0000
+  word 0: "和" w=12.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=true
+  word 1: "国" w=12.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=true
+  word 2: "是" w=12.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=true
+  word 3: "一" w=12.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=true
+  word 4: "个" w=12.0000 spaceAfter=12.0000 fontSize=12.0000 break=false embedded=true
+minWidth=120.0000 maxWidth=132.0000 measureHeight(W)=28.8000 lines(W)=2

--- a/layout/testdata/paragraph_golden/ellipsis.golden
+++ b/layout/testdata/paragraph_golden/ellipsis.golden
@@ -1,0 +1,4 @@
+line 0: width=54.9960 height=14.4000 spaceW=3.3360 isLast=true align=0 spaceBefore=0.0000
+  word 0: "This" w=22.6680 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "text..." w=28.9920 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+minWidth=22.6800 maxWidth=211.3920 measureHeight(W)=14.4000 lines(W)=1

--- a/layout/testdata/paragraph_golden/explicit_newlines.golden
+++ b/layout/testdata/paragraph_golden/explicit_newlines.golden
@@ -1,0 +1,10 @@
+line 0: width=46.0320 height=14.4000 spaceW=3.3360 isLast=false align=0 spaceBefore=0.0000
+  word 0: "Line" w=22.6800 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "one" w=20.0160 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 1: width=44.5680 height=14.4000 spaceW=3.3360 isLast=false align=0 spaceBefore=0.0000
+  word 0: "Line" w=22.6800 spaceAfter=3.3360 fontSize=12.0000 break=true embedded=false
+  word 1: "two" w=18.5520 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 2: width=53.3640 height=14.4000 spaceW=3.3360 isLast=true align=0 spaceBefore=0.0000
+  word 0: "Line" w=22.6800 spaceAfter=3.3360 fontSize=12.0000 break=true embedded=false
+  word 1: "three" w=27.3480 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+minWidth=52.0200 maxWidth=264.6840 measureHeight(W)=43.2000 lines(W)=3

--- a/layout/testdata/paragraph_golden/first_line_indent.golden
+++ b/layout/testdata/paragraph_golden/first_line_indent.golden
@@ -1,0 +1,13 @@
+line 0: width=51.7800 height=14.4000 spaceW=3.3360 isLast=false align=0 spaceBefore=0.0000
+  word 0: "The" w=20.6760 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "quick" w=27.7680 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 1: width=86.4600 height=14.4000 spaceW=3.3360 isLast=false align=0 spaceBefore=0.0000
+  word 0: "brown" w=32.4960 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "fox" w=15.2880 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 2: "jumps" w=32.0040 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 2: width=90.9000 height=14.4000 spaceW=3.3360 isLast=true align=0 spaceBefore=0.0000
+  word 0: "over" w=22.8600 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "the" w=16.6800 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 2: "lazy" w=21.3360 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 3: "dog" w=20.0160 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+minWidth=32.4960 maxWidth=239.1480 measureHeight(W)=43.2000 lines(W)=3

--- a/layout/testdata/paragraph_golden/justify.golden
+++ b/layout/testdata/paragraph_golden/justify.golden
@@ -1,0 +1,16 @@
+line 0: width=106.2360 height=14.4000 spaceW=3.3360 isLast=false align=3 spaceBefore=0.0000
+  word 0: "The" w=20.6760 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "quick" w=27.7680 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 2: "brown" w=32.4960 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 3: "fox" w=15.2880 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 1: width=102.8880 height=14.4000 spaceW=3.3360 isLast=false align=3 spaceBefore=0.0000
+  word 0: "jumps" w=32.0040 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "over" w=22.8600 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 2: "the" w=16.6800 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 3: "lazy" w=21.3360 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 2: width=85.8720 height=14.4000 spaceW=3.3360 isLast=true align=3 spaceBefore=0.0000
+  word 0: "dog." w=23.3520 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "It" w=6.6720 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 2: "runs" w=23.5200 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 3: "fast." w=22.3200 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+minWidth=32.4960 maxWidth=305.0040 measureHeight(W)=43.2000 lines(W)=3

--- a/layout/testdata/paragraph_golden/leading.golden
+++ b/layout/testdata/paragraph_golden/leading.golden
@@ -1,0 +1,5 @@
+line 0: width=27.3360 height=24.0000 spaceW=3.3360 isLast=false align=0 spaceBefore=0.0000
+  word 0: "Hello" w=27.3360 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 1: width=31.1520 height=24.0000 spaceW=3.3360 isLast=true align=0 spaceBefore=0.0000
+  word 0: "World" w=31.1520 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+minWidth=31.1520 maxWidth=65.1600 measureHeight(W)=48.0000 lines(W)=2

--- a/layout/testdata/paragraph_golden/long_word_break.golden
+++ b/layout/testdata/paragraph_golden/long_word_break.golden
@@ -1,0 +1,11 @@
+line 0: width=96.0000 height=14.4000 spaceW=0.0000 isLast=false align=0 spaceBefore=0.0000
+  word 0: "xxxxxxxxxxxxxxxx" w=96.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=false
+line 1: width=96.0000 height=14.4000 spaceW=0.0000 isLast=false align=0 spaceBefore=0.0000
+  word 0: "xxxxxxxxxxxxxxxx" w=96.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=false
+line 2: width=96.0000 height=14.4000 spaceW=0.0000 isLast=false align=0 spaceBefore=0.0000
+  word 0: "xxxxxxxxxxxxxxxx" w=96.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=false
+line 3: width=96.0000 height=14.4000 spaceW=0.0000 isLast=false align=0 spaceBefore=0.0000
+  word 0: "xxxxxxxxxxxxxxxx" w=96.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=false
+line 4: width=96.0000 height=14.4000 spaceW=0.0000 isLast=true align=0 spaceBefore=0.0000
+  word 0: "xxxxxxxxxxxxxxxx" w=96.0000 spaceAfter=0.0000 fontSize=12.0000 break=false embedded=false
+minWidth=480.0000 maxWidth=483.3360 measureHeight(W)=72.0000 lines(W)=5

--- a/layout/testdata/paragraph_golden/mixed_runs.golden
+++ b/layout/testdata/paragraph_golden/mixed_runs.golden
@@ -1,0 +1,5 @@
+line 0: width=90.5100 height=21.6000 spaceW=4.5000 isLast=true align=0 spaceBefore=0.0000
+  word 0: "Big" w=26.0100 spaceAfter=4.5000 fontSize=18.0000 break=false embedded=false
+  word 1: "small" w=30.0000 spaceAfter=6.0000 fontSize=10.0000 break=false embedded=false
+  word 2: "text" w=24.0000 spaceAfter=6.0000 fontSize=10.0000 break=false embedded=false
+minWidth=30.0000 maxWidth=96.5100 measureHeight(W)=21.6000 lines(W)=1

--- a/layout/testdata/paragraph_golden/simple_wrap.golden
+++ b/layout/testdata/paragraph_golden/simple_wrap.golden
@@ -1,0 +1,5 @@
+line 0: width=27.3360 height=14.4000 spaceW=3.3360 isLast=false align=0 spaceBefore=0.0000
+  word 0: "Hello" w=27.3360 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+line 1: width=31.1520 height=14.4000 spaceW=3.3360 isLast=true align=0 spaceBefore=0.0000
+  word 0: "World" w=31.1520 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+minWidth=31.1520 maxWidth=65.1600 measureHeight(W)=28.8000 lines(W)=2

--- a/layout/testdata/paragraph_golden/split_after_line.golden
+++ b/layout/testdata/paragraph_golden/split_after_line.golden
@@ -1,0 +1,6 @@
+== head ==
+line 0: width=27.3360 height=14.4000 spaceW=3.3360 isLast=true align=0 spaceBefore=0.0000
+  word 0: "Hello" w=27.3360 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+== tail ==
+line 0: width=31.1520 height=14.4000 spaceW=3.3360 isLast=true align=0 spaceBefore=0.0000
+  word 0: "World" w=31.1520 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false

--- a/layout/testdata/paragraph_golden/wide_single_line.golden
+++ b/layout/testdata/paragraph_golden/wide_single_line.golden
@@ -1,0 +1,4 @@
+line 0: width=61.8240 height=14.4000 spaceW=3.3360 isLast=true align=0 spaceBefore=0.0000
+  word 0: "Hello" w=27.3360 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+  word 1: "World" w=31.1520 spaceAfter=3.3360 fontSize=12.0000 break=false embedded=false
+minWidth=31.1520 maxWidth=65.1600 measureHeight(W)=14.4000 lines(W)=1


### PR DESCRIPTION
## Summary

Adds golden pins for HTML style resolution and paragraph geometry — a behavioral safety net for upcoming refactors (notably the god-file split) so any accidental change in computed style or line/word geometry fails loudly.

## Change (tests only)

- `html/style_golden_test.go` + 12 goldens: per-element computed style (font, size, weight/style, color, align, line-height, resolved margin/padding at a 400pt container, borders, decoration, letter-spacing/transform/white-space/indent, flex justify/align/gap) across inline/class/descendant/specificity/inheritance/relative-length/shorthand/variable/tag-default/flex cases.
- `layout/paragraph_golden_test.go` + 12 goldens: per-line and per-word geometry (width/height/space/align/isLast, word text/width/break/embedded) plus Min/Max width and measured height/lines, across wrap/justify/align/long-word/CJK/newline/mixed-run/leading/indent/split/ellipsis cases.

Deterministic (dumps assert non-NaN/Inf, run twice with identical output); no production code touched. Reuses the existing committed synthetic CJK font fixture — no new binaries.