### PR TITLE
examples: add CI test coverage for remaining examples (closes #231)

### DIFF
--- a/examples/fonts/main.go
+++ b/examples/fonts/main.go
@@ -25,6 +25,24 @@ import (
 )
 
 func main() {
+	doc, err := buildDocument()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "convert: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := doc.Save("fonts.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created fonts.pdf")
+}
+
+// buildDocument assembles the standard-fonts and discovered-custom-fonts
+// showcase and returns the ready-to-write Document. Extracted from
+// main() so the example test (main_test.go) can exercise the same
+// HTML-building pipeline against an in-memory buffer instead of disk.
+func buildDocument() (*document.Document, error) {
 	fonts := discoverFonts()
 
 	// Build @font-face rules and matching CSS classes.
@@ -83,10 +101,9 @@ hr { margin: 12px 0; }
 
 	htmlStr += `</body></html>`
 
-	result, err := html.ConvertFull(htmlStr, nil)
+	result, err := html.ConvertFull(htmlStr, &html.Options{AllowAbsolutePaths: true})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "convert: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
 	doc := document.NewDocument(document.PageSizeLetter)
@@ -97,11 +114,7 @@ hr { margin: 12px 0; }
 		doc.Add(e)
 	}
 
-	if err := doc.Save("fonts.pdf"); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("Created fonts.pdf")
+	return doc, nil
 }
 
 type fontEntry struct {

--- a/examples/fonts/main_test.go
+++ b/examples/fonts/main_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	folioFont "github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// examplePDFBytes runs the example's discovery + HTML + convert
+// pipeline once per test process and caches the result.
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	doc, err := buildDocument()
+	if err != nil {
+		panic("buildDocument: " + err.Error())
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+// TestFontsExampleProducesValidPDF asserts the example produces a
+// well-formed PDF of plausible size. This assertion needs no system
+// fonts: the standard-14 section renders regardless of what custom
+// fonts discoverFonts() finds.
+func TestFontsExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 2000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >2 KB", len(pdf))
+	}
+}
+
+// TestFontsExampleParsesAsValidPDF verifies the output is not just
+// header-shaped but actually parses: cross-reference table and page
+// tree both resolve.
+func TestFontsExampleParsesAsValidPDF(t *testing.T) {
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got < 1 {
+		t.Errorf("PageCount = %d, want >= 1", got)
+	}
+	title, author, _, _, _ := r.Info()
+	if title != "Folio Font Showcase" {
+		t.Errorf("/Info Title = %q, want %q", title, "Folio Font Showcase")
+	}
+	if author != "Folio" {
+		t.Errorf("/Info Author = %q, want %q", author, "Folio")
+	}
+}
+
+// TestFontsExampleStandardFontsEmbedded asserts the three standard-14
+// PDF fonts the example always exercises (Helvetica, Times, Courier)
+// appear as /BaseFont entries. These embed without any font file on
+// disk, so this must pass on every host, custom fonts or not.
+func TestFontsExampleStandardFontsEmbedded(t *testing.T) {
+	pdf := string(examplePDFBytes())
+	for _, marker := range []string{"/BaseFont /Helvetica", "/BaseFont /Times", "/BaseFont /Courier"} {
+		if !strings.Contains(pdf, marker) {
+			t.Errorf("no %q entry; standard-14 font section should always embed regardless of system fonts", marker)
+		}
+	}
+}
+
+// TestFontsExampleCustomFontsEmbedded mirrors the cjk example's
+// pattern: for each font discoverFonts() locates on this host, pin
+// that its PostScript name appears as a subset-prefixed /BaseFont in
+// the output. This is the assertion that would have caught the #391
+// regression where the example's @font-face rules used absolute paths
+// but did not opt into AllowAbsolutePaths, so no custom font embedded.
+// When discoverFonts() finds nothing (no candidate path exists on
+// this OS, e.g. Linux CI), the test skips rather than passing
+// vacuously — there is nothing font-specific to verify.
+func TestFontsExampleCustomFontsEmbedded(t *testing.T) {
+	fonts := discoverFonts()
+	if len(fonts) == 0 {
+		t.Skip("no custom fonts found on this host; skipping")
+	}
+
+	pdf := examplePDFBytes()
+	for _, f := range fonts {
+		face, err := folioFont.LoadFont(f.path)
+		if err != nil {
+			t.Fatalf("font.LoadFont(%q): %v", f.path, err)
+		}
+		ps := face.PostScriptName()
+		if ps == "" {
+			t.Fatalf("font at %q has empty PostScriptName; cannot pin embedding", f.path)
+		}
+		needle := []byte("+" + ps)
+		if !bytes.Contains(pdf, needle) {
+			t.Errorf("output PDF does not embed discovered font %q: looking for %q (subset of PostScriptName %q)", f.name, needle, ps)
+		}
+	}
+}

