### PR TITLE
layout: eliminate quadratic prefix re-measure in word chunking

### DIFF
--- a/font/metrics.go
+++ b/font/metrics.go
@@ -156,6 +156,163 @@ func (f *Standard) MeasureString(text string, fontSize float64) float64 {
 	return total / 1000.0 * fontSize
 }
 
+// MeasureStringPrefixes returns cumulative widths at every rune boundary of
+// text: element i is the width of the prefix holding the first i runes,
+// bit-identical to MeasureString(prefix, fontSize) for that prefix. One walk
+// computes all len(runes)+1 entries. Grapheme segmentation is prefix-stable,
+// so recording the running total at each rune boundary reproduces the exact
+// additions, in the same order, that an independent prefix measurement
+// performs.
+func (f *Standard) MeasureStringPrefixes(text string, fontSize float64) []float64 {
+	runeCount := utf8.RuneCountInString(text)
+	prefixes := make([]float64, runeCount+1)
+
+	widths := standardWidths[f.name]
+	if widths == nil {
+		// Fallback mirrors MeasureString's single-expression byte-length
+		// formula: each entry is computed fresh from the byte offset, not
+		// accumulated, so the bit pattern matches an independent measure.
+		idx := 0
+		byteLen := 0
+		for _, r := range text {
+			byteLen += utf8.RuneLen(r)
+			idx++
+			prefixes[idx] = float64(byteLen) * 600.0 / 1000.0 * fontSize
+		}
+		return prefixes
+	}
+
+	lookupWidth := func(r rune) float64 {
+		w, ok := widths[r]
+		if !ok {
+			w = widths[0] // .notdef / default width
+			if w == 0 {
+				w = 500 // reasonable default
+			}
+		}
+		return float64(w)
+	}
+
+	var total float64
+	var prevTail rune
+	havePrev := false
+	idx := 0
+
+	buf := breakBufPool.Get().(*[]int)
+	breaks := grapheme.AppendBreaks((*buf)[:0], text)
+	for i := 0; i+1 < len(breaks); i++ {
+		cluster := text[breaks[i]:breaks[i+1]]
+		baseRune, baseSize := utf8.DecodeRuneInString(cluster)
+		if havePrev {
+			total += f.Kern(prevTail, baseRune)
+		}
+		total += lookupWidth(baseRune)
+		idx++
+		prefixes[idx] = total / 1000.0 * fontSize
+		tail := baseRune
+		for off := baseSize; off < len(cluster); {
+			r, size := utf8.DecodeRuneInString(cluster[off:])
+			if grapheme.PropertyOf(r) == grapheme.PropSpacingMark {
+				total += lookupWidth(r)
+				tail = r
+			}
+			idx++
+			prefixes[idx] = total / 1000.0 * fontSize
+			off += size
+		}
+		prevTail = tail
+		havePrev = true
+	}
+	*buf = breaks
+	breakBufPool.Put(buf)
+
+	return prefixes
+}
+
+// PrefixFit scans text accumulating cumulative rune-boundary widths (each
+// bit-identical to MeasureString of that prefix) and returns the byte length,
+// rune count, and width of the longest leading run that fits maxWidth under
+// the first-overflow rule used by word chunking: runes are added while the
+// width including the next rune stays within maxWidth, always keeping at least
+// one rune. The scan stops at the first overflow, so it is O(fit length), not
+// O(len(text)).
+func (f *Standard) PrefixFit(text string, fontSize, maxWidth float64) (byteLen, runeLen int, width float64) {
+	widths := standardWidths[f.name]
+	if widths == nil {
+		// Fallback width is a single expression on the prefix byte length
+		// (see MeasureString) and is non-decreasing, so the same
+		// first-overflow scan applies over rune boundaries. The expression
+		// must match MeasureString's left-to-right form exactly for the
+		// returned width to be bit-identical.
+		for i := 0; i < len(text); {
+			_, size := utf8.DecodeRuneInString(text[i:])
+			nb := byteLen + size
+			w := float64(nb) * 600.0 / 1000.0 * fontSize
+			if runeLen >= 1 && w > maxWidth {
+				return byteLen, runeLen, width
+			}
+			byteLen, runeLen, width = nb, runeLen+1, w
+			i += size
+		}
+		return byteLen, runeLen, width
+	}
+
+	lookupWidth := func(r rune) float64 {
+		w, ok := widths[r]
+		if !ok {
+			w = widths[0] // .notdef / default width
+			if w == 0 {
+				w = 500 // reasonable default
+			}
+		}
+		return float64(w)
+	}
+
+	var total float64
+	var prevTail rune
+	havePrev := false
+	pos := 0
+
+	buf := breakBufPool.Get().(*[]int)
+	breaks := grapheme.AppendBreaks((*buf)[:0], text)
+outer:
+	for i := 0; i+1 < len(breaks); i++ {
+		cluster := text[breaks[i]:breaks[i+1]]
+		baseRune, baseSize := utf8.DecodeRuneInString(cluster)
+		if havePrev {
+			total += f.Kern(prevTail, baseRune)
+		}
+		total += lookupWidth(baseRune)
+		pos += baseSize
+		w := total / 1000.0 * fontSize
+		if runeLen >= 1 && w > maxWidth {
+			break outer
+		}
+		byteLen, runeLen, width = pos, runeLen+1, w
+		tail := baseRune
+		for off := baseSize; off < len(cluster); {
+			r, size := utf8.DecodeRuneInString(cluster[off:])
+			if grapheme.PropertyOf(r) == grapheme.PropSpacingMark {
+				total += lookupWidth(r)
+				tail = r
+			}
+			pos += size
+			w := total / 1000.0 * fontSize
+			if w > maxWidth {
+				break outer
+			}
+			byteLen, runeLen, width = pos, runeLen+1, w
+			off += size
+		}
+		prevTail = tail
+		havePrev = true
+	}
+	*buf = breaks
+	breakBufPool.Put(buf)
+
+	return byteLen, runeLen, width
+}
+
 // MeasureString implements TextMeasurer for embedded fonts. The returned
 // width is in PDF points and accounts for any kerning pairs the font
 // supplies via its kern table, so wrapping widths agree with the
