### PR TITLE
font: fold GSUB/GPOS/GIDToUnicode onto font.Face (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
+- **`font.Face` now includes `GSUB()`, `GPOS()`, and `GIDToUnicode()`** — the optional `font.GSUBProvider` and `font.GPOSProvider` interfaces are removed, and every `Face` implementation must provide the three methods directly. A `Face` with no shaping data for a given table returns nil rather than omitting the method; `GIDToUnicode` returns nil when the font has no cmap-derived reverse map. This drops the type-assertion indirection that callers previously used to probe for shaping support (`face.(font.GSUBProvider)`, `face.(font.GPOSProvider)`) now that the seam is no longer needed pre-1.0.
 - **`html` no longer fetches remote or absolute-path assets by default** — a document's `http(s)` references (`<img>`, `background-image: url()`, linked stylesheets, `@font-face url()`) are only fetched when `Options.AllowRemoteFetch` is set, and absolute filesystem paths in document content are only read when `Options.AllowAbsolutePaths` is set (both default false). When remote fetch is enabled with no `Options.URLPolicy`, the built-in `html.DenyInternalHosts` policy blocks loopback, RFC1918, link-local, and non-http(s) targets and is re-checked on every redirect hop; absolute-path reads are size-capped like HTTP reads. Set `URLPolicy` to a function returning nil to allow every host. `Options.FallbackFontPath` and the built-in system-font search are unaffected.
 
 ### Added

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -4,6 +4,51 @@ For the full list of new features and fixes, see [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
+## Upgrading from v0.9.x to v0.10.0
+
+### `font.Face` gains `GSUB()`, `GPOS()`, and `GIDToUnicode()`; `GSUBProvider`/`GPOSProvider` are removed
+
+Shaping support used to be an optional side-interface a `Face` could
+implement, discovered by callers via type assertion. Both provider
+interfaces are gone; `Face` now declares the three methods directly, so
+every implementation must provide them. Return nil to mean "no data for
+this font" — that was already the nil-return contract for the removed
+interfaces.
+
+Migration for external `Face` implementers:
+
+```go
+// before
+type myFace struct{ /* ... */ }
+
+// (GSUB/GPOS/GIDToUnicode only needed to satisfy the optional
+// GSUBProvider/GPOSProvider interfaces)
+
+// after
+type myFace struct{ /* ... */ }
+
+func (f *myFace) GSUB() *font.GSUBSubstitutions { return nil }
+func (f *myFace) GIDToUnicode() map[uint16]rune { return nil }
+func (f *myFace) GPOS() *font.GPOSAdjustments   { return nil }
+```
+
+Migration for callers that probed for shaping support:
+
+```go
+// before
+gp, ok := face.(font.GSUBProvider)
+if !ok {
+    // no shaping data
+}
+gsub := gp.GSUB()
+
+// after
+gsub := face.GSUB()
+if gsub == nil {
+    // no shaping data
+}
+```
+
 ## Upgrading from v0.7.x to v0.8.0
 
 ### `html.Options.BasePath` is removed

--- a/font/face.go
+++ b/font/face.go
@@ -75,33 +75,19 @@ type Face interface {
 
 	// NumGlyphs returns the total number of glyphs in the font.
 	NumGlyphs() int
-}
 
-// GSUBProvider is an optional interface that a Face may implement to
-// expose parsed OpenType GSUB substitution tables for Arabic positional
-// shaping features (init, medi, fina, isol). Callers should type-assert
-// to check availability rather than requiring all Face implementations
-// to support GSUB. This avoids breaking external Face implementers
-// during v0.x.
-//
-// TODO: at v1.0, merge GSUB() back into Face. The type-assertion
-// indirection adds no value once the API is stable.
-type GSUBProvider interface {
+	// GSUB returns the font's parsed OpenType GSUB substitution tables,
+	// or nil when the font has none. Used for Arabic positional shaping
+	// and Indic conjunct formation.
 	GSUB() *GSUBSubstitutions
-	// GIDToUnicode returns a reverse mapping from glyph ID to Unicode
-	// codepoint, built from the font's cmap table. Used to convert
-	// GSUB-substituted GIDs back to codepoints for the text pipeline.
-	// The result is cached after the first call.
-	GIDToUnicode() map[uint16]rune
-}
 
-// GPOSProvider is an optional interface that a Face may implement to
-// expose parsed OpenType GPOS positioning tables. GPOS() returns nil
-// when the font has no recognized positioning data. See GSUBProvider
-// for the rationale behind the optional-interface pattern during v0.x.
-//
-// TODO: at v1.0, merge GPOS() back into Face.
-type GPOSProvider interface {
+	// GIDToUnicode returns a reverse glyph-ID-to-Unicode mapping built
+	// from the cmap table, or nil when unavailable. The result is cached
+	// after the first call.
+	GIDToUnicode() map[uint16]rune
+
+	// GPOS returns the font's parsed OpenType GPOS positioning tables,
+	// or nil when the font has no recognized positioning data.
 	GPOS() *GPOSAdjustments
 }
 

--- a/font/fallback_test.go
+++ b/font/fallback_test.go
@@ -22,20 +22,23 @@ func newFakeFace(runes ...rune) *fakeFace {
 	return &fakeFace{covers: covers}
 }
 
-func (f *fakeFace) PostScriptName() string    { return "FakeFace" }
-func (f *fakeFace) UnitsPerEm() int           { return 1000 }
-func (f *fakeFace) GlyphIndex(r rune) uint16  { return f.covers[r] }
-func (f *fakeFace) GlyphAdvance(_ uint16) int { return 500 }
-func (f *fakeFace) Ascent() int               { return 800 }
-func (f *fakeFace) Descent() int              { return -200 }
-func (f *fakeFace) BBox() [4]int              { return [4]int{0, -200, 1000, 800} }
-func (f *fakeFace) ItalicAngle() float64      { return 0 }
-func (f *fakeFace) CapHeight() int            { return 700 }
-func (f *fakeFace) StemV() int                { return 80 }
-func (f *fakeFace) Kern(_, _ uint16) int      { return 0 }
-func (f *fakeFace) Flags() uint32             { return 0 }
-func (f *fakeFace) RawData() []byte           { return nil }
-func (f *fakeFace) NumGlyphs() int            { return len(f.covers) + 1 }
+func (f *fakeFace) PostScriptName() string        { return "FakeFace" }
+func (f *fakeFace) UnitsPerEm() int               { return 1000 }
+func (f *fakeFace) GlyphIndex(r rune) uint16      { return f.covers[r] }
+func (f *fakeFace) GlyphAdvance(_ uint16) int     { return 500 }
+func (f *fakeFace) Ascent() int                   { return 800 }
+func (f *fakeFace) Descent() int                  { return -200 }
+func (f *fakeFace) BBox() [4]int                  { return [4]int{0, -200, 1000, 800} }
+func (f *fakeFace) ItalicAngle() float64          { return 0 }
+func (f *fakeFace) CapHeight() int                { return 700 }
+func (f *fakeFace) StemV() int                    { return 80 }
+func (f *fakeFace) Kern(_, _ uint16) int          { return 0 }
+func (f *fakeFace) Flags() uint32                 { return 0 }
+func (f *fakeFace) RawData() []byte               { return nil }
+func (f *fakeFace) NumGlyphs() int                { return len(f.covers) + 1 }
+func (f *fakeFace) GSUB() *GSUBSubstitutions      { return nil }
+func (f *fakeFace) GIDToUnicode() map[uint16]rune { return nil }
+func (f *fakeFace) GPOS() *GPOSAdjustments        { return nil }
 
 func TestNewFallbackPanicsOnEmpty(t *testing.T) {
 	defer func() {

--- a/font/truetype_test.go
+++ b/font/truetype_test.go
@@ -386,12 +386,8 @@ func TestFlagsItalic(t *testing.T) {
 
 func TestFaceGSUBCaching(t *testing.T) {
 	face := loadTestFace(t)
-	provider, ok := face.(GSUBProvider)
-	if !ok {
-		t.Fatal("sfntFace should implement GSUBProvider")
-	}
-	first := provider.GSUB()
-	second := provider.GSUB()
+	first := face.GSUB()
+	second := face.GSUB()
 
 	// Both calls must agree on nil-ness.
 	if (first == nil) != (second == nil) {
@@ -410,11 +406,7 @@ func TestFaceGSUBCaching(t *testing.T) {
 
 func TestFaceGIDToUnicode(t *testing.T) {
 	face := loadTestFace(t)
-	provider, ok := face.(GSUBProvider)
-	if !ok {
-		t.Fatal("sfntFace should implement GSUBProvider")
-	}
-	m := provider.GIDToUnicode()
+	m := face.GIDToUnicode()
 	if len(m) == 0 {
 		t.Fatal("GIDToUnicode returned empty map")
 	}
@@ -432,7 +424,7 @@ func TestFaceGIDToUnicode(t *testing.T) {
 	}
 
 	// Cache check: second call returns equivalent map.
-	m2 := provider.GIDToUnicode()
+	m2 := face.GIDToUnicode()
 	if len(m2) != len(m) {
 		t.Errorf("GIDToUnicode map length changed: first=%d second=%d", len(m), len(m2))
 	}
@@ -480,15 +472,6 @@ func TestBuildGIDToUnicodeInvalidData(t *testing.T) {
 // confirms synchronization didn't change what gets computed.
 func TestSfntFaceConcurrentLazyCaches(t *testing.T) {
 	exercise := func(t *testing.T, face Face) {
-		gsub, ok := face.(GSUBProvider)
-		if !ok {
-			t.Fatal("face should implement GSUBProvider")
-		}
-		gpos, ok := face.(GPOSProvider)
-		if !ok {
-			t.Fatal("face should implement GPOSProvider")
-		}
-
 		gidA, gidV := face.GlyphIndex('A'), face.GlyphIndex('V')
 		if gidA == 0 {
 			gidA = 1
@@ -507,9 +490,9 @@ func TestSfntFaceConcurrentLazyCaches(t *testing.T) {
 				for j := 0; j < 100; j++ {
 					_ = face.Kern(gidA, gidV)
 					_ = face.GlyphAdvance(gidA)
-					_ = gsub.GSUB()
-					_ = gsub.GIDToUnicode()
-					_ = gpos.GPOS()
+					_ = face.GSUB()
+					_ = face.GIDToUnicode()
+					_ = face.GPOS()
 				}
 			}()
 		}

--- a/layout/arabic.go
+++ b/layout/arabic.go
@@ -236,15 +236,11 @@ func ShapeArabicWithFont(s string, face font.Face) string {
 	if face == nil {
 		return shapeArabicWithFont(s, nil, nil, nil)
 	}
-	gp, ok := face.(font.GSUBProvider)
-	if !ok {
+	gsub := face.GSUB()
+	if gsub == nil {
 		return shapeArabicWithFont(s, nil, nil, nil)
 	}
-	gsub := gp.GSUB()
-	var gidReverse map[uint16]rune
-	if gsub != nil {
-		gidReverse = gp.GIDToUnicode()
-	}
+	gidReverse := face.GIDToUnicode()
 	return shapeArabicWithFont(s, gsub, face, gidReverse)
 }
 

--- a/layout/arabic_gsub_test.go
+++ b/layout/arabic_gsub_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/carlos7ags/folio/font"
 )
 
-// --- Mock GSUBProvider for deterministic CI-safe tests ---
+// --- Mock face for deterministic CI-safe tests ---
 
-// mockGSUBFace implements font.Face and font.GSUBProvider with synthetic
-// data so tests don't depend on system fonts.
+// mockGSUBFace implements font.Face with synthetic GSUB data so tests
+// don't depend on system fonts.
 type mockGSUBFace struct {
 	glyphMap      map[rune]uint16         // cmap: rune -> GID
 	reverseMap    map[uint16]rune         // reverse cmap: GID -> rune
@@ -42,6 +42,7 @@ func (m *mockGSUBFace) RawData() []byte               { return nil }
 func (m *mockGSUBFace) NumGlyphs() int                { return 100 }
 func (m *mockGSUBFace) GSUB() *font.GSUBSubstitutions { return m.substitutions }
 func (m *mockGSUBFace) GIDToUnicode() map[uint16]rune { return m.reverseMap }
+func (m *mockGSUBFace) GPOS() *font.GPOSAdjustments   { return nil }
 
 // newMockArabicFace creates a mock face with synthetic GSUB data for
 // beh (U+0628) and alef (U+0627). The GSUB maps base GIDs to synthetic
@@ -163,16 +164,13 @@ func TestGSUBNilFaceMatchesPFB(t *testing.T) {
 	}
 }
 
-// TestGSUBFaceWithoutProvider verifies that a Face that does NOT
-// implement GSUBProvider falls back to PFB without error.
+// TestGSUBFaceWithoutProvider verifies that a face reporting no GSUB
+// tables falls back to PFB without error.
 func TestGSUBFaceWithoutProvider(t *testing.T) {
-	// Use a real face that implements Face but check the path works.
-	// Since we can't easily create a non-GSUBProvider face (sfntFace
-	// always implements it), just verify the nil GSUB path.
 	input := "\u0628"
 	shaped := ShapeArabicWithFont(input, nil)
 	if shaped == input {
-		t.Error("expected shaping even without GSUBProvider")
+		t.Error("expected shaping even without GSUB tables")
 	}
 }
 
@@ -185,11 +183,10 @@ func TestShapeArabicWithRealFontGSUB(t *testing.T) {
 	if face == nil {
 		t.Skip("no system Arabic font with GSUB found")
 	}
-	gp, ok := face.(font.GSUBProvider)
-	if !ok || gp.GSUB() == nil {
+	if face.GSUB() == nil {
 		t.Skip("no GSUB tables")
 	}
-	sub := gp.GSUB()
+	sub := face.GSUB()
 	t.Logf("GSUB features: init=%d medi=%d fina=%d isol=%d",
 		len(sub.Single[font.GSUBInit]), len(sub.Single[font.GSUBMedi]),
 		len(sub.Single[font.GSUBFina]), len(sub.Single[font.GSUBIsol]))

--- a/layout/draw.go
+++ b/layout/draw.go
@@ -366,11 +366,7 @@ func markPositioningEligible(word Word) bool {
 	if word.Embedded == nil || word.LetterSpacing != 0 {
 		return false
 	}
-	provider, ok := word.Embedded.Face().(font.GPOSProvider)
-	if !ok {
-		return false
-	}
-	gpos := provider.GPOS()
+	gpos := word.Embedded.Face().GPOS()
 	if gpos == nil {
 		return false
 	}
@@ -404,11 +400,7 @@ func cursivePositioningEligible(word Word) bool {
 	if word.Embedded == nil || len(word.GIDs) < 2 || word.LetterSpacing != 0 {
 		return false
 	}
-	provider, ok := word.Embedded.Face().(font.GPOSProvider)
-	if !ok {
-		return false
-	}
-	gpos := provider.GPOS()
+	gpos := word.Embedded.Face().GPOS()
 	if gpos == nil {
 		return false
 	}
@@ -442,8 +434,7 @@ func drawShapedGIDsCursive(stream *content.Stream, word Word) {
 		stream.ShowTextHex(ef.EncodeGIDs(word.GIDs, word.OriginalText))
 		return
 	}
-	provider, _ := face.(font.GPOSProvider)
-	gpos := provider.GPOS()
+	gpos := face.GPOS()
 	scale := word.FontSize / float64(upem)
 
 	// Per-glyph Tj emission. We use one EncodeGIDs call per glyph so
@@ -502,8 +493,7 @@ func drawWordEmbeddedWithMarks(stream *content.Stream, word Word) {
 		stream.ShowTextHex(ef.EncodeString(word.Text))
 		return
 	}
-	provider, _ := face.(font.GPOSProvider)
-	gpos := provider.GPOS()
+	gpos := face.GPOS()
 	fontSize := word.FontSize
 	scale := fontSize / float64(upem)
 

--- a/layout/fallback_test.go
+++ b/layout/fallback_test.go
@@ -25,20 +25,23 @@ func newFakeFace(runes ...rune) *fakeFace {
 	return &fakeFace{covers: covers}
 }
 
-func (f *fakeFace) PostScriptName() string    { return "FakeFace" }
-func (f *fakeFace) UnitsPerEm() int           { return 1000 }
-func (f *fakeFace) GlyphIndex(r rune) uint16  { return f.covers[r] }
-func (f *fakeFace) GlyphAdvance(_ uint16) int { return 500 }
-func (f *fakeFace) Ascent() int               { return 800 }
-func (f *fakeFace) Descent() int              { return -200 }
-func (f *fakeFace) BBox() [4]int              { return [4]int{0, -200, 1000, 800} }
-func (f *fakeFace) ItalicAngle() float64      { return 0 }
-func (f *fakeFace) CapHeight() int            { return 700 }
-func (f *fakeFace) StemV() int                { return 80 }
-func (f *fakeFace) Kern(_, _ uint16) int      { return 0 }
-func (f *fakeFace) Flags() uint32             { return 0 }
-func (f *fakeFace) RawData() []byte           { return nil }
-func (f *fakeFace) NumGlyphs() int            { return len(f.covers) + 1 }
+func (f *fakeFace) PostScriptName() string        { return "FakeFace" }
+func (f *fakeFace) UnitsPerEm() int               { return 1000 }
+func (f *fakeFace) GlyphIndex(r rune) uint16      { return f.covers[r] }
+func (f *fakeFace) GlyphAdvance(_ uint16) int     { return 500 }
+func (f *fakeFace) Ascent() int                   { return 800 }
+func (f *fakeFace) Descent() int                  { return -200 }
+func (f *fakeFace) BBox() [4]int                  { return [4]int{0, -200, 1000, 800} }
+func (f *fakeFace) ItalicAngle() float64          { return 0 }
+func (f *fakeFace) CapHeight() int                { return 700 }
+func (f *fakeFace) StemV() int                    { return 80 }
+func (f *fakeFace) Kern(_, _ uint16) int          { return 0 }
+func (f *fakeFace) Flags() uint32                 { return 0 }
+func (f *fakeFace) RawData() []byte               { return nil }
+func (f *fakeFace) NumGlyphs() int                { return len(f.covers) + 1 }
+func (f *fakeFace) GSUB() *font.GSUBSubstitutions { return nil }
+func (f *fakeFace) GIDToUnicode() map[uint16]rune { return nil }
+func (f *fakeFace) GPOS() *font.GPOSAdjustments   { return nil }
 
 func TestNewParagraphFallbackPanicsOnNil(t *testing.T) {
 	defer func() {

--- a/layout/gpos_mark_draw_test.go
+++ b/layout/gpos_mark_draw_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/carlos7ags/folio/font"
 )
 
-// mockGPOSFace is a deterministic Face + GPOSProvider used to exercise
+// mockGPOSFace is a deterministic Face used to exercise
 // drawWordEmbeddedWithMarks. Each rune is mapped to a GID by a lookup
 // table; advances and upem are fixed; GPOS data is injected directly.
 type mockGPOSFace struct {
@@ -42,8 +42,9 @@ func (m *mockGPOSFace) Flags() uint32           { return 0 }
 func (m *mockGPOSFace) RawData() []byte         { return nil }
 func (m *mockGPOSFace) NumGlyphs() int          { return 4096 }
 
-// GPOS satisfies font.GPOSProvider.
-func (m *mockGPOSFace) GPOS() *font.GPOSAdjustments { return m.gpos }
+func (m *mockGPOSFace) GPOS() *font.GPOSAdjustments   { return m.gpos }
+func (m *mockGPOSFace) GSUB() *font.GSUBSubstitutions { return nil }
+func (m *mockGPOSFace) GIDToUnicode() map[uint16]rune { return nil }
 
 // newLamFathaFace constructs a mock face with lam (U+0644) as a base
 // glyph and fatha (U+064E) as a combining mark, plus a single GPOS

--- a/layout/indic.go
+++ b/layout/indic.go
@@ -1340,10 +1340,7 @@ func ShapeIndicWithEmbedded(s string, ef *font.EmbeddedFont, sc Script) ([]uint1
 	if face == nil {
 		return nil, false
 	}
-	var gsub *font.GSUBSubstitutions
-	if gp, ok := face.(font.GSUBProvider); ok {
-		gsub = gp.GSUB()
-	}
+	gsub := face.GSUB()
 	gids := ShapeIndic(s, face, gsub, cfg)
 	if len(gids) == 0 {
 		return nil, false

--- a/layout/indic_scripts_test.go
+++ b/layout/indic_scripts_test.go
@@ -40,6 +40,7 @@ func (m *mockIndicFace) RawData() []byte               { return nil }
 func (m *mockIndicFace) NumGlyphs() int                { return 65535 }
 func (m *mockIndicFace) GSUB() *font.GSUBSubstitutions { return m.substitutions }
 func (m *mockIndicFace) GIDToUnicode() map[uint16]rune { return nil }
+func (m *mockIndicFace) GPOS() *font.GPOSAdjustments   { return nil }
 
 func gid(r rune) uint16 { return uint16(r) + 1000 }
 

--- a/layout/indic_test.go
+++ b/layout/indic_test.go
@@ -14,9 +14,9 @@ import (
 
 // --- Mock face for Devanagari shaping tests ---------------------------------
 
-// mockDevaFace implements font.Face and font.GSUBProvider for synthetic
-// Devanagari tests. Glyph advances are a fixed 500 units and UnitsPerEm
-// is 1000 so width math is trivial (500/1000 * fontSize per GID).
+// mockDevaFace implements font.Face for synthetic Devanagari tests.
+// Glyph advances are a fixed 500 units and UnitsPerEm is 1000 so width
+// math is trivial (500/1000 * fontSize per GID).
 type mockDevaFace struct {
 	glyphMap      map[rune]uint16
 	reverseMap    map[uint16]rune
@@ -44,6 +44,7 @@ func (m *mockDevaFace) RawData() []byte               { return nil }
 func (m *mockDevaFace) NumGlyphs() int                { return 1000 }
 func (m *mockDevaFace) GSUB() *font.GSUBSubstitutions { return m.substitutions }
 func (m *mockDevaFace) GIDToUnicode() map[uint16]rune { return m.reverseMap }
+func (m *mockDevaFace) GPOS() *font.GPOSAdjustments   { return nil }
 
 // newMockDevaFace returns a face with a small Devanagari cmap:
 //

--- a/layout/kashida_paragraph_test.go
+++ b/layout/kashida_paragraph_test.go
@@ -42,16 +42,19 @@ func (m *mockArabicFace) GlyphAdvance(gid uint16) int {
 	}
 	return m.advance
 }
-func (m *mockArabicFace) Ascent() int             { return 800 }
-func (m *mockArabicFace) Descent() int            { return -200 }
-func (m *mockArabicFace) BBox() [4]int            { return [4]int{0, -200, 1000, 800} }
-func (m *mockArabicFace) ItalicAngle() float64    { return 0 }
-func (m *mockArabicFace) CapHeight() int          { return 700 }
-func (m *mockArabicFace) StemV() int              { return 80 }
-func (m *mockArabicFace) Kern(uint16, uint16) int { return 0 }
-func (m *mockArabicFace) Flags() uint32           { return 0 }
-func (m *mockArabicFace) RawData() []byte         { return nil }
-func (m *mockArabicFace) NumGlyphs() int          { return 4096 }
+func (m *mockArabicFace) Ascent() int                   { return 800 }
+func (m *mockArabicFace) Descent() int                  { return -200 }
+func (m *mockArabicFace) BBox() [4]int                  { return [4]int{0, -200, 1000, 800} }
+func (m *mockArabicFace) ItalicAngle() float64          { return 0 }
+func (m *mockArabicFace) CapHeight() int                { return 700 }
+func (m *mockArabicFace) StemV() int                    { return 80 }
+func (m *mockArabicFace) Kern(uint16, uint16) int       { return 0 }
+func (m *mockArabicFace) Flags() uint32                 { return 0 }
+func (m *mockArabicFace) RawData() []byte               { return nil }
+func (m *mockArabicFace) NumGlyphs() int                { return 4096 }
+func (m *mockArabicFace) GSUB() *font.GSUBSubstitutions { return nil }
+func (m *mockArabicFace) GIDToUnicode() map[uint16]rune { return nil }
+func (m *mockArabicFace) GPOS() *font.GPOSAdjustments   { return nil }
 
 // newMockArabicEmbedded returns a font.EmbeddedFont backed by mockArabicFace.
 // The advance/upem ratio is 1:2 so each glyph at FontSize=12 measures 6 pt.


### PR DESCRIPTION
## Summary — BREAKING (pre-1.0 API cleanup)

`GSUB()`, `GPOS()`, and `GIDToUnicode()` lived on two optional side-interfaces (`font.GSUBProvider`, `font.GPOSProvider`) reached by type assertion. This folds those three methods directly onto `font.Face` (nil return = "no data") and removes both provider interfaces.

## Behavior

Pure interface plumbing — **shaping output is byte-identical**. Two control-flow simplifications are provably equivalent (the collapsed nil checks take the same branch as the old `ok`/`nil` pair; the GPOS draw sites are only reached after an eligibility gate that already established `GPOS() != nil`, which also removes a latent nil-interface panic path). The Arabic/Indic/GPOS/kashida golden and shaping suites all pass unchanged.

## Migration (see MIGRATING.md → v0.10.0)

External `Face` implementers now implement `GSUB`/`GPOS`/`GIDToUnicode` on the type directly; callers drop the `face.(font.GSUBProvider)` type assertions and call the methods directly. All in-repo callers (`layout/arabic.go`, `layout/indic.go`, `layout/draw.go`) are migrated. CHANGELOG + MIGRATING updated.

golangci-lint clean; no remaining `GSUBProvider`/`GPOSProvider` references or type assertions repo-wide.