--- a/examples/forms/main.go
+++ b/examples/forms/main.go
@@ -30,6 +30,19 @@ import (
 )
 
 func main() {
+	doc := buildDocument()
+	if err := doc.Save("forms.pdf"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("Created forms.pdf — open in Adobe Acrobat to interact with fields")
+}
+
+// buildDocument assembles the example's AcroForm showcase and returns
+// the ready-to-write Document. Extracted from main() so the example
+// test (main_test.go) can exercise the same field-building pipeline
+// against an in-memory buffer instead of disk.
+func buildDocument() *document.Document {
 	doc := document.NewDocument(document.PageSizeLetter)
 	doc.Info.Title = "Folio Forms Showcase"
 	doc.Info.Author = "Folio"
@@ -170,11 +183,7 @@ func main() {
 
 	doc.SetAcroForm(form)
 
-	if err := doc.Save("forms.pdf"); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	fmt.Println("Created forms.pdf — open in Adobe Acrobat to interact with fields")
+	return doc
 }
 
 // rect creates a field rectangle [x1, y1, x2, y2].

--- a/examples/forms/main_test.go
+++ b/examples/forms/main_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// examplePDFBytes runs the example's field-building pipeline once per
+// test process and caches the result.
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	doc := buildDocument()
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+// TestFormsExampleProducesValidPDF asserts the example produces a
+// well-formed PDF of plausible size. The size floor catches the
+// regression where AcroForm assembly silently drops fields and writes
+// a near-empty file.
+func TestFormsExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 3000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >3 KB", len(pdf))
+	}
+}
+
+// TestFormsExampleHasAcroForm asserts the interactive form dictionary
+// is present. Without it, the fields would just be inert annotations
+// with no AcroForm root — the whole point of this example.
+func TestFormsExampleHasAcroForm(t *testing.T) {
+	pdf := string(examplePDFBytes())
+	if !strings.Contains(pdf, "/AcroForm") {
+		t.Fatal("no /AcroForm dictionary; doc.SetAcroForm(form) should register the interactive form root")
+	}
+}
+
+// TestFormsExampleFieldNamesPresent locks in every field name the
+// example registers via forms.New*Field. A regression that drops a
+// field from the AcroForm (e.g. a missed form.Add call) surfaces here
+// as a missing name, rather than only as a visual gap in the PDF.
+func TestFormsExampleFieldNamesPresent(t *testing.T) {
+	pdf := string(examplePDFBytes())
+	names := []string{
+		"fullName", "email", "password", "readonly", "comments",
+		"agreeTerms", "subscribe", "preference", "country", "languages",
+		"signature", "blue", "green",
+	}
+	for _, name := range names {
+		if !strings.Contains(pdf, "("+name+")") {
+			t.Errorf("field name %q not found in PDF; expected it in a /T (field name) entry", name)
+		}
+	}
+}
+
+// TestFormsExampleDistinctFieldTypesPresent asserts the three AcroForm
+// field-type families the example demonstrates (text, button/checkbox,
+// choice) all appear. This catches a regression where one whole field
+// category (e.g. all checkboxes) is silently mistyped or dropped.
+func TestFormsExampleDistinctFieldTypesPresent(t *testing.T) {
+	pdf := string(examplePDFBytes())
+	types := map[string]string{
+		"/FT /Tx":  "text fields (name, email, password, comments, ...)",
+		"/FT /Btn": "button fields (checkboxes, radio group)",
+		"/FT /Ch":  "choice fields (dropdown, list box)",
+	}
+	for marker, desc := range types {
+		if !strings.Contains(pdf, marker) {
+			t.Errorf("no %q field type marker found (%s)", marker, desc)
+		}
+	}
+}

--- a/examples/indic/main.go
+++ b/examples/indic/main.go
@@ -36,6 +36,19 @@ import (
 )
 
 func main() {
+	doc := buildDocument()
+	if err := doc.Save("indic.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created indic.pdf")
+}
+
+// buildDocument assembles the Indic shaping showcase and returns the
+// ready-to-write Document. Extracted from main() so the example test
+// (main_test.go) can exercise the same shaping pipeline against an
+// in-memory buffer instead of disk.
+func buildDocument() *document.Document {
 	doc := document.NewDocument(document.PageSizeLetter)
 	doc.Info.Title = "Indic Text Shaping"
 	doc.Info.Author = "Folio"
@@ -51,11 +64,7 @@ func main() {
 
 	devanagariSection(doc)
 
-	if err := doc.Save("indic.pdf"); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("Created indic.pdf")
+	return doc
 }
 
 // devanagariSection renders Devanagari paragraphs that exercise

--- a/examples/indic/main_test.go
+++ b/examples/indic/main_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+// examplePDFBytes runs the example's shaping pipeline once per test
+// process and caches the result.
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	doc := buildDocument()
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+// TestIndicExampleProducesValidPDF asserts the example produces a
+// well-formed PDF of plausible size. This needs no system font: the
+// intro paragraph renders in Helvetica regardless of what
+// loadDevanagariFont finds.
+func TestIndicExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 1500 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >1.5 KB", len(pdf))
+	}
+}
+
+// TestIndicExampleMetadataInInfoDict verifies the /Info dictionary
+// carries the Title/Author main() sets on the Document.
+func TestIndicExampleMetadataInInfoDict(t *testing.T) {
+	r := examplePDFReader(t)
+	title, author, _, _, _ := r.Info()
+	if title != "Indic Text Shaping" {
+		t.Errorf("/Info Title = %q, want %q", title, "Indic Text Shaping")
+	}
+	if author != "Folio" {
+		t.Errorf("/Info Author = %q, want %q", author, "Folio")
+	}
+}
+
+// TestIndicExampleDevanagariFontEmbedded mirrors the cjk example's
+// pattern: when loadDevanagariFont finds a usable system font, pin
+// that its PostScript name appears as a subset-prefixed /BaseFont in
+// the output — proof the shaping pipeline actually ran with an
+// embedded Devanagari-capable face, not just that the section's
+// static English fallback paragraph rendered. Skips (rather than
+// passing vacuously) when no such font exists on the host.
+func TestIndicExampleDevanagariFontEmbedded(t *testing.T) {
+	ef := loadDevanagariFont()
+	if ef == nil {
+		t.Skip("no Devanagari font found on this host; skipping")
+	}
+	ps := ef.Face().PostScriptName()
+	if ps == "" {
+		t.Fatal("Devanagari font has empty PostScriptName; cannot pin embedding")
+	}
+
+	pdf := examplePDFBytes()
+	needle := []byte("+" + ps)
+	if !bytes.Contains(pdf, needle) {
+		t.Errorf("output PDF does not embed the Devanagari font: looking for %q (subset of PostScriptName %q)", needle, ps)
+	}
+}