@@ -207,6 +364,118 @@ func (ef *EmbeddedFont) MeasureString(text string, fontSize float64) float64 {
 	*buf = breaks
 	breakBufPool.Put(buf)
 	return total / float64(upem) * fontSize
+}
+
+// MeasureStringPrefixes returns cumulative widths at every rune boundary of
+// text, bit-identical to MeasureString(prefix, fontSize) for each prefix.
+// See Standard.MeasureStringPrefixes for the prefix-stability argument.
+func (ef *EmbeddedFont) MeasureStringPrefixes(text string, fontSize float64) []float64 {
+	runeCount := utf8.RuneCountInString(text)
+	prefixes := make([]float64, runeCount+1)
+
+	face := ef.face
+	upem := face.UnitsPerEm()
+	if upem == 0 {
+		// MeasureString returns 0 for every input in this case.
+		return prefixes
+	}
+
+	var total float64
+	var prevTail uint16
+	havePrev := false
+	idx := 0
+
+	buf := breakBufPool.Get().(*[]int)
+	breaks := grapheme.AppendBreaks((*buf)[:0], text)
+	for i := 0; i+1 < len(breaks); i++ {
+		cluster := text[breaks[i]:breaks[i+1]]
+		baseRune, baseSize := utf8.DecodeRuneInString(cluster)
+		baseGID := face.GlyphIndex(baseRune)
+		if havePrev {
+			total += float64(face.Kern(prevTail, baseGID))
+		}
+		total += float64(face.GlyphAdvance(baseGID))
+		idx++
+		prefixes[idx] = total / float64(upem) * fontSize
+		tail := baseGID
+		for off := baseSize; off < len(cluster); {
+			r, size := utf8.DecodeRuneInString(cluster[off:])
+			if grapheme.PropertyOf(r) == grapheme.PropSpacingMark {
+				gid := face.GlyphIndex(r)
+				total += float64(face.GlyphAdvance(gid))
+				tail = gid
+			}
+			idx++
+			prefixes[idx] = total / float64(upem) * fontSize
+			off += size
+		}
+		prevTail = tail
+		havePrev = true
+	}
+	*buf = breaks
+	breakBufPool.Put(buf)
+
+	return prefixes
+}
+
+// PrefixFit is the embedded-font counterpart of Standard.PrefixFit: it
+// returns the byte length, rune count, and width of the longest leading run of
+// text that fits maxWidth under the first-overflow rule, scanning only as far
+// as the break point.
+func (ef *EmbeddedFont) PrefixFit(text string, fontSize, maxWidth float64) (byteLen, runeLen int, width float64) {
+	face := ef.face
+	upem := face.UnitsPerEm()
+	if upem == 0 {
+		// MeasureString returns 0 for every prefix; nothing overflows, so
+		// the whole text fits as one run.
+		return len(text), utf8.RuneCountInString(text), 0
+	}
+
+	var total float64
+	var prevTail uint16
+	havePrev := false
+	pos := 0
+
+	buf := breakBufPool.Get().(*[]int)
+	breaks := grapheme.AppendBreaks((*buf)[:0], text)
+outer:
+	for i := 0; i+1 < len(breaks); i++ {
+		cluster := text[breaks[i]:breaks[i+1]]
+		baseRune, baseSize := utf8.DecodeRuneInString(cluster)
+		baseGID := face.GlyphIndex(baseRune)
+		if havePrev {
+			total += float64(face.Kern(prevTail, baseGID))
+		}
+		total += float64(face.GlyphAdvance(baseGID))
+		pos += baseSize
+		w := total / float64(upem) * fontSize
+		if runeLen >= 1 && w > maxWidth {
+			break outer
+		}
+		byteLen, runeLen, width = pos, runeLen+1, w
+		tail := baseGID
+		for off := baseSize; off < len(cluster); {
+			r, size := utf8.DecodeRuneInString(cluster[off:])
+			if grapheme.PropertyOf(r) == grapheme.PropSpacingMark {
+				gid := face.GlyphIndex(r)
+				total += float64(face.GlyphAdvance(gid))
+				tail = gid
+			}
+			pos += size
+			w := total / float64(upem) * fontSize
+			if w > maxWidth {
+				break outer
+			}
+			byteLen, runeLen, width = pos, runeLen+1, w
+			off += size
+		}
+		prevTail = tail
+		havePrev = true
+	}
+	*buf = breaks
+	breakBufPool.Put(buf)
+
+	return byteLen, runeLen, width
 }
 
 // Kern returns the kerning adjustment between two characters in thousandths

