### PR TITLE
layout: count runes with utf8.RuneCountInString instead of len([]rune)

### DIFF
--- a/layout/bidi.go
+++ b/layout/bidi.go
@@ -84,7 +84,7 @@ func resolveLineBidi(words []Word, base Direction) ([]Word, Direction) {
 		}
 		spans[i].start = runePos
 		sb.WriteString(w.Text)
-		runePos += len([]rune(w.Text))
+		runePos += utf8.RuneCountInString(w.Text)
 		spans[i].end = runePos
 		textWordCount++
 	}

--- a/layout/kashida.go
+++ b/layout/kashida.go
@@ -404,7 +404,7 @@ func applyKashidaJustification(words []Word, slack float64) float64 {
 		// Re-measure with the same TextMeasurer used at layout time.
 		newWidth := words[e.idx].Embedded.MeasureString(newText, words[e.idx].FontSize)
 		if words[e.idx].LetterSpacing != 0 {
-			n := len([]rune(newText))
+			n := utf8.RuneCountInString(newText)
 			if n > 1 {
 				newWidth += words[e.idx].LetterSpacing * float64(n-1)
 			}

--- a/layout/paragraph_break.go
+++ b/layout/paragraph_break.go
@@ -5,6 +5,7 @@ package layout
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/carlos7ags/folio/font"
 )
@@ -61,8 +62,10 @@ func shapeAndMeasureWord(w *Word, run TextRun, measurer font.TextMeasurer) {
 		measureText = expandCountersForMeasure(measureText)
 	}
 	w.Width = measurer.MeasureString(measureText, run.FontSize)
-	if run.LetterSpacing != 0 && len([]rune(measureText)) > 1 {
-		w.Width += run.LetterSpacing * float64(len([]rune(measureText))-1)
+	if run.LetterSpacing != 0 {
+		if n := utf8.RuneCountInString(measureText); n > 1 {
+			w.Width += run.LetterSpacing * float64(n-1)
+		}
 	}
 	if w.Text != origText {
 		w.OriginalText = origText
@@ -100,8 +103,10 @@ func breakCJKWords(words []Word) []Word {
 			sub := w
 			sub.Text = tok
 			sub.Width = measure(tok)
-			if sub.LetterSpacing != 0 && len([]rune(tok)) > 1 {
-				sub.Width += sub.LetterSpacing * float64(len([]rune(tok))-1)
+			if sub.LetterSpacing != 0 {
+				if n := utf8.RuneCountInString(tok); n > 1 {
+					sub.Width += sub.LetterSpacing * float64(n-1)
+				}
 			}
 			if j < len(tokens)-1 {
 				sub.SpaceAfter = 0 // no inter-word space within CJK run

--- a/layout/paragraph_measure.go
+++ b/layout/paragraph_measure.go
@@ -3,7 +3,11 @@
 
 package layout
 
-import "github.com/carlos7ags/folio/font"
+import (
+	"unicode/utf8"
+
+	"github.com/carlos7ags/folio/font"
+)
 
 // runMeasurer returns the text measurer for a run, defaulting to
 // Helvetica if no font is set (defensive).
@@ -143,8 +147,10 @@ func (p *Paragraph) MinWidth() float64 {
 		measurer := runMeasurer(run)
 		for _, w := range splitWords(run.Text) {
 			ww := measurer.MeasureString(w, run.FontSize)
-			if run.LetterSpacing != 0 && len([]rune(w)) > 1 {
-				ww += run.LetterSpacing * float64(len([]rune(w))-1)
+			if run.LetterSpacing != 0 {
+				if n := utf8.RuneCountInString(w); n > 1 {
+					ww += run.LetterSpacing * float64(n-1)
+				}
 			}
 			if ww > maxWordW {
 				maxWordW = ww
@@ -176,8 +182,10 @@ func (p *Paragraph) MaxWidth() float64 {
 		spaceW := measurer.MeasureString(" ", run.FontSize)
 		for i, w := range words {
 			ww := measurer.MeasureString(w, run.FontSize)
-			if run.LetterSpacing != 0 && len([]rune(w)) > 1 {
-				ww += run.LetterSpacing * float64(len([]rune(w))-1)
+			if run.LetterSpacing != 0 {
+				if n := utf8.RuneCountInString(w); n > 1 {
+					ww += run.LetterSpacing * float64(n-1)
+				}
 			}
 			total += ww
 			if i < len(words)-1 {
@@ -313,7 +321,7 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 					}
 					prev.Width = prevMeasurer.MeasureString(prevMeasureText, prev.FontSize)
 					if prev.LetterSpacing != 0 {
-						prev.Width += prev.LetterSpacing * float64(len([]rune(prevMeasureText))-1)
+						prev.Width += prev.LetterSpacing * float64(utf8.RuneCountInString(prevMeasureText)-1)
 					}
 					text = rest
 				}


### PR DESCRIPTION
## Summary

Several layout sites computed a rune count via `len([]rune(s))`, which allocates a full rune slice just to count. Replace those count-only uses with `utf8.RuneCountInString(s)` (same result, no allocation).

## Change

7 count-only sites converted across `paragraph_break.go`, `paragraph_measure.go`, `bidi.go`, and `kashida.go` (double-conversions hoisted to a single count where present). Sites where the `[]rune` slice itself is used are left unchanged. Behavior is identical.

golangci-lint clean; full `go test ./...` passes.