--- a/examples/invoice/main.go
+++ b/examples/invoice/main.go
@@ -171,9 +171,38 @@ const invoiceBody = `
 func main() {
 	flag.Parse()
 
+	doc, err := buildDocument(*useTailwind)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "AddHTML: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write PDF.
+	f, err := os.Create("invoice.pdf")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Create: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() { _ = f.Close() }()
+
+	n, err := doc.WriteTo(f)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WriteTo: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Generated invoice.pdf (%d bytes)\n", n)
+}
+
+// buildDocument assembles the invoice HTML (optionally pulling in the
+// Tailwind CDN stylesheet when useTailwind is true) and converts it
+// into a ready-to-write Document. Extracted from main() so the
+// example test (main_test.go) can exercise the offline (useTailwind
+// false) path directly, without opening a socket.
+func buildDocument(useTailwind bool) (*document.Document, error) {
 	// Build the full HTML document.
 	var cssBlock string
-	if *useTailwind {
+	if useTailwind {
 		// Tailwind v2 CDN: pre-built CSS with all utility classes (2.9MB).
 		// Tailwind v3+ requires a build step — no pre-built CDN file available.
 		cssBlock = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">`
@@ -198,8 +227,7 @@ func main() {
 		PageWidth:  document.PageSizeLetter.Width,
 		PageHeight: document.PageSizeLetter.Height,
 	}); err != nil {
-		fmt.Fprintf(os.Stderr, "AddHTML: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
 	// Footer with page numbers.
@@ -208,19 +236,5 @@ func main() {
 			SetAlign(layout.AlignCenter)
 	})
 
-	// Write PDF.
-	f, err := os.Create("invoice.pdf")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Create: %v\n", err)
-		os.Exit(1)
-	}
-	defer func() { _ = f.Close() }()
-
-	n, err := doc.WriteTo(f)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "WriteTo: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Printf("Generated invoice.pdf (%d bytes)\n", n)
+	return doc, nil
 }

--- a/examples/invoice/main_test.go
+++ b/examples/invoice/main_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+// examplePDFBytes runs the example's default (no --tailwind) pipeline
+// once per test process and caches the result. Passing false
+// explicitly (rather than reading the package-level flag) keeps the
+// test off the network regardless of how the test binary is invoked.
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	doc, err := buildDocument(false)
+	if err != nil {
+		panic("buildDocument: " + err.Error())
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+// TestInvoiceExampleProducesValidPDF asserts the default (offline)
+// path produces a well-formed PDF of plausible size. The size floor
+// catches the regression where the CSS grid/flexbox layout silently
+// collapses to near-empty output.
+func TestInvoiceExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 3000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >3 KB", len(pdf))
+	}
+}
+
+// TestInvoiceExampleOnePage asserts the invoice fits on a single
+// page, matching its documented one-page layout. A regression that
+// broke the flexbox/grid sizing could overflow content onto a
+// spurious second page.
+func TestInvoiceExampleOnePage(t *testing.T) {
+	r := examplePDFReader(t)
+	if got := r.PageCount(); got != 1 {
+		t.Errorf("PageCount = %d, want 1", got)
+	}
+}
+
+// TestInvoiceExampleMetadataFromDocument reads /Info directly rather
+// than grepping serialized bytes, since "FolioPDF Inc." also appears
+// in the rendered "From" card body text — a dropped /Info /Author
+// would slip past a substring-only check.
+func TestInvoiceExampleMetadataFromDocument(t *testing.T) {
+	r := examplePDFReader(t)
+	title, author, _, _, _ := r.Info()
+	if title != "Invoice INV-2026-0042" {
+		t.Errorf("/Info Title = %q, want %q", title, "Invoice INV-2026-0042")
+	}
+	if author != "FolioPDF Inc." {
+		t.Errorf("/Info Author = %q, want %q", author, "FolioPDF Inc.")
+	}
+}
+
+// TestInvoiceExampleContentPresent pins invoice-specific strings from
+// the example's embedded HTML: the invoice number, the line-item
+// table content, and the computed total. A regression in the HTML
+// converter that dropped table rows or the totals block would surface
+// here even though the PDF still "looks" valid structurally.
+func TestInvoiceExampleContentPresent(t *testing.T) {
+	page, err := examplePDFReader(t).Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	text, err := page.ExtractText()
+	if err != nil {
+		t.Fatalf("ExtractText: %v", err)
+	}
+	for _, want := range []string{"INV-2026-0042", "Growth Plan", "$413.10"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("page text does not contain %q; extracted text:\n%s", want, text)
+		}
+	}
+}
+
+// TestInvoiceExampleTailwindFlagDefaultsFalse guards the flag.Bool
+// default passed to useTailwind. If it ever flipped to true, a plain
+// `go run ./examples/invoice` (and this test's own buildDocument(false)
+// calls) would start fetching the Tailwind CDN stylesheet over the
+// network on every run.
+func TestInvoiceExampleTailwindFlagDefaultsFalse(t *testing.T) {
+	if *useTailwind {
+		t.Error("useTailwind flag defaults to true; the example's offline path must be the default")
+	}
+}