--- a/font/metrics_prefixes_test.go
+++ b/font/metrics_prefixes_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package font
+
+import (
+	"math"
+	"testing"
+)
+
+// prefixesCorpus reuses characterizationCorpus plus a few extra strings
+// with long runs, so the cumulative-walk path in MeasureStringPrefixes is
+// exercised over more than a handful of rune boundaries.
+var prefixesCorpus = append(append([]string{}, characterizationCorpus...),
+	"abcdefghijabcdefghij",
+	"AVAWAToToAVAWAToTo",
+	"中华人民共和国是一个历史悠久的文明古国",
+)
+
+var prefixesSizes = []float64{8, 12, 12.5}
+
+// checkPrefixes asserts prefixes has one entry per rune boundary and that
+// every entry is bit-identical to measuring that prefix independently.
+func checkPrefixes(t *testing.T, label string, s string, prefixes []float64, measure func(string) float64) {
+	t.Helper()
+	runes := []rune(s)
+	if len(prefixes) != len(runes)+1 {
+		t.Fatalf("%s: len(prefixes) = %d, want %d", label, len(prefixes), len(runes)+1)
+	}
+	for i := 0; i <= len(runes); i++ {
+		want := measure(string(runes[:i]))
+		if math.Float64bits(prefixes[i]) != math.Float64bits(want) {
+			t.Errorf("%s: prefixes[%d] = %v (0x%x), want bit-identical %v (0x%x)",
+				label, i, prefixes[i], math.Float64bits(prefixes[i]), want, math.Float64bits(want))
+		}
+	}
+}
+
+func TestMeasureStringPrefixesStandard(t *testing.T) {
+	fonts := []*Standard{Helvetica, Symbol}
+	for _, f := range fonts {
+		for _, s := range prefixesCorpus {
+			for _, size := range prefixesSizes {
+				prefixes := f.MeasureStringPrefixes(s, size)
+				checkPrefixes(t, f.name, s, prefixes, func(prefix string) float64 {
+					return f.MeasureString(prefix, size)
+				})
+			}
+		}
+	}
+}
+
+// TestMeasureStringPrefixesStandardNilWidths exercises the fallback path
+// (no width table for the font name) via an unexported Standard built with
+// an unknown name — standardWidths covers every exported standard font, so
+// this is the only way to reach the byte-length fallback formula.
+func TestMeasureStringPrefixesStandardNilWidths(t *testing.T) {
+	f := &Standard{name: "Unknown"}
+	for _, s := range prefixesCorpus {
+		for _, size := range prefixesSizes {
+			prefixes := f.MeasureStringPrefixes(s, size)
+			checkPrefixes(t, "Unknown", s, prefixes, func(prefix string) float64 {
+				return f.MeasureString(prefix, size)
+			})
+		}
+	}
+}
+
+func TestMeasureStringPrefixesEmbedded(t *testing.T) {
+	face, err := LoadFont("testdata/synthetic_cjk.ttf")
+	if err != nil {
+		t.Fatalf("LoadFont: %v", err)
+	}
+	ef := NewEmbeddedFont(face)
+
+	for _, s := range prefixesCorpus {
+		for _, size := range prefixesSizes {
+			prefixes := ef.MeasureStringPrefixes(s, size)
+			checkPrefixes(t, "embedded", s, prefixes, func(prefix string) float64 {
+				return ef.MeasureString(prefix, size)
+			})
+		}
+	}
+}
+
+// refPrefixFit derives the expected (byteLen, runeLen, width) of PrefixFit
+// from the full prefix widths, mirroring the first-overflow scan that word
+// chunking runs: start with one rune, extend while the next rune boundary
+// stays within maxWidth, stop at the first overflow.
+func refPrefixFit(s string, prefixes []float64, maxWidth float64) (byteLen, runeLen int, width float64) {
+	runes := []rune(s)
+	n := len(runes)
+	if n == 0 {
+		return 0, 0, 0
+	}
+	end := 1
+	for end < n {
+		if prefixes[end+1] > maxWidth {
+			break
+		}
+		end++
+	}
+	return len(string(runes[:end])), end, prefixes[end]
+}
+
+// checkPrefixFit compares PrefixFit against the reference over a spread of
+// maxWidth values, including exact rune-boundary widths (boundary equality).
+func checkPrefixFit(t *testing.T, label, s string, prefixes []float64, fit func(maxWidth float64) (int, int, float64)) {
+	t.Helper()
+	total := prefixes[len(prefixes)-1]
+	widths := []float64{0, total * 0.1, total * 0.25, total * 0.5, total * 0.9, total, total * 2}
+	widths = append(widths, prefixes...) // exact rune-boundary widths
+	for _, mw := range widths {
+		wantBytes, wantRunes, wantWidth := refPrefixFit(s, prefixes, mw)
+		gotBytes, gotRunes, gotWidth := fit(mw)
+		if gotBytes != wantBytes || gotRunes != wantRunes {
+			t.Errorf("%s PrefixFit(%q, maxWidth=%v) = (bytes=%d, runes=%d), want (bytes=%d, runes=%d)",
+				label, s, mw, gotBytes, gotRunes, wantBytes, wantRunes)
+		}
+		if math.Float64bits(gotWidth) != math.Float64bits(wantWidth) {
+			t.Errorf("%s PrefixFit(%q, maxWidth=%v) width = %v (0x%x), want bit-identical %v (0x%x)",
+				label, s, mw, gotWidth, math.Float64bits(gotWidth), wantWidth, math.Float64bits(wantWidth))
+		}
+	}
+}
+
+func TestPrefixFitStandard(t *testing.T) {
+	fonts := []*Standard{Helvetica, Symbol, {name: "Unknown"}}
+	for _, f := range fonts {
+		for _, s := range prefixesCorpus {
+			if s == "" {
+				continue
+			}
+			for _, size := range prefixesSizes {
+				prefixes := f.MeasureStringPrefixes(s, size)
+				checkPrefixFit(t, f.name, s, prefixes, func(mw float64) (int, int, float64) {
+					return f.PrefixFit(s, size, mw)
+				})
+			}
+		}
+	}
+}
+
+func TestPrefixFitEmbedded(t *testing.T) {
+	face, err := LoadFont("testdata/synthetic_cjk.ttf")
+	if err != nil {
+		t.Fatalf("LoadFont: %v", err)
+	}
+	ef := NewEmbeddedFont(face)
+	for _, s := range prefixesCorpus {
+		if s == "" {
+			continue
+		}
+		for _, size := range prefixesSizes {
+			prefixes := ef.MeasureStringPrefixes(s, size)
+			checkPrefixFit(t, "embedded", s, prefixes, func(mw float64) (int, int, float64) {
+				return ef.PrefixFit(s, size, mw)
+			})
+		}
+	}
+}
+
+// zeroUpemFace wraps fakeFace to force the UnitsPerEm() == 0 path, where
+// MeasureString returns 0 for every input.
+type zeroUpemFace struct{ *fakeFace }
+
+func (zeroUpemFace) UnitsPerEm() int { return 0 }
+
+// TestMeasureStringPrefixesEmbeddedZeroUpem exercises the upem==0 path,
+// where MeasureString returns 0 for every input.
+func TestMeasureStringPrefixesEmbeddedZeroUpem(t *testing.T) {
+	face := zeroUpemFace{newFakeFace()}
+	ef := NewEmbeddedFont(face)
+
+	for _, s := range prefixesCorpus {
+		prefixes := ef.MeasureStringPrefixes(s, 12)
+		checkPrefixes(t, "zero-upem", s, prefixes, func(prefix string) float64 {
+			return ef.MeasureString(prefix, 12)
+		})
+	}
+}

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -854,17 +854,42 @@ func breakLongWords(words []Word, maxWidth float64) []Word {
 		}
 
 		start := 0
