### PR TITLE
layout: keep table rowspan groups intact across page breaks (closes #362)

### DIFF
--- a/examples/table-rowspan/main.go
+++ b/examples/table-rowspan/main.go
@@ -1,8 +1,9 @@
 // Copyright 2026 Carlos Munoz and the Folio Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Table-rowspan creates a one-page PDF demonstrating cells that span
-// multiple rows (rowspan) alongside multi-column spans (colspan).
+// Table-rowspan creates a multi-page PDF demonstrating cells that span
+// multiple rows (rowspan) alongside multi-column spans (colspan), including
+// a long table whose rowspan group is pushed intact across a page break.
 //
 // Usage:
 //
@@ -26,9 +27,10 @@ func main() {
 	fmt.Println("Created table-rowspan.pdf")
 }
 
-// buildDocument assembles a page with two tables: the minimal rowspan
-// case from issue #357, and a richer schedule grid where a cell spans
-// three rows. Extracted from main() so the example test can build the
+// buildDocument assembles three sections: the minimal rowspan case from
+// issue #357, a richer schedule grid where a cell spans three rows, and a
+// long roster table that crosses a page break with a rowspan group intact
+// (issue #362). Extracted from main() so the example test can build the
 // same document against an in-memory buffer.
 func buildDocument() *document.Document {
 	doc := document.NewDocument(document.PageSizeA4)
@@ -75,6 +77,58 @@ func buildDocument() *document.Document {
 	row3.AddCell("Workshop intro", font.Helvetica, 10)
 
 	doc.Add(sched)
+
+	doc.Add(layout.NewHeading("Rowspan across a page break", layout.H2))
+	doc.Add(layout.NewParagraph(
+		"A long roster where a rowspanning \"Platform Team\" cell would normally "+
+			"land right at the page boundary. The whole group is pushed to the "+
+			"next page instead of being split mid-span.",
+		font.Helvetica, 11,
+	))
+
+	roster := layout.NewTable()
+	roster.SetColumnWidths([]float64{90, 160, 160})
+
+	rh := roster.AddHeaderRow()
+	rh.AddCell("Team", font.HelveticaBold, 10)
+	rh.AddCell("Member", font.HelveticaBold, 10)
+	rh.AddCell("Role", font.HelveticaBold, 10)
+
+	// Enough plain rows to push the page boundary right up against the
+	// rowspan group below, then a 4-row group so the split can't land
+	// inside it — the whole group moves to the next page.
+	for i := 1; i <= 24; i++ {
+		row := roster.AddRow()
+		row.AddCell(fmt.Sprintf("Team %d", i), font.Helvetica, 10)
+		row.AddCell(fmt.Sprintf("Member %d", i), font.Helvetica, 10)
+		row.AddCell("Contributor", font.Helvetica, 10)
+	}
+
+	group := roster.AddRow()
+	group.AddCell("Platform Team", font.HelveticaBold, 10).SetRowspan(4).SetVAlign(layout.VAlignMiddle)
+	group.AddCell("Alice", font.Helvetica, 10)
+	group.AddCell("Lead", font.Helvetica, 10)
+
+	member2 := roster.AddRow()
+	member2.AddCell("Bilal", font.Helvetica, 10)
+	member2.AddCell("Engineer", font.Helvetica, 10)
+
+	member3 := roster.AddRow()
+	member3.AddCell("Chen", font.Helvetica, 10)
+	member3.AddCell("Engineer", font.Helvetica, 10)
+
+	member4 := roster.AddRow()
+	member4.AddCell("Divya", font.Helvetica, 10)
+	member4.AddCell("Engineer", font.Helvetica, 10)
+
+	for i := 25; i <= 30; i++ {
+		row := roster.AddRow()
+		row.AddCell(fmt.Sprintf("Team %d", i), font.Helvetica, 10)
+		row.AddCell(fmt.Sprintf("Member %d", i), font.Helvetica, 10)
+		row.AddCell("Contributor", font.Helvetica, 10)
+	}
+
+	doc.Add(roster)
 
 	return doc
 }

--- a/examples/table-rowspan/main_test.go
+++ b/examples/table-rowspan/main_test.go
@@ -39,10 +39,14 @@ func TestRowspanExampleProducesValidPDF(t *testing.T) {
 	}
 }
 
-func TestRowspanExampleSinglePage(t *testing.T) {
+// TestRowspanExampleMultiPage checks the document now spans multiple
+// pages: the roster section is long enough to force a page break, and
+// (per TestRowspanExampleGroupCrossesPageBreak) that break lands right
+// before a rowspan group.
+func TestRowspanExampleMultiPage(t *testing.T) {
 	r := examplePDFReader(t)
-	if got := r.PageCount(); got != 1 {
-		t.Errorf("PageCount = %d, want 1", got)
+	if got := r.PageCount(); got < 2 {
+		t.Errorf("PageCount = %d, want >= 2", got)
 	}
 }
 
@@ -69,5 +73,56 @@ func TestRowspanExampleContent(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Errorf("page text missing %q; extracted:\n%s", want, text)
 		}
+	}
+}
+
+// TestRowspanExampleGroupCrossesPageBreak is the issue #362 regression:
+// the roster's rowspanning "Platform Team" cell and the three rows under
+// it must land together on the page after the split, not be torn between
+// the page where the split occurs and the next one.
+func TestRowspanExampleGroupCrossesPageBreak(t *testing.T) {
+	r := examplePDFReader(t)
+	n := r.PageCount()
+	if n < 2 {
+		t.Fatalf("expected >= 2 pages, got %d", n)
+	}
+
+	pageText := func(i int) string {
+		page, err := r.Page(i)
+		if err != nil {
+			t.Fatalf("Page(%d): %v", i, err)
+		}
+		text, err := page.ExtractText()
+		if err != nil {
+			t.Fatalf("Page(%d).ExtractText: %v", i, err)
+		}
+		return text
+	}
+
+	// Find the page where the group's members appear; the group cell
+	// text and all of its rows must be on that same page.
+	groupMembers := []string{"Alice", "Bilal", "Chen", "Divya"}
+	groupPage := -1
+	for i := 0; i < n; i++ {
+		text := pageText(i)
+		if strings.Contains(text, "Alice") {
+			groupPage = i
+			break
+		}
+	}
+	if groupPage == -1 {
+		t.Fatal("could not find the page containing the rowspan group")
+	}
+	text := pageText(groupPage)
+	if !strings.Contains(text, "Platform Team") {
+		t.Errorf("page %d has the group's first member but not the spanning cell text", groupPage)
+	}
+	for _, member := range groupMembers {
+		if !strings.Contains(text, member) {
+			t.Errorf("page %d missing group member %q — the group was split across pages", groupPage, member)
+		}
+	}
+	if groupPage == 0 {
+		t.Error("expected the rowspan group on a later page than the first (it should have been pushed past the natural split)")
 	}
 }

--- a/layout/table.go
+++ b/layout/table.go
@@ -826,9 +826,10 @@ func (t *Table) buildGrid(colWidths []float64) []gridRow {
 // is then the total covered height (spanned row heights plus the spacing gaps
 // between them).
 //
-// Note: a rowspan that straddles a page break is not handled — PlanLayout
-// splits between rows without span awareness, so such a cell draws its full
-// height past the page bottom. Tracked as a known limitation (issue #357).
+// Note: PlanLayout keeps a rowspan and every row it covers together as one
+// atomic group when splitting across a page break (issue #362); a group
+// taller than a full page falls back to drawing past the page bottom, same
+// as an oversized plain row.
 func (t *Table) resolveRowspanHeights(grid []gridRow) {
 	sv := t.effectiveSpacingV()
 
@@ -866,6 +867,33 @@ func (t *Table) resolveRowspanHeights(grid []gridRow) {
 			gc.spanHeight = h
 		}
 	}
+}
+
+// spanGroupStarts returns, for each grid row, the index of the first row of
+// the atomic span group containing it. A group is the transitive closure of
+// rowspan coverage: any row covered by a span belongs to the span's starting
+// row's group, and a span starting inside a group extends that group. Rows
+// without span coverage are their own group.
+func spanGroupStarts(grid []gridRow) []int {
+	starts := make([]int, len(grid))
+	i := 0
+	for i < len(grid) {
+		end := i + 1
+		for j := i; j < end; j++ {
+			for _, gc := range grid[j].cells {
+				if gc.cell.rowspan > 1 {
+					if e := min(j+gc.cell.rowspan, len(grid)); e > end {
+						end = e
+					}
+				}
+			}
+		}
+		for j := i; j < end; j++ {
+			starts[j] = i
+		}
+		i = end
+	}
+	return starts
 }
 
 // cellContentHeight computes the height needed for a cell's content.
@@ -952,8 +980,8 @@ func (t *Table) Layout(maxWidth float64) []Line {
 	return lines
 }
 
-// PlanLayout implements Element. Tables split between rows, repeating
-// header rows on each new page.
+// PlanLayout implements Element. Tables split between rows — never inside a
+// rowspan group — repeating header rows on each new page.
 func (t *Table) PlanLayout(area LayoutArea) LayoutPlan {
 	if area.Height <= 0 {
 		return LayoutPlan{Status: LayoutNothing}
@@ -969,6 +997,10 @@ func (t *Table) PlanLayout(area LayoutArea) LayoutPlan {
 	if t.borderCollapse {
 		collapseBorders(grid)
 	}
+
+	// groupStarts[i] is the first row of the rowspan group containing row
+	// i; a split must never land strictly inside a group (issue #362).
+	groupStarts := spanGroupStarts(grid)
 
 	// Identify header rows (at start) and footer rows (at end).
 	var headerHeight float64
@@ -1011,15 +1043,25 @@ func (t *Table) PlanLayout(area LayoutArea) LayoutPlan {
 		// Add vertical spacing before this row.
 		curY += sv
 
-		// Check if this body row fits (reserve space for footer if splitting).
-		needsFooter := footerRowCount > 0 && i > headerRowCount
-		reserveH := 0.0
-		if needsFooter {
-			reserveH = footerHeight
-		}
-		if curY+gr.height+reserveH > area.Height && area.Height > 0 && i > headerRowCount {
-			splitIdx = i
-			break
+		// Check if this row's span group fits (reserve space for footer if
+		// splitting). A row that isn't its group's leader never triggers a
+		// split — the group's space was reserved when the leader was
+		// checked. For a span-free row the group is just the row itself,
+		// so this reduces to the plain per-row check.
+		if groupStarts[i] == i {
+			needsFooter := footerRowCount > 0 && i > headerRowCount
+			reserveH := 0.0
+			if needsFooter {
+				reserveH = footerHeight
+			}
+			groupH := gr.height
+			for k := i + 1; k < len(grid) && groupStarts[k] == i; k++ {
+				groupH += sv + grid[k].height
+			}
+			if curY+groupH+reserveH > area.Height && area.Height > 0 && i > headerRowCount {
+				splitIdx = i
+				break
+			}
 		}
 
 		capturedGrid := grid

--- a/layout/table_test.go
+++ b/layout/table_test.go
@@ -4,6 +4,7 @@
 package layout
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -1164,6 +1165,303 @@ func TestTableAutoColumnWidthsContentSized(t *testing.T) {
 	}
 	if plan.Consumed <= 0 {
 		t.Error("expected positive consumed height")
+	}
+}
+
+// TestTableSplitNoSpanCharacterization pins the span-free split arithmetic
+// so the rowspan-group fix below provably leaves it unchanged: no cell in
+// this table has rowspan > 1, so every row is its own group and the group
+// fit check must reduce to the plain per-row check.
+func TestTableSplitNoSpanCharacterization(t *testing.T) {
+	tbl := NewTable()
+	h := tbl.AddHeaderRow()
+	h.AddCell("Header", font.HelveticaBold, 10)
+	for range 20 {
+		tbl.AddRow().AddCell("Row", font.Helvetica, 10)
+	}
+
+	// Height chosen so roughly half the rows fit.
+	plan := tbl.PlanLayout(LayoutArea{Width: 400, Height: 130})
+	if plan.Status != LayoutPartial {
+		t.Fatalf("expected LayoutPartial, got %v", plan.Status)
+	}
+	if len(plan.Blocks) != 1 || plan.Blocks[0].Tag != "Table" {
+		t.Fatalf("expected one wrapping Table block, got %+v", plan.Blocks)
+	}
+	renderedRows := len(plan.Blocks[0].Children)
+
+	overflow, ok := plan.Overflow.(*Table)
+	if !ok {
+		t.Fatalf("expected *Table overflow, got %T", plan.Overflow)
+	}
+	overflowPlan := overflow.PlanLayout(LayoutArea{Width: 400, Height: 10000})
+	if overflowPlan.Status != LayoutFull {
+		t.Fatalf("expected overflow to fit fully, got %v", overflowPlan.Status)
+	}
+	overflowRows := overflowPlan.Blocks[0].Children
+	if len(overflowRows) == 0 || overflowRows[0].Tag != "TR" {
+		t.Fatalf("expected overflow rows, got %+v", overflowRows)
+	}
+
+	// Header is rendered on page one but not counted as a data row; the
+	// overflow re-adds its own header. Total data rows across both pages
+	// must equal the 20 body rows, and the overflow's first row is a
+	// repeated header.
+	pageOneDataRows := renderedRows - 1 // minus the header row
+	overflowDataRows := len(overflowRows) - 1
+	if pageOneDataRows+overflowDataRows != 20 {
+		t.Errorf("data rows: page one %d + overflow %d = %d, want 20",
+			pageOneDataRows, overflowDataRows, pageOneDataRows+overflowDataRows)
+	}
+	if len(overflow.rows) == 0 || !overflow.rows[0].isHeader {
+		t.Error("expected overflow's first row to be the repeated header")
+	}
+}
+
+// TestSpanGroupStarts is a table-driven unit test of the span group
+// computation: identity for span-free grids, a simple span, chained
+// overlapping spans, and a span clipped by the end of the grid.
+func TestSpanGroupStarts(t *testing.T) {
+	plainCell := func() gridCell { return gridCell{cell: &Cell{rowspan: 1}} }
+	spanCell := func(n int) gridCell { return gridCell{cell: &Cell{rowspan: n}} }
+
+	tests := []struct {
+		name string
+		grid []gridRow
+		want []int
+	}{
+		{
+			name: "no spans is identity",
+			grid: []gridRow{
+				{cells: []gridCell{plainCell()}},
+				{cells: []gridCell{plainCell()}},
+				{cells: []gridCell{plainCell()}},
+			},
+			want: []int{0, 1, 2},
+		},
+		{
+			name: "simple 3-row span",
+			grid: []gridRow{
+				{cells: []gridCell{spanCell(3)}},
+				{cells: []gridCell{plainCell()}},
+				{cells: []gridCell{plainCell()}},
+				{cells: []gridCell{plainCell()}},
+			},
+			want: []int{0, 0, 0, 3},
+		},
+		{
+			name: "chained overlapping spans",
+			grid: []gridRow{
+				{cells: []gridCell{plainCell()}},
+				{cells: []gridCell{spanCell(2)}},
+				{cells: []gridCell{spanCell(2)}},
+				{cells: []gridCell{plainCell()}},
+			},
+			// Row 1 spans rows 1-2; row 2's span extends the group to row 3.
+			want: []int{0, 1, 1, 1},
+		},
+		{
+			name: "span clipped by grid end",
+			grid: []gridRow{
+				{cells: []gridCell{plainCell()}},
+				{cells: []gridCell{spanCell(5)}},
+			},
+			want: []int{0, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := spanGroupStarts(tt.grid)
+			if len(got) != len(tt.want) {
+				t.Fatalf("length: got %d, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("row %d: got group start %d, want %d", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// buildRowspanSplitTable builds a 2-column, 12-row table: 6 plain rows,
+// then a 3-row group (row 7 has a rowspan(3) cell plus a plain cell; rows
+// 8-9 each have one cell that lands under the span), then 3 more plain
+// rows. Every row is 20pt tall (verified by the tests below), so callers
+// can pick a Height in multiples of 20 to force a split at a known row.
+func buildRowspanSplitTable() *Table {
+	tbl := NewTable()
+	tbl.SetColumnWidths([]float64{100, 100})
+	for i := 1; i <= 6; i++ {
+		tbl.AddRow().AddCell(fmt.Sprintf("Row%d", i), font.Helvetica, 10)
+	}
+	r7 := tbl.AddRow()
+	r7.AddCell("Span", font.Helvetica, 10).SetRowspan(3)
+	r7.AddCell("Row7", font.Helvetica, 10)
+	tbl.AddRow().AddCell("Row8", font.Helvetica, 10)
+	tbl.AddRow().AddCell("Row9", font.Helvetica, 10)
+	for i := 10; i <= 12; i++ {
+		tbl.AddRow().AddCell(fmt.Sprintf("Row%d", i), font.Helvetica, 10)
+	}
+	return tbl
+}
+
+// TestTableRowspanSplitPushesGroupToNextPage is the core regression for
+// issue #362: a split that would otherwise land inside a rowspan group
+// must move up to the group's first row instead.
+func TestTableRowspanSplitPushesGroupToNextPage(t *testing.T) {
+	tbl := buildRowspanSplitTable()
+
+	grid := tbl.buildGrid(tbl.resolveColWidths(400))
+	if len(grid) != 12 {
+		t.Fatalf("expected 12 grid rows, got %d", len(grid))
+	}
+	if grid[0].height != 20 {
+		t.Fatalf("row height assumption broken: got %g, want 20 (adjust Height below)", grid[0].height)
+	}
+
+	// 170 = 6 rows (120) + the group leader's own row (20) + 30 spare —
+	// enough for the group leader alone but not the full 3-row group.
+	plan := tbl.PlanLayout(LayoutArea{Width: 400, Height: 170})
+	if plan.Status != LayoutPartial {
+		t.Fatalf("expected LayoutPartial, got %v", plan.Status)
+	}
+	if len(plan.Blocks) != 1 {
+		t.Fatalf("expected one wrapping Table block, got %d", len(plan.Blocks))
+	}
+	if got := len(plan.Blocks[0].Children); got != 6 {
+		t.Errorf("page one TR count: got %d, want 6 (split pushed up to the group leader)", got)
+	}
+
+	overflow, ok := plan.Overflow.(*Table)
+	if !ok {
+		t.Fatalf("expected *Table overflow, got %T", plan.Overflow)
+	}
+	ogrid := overflow.buildGrid(overflow.resolveColWidths(400))
+	if len(ogrid) == 0 || len(ogrid[0].cells) == 0 {
+		t.Fatal("overflow grid has no rows/cells")
+	}
+	span := ogrid[0].cells[0]
+	if span.cell.text != "Span" {
+		t.Fatalf("expected overflow's first cell to be the span cell, got %q", span.cell.text)
+	}
+	if span.spanHeight <= 0 {
+		t.Error("expected span cell to carry a positive spanHeight in the overflow table")
+	}
+
+	// The row after the leader must keep its cell in column 1 (the
+	// occupied column skipped), not shift left into column 0.
+	if len(ogrid) < 2 || len(ogrid[1].cells) == 0 {
+		t.Fatal("overflow grid missing the row under the span")
+	}
+	if got := ogrid[1].cells[0].col; got != 1 {
+		t.Errorf("row under span: cell col got %d, want 1 (no column shift)", got)
+	}
+}
+
+// TestTableRowspanSplitNoContentLoss checks that every body row from the
+// source table appears exactly once across page one and the overflow.
+func TestTableRowspanSplitNoContentLoss(t *testing.T) {
+	tbl := buildRowspanSplitTable()
+
+	plan := tbl.PlanLayout(LayoutArea{Width: 400, Height: 170})
+	if plan.Status != LayoutPartial {
+		t.Fatalf("expected LayoutPartial, got %v", plan.Status)
+	}
+	pageOneRows := len(plan.Blocks[0].Children)
+
+	overflow, ok := plan.Overflow.(*Table)
+	if !ok {
+		t.Fatalf("expected *Table overflow, got %T", plan.Overflow)
+	}
+	if got := len(overflow.rows); got != 12-pageOneRows {
+		t.Errorf("overflow row count: got %d, want %d (12 total - %d on page one)",
+			got, 12-pageOneRows, pageOneRows)
+	}
+	if len(overflow.rows) == 0 || len(overflow.rows[0].cells) == 0 || overflow.rows[0].cells[0].text != "Span" {
+		t.Error("expected the span-defining row to be preserved whole in the overflow table")
+	}
+}
+
+// TestTableRowspanChainedGroupsSplitTogether checks that overlapping spans
+// form one transitive group: a span starting inside another span's
+// coverage extends the group, and a split inside the extended group must
+// move the whole thing to the next page.
+func TestTableRowspanChainedGroupsSplitTogether(t *testing.T) {
+	tbl := NewTable()
+	tbl.SetColumnWidths([]float64{100, 100, 100})
+	// 3 cells per plain row so the table has 3 real columns (column count
+	// is derived from the widest row, not from SetColumnWidths).
+	addPlainRow3 := func(prefix string) {
+		r := tbl.AddRow()
+		r.AddCell(prefix+"A", font.Helvetica, 10)
+		r.AddCell(prefix+"B", font.Helvetica, 10)
+		r.AddCell(prefix+"C", font.Helvetica, 10)
+	}
+	for i := 1; i <= 4; i++ {
+		addPlainRow3(fmt.Sprintf("Row%d", i))
+	}
+	// Row A covers A,B in col 0; row B covers B,C in col 1. The group is
+	// the transitive closure A-C. Every row carries a plain cell so its
+	// natural height is 20, matching the plain rows around it.
+	rowA := tbl.AddRow()
+	rowA.AddCell("A", font.Helvetica, 10).SetRowspan(2)
+	rowA.AddCell("A-col1", font.Helvetica, 10)
+	rowA.AddCell("A-col2", font.Helvetica, 10)
+	rowB := tbl.AddRow()
+	rowB.AddCell("B-col1", font.Helvetica, 10).SetRowspan(2)
+	rowB.AddCell("B-col2", font.Helvetica, 10)
+	rowC := tbl.AddRow()
+	rowC.AddCell("C-col0", font.Helvetica, 10)
+	rowC.AddCell("C-col2", font.Helvetica, 10)
+	for i := 1; i <= 3; i++ {
+		addPlainRow3(fmt.Sprintf("Tail%d", i))
+	}
+
+	grid := tbl.buildGrid(tbl.resolveColWidths(400))
+	if grid[0].height != 20 || grid[4].height != 20 || grid[5].height != 20 || grid[6].height != 20 {
+		t.Fatalf("row height assumption broken: got %v, want 20 for every row", []float64{grid[0].height, grid[4].height, grid[5].height, grid[6].height})
+	}
+
+	// 4 plain rows (80) + row A (20) fits; row B does not (100+20=120>110),
+	// so the split must move up to A, the group's leader.
+	plan := tbl.PlanLayout(LayoutArea{Width: 400, Height: 110})
+	if plan.Status != LayoutPartial {
+		t.Fatalf("expected LayoutPartial, got %v", plan.Status)
+	}
+	if got := len(plan.Blocks[0].Children); got != 4 {
+		t.Errorf("page one TR count: got %d, want 4 (whole A-C group pushed to overflow)", got)
+	}
+	overflow, ok := plan.Overflow.(*Table)
+	if !ok {
+		t.Fatalf("expected *Table overflow, got %T", plan.Overflow)
+	}
+	if got := len(overflow.rows); got != 6 {
+		t.Errorf("overflow row count: got %d, want 6 (A, B, C, and 3 tail rows)", got)
+	}
+}
+
+// TestTableRowspanTallerThanPageFallsBack pins the documented fallback for
+// a span group taller than a full page: PlanLayout must still terminate
+// with progress rather than looping forever trying to push the group to a
+// page it will never fit on.
+func TestTableRowspanTallerThanPageFallsBack(t *testing.T) {
+	tbl := NewTable()
+	tbl.SetColumnWidths([]float64{100, 100})
+	r := tbl.AddRow()
+	r.AddCell("Span", font.Helvetica, 10).SetRowspan(20)
+	r.AddCell("Row1", font.Helvetica, 10)
+	for i := 2; i <= 20; i++ {
+		tbl.AddRow().AddCell(fmt.Sprintf("Row%d", i), font.Helvetica, 10)
+	}
+
+	plan := tbl.PlanLayout(LayoutArea{Width: 400, Height: 50})
+	if plan.Status == LayoutNothing {
+		t.Fatal("expected progress (LayoutFull or LayoutPartial), got LayoutNothing")
+	}
+	if len(plan.Blocks) == 0 || len(plan.Blocks[0].Children) == 0 {
+		t.Fatal("expected at least one row placed despite the oversized group")
 	}
 }
 


### PR DESCRIPTION
## Summary

When a table paginated, a `rowspan` group could be split across a page boundary — the spanning cell and its member rows landed on different pages, corrupting the layout. This keeps each rowspan group atomic: a page break can only land on a group boundary.

Closes #362.

## Change

- `spanGroupStarts(grid)` maps each grid row to the first row of its atomic rowspan group (transitive closure over chained/overlapping spans).
- In `PlanLayout`, the per-row page-fit check fires only for a group's leader and measures the whole group's height (leader + members + inter-row spacing) against the page boundary. A non-leader row can never set the split index, so a split lands only on a group boundary; the overflow rebuild re-adds the span-defining row intact and re-derives column occupancy (no column shift).

## No regression to plain pagination

For a span-free table every group has size 1, so the check reduces bit-for-bit to the old per-row check (`TestTableSplitNoSpanCharacterization`). A rowspan group taller than a page falls back to draw-and-bleed on its own page, same as an oversized plain row (`TestTableRowspanTallerThanPageFallsBack`), with no infinite loop.

## Tests & demo

Unit + split tests for identity/chained/clipped groups, group-pushed-to-next-page, no-content-loss, and chained groups splitting together; existing table/overflow tests stay green. `examples/table-rowspan` gains a section where a 4-row rowspan group is pushed whole onto page 2 (visually verified). golangci-lint clean.