--- a/examples/optimize/main_test.go
+++ b/examples/optimize/main_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+// TestOptimizeExampleFixturesProduceValidPDFs runs the example's
+// writeAll pipeline (the same one main() drives) against every
+// fixture and asserts each of the five comparison outputs is a valid,
+// parseable PDF. A regression in any WriteOptions combination would
+// surface here rather than only in the printed byte-count table a
+// human has to eyeball.
+func TestOptimizeExampleFixturesProduceValidPDFs(t *testing.T) {
+	fixtures := []fixture{
+		{name: "text-heavy", build: textHeavy},
+		{name: "many empty pages", build: manyPages},
+		{name: "table-heavy", build: tableHeavy},
+		{name: "imported text-heavy", build: importedTextHeavy},
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.name, func(t *testing.T) {
+			def, packed, swept, recompress, full, err := writeAll(f)
+			if err != nil {
+				t.Fatalf("writeAll: %v", err)
+			}
+			for label, pdf := range map[string][]byte{
+				"default":     def,
+				"xref+obj":    packed,
+				"+sweep":      swept,
+				"+recompress": recompress,
+				"+full":       full,
+			} {
+				if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+					t.Errorf("%s: output does not start with %%PDF- header (got %q)", label, pdf[:min(8, len(pdf))])
+				}
+				if _, err := reader.Parse(pdf); err != nil {
+					t.Errorf("%s: reader.Parse failed: %v", label, err)
+				}
+			}
+		})
+	}
+}
+
+// TestOptimizeExampleFullNotLargerThanDefault pins the headline claim
+// the example's printed table exists to demonstrate: every lossless
+// toggle enabled (+full) must never produce a larger file than the
+// traditional writer (default). A regression that made optimization
+// pessimal for some fixture shape would invert this inequality.
+func TestOptimizeExampleFullNotLargerThanDefault(t *testing.T) {
+	fixtures := []fixture{
+		{name: "text-heavy", build: textHeavy},
+		{name: "many empty pages", build: manyPages},
+		{name: "table-heavy", build: tableHeavy},
+		{name: "imported text-heavy", build: importedTextHeavy},
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.name, func(t *testing.T) {
+			def, _, _, _, full, err := writeAll(f)
+			if err != nil {
+				t.Fatalf("writeAll: %v", err)
+			}
+			if len(full) > len(def) {
+				t.Errorf("+full (%d bytes) is larger than default (%d bytes); optimization regressed for %q", len(full), len(def), f.name)
+			}
+		})
+	}
+}
+
+// TestOptimizeExampleImportedFixtureRecompressionWins pins the
+// specific claim in the example's doc comment: imported documents
+// carry raw (uncompressed) content streams, so +recompress should
+// shrink them relative to the default writer. This is the scenario
+// where the optimizer's win is most visible, and a regression that
+// silently disabled recompression for imported pages would slip past
+// the more lenient "not larger" check in the sibling test.
+func TestOptimizeExampleImportedFixtureRecompressionWins(t *testing.T) {
+	def, _, _, recompress, _, err := writeAll(fixture{name: "imported text-heavy", build: importedTextHeavy})
+	if err != nil {
+		t.Fatalf("writeAll: %v", err)
+	}
+	if len(recompress) >= len(def) {
+		t.Errorf("+recompress (%d bytes) is not smaller than default (%d bytes) for the imported fixture; expected Flate recompression to shrink raw content streams", len(recompress), len(def))
+	}
+}
+
+// TestOptimizeExampleManyPagesFixtureHasFiftyPages sanity-checks the
+// manyPages fixture builder itself: a regression that changed the
+// loop bound or broke AddPage would silently alter the shape of the
+// page-tree-heavy comparison row.
+func TestOptimizeExampleManyPagesFixtureHasFiftyPages(t *testing.T) {
+	pdf, err := manyPages().ToBytes()
+	if err != nil {
+		t.Fatalf("ToBytes: %v", err)
+	}
+	r, err := reader.Parse(pdf)
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	if got := r.PageCount(); got != 50 {
+		t.Errorf("PageCount = %d, want 50", got)
+	}
+}