+		byteStart := 0
 		for start < len(runes) {
-			end := start + 1
-			for end < len(runes) {
-				_, _, width, _ := shapeChunk(string(runes[start : end+1]))
-				if width > maxWidth {
-					break
+			var chunkSource, chunkText string
+			var chunkGIDs []uint16
+			var chunkWidth float64
+			var runeLen int
+			if !shaped {
+				// Unshaped words measure with MeasureString, which is prefix-
+				// summable (grapheme boundaries are prefix-stable) and carries no
+				// kerning across a chunk boundary. One walk from the chunk start
+				// finds the first-overflow break point and its width bit-
+				// identically, and stops there — so a token that splits into a few
+				// large chunks costs O(token) total rather than re-measuring every
+				// candidate prefix. The chunk is a zero-copy slice of the source.
+				byteLen, rl, cw := wordPrefixFit(&w, sourceText[byteStart:], maxWidth)
+				runeLen = rl
+				chunkSource = sourceText[byteStart : byteStart+byteLen]
+				chunkText = chunkSource
+				chunkWidth = cw
+				byteStart += byteLen
+			} else {
+				// Shaped words re-shape per candidate: Arabic/Indic widths are
+				// context-sensitive, not prefix-summable, so no cumulative
+				// shortcut applies.
+				end := start + 1
+				for end < len(runes) {
+					_, _, width, _ := shapeChunk(string(runes[start : end+1]))
+					if width > maxWidth {
+						break
+					}
+					end++
 				}
-				end++
+				runeLen = end - start
+				chunkSource = string(runes[start:end])
+				chunkText, chunkGIDs, chunkWidth, _ = shapeChunk(chunkSource)
 			}
-			chunkSource := string(runes[start:end])
-			chunkText, chunkGIDs, chunkWidth, _ := shapeChunk(chunkSource)
 			chunk := Word{
 				Text:          chunkText,
 				Width:         chunkWidth,
@@ -885,10 +910,32 @@ func breakLongWords(words []Word, maxWidth float64) []Word {
 				chunk.OriginalText = chunkSource
 			}
 			result = append(result, chunk)
-			start = end
+			start += runeLen
 		}
 	}
 	return result
+}
+
+// wordPrefixFit finds the first-overflow break for the unshaped chunk starting
+// at s, using the word's measurer. The measurer probe in breakLongWords
+// guarantees a Font or Embedded is set before this is reached.
+func wordPrefixFit(w *Word, s string, maxWidth float64) (byteLen, runeLen int, width float64) {
+	if w.Embedded != nil {
+		return w.Embedded.PrefixFit(s, w.FontSize, maxWidth)
+	}
+	return w.Font.PrefixFit(s, w.FontSize, maxWidth)
+}
+
+// wordPrefixWidths returns cumulative rune-boundary widths of s for the
+// word's measurer, or nil when the word has no measurer.
+func wordPrefixWidths(w *Word, s string) []float64 {
+	if w.Embedded != nil {
+		return w.Embedded.MeasureStringPrefixes(s, w.FontSize)
+	}
+	if w.Font != nil {
+		return w.Font.MeasureStringPrefixes(s, w.FontSize)
+	}
+	return nil
 }
 
 // shapedChunkBuilder returns a function that produces (post-shape text,
@@ -957,6 +1004,12 @@ func hyphenateWord(w Word, available float64) (part, rest Word, ok bool) {
 
 	hyphenW := measure("-")
 
+	// Cumulative rune-boundary widths of the whole word, computed once.
+	// Bit-identical to measure(string(runes[:i])) for every i (grapheme
+	// boundaries are prefix-stable), so both candidate loops below become
+	// O(1) array lookups instead of an O(prefix) re-measure per candidate.
+	prefixes := wordPrefixWidths(&w, w.Text)
+
 	// Get linguistically valid break points from the hyphenator.
 	// Only attempt pattern-based hyphenation for pure-alpha words;
 	// fall back to character-boundary splitting for others.
@@ -970,8 +1023,7 @@ func hyphenateWord(w Word, available float64) (part, rest Word, ok bool) {
 	if len(breakPoints) > 0 {
 		for i := len(breakPoints) - 1; i >= 0; i-- {
 			bp := breakPoints[i]
-			prefix := string(runes[:bp])
-			pw := measure(prefix) + hyphenW
+			pw := prefixes[bp] + hyphenW
 			if pw <= available {
 				bestSplit = bp
 				break
@@ -983,8 +1035,7 @@ func hyphenateWord(w Word, available float64) (part, rest Word, ok bool) {
 	// (at least 2 chars from each end) for very long words.
 	if bestSplit < 0 {
 		for i := len(runes) - 2; i >= 2; i-- {
-			prefix := string(runes[:i])
-			pw := measure(prefix) + hyphenW
+			pw := prefixes[i] + hyphenW
 			if pw <= available {
 				bestSplit = i
 				break

--- a/layout/paragraph_chunking_characterization_test.go
+++ b/layout/paragraph_chunking_characterization_test.go
@@ -1,0 +1,471 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// This file pins the exact chunking behavior of breakLongWords and
+// hyphenateWord as it exists today, before their candidate-scan loops
+// are rewritten to use cumulative prefix widths instead of re-measuring
+// each candidate from scratch. The expectations below were captured by
+// running the corpus against the pre-optimization code; they must not
+// be edited by the optimization that follows — any divergence means the
+// break/hyphenation choice changed.
+
+type chunkExpectation struct {
+	text  string
+	width uint64 // math.Float64bits(Word.Width)
+}
+
+func TestBreakLongWordsCharacterization(t *testing.T) {
+	cjkFace, err := font.LoadFont("../font/testdata/synthetic_cjk.ttf")
+	if err != nil {
+		t.Fatalf("LoadFont: %v", err)
+	}
+	cjkFont := font.NewEmbeddedFont(cjkFace)
+
+	tests := []struct {
+		name     string
+		text     string
+		fontSize float64
+		maxWidth float64
+		std      *font.Standard
+		embedded *font.EmbeddedFont
+		want     []chunkExpectation
+	}{
+		{
+			name:     "kern-bearing ascii",
+			text:     strings.Repeat("abcdefghij", 40),
+			fontSize: 12,
+			maxWidth: 100,
+			std:      font.Helvetica,
+			want: []chunkExpectation{
+				{text: "abcdefghijabcdefg", width: 0x40585916872b020c},
+				{text: "hijabcdefghijabcde", width: 0x4058d89374bc6a7f},
+				{text: "fghijabcdefghijabc", width: 0x405803126e978d50},
+				{text: "defghijabcdefghija", width: 0x40582e147ae147ae},
+				{text: "bcdefghijabcdefgh", width: 0x40585916872b020c},
+				{text: "ijabcdefghijabcdef", width: 0x405803126e978d50},
+				{text: "ghijabcdefghijabcd", width: 0x4058d89374bc6a7f},
+				{text: "efghijabcdefghijab", width: 0x40582e147ae147ae},
+				{text: "cdefghijabcdefghij", width: 0x405803126e978d50},
+				{text: "abcdefghijabcdefg", width: 0x40585916872b020c},
+				{text: "hijabcdefghijabcde", width: 0x4058d89374bc6a7f},
+				{text: "fghijabcdefghijabc", width: 0x405803126e978d50},
+				{text: "defghijabcdefghija", width: 0x40582e147ae147ae},
+				{text: "bcdefghijabcdefgh", width: 0x40585916872b020c},
+				{text: "ijabcdefghijabcdef", width: 0x405803126e978d50},
+				{text: "ghijabcdefghijabcd", width: 0x4058d89374bc6a7f},
+				{text: "efghijabcdefghijab", width: 0x40582e147ae147ae},
+				{text: "cdefghijabcdefghij", width: 0x405803126e978d50},
+				{text: "abcdefghijabcdefg", width: 0x40585916872b020c},
+				{text: "hijabcdefghijabcde", width: 0x4058d89374bc6a7f},
+				{text: "fghijabcdefghijabc", width: 0x405803126e978d50},
+				{text: "defghijabcdefghija", width: 0x40582e147ae147ae},
+				{text: "bcdefghij", width: 0x404803126e978d50},
+			},
+		},
+		{
+			name:     "non-monotonic kern pairs",
+			text:     strings.Repeat("AVAWAToTo", 50),
+			fontSize: 12,
+			maxWidth: 80,
+			std:      font.Helvetica,
+			want: []chunkExpectation{
+				{text: "AVAWAToToAV", width: 0x4053cccccccccccc},
+				{text: "AWAToToAVA", width: 0x4052024dd2f1a9fc},
+				{text: "WAToToAVAW", width: 0x4052d70a3d70a3d7},
+				{text: "AToToAVAWAT", width: 0x40537b645a1cac08},
+				{text: "oToAVAWAToT", width: 0x4053824dd2f1a9fc},
+				{text: "oAVAWAToToA", width: 0x4053ad4fdf3b645a},
+				{text: "VAWAToToAVA", width: 0x4053c51eb851eb85},
+				{text: "WAToToAVAW", width: 0x4052d70a3d70a3d7},
+				{text: "AToToAVAWAT", width: 0x40537b645a1cac08},
+				{text: "oToAVAWAToT", width: 0x4053824dd2f1a9fc},
+				{text: "oAVAWAToToA", width: 0x4053ad4fdf3b645a},
+				{text: "VAWAToToAVA", width: 0x4053c51eb851eb85},
+				{text: "WAToToAVAW", width: 0x4052d70a3d70a3d7},
+				{text: "AToToAVAWAT", width: 0x40537b645a1cac08},
+				{text: "oToAVAWAToT", width: 0x4053824dd2f1a9fc},
+				{text: "oAVAWAToToA", width: 0x4053ad4fdf3b645a},
+				{text: "VAWAToToAVA", width: 0x4053c51eb851eb85},
+				{text: "WAToToAVAW", width: 0x4052d70a3d70a3d7},
+				{text: "AToToAVAWAT", width: 0x40537b645a1cac08},
+				{text: "oToAVAWAToT", width: 0x4053824dd2f1a9fc},
+				{text: "oAVAWAToToA", width: 0x4053ad4fdf3b645a},
+				{text: "VAWAToToAVA", width: 0x4053c51eb851eb85},
+				{text: "WAToToAVAW", width: 0x4052d70a3d70a3d7},
+				{text: "AToToAVAWAT", width: 0x40537b645a1cac08},
+				{text: "oToAVAWAToT", width: 0x4053824dd2f1a9fc},
+				{text: "oAVAWAToToA", width: 0x4053ad4fdf3b645a},
+				{text: "VAWAToToAVA", width: 0x4053c51eb851eb85},
+				{text: "WAToToAVAW", width: 0x4052d70a3d70a3d7},
+				{text: "AToToAVAWAT", width: 0x40537b645a1cac08},
+				{text: "oToAVAWAToT", width: 0x4053824dd2f1a9fc},
+				{text: "oAVAWAToToA", width: 0x4053ad4fdf3b645a},
+				{text: "VAWAToToAVA", width: 0x4053c51eb851eb85},
+				{text: "WAToToAVAW", width: 0x4052d70a3d70a3d7},
+				{text: "AToToAVAWAT", width: 0x40537b645a1cac08},
+				{text: "oToAVAWAToT", width: 0x4053824dd2f1a9fc},
+				{text: "oAVAWAToToA", width: 0x4053ad4fdf3b645a},
+				{text: "VAWAToToAVA", width: 0x4053c51eb851eb85},
+				{text: "WAToToAVAW", width: 0x4052d70a3d70a3d7},
+				{text: "AToToAVAWAT", width: 0x40537b645a1cac08},
+				{text: "oToAVAWAToT", width: 0x4053824dd2f1a9fc},
+				{text: "oAVAWAToToA", width: 0x4053ad4fdf3b645a},
+				{text: "VAWAToTo", width: 0x404c6f1a9fbe76c8},
+			},
+		},
+		{
+			name:     "combining marks",
+			text:     strings.Repeat("éx̂", 100),
+			fontSize: 12,
+			maxWidth: 60,
+			std:      font.Helvetica,
+			want: []chunkExpectation{
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂éx̂éx̂éx̂é", width: 0x404b3d70a3d70a3e},
+				{text: "x̂éx̂éx̂éx̂éx̂", width: 0x404ae76c8b439581},
+				{text: "éx̂", width: 0x40289fbe76c8b43a},
+			},
+		},
+		{
+			name:     "embedded kern-bearing ascii",
+			text:     strings.Repeat("abcdefghij", 40),
+			fontSize: 12,
+			maxWidth: 100,
+			embedded: cjkFont,
+			want: []chunkExpectation{
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+				{text: "abcdefgh", width: 0x4058000000000000},
+				{text: "ijabcdef", width: 0x4058000000000000},
+				{text: "ghijabcd", width: 0x4058000000000000},
+				{text: "efghijab", width: 0x4058000000000000},
+				{text: "cdefghij", width: 0x4058000000000000},
+			},
+		},
+		{
+			name:     "embedded combining marks",
+			text:     strings.Repeat("éx̂", 100),
+			fontSize: 12,
+			maxWidth: 60,
+			embedded: cjkFont,
+			want: []chunkExpectation{
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+				{text: "éx̂éx̂é", width: 0x404e000000000000},
+				{text: "x̂éx̂éx̂", width: 0x404e000000000000},
+			},
+		},
+		{
+			name:     "embedded CJK token",
+			text:     strings.Repeat("中华人民共和国是一个历史悠久的文明古国", 20),
+			fontSize: 12,
+			maxWidth: 80,
+			embedded: cjkFont,
+			want: []chunkExpectation{
+				{text: "中华人民共和", width: 0x4052000000000000},
+				{text: "国是一个历史", width: 0x4052000000000000},
+				{text: "悠久的文明古", width: 0x4052000000000000},
+				{text: "国中华人民共", width: 0x4052000000000000},
+				{text: "和国是一个历", width: 0x4052000000000000},
+				{text: "史悠久的文明", width: 0x4052000000000000},
+				{text: "古国中华人民", width: 0x4052000000000000},
+				{text: "共和国是一个", width: 0x4052000000000000},
+				{text: "历史悠久的文", width: 0x4052000000000000},
+				{text: "明古国中华人", width: 0x4052000000000000},
+				{text: "民共和国是一", width: 0x4052000000000000},
+				{text: "个历史悠久的", width: 0x4052000000000000},
+				{text: "文明古国中华", width: 0x4052000000000000},
+				{text: "人民共和国是", width: 0x4052000000000000},
+				{text: "一个历史悠久", width: 0x4052000000000000},
+				{text: "的文明古国中", width: 0x4052000000000000},
+				{text: "华人民共和国", width: 0x4052000000000000},
+				{text: "是一个历史悠", width: 0x4052000000000000},
+				{text: "久的文明古国", width: 0x4052000000000000},
+				{text: "中华人民共和", width: 0x4052000000000000},
+				{text: "国是一个历史", width: 0x4052000000000000},
+				{text: "悠久的文明古", width: 0x4052000000000000},
+				{text: "国中华人民共", width: 0x4052000000000000},
+				{text: "和国是一个历", width: 0x4052000000000000},
+				{text: "史悠久的文明", width: 0x4052000000000000},
+				{text: "古国中华人民", width: 0x4052000000000000},
+				{text: "共和国是一个", width: 0x4052000000000000},
+				{text: "历史悠久的文", width: 0x4052000000000000},
+				{text: "明古国中华人", width: 0x4052000000000000},
+				{text: "民共和国是一", width: 0x4052000000000000},
+				{text: "个历史悠久的", width: 0x4052000000000000},
+				{text: "文明古国中华", width: 0x4052000000000000},
+				{text: "人民共和国是", width: 0x4052000000000000},
+				{text: "一个历史悠久", width: 0x4052000000000000},
+				{text: "的文明古国中", width: 0x4052000000000000},
+				{text: "华人民共和国", width: 0x4052000000000000},
+				{text: "是一个历史悠", width: 0x4052000000000000},
+				{text: "久的文明古国", width: 0x4052000000000000},
+				{text: "中华人民共和", width: 0x4052000000000000},
+				{text: "国是一个历史", width: 0x4052000000000000},
+				{text: "悠久的文明古", width: 0x4052000000000000},
+				{text: "国中华人民共", width: 0x4052000000000000},
+				{text: "和国是一个历", width: 0x4052000000000000},
+				{text: "史悠久的文明", width: 0x4052000000000000},
+				{text: "古国中华人民", width: 0x4052000000000000},
+				{text: "共和国是一个", width: 0x4052000000000000},
+				{text: "历史悠久的文", width: 0x4052000000000000},
+				{text: "明古国中华人", width: 0x4052000000000000},
+				{text: "民共和国是一", width: 0x4052000000000000},
+				{text: "个历史悠久的", width: 0x4052000000000000},
+				{text: "文明古国中华", width: 0x4052000000000000},
+				{text: "人民共和国是", width: 0x4052000000000000},
+				{text: "一个历史悠久", width: 0x4052000000000000},
+				{text: "的文明古国中", width: 0x4052000000000000},
+				{text: "华人民共和国", width: 0x4052000000000000},
+				{text: "是一个历史悠", width: 0x4052000000000000},
+				{text: "久的文明古国", width: 0x4052000000000000},
+				{text: "中华人民共和", width: 0x4052000000000000},
+				{text: "国是一个历史", width: 0x4052000000000000},
+				{text: "悠久的文明古", width: 0x4052000000000000},
+				{text: "国中华人民共", width: 0x4052000000000000},
+				{text: "和国是一个历", width: 0x4052000000000000},
+				{text: "史悠久的文明", width: 0x4052000000000000},
+				{text: "古国", width: 0x4038000000000000},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var measurer font.TextMeasurer
+			w := Word{
+				Text:     tt.text,
+				FontSize: tt.fontSize,
+				Font:     tt.std,
+				Embedded: tt.embedded,
+			}
+			if tt.embedded != nil {
+				measurer = tt.embedded
+			} else {
+				measurer = tt.std
+			}
+			w.Width = measurer.MeasureString(tt.text, tt.fontSize)
+
+			chunks := breakLongWords([]Word{w}, tt.maxWidth)
+
+			if tt.want == nil {
+				for _, c := range chunks {
+					t.Logf("{text: %q, width: 0x%x /* %v */},", c.Text, math.Float64bits(c.Width), c.Width)
+				}
+				t.Fatal("no expectations set — paste the logged literals above")
+			}
+
+			if len(chunks) != len(tt.want) {
+				t.Fatalf("got %d chunks, want %d", len(chunks), len(tt.want))
+			}
+			for i, c := range chunks {
+				want := tt.want[i]
+				if c.Text != want.text {
+					t.Errorf("chunk %d: Text = %q, want %q", i, c.Text, want.text)
+				}
+				if got := math.Float64bits(c.Width); got != want.width {
+					t.Errorf("chunk %d: Width bits = 0x%x (%v), want 0x%x (%v)",
+						i, got, c.Width, want.width, math.Float64frombits(want.width))
+				}
+			}
+		})
+	}
+}
+
+type hyphenExpectation struct {
+	partText  string
+	partWidth uint64
+	restText  string
+	restWidth uint64
+	ok        bool
+}
+
+func TestHyphenateWordCharacterization(t *testing.T) {
+	tests := []struct {
+		name      string
+		text      string
+		fontSize  float64
+		available float64
+		want      hyphenExpectation
+	}{
+		{
+			name:      "pattern-based split",
+			text:      "hyphenation",
+			fontSize:  12,
+			available: 200,
+			want: hyphenExpectation{
+				partText:  "hyphen-",
+				partWidth: 0x40457f7ced916873,
+				restText:  "ation",
+				restWidth: 0x403a04189374bc6b,
+				ok:        true,
+			},
+		},
+		{
+			name:      "fallback char-boundary split",
+			text:      "abc123def456ghi789jkl012mno345",
+			fontSize:  12,
+			available: 80,
+			want: hyphenExpectation{
+				partText:  "abc123def45-",
+				partWidth: 0x40525851eb851eb8,
+				restText:  "6ghi789jkl012mno345",
+				restWidth: 0x405d595810624dd2,
+				ok:        true,
+			},
+		},
+		{
+			name:      "no split fits",
+			text:      "hyphenation",
+			fontSize:  12,
+			available: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := Word{
+				Text:     tt.text,
+				FontSize: tt.fontSize,
+				Font:     font.Helvetica,
+			}
+			part, rest, ok := hyphenateWord(w, tt.available)
+
+			if !tt.want.ok && ok {
+				t.Logf("part: {text: %q, width: 0x%x /* %v */}", part.Text, math.Float64bits(part.Width), part.Width)
+				t.Logf("rest: {text: %q, width: 0x%x /* %v */}", rest.Text, math.Float64bits(rest.Width), rest.Width)
+				t.Logf("ok: %v", ok)
+				t.Fatal("no expectations set — paste the logged literals above")
+			}
+
+			if ok != tt.want.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.want.ok)
+			}
+			if !ok {
+				return
+			}
+			if part.Text != tt.want.partText {
+				t.Errorf("part.Text = %q, want %q", part.Text, tt.want.partText)
+			}
+			if got := math.Float64bits(part.Width); got != tt.want.partWidth {
+				t.Errorf("part.Width bits = 0x%x (%v), want 0x%x (%v)",
+					got, part.Width, tt.want.partWidth, math.Float64frombits(tt.want.partWidth))
+			}
+			if rest.Text != tt.want.restText {
+				t.Errorf("rest.Text = %q, want %q", rest.Text, tt.want.restText)
+			}
+			if got := math.Float64bits(rest.Width); got != tt.want.restWidth {
+				t.Errorf("rest.Width bits = 0x%x (%v), want 0x%x (%v)",
+					got, rest.Width, tt.want.restWidth, math.Float64frombits(tt.want.restWidth))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`breakLongWords` (unshaped path) and `hyphenateWord` re-measured a growing prefix from scratch for each candidate, so splitting a long unbreakable token was O(n²) — a pathological CPU cost (a 2000-char token splitting into a few chunks measured ~20 ms).

## Change

- Add `font.PrefixFit(text, size, maxWidth)` (Standard + Embedded): walks grapheme clusters from the chunk start accumulating width exactly as `MeasureString`, and stops at the first rune boundary exceeding `maxWidth` — the same first-overflow break the old scan produced. Each walk is O(chunkLen), so a full token split is O(n).
- `breakLongWords` passes a zero-copy substring and slices by the returned byte length (no per-chunk `string(runes[...])` allocation).
- `hyphenateWord` uses a single full-word prefix walk (already O(n), down from O(n²)); its descending-order fallback is preserved for byte-identity. The shaped (Arabic/Indic) path is untouched.

## Correctness & perf

Output is **byte-identical** — characterization tests pin the exact `(text, width-bits)` chunk sequences from the original code; a differential test proves `PrefixFit` matches the reference first-overflow scan (including exact-boundary and non-monotonic-kerning cases).

Benchmarks (M1 Pro): `BreakLongWordsUnshaped` ~153µs → ~24µs (−84%), allocs 429 → 7; the few-large-chunks pathology ~20.3ms → ~54µs (~373×); the shaped `Indic` benchmark is unchanged.