### PR TITLE
export: add handle-table Go tests and C harness error-path stage

### DIFF
--- a/export/internal_test.go
+++ b/export/internal_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build cgo && !js && !wasm
+
+package main
+
+import (
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+func newTestHandleTable() *handleTable {
+	return &handleTable{handles: make(map[uint64]any), next: 1}
+}
+
+func TestHandleTableStoreLoad(t *testing.T) {
+	ht := newTestHandleTable()
+	id1 := ht.store("a")
+	id2 := ht.store("b")
+
+	if id1 == 0 || id2 == 0 {
+		t.Fatalf("store returned a zero handle: id1=%d id2=%d", id1, id2)
+	}
+	if id1 == id2 {
+		t.Fatalf("store returned duplicate handles: %d", id1)
+	}
+	if got := ht.load(id1); got != "a" {
+		t.Errorf("load(id1) = %v, want %q", got, "a")
+	}
+	if got := ht.load(id2); got != "b" {
+		t.Errorf("load(id2) = %v, want %q", got, "b")
+	}
+}
+
+func TestHandleTableHandleZeroInvalid(t *testing.T) {
+	ht := newTestHandleTable()
+	if got := ht.load(0); got != nil {
+		t.Errorf("load(0) = %v, want nil", got)
+	}
+	if ok := ht.delete(0); ok {
+		t.Errorf("delete(0) = true, want false")
+	}
+}
+
+func TestHandleTableUnknownID(t *testing.T) {
+	ht := newTestHandleTable()
+	if got := ht.load(12345); got != nil {
+		t.Errorf("load(12345) = %v, want nil", got)
+	}
+	if ok := ht.delete(12345); ok {
+		t.Errorf("delete(12345) = true, want false")
+	}
+}
+
+func TestHandleTableDeleteTwice(t *testing.T) {
+	ht := newTestHandleTable()
+	id := ht.store("x")
+
+	if ok := ht.delete(id); !ok {
+		t.Fatalf("first delete(%d) = false, want true", id)
+	}
+	if ok := ht.delete(id); ok {
+		t.Errorf("second delete(%d) = true, want false", id)
+	}
+	if got := ht.load(id); got != nil {
+		t.Errorf("load after delete = %v, want nil", got)
+	}
+}
+
+func TestHandleTableCount(t *testing.T) {
+	ht := newTestHandleTable()
+	if n := ht.count(); n != 0 {
+		t.Fatalf("count() on empty table = %d, want 0", n)
+	}
+
+	id1 := ht.store("a")
+	id2 := ht.store("b")
+	if n := ht.count(); n != 2 {
+		t.Errorf("count() after two stores = %d, want 2", n)
+	}
+
+	ht.delete(id1)
+	if n := ht.count(); n != 1 {
+		t.Errorf("count() after one delete = %d, want 1", n)
+	}
+
+	ht.delete(id2)
+	if n := ht.count(); n != 0 {
+		t.Errorf("count() after all deleted = %d, want 0", n)
+	}
+}
+
+func TestHandleTableConcurrent(t *testing.T) {
+	ht := newTestHandleTable()
+	const goroutines = 8
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				id := ht.store(i)
+				if got := ht.load(id); got != i {
+					t.Errorf("load(%d) = %v, want %d", id, got, i)
+				}
+				if ok := ht.delete(id); !ok {
+					t.Errorf("delete(%d) = false, want true", id)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if n := ht.count(); n != 0 {
+		t.Errorf("count() after concurrent store/load/delete = %d, want 0", n)
+	}
+}
+
+func TestNewCBufferEmpty(t *testing.T) {
+	for _, data := range [][]byte{nil, {}} {
+		b := newCBuffer(data)
+		if b.ptr != nil {
+			t.Errorf("newCBuffer(%v).ptr = %v, want nil", data, b.ptr)
+		}
+		if b.len != 0 {
+			t.Errorf("newCBuffer(%v).len = %d, want 0", data, b.len)
+		}
+	}
+}
+
+func TestNewCBufferNonEmpty(t *testing.T) {
+	want := "hello"
+	b := newCBuffer([]byte(want))
+	// C.free is unreachable from _test.go; the 5-byte leak is confined to
+	// the test binary's lifetime.
+	if b.len != len(want) {
+		t.Fatalf("len = %d, want %d", b.len, len(want))
+	}
+	if b.ptr == nil {
+		t.Fatalf("ptr is nil for non-empty data")
+	}
+	got := unsafe.Slice((*byte)(b.ptr), b.len)
+	if string(got) != want {
+		t.Errorf("copied bytes = %q, want %q", got, want)
+	}
+}
+
+func TestSetClearLastError(t *testing.T) {
+	// No C-side readback is possible here (folio_last_error returns
+	// *C.char); this only exercises the store/clear/overwrite paths
+	// under -race. The C harness verifies the actual message contents.
+	setLastError("boom")
+	clearLastError()
+	setLastError("x")
+	setLastError("x")
+}
+
+func TestErrorCodes(t *testing.T) {
+	// Pins the numeric contract FFI callers depend on. Renumbering any of
+	// these is an ABI break.
+	cases := []struct {
+		name string
+		code int32
+		want int32
+	}{
+		{"errOK", errOK, 0},
+		{"errInvalidHandle", errInvalidHandle, -1},
+		{"errInvalidArg", errInvalidArg, -2},
+		{"errIO", errIO, -3},
+		{"errPDF", errPDF, -4},
+		{"errTypeMismatch", errTypeMismatch, -5},
+		{"errInternalError", errInternalError, -6},
+	}
+	for _, c := range cases {
+		if c.code != c.want {
+			t.Errorf("%s = %d, want %d", c.name, c.code, c.want)
+		}
+	}
+}

--- a/export/testdata/test_cabi.c
+++ b/export/testdata/test_cabi.c
@@ -1870,6 +1870,56 @@ int main(void) {
         folio_string_free(NULL); /* NULL is a documented no-op */
     }
 
+    /* ===== Stage 42: Error paths — handles, buffers, IO ===== */
+    printf("Testing error paths...\n");
+
+    /* Buffer lifecycle: freed and invalid handles are safe and inert */
+    doc = folio_document_new_letter();
+    folio_document_add_page(doc);
+    buf = folio_document_write_to_buffer(doc);
+    ASSERT(buf != 0, "write_to_buffer for error-path stage");
+    ASSERT(folio_buffer_len(buf) > 0, "buffer live before free");
+    folio_buffer_free(buf);
+    ASSERT(folio_buffer_data(buf) == NULL, "buffer_data on freed handle is NULL");
+    ASSERT(folio_buffer_len(buf) == 0, "buffer_len on freed handle is 0");
+    folio_buffer_free(buf); /* double-free: documented no-op, must not crash */
+    ASSERT(folio_buffer_data(0) == NULL, "buffer_data on handle 0 is NULL");
+    ASSERT(folio_buffer_len(99999) == 0, "buffer_len on unknown handle is 0");
+
+    /* Wrong-type handle: a document handle is not a buffer */
+    ASSERT(folio_buffer_data(doc) == NULL, "buffer_data on doc handle is NULL");
+    ASSERT(folio_buffer_len(doc) == 0, "buffer_len on doc handle is 0");
+
+    /* Invalid handles across modules return documented error values */
+    ASSERT(folio_document_add_page(99999) == 0, "add_page on bad doc returns 0 handle");
+    ASSERT(folio_document_page_count(99999) == 0, "page_count on bad doc returns 0"); /* pins current contract: errors are not encoded in this int32_t's sign */
+    ASSERT(folio_paragraph_set_leading(99999, 1.5) != 0, "paragraph op on bad handle errors");
+    ASSERT(folio_table_set_min_width(99999, 10) != 0, "table op on bad handle errors");
+    ASSERT(folio_div_set_padding(99999, 1, 1, 1, 1) != 0, "div op on bad handle errors");
+    ASSERT(folio_flex_set_gap(99999, 1) != 0, "flex op on bad handle errors");
+    ASSERT(folio_form_add_text_field(99999, "f", 0, 0, 10, 10, 0) != 0, "form op on bad handle errors");
+    ASSERT(folio_svg_width(99999) == 0, "svg_width on bad handle is 0");
+    ASSERT(folio_barcode_width(99999) == 0, "barcode_width on bad handle is 0");
+    ASSERT(folio_reader_page_count(99999) == 0, "reader_page_count on bad handle is 0"); /* pins current contract */
+
+    /* last_error is populated after a failing call; caller owns the copy */
+    folio_document_set_title(99999, "x");
+    const char* errPath = folio_last_error();
+    ASSERT(errPath != NULL, "last_error non-NULL after failure");
+    folio_string_free(errPath);
+
+    /* IO error: unwritable path */
+    rc = folio_document_save(doc, "/nonexistent-dir-folio-test/out.pdf");
+    ASSERT(rc != 0, "save to unwritable path returns error");
+
+    /* Type mismatch: pass a font handle where an element is expected */
+    helv = folio_font_helvetica();
+    rc = folio_document_add(doc, helv);
+    ASSERT(rc != 0, "document_add rejects non-element handle");
+
+    folio_document_free(doc);
+    folio_document_free(doc); /* double-free of document: must not crash */
+
     /* Summary */
     printf("\n%d passed, %d failed\n", passes, failures);
     return failures > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

Adds the first Go-side unit tests for the `export/` C-ABI internals and an error-path stage to the C harness, covering the handle table, buffer lifetime, and last-error behavior that previously had no direct tests.

## Change (tests only)

- `export/internal_test.go` (new): handle-table store/load, invalid/zero/unknown handles, double-delete, count, and an 8×1000-goroutine concurrent test under `-race`; `newCBuffer` empty/non-empty memcpy; set/clear last-error; and a pin of the ABI error-code numbering.
- `export/testdata/test_cabi.c`: a new stage asserting buffer double-free is a no-op, freed/invalid/wrong-type handle queries, invalid-handle error codes across modules, caller-owned last-error copy + `folio_string_free`, unwritable-save `errIO`, and document double-free.

NULL/negative-count array and NULL-string cases are intentionally left to the existing `unsafe.Slice` bounds stage (not duplicated). Harness: 446 checks pass; header/exports audit in sync.