--- a/examples/rtl/main.go
+++ b/examples/rtl/main.go
@@ -48,6 +48,19 @@ import (
 )
 
 func main() {
+	doc := buildDocument()
+	if err := doc.Save("rtl.pdf"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Created rtl.pdf")
+}
+
+// buildDocument assembles the RTL/bidi/shaping showcase and returns
+// the ready-to-write Document. Extracted from main() so the example
+// test (main_test.go) can exercise the same pipeline against an
+// in-memory buffer instead of disk.
+func buildDocument() *document.Document {
 	doc := document.NewDocument(document.PageSizeLetter)
 	doc.Info.Title = "Right-To-Left Text"
 	doc.Info.Author = "Folio"
@@ -296,13 +309,7 @@ func main() {
 		doc.Add(mixed)
 	}
 
-	// --- Save ---
-
-	if err := doc.Save("rtl.pdf"); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println("Created rtl.pdf")
+	return doc
 }
 
 // makeParagraph creates a paragraph with either an embedded font or a

--- a/examples/rtl/main_test.go
+++ b/examples/rtl/main_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+// examplePDFBytes runs the example's font-discovery and layout
+// pipeline once per test process and caches the result.
+var examplePDFBytes = sync.OnceValue(func() []byte {
+	doc := buildDocument()
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+func examplePDFReader(t *testing.T) *reader.PdfReader {
+	t.Helper()
+	r, err := reader.Parse(examplePDFBytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r
+}
+
+// TestRTLExampleProducesValidPDF asserts the example produces a
+// well-formed PDF of plausible size. This needs no system fonts: the
+// section intros render in Helvetica via makeParagraph's nil-EmbeddedFont
+// fallback regardless of what Hebrew/Arabic fonts get discovered.
+func TestRTLExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFBytes()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 3000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >3 KB", len(pdf))
+	}
+}
+
+// TestRTLExampleMetadataInInfoDict verifies the /Info dictionary
+// carries the Title/Author main() sets on the Document.
+func TestRTLExampleMetadataInInfoDict(t *testing.T) {
+	r := examplePDFReader(t)
+	title, author, _, _, _ := r.Info()
+	if title != "Right-To-Left Text" {
+		t.Errorf("/Info Title = %q, want %q", title, "Right-To-Left Text")
+	}
+	if author != "Folio" {
+		t.Errorf("/Info Author = %q, want %q", author, "Folio")
+	}
+}
+
+// TestRTLExampleHebrewFontEmbedded mirrors the cjk example's pattern:
+// when loadHebrewFont finds a usable system font, pin that its
+// PostScript name appears as a subset-prefixed /BaseFont in the
+// output — proof the Hebrew bidi sections actually rendered with an
+// embedded face. Skips (rather than passing vacuously) when no
+// Hebrew-capable font exists on the host.
+func TestRTLExampleHebrewFontEmbedded(t *testing.T) {
+	ef := loadHebrewFont()
+	if ef == nil {
+		t.Skip("no Hebrew font found on this host; skipping")
+	}
+	ps := ef.Face().PostScriptName()
+	if ps == "" {
+		t.Fatal("Hebrew font has empty PostScriptName; cannot pin embedding")
+	}
+
+	pdf := examplePDFBytes()
+	needle := []byte("+" + ps)
+	if !bytes.Contains(pdf, needle) {
+		t.Errorf("output PDF does not embed the Hebrew font: looking for %q (subset of PostScriptName %q)", needle, ps)
+	}
+}
+
+// TestRTLExampleArabicFontEmbedded is the Arabic counterpart of
+// TestRTLExampleHebrewFontEmbedded, pinning the font that carries
+// contextual shaping, ligatures, GPOS mark attachment, and kashida
+// justification in sections 2-2c.
+func TestRTLExampleArabicFontEmbedded(t *testing.T) {
+	ef := loadArabicFont()
+	if ef == nil {
+		t.Skip("no Arabic font found on this host; skipping")
+	}
+	ps := ef.Face().PostScriptName()
+	if ps == "" {
+		t.Fatal("Arabic font has empty PostScriptName; cannot pin embedding")
+	}
+
+	pdf := examplePDFBytes()
+	needle := []byte("+" + ps)
+	if !bytes.Contains(pdf, needle) {
+		t.Errorf("output PDF does not embed the Arabic font: looking for %q (subset of PostScriptName %q)", needle, ps)
+	}
+}

--- a/examples/sign/main.go
+++ b/examples/sign/main.go
@@ -38,12 +38,53 @@ import (
 )
 
 func main() {
+	signed, err := buildSignedPDF()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// --- Step 4: Save ---
+	if err := os.WriteFile("signed.pdf", signed, 0644); err != nil {
+		fmt.Fprintln(os.Stderr, "save:", err)
+		os.Exit(1)
+	}
+
+	// --- Step 5: Verify the signed PDF is readable ---
+	r, err := reader.Parse(signed)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "verify parse:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("\nVerification:\n")
+	fmt.Printf("  Pages: %d\n", r.PageCount())
+	fmt.Printf("  Version: %s\n", r.Version())
+	title, author, _, _, _ := r.Info()
+	fmt.Printf("  Title: %s\n", title)
+	fmt.Printf("  Author: %s\n", author)
+
+	// Check for signature dictionary in the PDF.
+	if strings.Contains(string(signed), "/Type /Sig") {
+		fmt.Println("  Signature: present")
+	}
+	if strings.Contains(string(signed), "/ByteRange") {
+		fmt.Println("  ByteRange: present")
+	}
+
+	fmt.Println("\nCreated signed.pdf — open in Adobe Acrobat to view the signature panel")
+}
+
+// buildSignedPDF generates a self-signed certificate, builds a PDF
+// describing it, and signs the PDF with a PAdES B-B signature.
+// Extracted from main() so the example test (main_test.go) can
+// exercise the same certificate + sign pipeline against an in-memory
+// buffer instead of disk.
+func buildSignedPDF() ([]byte, error) {
 	// --- Step 1: Generate a self-signed certificate ---
 	fmt.Println("Generating RSA-2048 key pair and self-signed certificate...")
 	key, cert, err := generateCert()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "cert:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("cert: %w", err)
 	}
 	fmt.Printf("  Subject: %s\n", cert.Subject.CommonName)
 	fmt.Printf("  Valid:   %s to %s\n",
@@ -82,8 +123,7 @@ func main() {
 
 	var buf bytes.Buffer
 	if _, err := doc.WriteTo(&buf); err != nil {
-		fmt.Fprintln(os.Stderr, "write:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("write: %w", err)
 	}
 	fmt.Printf("  Unsigned PDF: %d bytes\n", buf.Len())
 
@@ -91,8 +131,7 @@ func main() {
 	fmt.Println("\nSigning with PAdES B-B (RSA + SHA-256)...")
 	signer, err := sign.NewLocalSigner(key, []*x509.Certificate{cert})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "signer:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("signer: %w", err)
 	}
 
 	signed, err := sign.SignPDF(buf.Bytes(), sign.Options{
@@ -104,40 +143,12 @@ func main() {
 		ContactInfo: "legal@example.com",
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "sign:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("sign: %w", err)
 	}
 	fmt.Printf("  Signed PDF: %d bytes (+%d bytes for signature)\n",
 		len(signed), len(signed)-buf.Len())
 
-	// --- Step 4: Save ---
-	if err := os.WriteFile("signed.pdf", signed, 0644); err != nil {
-		fmt.Fprintln(os.Stderr, "save:", err)
-		os.Exit(1)
-	}
-
-	// --- Step 5: Verify the signed PDF is readable ---
-	r, err := reader.Parse(signed)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "verify parse:", err)
-		os.Exit(1)
-	}
-	fmt.Printf("\nVerification:\n")
-	fmt.Printf("  Pages: %d\n", r.PageCount())
-	fmt.Printf("  Version: %s\n", r.Version())
-	title, author, _, _, _ := r.Info()
-	fmt.Printf("  Title: %s\n", title)
-	fmt.Printf("  Author: %s\n", author)
-
-	// Check for signature dictionary in the PDF.
-	if strings.Contains(string(signed), "/Type /Sig") {
-		fmt.Println("  Signature: present")
-	}
-	if strings.Contains(string(signed), "/ByteRange") {
-		fmt.Println("  ByteRange: present")
-	}
-
-	fmt.Println("\nCreated signed.pdf — open in Adobe Acrobat to view the signature panel")
+	return signed, nil
 }
 
 // generateCert creates a self-signed RSA certificate for demonstration.

--- a/examples/sign/main_test.go
+++ b/examples/sign/main_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+// exampleSignedPDF runs the example's certificate + sign pipeline
+// once per test process and caches the result. The pipeline generates
+// a fresh RSA-2048 key each run, so caching also keeps the test suite
+// from paying that cost once per assertion.
+var exampleSignedPDF = sync.OnceValue(func() []byte {
+	signed, err := buildSignedPDF()
+	if err != nil {
+		panic("buildSignedPDF: " + err.Error())
+	}
+	return signed
+})
+
+// TestSignExampleProducesValidPDF asserts the signed output is a
+// well-formed PDF of plausible size. The size floor catches the
+// regression where signing silently truncates the byte range or the
+// underlying document fails to render.
+func TestSignExampleProducesValidPDF(t *testing.T) {
+	pdf := exampleSignedPDF()
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 2000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >2 KB", len(pdf))
+	}
+}
+
+// TestSignExampleParsesAsValidPDF verifies the signed PDF is not just
+// header-shaped but actually parses: cross-reference table, page tree,
+// and /Info dictionary all resolve. A signature that corrupts the
+// byte range or trailer would otherwise still pass the header check.
+func TestSignExampleParsesAsValidPDF(t *testing.T) {
+	r, err := reader.Parse(exampleSignedPDF())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	if got := r.PageCount(); got != 1 {
+		t.Errorf("PageCount = %d, want 1", got)
+	}
+	title, _, _, _, _ := r.Info()
+	if title != "Signed Document" {
+		t.Errorf("/Info Title = %q, want %q", title, "Signed Document")
+	}
+}
+
+// TestSignExampleHasSignatureDictAndByteRange pins the PAdES B-B
+// structural markers the example's own verification step checks for:
+// a /Type /Sig dictionary and a /ByteRange entry delimiting the
+// signed byte ranges (ISO 32000-2 §12.8.1). Losing either would mean
+// the "signature" is cosmetic only — no viewer would recognize it.
+func TestSignExampleHasSignatureDictAndByteRange(t *testing.T) {
+	pdf := string(exampleSignedPDF())
+	if !strings.Contains(pdf, "/Type /Sig") {
+		t.Error("no /Type /Sig dictionary; sign.SignPDF should emit a signature dictionary")
+	}
+	if !strings.Contains(pdf, "/ByteRange") {
+		t.Error("no /ByteRange entry; sign.SignPDF should delimit the signed byte ranges")
+	}
+	if !strings.Contains(pdf, "/SubFilter") {
+		t.Error("no /SubFilter entry; expected a PAdES subfilter identifying the signature format")
+	}
+}
+
+// TestSignExampleSignerNameInDictionary asserts the certificate's
+// CommonName (the value passed as sign.Options.Name) is embedded in
+// the signature dictionary's /Name entry, not just used to render
+// visible text elsewhere in the PDF.
+func TestSignExampleSignerNameInDictionary(t *testing.T) {
+	pdf := string(exampleSignedPDF())
+	if !strings.Contains(pdf, "Folio Example Signer") {
+		t.Error("certificate CommonName \"Folio Example Signer\" not found in signed PDF; sign.Options.Name may not be wired through")
+	}
+}

--- a/examples/zugferd/main.go
+++ b/examples/zugferd/main.go
@@ -31,6 +31,24 @@ import (
 )
 
 func main() {
+	doc, err := buildDocument()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if err := doc.Save("zugferd-invoice.pdf"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("Created zugferd-invoice.pdf")
+}
+
+// buildDocument assembles the PDF/A-3B Factur-X invoice and returns
+// the ready-to-write Document. Extracted from main() so the example
+// test (main_test.go) can exercise the same font-discovery, HTML, and
+// attachment pipeline against an in-memory buffer instead of disk.
+func buildDocument() (*document.Document, error) {
 	doc := document.NewDocument(document.PageSizeA4)
 	doc.SetMargins(layout.Margins{Top: 40, Right: 40, Bottom: 40, Left: 40})
 	doc.Info.Title = "Invoice 2024-001"
@@ -39,8 +57,7 @@ func main() {
 	// --- Discover a system font for embedding (PDF/A requires it) ---
 	fontPath := findSystemFont()
 	if fontPath == "" {
-		fmt.Fprintln(os.Stderr, "no suitable system font found for PDF/A embedding")
-		os.Exit(1)
+		return nil, fmt.Errorf("no suitable system font found for PDF/A embedding")
 	}
 
 	// --- Invoice content via HTML (auto-embeds fonts for PDF/A) ---
@@ -90,10 +107,9 @@ hr { margin: 8px 0; border: none; border-top: 1px solid #ccc; }
 
 </body></html>`
 
-	elems, err := html.Convert(invoiceHTML, nil)
+	elems, err := html.Convert(invoiceHTML, &html.Options{AllowAbsolutePaths: true})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "html:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("html: %w", err)
 	}
 	for _, e := range elems {
 		doc.Add(e)
@@ -173,12 +189,7 @@ hr { margin: 8px 0; border: none; border-top: 1px solid #ccc; }
 		Data:           xmlData,
 	})
 
-	// --- Write ---
-	if err := doc.Save("zugferd-invoice.pdf"); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	fmt.Println("Created zugferd-invoice.pdf")
+	return doc, nil
 }
 
 // findSystemFont returns the path to a TrueType font available on the

--- a/examples/zugferd/main_test.go
+++ b/examples/zugferd/main_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/carlos7ags/folio/reader"
+)
+
+// exampleZUGFeRDPDF runs the example's font-discovery, HTML, and
+// PDF/A attachment pipeline once per test process and caches the
+// result. Returns nil when buildDocument reports no embeddable system
+// font (the same condition findSystemFont guards); callers skip in
+// that case via examplePDFOrSkip rather than treating it as a
+// failure. A genuine build failure with a font present still panics.
+var exampleZUGFeRDPDF = sync.OnceValue(func() []byte {
+	doc, err := buildDocument()
+	if err != nil {
+		if findSystemFont() == "" {
+			return nil // no system font on this host; caller skips
+		}
+		panic("buildDocument: " + err.Error())
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		panic("WriteTo: " + err.Error())
+	}
+	return buf.Bytes()
+})
+
+// examplePDFOrSkip returns the cached PDF bytes, skipping the test
+// when findSystemFont locates no font to embed (PDF/A requires one).
+// This is the same candidate-list check the example itself uses, so
+// the test runs wherever the example would succeed — and skips
+// cleanly on CI hosts (e.g. Linux) that lack the macOS system-font
+// paths, rather than hard-failing.
+func examplePDFOrSkip(t *testing.T) []byte {
+	t.Helper()
+	if findSystemFont() == "" {
+		t.Skip("no system font found for PDF/A embedding; skipping")
+	}
+	pdf := exampleZUGFeRDPDF()
+	if pdf == nil {
+		t.Fatal("buildDocument failed despite findSystemFont() returning a path")
+	}
+	return pdf
+}
+
+// TestZUGFeRDExampleProducesValidPDF asserts the example produces a
+// well-formed PDF of plausible size. The size floor catches the
+// regression where the HTML conversion or attachment step silently
+// no-ops.
+func TestZUGFeRDExampleProducesValidPDF(t *testing.T) {
+	pdf := examplePDFOrSkip(t)
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		t.Errorf("output does not start with %%PDF- header (got %q)", pdf[:min(8, len(pdf))])
+	}
+	if len(pdf) < 4000 {
+		t.Errorf("output PDF is suspiciously small (%d bytes); expected >4 KB", len(pdf))
+	}
+}
+
+// TestZUGFeRDExampleParsesAsValidPDF verifies the PDF actually parses
+// and carries the expected page count and title.
+func TestZUGFeRDExampleParsesAsValidPDF(t *testing.T) {
+	pdf := examplePDFOrSkip(t)
+	r, err := reader.Parse(pdf)
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	if got := r.PageCount(); got != 1 {
+		t.Errorf("PageCount = %d, want 1", got)
+	}
+	title, _, _, _, _ := r.Info()
+	if title != "Invoice 2024-001" {
+		t.Errorf("/Info Title = %q, want %q", title, "Invoice 2024-001")
+	}
+}
+
+// TestZUGFeRDExampleHasEmbeddedFileAttachment pins the two structural
+// markers that make this a hybrid Factur-X document: the
+// /EmbeddedFiles name tree (or /AF associated-files array) and the
+// literal attachment filename the example sets via FileAttachment.
+// Losing either would silently degrade the PDF back into a plain
+// invoice with no machine-readable data.
+func TestZUGFeRDExampleHasEmbeddedFileAttachment(t *testing.T) {
+	pdf := string(examplePDFOrSkip(t))
+	if !strings.Contains(pdf, "/EmbeddedFiles") && !strings.Contains(pdf, "/AF") {
+		t.Error("no /EmbeddedFiles or /AF entry; doc.AttachFile should register the Factur-X XML in the file-attachment tree")
+	}
+	if !strings.Contains(pdf, "factur-x.xml") {
+		t.Error(`attachment filename "factur-x.xml" not found in PDF`)
+	}
+}
+
+// TestZUGFeRDExamplePdfAMarkerPresent asserts the PDF/A conformance
+// marker (XMP pdfaid schema, set via doc.SetPdfA) is present. PDF/A-3B
+// is the only PDF/A level permitting file attachments (ISO 19005-3
+// §6.4); losing this marker would mean the output no longer declares
+// PDF/A conformance at all, even though it still carries an
+// attachment.
+func TestZUGFeRDExamplePdfAMarkerPresent(t *testing.T) {
+	pdf := string(examplePDFOrSkip(t))
+	if !strings.Contains(pdf, "pdfaid") {
+		t.Error("no pdfaid XMP schema found; doc.SetPdfA(PdfA3B) should emit a PDF/A conformance marker")
+	}
+	if !strings.Contains(pdf, "Factur-X PDFA Extension Schema") {
+		t.Error("Factur-X XMP extension schema not found; doc.SetPdfA's XMPSchemas should be embedded")
+	}
+}


### PR DESCRIPTION
## Summary

Finishes CI coverage for the runnable examples (closes #231): every remaining example (`fonts`, `forms`, `indic`, `invoice`, `optimize`, `rtl`, `sign`, `zugferd`) now has a `main_test.go` that builds it and asserts a valid, parseable PDF with the expected structure.

## Regression fix

Adding tests that actually run the examples surfaced that the "safe by default asset resolution" change (#391) broke two examples that load fonts via absolute-path `@font-face` — #391 opted `examples/cjk` in but missed these:
- `examples/fonts` — custom fonts silently fell back to Helvetica.
- `examples/zugferd` — crashed (PDF/A rejects the non-embedded fallback).

Both now set `html.Options{AllowAbsolutePaths: true}` (matching `cjk`), restoring correct embedding.

## Tests

Each example's `main()` is refactored to a testable `buildDocument()`/builder (the pattern `report`/`html-to-pdf` already use), preserving `go run` behavior. Font-dependent assertions use the existing skip-on-missing-font guard, so they assert real embedding where the system font exists and skip cleanly on hosts (e.g. Linux CI) where the path is absent. `.github/workflows/ci.yml` is unchanged — `go test ./...` already picks these up.