### PR TITLE
internal/cssunit: unify CSS length/unit parsing across html and svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ rowspan geometry (#357), `Document.AddConvertResult`, and
 
 ### Fixed
 
+- **`svg` dimension parsing no longer accepts multi-suffix garbage** — attribute values like `width="10empx"` were parsed by stripping every known unit suffix in sequence, so leftover garbage silently fell through to a clean number instead of failing. `svg` length parsing now consumes exactly one unit suffix; anything left over is rejected.
+- **`svg` `font-size` style now accepts `pt`-suffixed values** — `font-size: 12pt` previously failed to parse (only `px` was recognized) and silently left the inherited font size in place; it is now read as 12 user units, consistent with how the `width`/`height`/`r` attributes already treat `pt`.
+
 #### `border-radius` (#329)
 
 - **Percentage `border-radius` renders as a true rounded corner** — `border-radius: 50%` was resolving against a zero reference and collapsing to 0 (square corners). It now resolves per-axis: a circle on a square box, an ellipse on a rectangle, per CSS Backgrounds §5.5 corner clamping (#329)

--- a/html/properties.go
+++ b/html/properties.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/carlos7ags/folio/internal/csscolor"
+	"github.com/carlos7ags/folio/internal/cssunit"
 	"github.com/carlos7ags/folio/layout"
 )
 
@@ -196,25 +197,14 @@ func parseLength(value string) *cssLength {
 
 // parsePlainLength parses a simple CSS length (no calc).
 func parsePlainLength(value string) *cssLength {
-	value = strings.TrimSpace(value)
-	// Check rem before em to avoid "1rem" matching "em" suffix first.
-	for _, unit := range []string{"px", "pt", "rem", "em", "mm", "cm", "in", "%"} {
-		if strings.HasSuffix(value, unit) {
-			numStr := strings.TrimSpace(value[:len(value)-len(unit)])
-			num, err := strconv.ParseFloat(numStr, 64)
-			if err != nil {
-				return nil
-			}
-			return &cssLength{Value: num, Unit: unit}
-		}
+	num, unit, ok := cssunit.Parse(value)
+	if !ok {
+		return nil
 	}
-
-	// Bare number — treat as px.
-	if num, err := strconv.ParseFloat(value, 64); err == nil {
-		return &cssLength{Value: num, Unit: "px"}
+	if unit == "" {
+		unit = "px" // bare number — treat as px
 	}
-
-	return nil
+	return &cssLength{Value: num, Unit: unit}
 }
 
 // parseCalcExpr parses the inside of a calc() expression.

--- a/internal/cssunit/cssunit.go
+++ b/internal/cssunit/cssunit.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cssunit tokenizes CSS/SVG length values into a numeric value
+// and a unit suffix. It has no opinion on unit conversion — the html
+// package converts to PDF points with its own policy, and the svg
+// package treats every unit as an SVG user unit — so callers apply
+// their own conversion after tokenizing.
+package cssunit
+
+import (
+	"strconv"
+	"strings"
+)
+
+// units is checked in order; "rem" must precede "em" since "1rem" also
+// ends in the two characters "em".
+var units = []string{"px", "pt", "rem", "em", "mm", "cm", "in", "%"}
+
+// Parse splits a CSS/SVG length into numeric value and unit.
+// Recognized units: "px", "pt", "rem", "em", "mm", "cm", "in", "%".
+// A bare number returns unit "". Exactly one unit suffix is consumed;
+// leftover characters make the parse fail (ok=false).
+func Parse(s string) (value float64, unit string, ok bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, "", false
+	}
+
+	for _, u := range units {
+		if strings.HasSuffix(s, u) {
+			numStr := strings.TrimSpace(s[:len(s)-len(u)])
+			num, err := strconv.ParseFloat(numStr, 64)
+			if err != nil {
+				return 0, "", false
+			}
+			return num, u, true
+		}
+	}
+
+	num, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, "", false
+	}
+	return num, "", true
+}
+
+// PointsPerUnit returns the multiplier converting one <unit> to PDF points
+// at 96dpi CSS pixel density. fontSize is used for "em".
+// Returns ok=false for "%" and "" (caller-specific policies).
+func PointsPerUnit(unit string, fontSize float64) (factor float64, ok bool) {
+	switch unit {
+	case "pt":
+		return 1, true
+	case "px":
+		return 0.75, true
+	case "em":
+		return fontSize, true
+	case "rem":
+		return 16 * 0.75, true
+	case "mm":
+		return 72 / 25.4, true
+	case "cm":
+		return 72 / 2.54, true
+	case "in":
+		return 72, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/cssunit/cssunit_test.go
+++ b/internal/cssunit/cssunit_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cssunit
+
+import (
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const eps = 1e-9
+
+func approxEq(a, b float64) bool {
+	return math.Abs(a-b) < eps
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantValue float64
+		wantUnit  string
+		wantOK    bool
+	}{
+		{"px", "12px", 12, "px", true},
+		{"pt", "10pt", 10, "pt", true},
+		{"rem", "1rem", 1, "rem", true},
+		{"em", "1.5em", 1.5, "em", true},
+		{"mm", "5mm", 5, "mm", true},
+		{"cm", "2cm", 2, "cm", true},
+		{"in", "1in", 1, "in", true},
+		{"percent", "50%", 50, "%", true},
+
+		// rem vs em disambiguation: "rem" must not be mistaken for "em".
+		{"rem-not-em", "2rem", 2, "rem", true},
+		{"em-not-rem", "2em", 2, "em", true},
+
+		// Bare number.
+		{"bare-int", "100", 100, "", true},
+		{"bare-float", "12.5", 12.5, "", true},
+
+		// Negative and decimal values.
+		{"negative", "-10px", -10, "px", true},
+		{"negative-bare", "-5", -5, "", true},
+		{"decimal", "0.5em", 0.5, "em", true},
+
+		// Internal whitespace: parsePlainLength trimmed the numeric part
+		// after stripping the suffix, so "12 px" parsed as 12px.
+		{"internal-space", "12 px", 12, "px", true},
+		{"leading-trailing-space", "  12px  ", 12, "px", true},
+
+		// Empty and garbage.
+		{"empty", "", 0, "", false},
+		{"garbage", "abc", 0, "", false},
+		{"unit-only", "px", 0, "", false},
+
+		// Multi-suffix garbage is rejected — exactly one unit is consumed.
+		{"multi-suffix", "10pxpx", 0, "", false},
+		{"multi-suffix-mixed", "10empx", 0, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, unit, ok := Parse(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("Parse(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if !approxEq(v, tt.wantValue) || unit != tt.wantUnit {
+				t.Errorf("Parse(%q) = (%v, %q), want (%v, %q)", tt.input, v, unit, tt.wantValue, tt.wantUnit)
+			}
+		})
+	}
+}
+
+func TestPointsPerUnit(t *testing.T) {
+	const fontSize = 12.0
+	tests := []struct {
+		unit       string
+		wantFactor float64
+		wantOK     bool
+	}{
+		{"pt", 1, true},
+		{"px", 0.75, true},
+		{"em", fontSize, true},
+		{"rem", 16 * 0.75, true},
+		{"mm", 72 / 25.4, true},
+		{"cm", 72 / 2.54, true},
+		{"in", 72, true},
+		{"%", 0, false},
+		{"", 0, false},
+		{"bogus", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.unit, func(t *testing.T) {
+			factor, ok := PointsPerUnit(tt.unit, fontSize)
+			if ok != tt.wantOK {
+				t.Fatalf("PointsPerUnit(%q) ok = %v, want %v", tt.unit, ok, tt.wantOK)
+			}
+			if ok && !approxEq(factor, tt.wantFactor) {
+				t.Errorf("PointsPerUnit(%q) = %v, want %v", tt.unit, factor, tt.wantFactor)
+			}
+		})
+	}
+}
+
+// oldParsePlainLength reproduces html's pre-migration parsePlainLength
+// (html/properties.go) byte for byte, so TestParseMatchesOldHTMLParser can
+// assert the shared tokenizer is a drop-in replacement.
+func oldParsePlainLength(value string) (float64, string, bool) {
+	value = strings.TrimSpace(value)
+	for _, unit := range []string{"px", "pt", "rem", "em", "mm", "cm", "in", "%"} {
+		if strings.HasSuffix(value, unit) {
+			numStr := strings.TrimSpace(value[:len(value)-len(unit)])
+			num, err := strconv.ParseFloat(numStr, 64)
+			if err != nil {
+				return 0, "", false
+			}
+			return num, unit, true
+		}
+	}
+	if num, err := strconv.ParseFloat(value, 64); err == nil {
+		return num, "px", true
+	}
+	return 0, "", false
+}
+
+func TestParseMatchesOldHTMLParser(t *testing.T) {
+	inputs := []string{
+		"12px", "10pt", "1rem", "1.5em", "5mm", "2cm", "1in", "50%",
+		"100", "12.5", "-10px", "-5", "0.5em", "12 px", "  12px  ",
+		"", "abc", "px", "10pxpx", "10empx", "0", "0px",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			wantVal, wantUnit, wantOK := oldParsePlainLength(in)
+			gotVal, gotUnit, gotOK := Parse(in)
+			// The old parser defaulted a bare number to unit "px"; Parse
+			// returns unit "" for a bare number and lets the caller apply
+			// its own default (html/properties.go parsePlainLength does).
+			if gotOK && gotUnit == "" {
+				gotUnit = "px"
+			}
+			if gotOK != wantOK {
+				t.Fatalf("ok mismatch for %q: got %v, want %v", in, gotOK, wantOK)
+			}
+			if gotOK && (!approxEq(gotVal, wantVal) || gotUnit != wantUnit) {
+				t.Errorf("mismatch for %q: got (%v, %q), want (%v, %q)", in, gotVal, gotUnit, wantVal, wantUnit)
+			}
+		})
+	}
+}
+
+// oldParseDimension reproduces svg's pre-migration parseDimension
+// (svg/parser.go), including its multi-suffix-stripping quirk, so
+// TestParseDimensionBugFix can pin the intentional behavior change.
+func oldParseDimension(s string) float64 {
+	s = strings.TrimSpace(s)
+	for _, suffix := range []string{"px", "pt", "em", "rem", "cm", "mm", "in", "%"} {
+		s = strings.TrimSuffix(s, suffix)
+	}
+	s = strings.TrimSpace(s)
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+func TestParseDimensionBugFix(t *testing.T) {
+	tests := []struct {
+		input     string
+		oldWant   float64
+		newWant   float64
+		regresses bool // old and new intentionally disagree
+	}{
+		{"100px", 100, 100, false},
+		{"10cm", 10, 10, false},
+		{"50%", 50, 50, false},
+		{"100", 100, 100, false},
+		{"", 0, 0, false},
+		{"10pxpx", 0, 0, false}, // "px" strips once, leftover "10px" fails to parse — already 0 today
+		{"10empx", 10, 0, true}, // "px" then "em" strip in sequence, leaving "10" — old parsed it, new rejects it
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := oldParseDimension(tt.input); !approxEq(got, tt.oldWant) {
+				t.Fatalf("oldParseDimension(%q) = %v, want %v (old-parser pin is stale)", tt.input, got, tt.oldWant)
+			}
+			v, _, ok := Parse(tt.input)
+			if !ok {
+				v = 0
+			}
+			if !approxEq(v, tt.newWant) {
+				t.Errorf("Parse(%q) value = %v, want %v", tt.input, v, tt.newWant)
+			}
+			if !tt.regresses && !approxEq(tt.oldWant, tt.newWant) {
+				t.Errorf("%q: expected old/new agreement, old=%v new=%v", tt.input, tt.oldWant, tt.newWant)
+			}
+		})
+	}
+}

--- a/svg/gradient.go
+++ b/svg/gradient.go
@@ -6,6 +6,8 @@ package svg
 import (
 	"strconv"
 	"strings"
+
+	"github.com/carlos7ags/folio/internal/cssunit"
 )
 
 // BBox is an axis-aligned bounding box in SVG local user-space coordinates.
@@ -100,22 +102,18 @@ func (n *Node) RadialGradient() *RadialGradientInfo {
 // number, a percentage ("50%"), or empty. Returns def for empty/invalid.
 // Percentages are returned as fractions in [0, 1].
 func parseGradientCoord(s string, def float64) float64 {
-	s = strings.TrimSpace(s)
-	if s == "" {
+	v, unit, ok := cssunit.Parse(s)
+	if !ok {
 		return def
 	}
-	if strings.HasSuffix(s, "%") {
-		if v, err := strconv.ParseFloat(strings.TrimSuffix(s, "%"), 64); err == nil {
-			return v / 100
-		}
-		return def
-	}
-	// Strip unit suffix if present.
-	s = strings.TrimSuffix(s, "px")
-	if v, err := strconv.ParseFloat(s, 64); err == nil {
+	switch unit {
+	case "%":
+		return v / 100
+	case "", "px":
 		return v
+	default:
+		return def
 	}
-	return def
 }
 
 // parseStops walks the child <stop> elements of a gradient node and returns

--- a/svg/parser.go
+++ b/svg/parser.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/carlos7ags/folio/internal/cssunit"
 )
 
 // SVG is a parsed SVG document ready to be rendered.
@@ -260,16 +262,10 @@ func findSVGRoot(node *Node) *Node {
 }
 
 // parseDimension parses a dimension value like "100", "100px", "100.5px" into a float64.
-// Only "px" and unitless values are supported; other units are stripped and parsed as-is.
+// Every unit is treated as an SVG user unit 1:1; the suffix is stripped, not converted.
 func parseDimension(s string) float64 {
-	s = strings.TrimSpace(s)
-	// Strip known suffixes.
-	for _, suffix := range []string{"px", "pt", "em", "rem", "cm", "mm", "in", "%"} {
-		s = strings.TrimSuffix(s, suffix)
-	}
-	s = strings.TrimSpace(s)
-	v, err := strconv.ParseFloat(s, 64)
-	if err != nil {
+	v, _, ok := cssunit.Parse(s)
+	if !ok {
 		return 0
 	}
 	return v

--- a/svg/render.go
+++ b/svg/render.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/carlos7ags/folio/content"
+	"github.com/carlos7ags/folio/internal/cssunit"
 )
 
 // RenderOptions configures SVG rendering into a PDF content stream.
@@ -1086,12 +1087,9 @@ func attrFloat(node *Node, attr string, def float64) float64 {
 	if !ok || s == "" {
 		return def
 	}
-	// Strip trailing "px" or other simple unit suffixes.
-	s = strings.TrimSpace(s)
-	s = strings.TrimSuffix(s, "px")
-	s = strings.TrimSuffix(s, "pt")
-	v, err := strconv.ParseFloat(s, 64)
-	if err != nil {
+	// User units — px/pt suffixes are stripped, not converted.
+	v, unit, ok := cssunit.Parse(s)
+	if !ok || (unit != "" && unit != "px" && unit != "pt") {
 		return def
 	}
 	return v

--- a/svg/style.go
+++ b/svg/style.go
@@ -6,6 +6,8 @@ package svg
 import (
 	"strconv"
 	"strings"
+
+	"github.com/carlos7ags/folio/internal/cssunit"
 )
 
 // Style holds resolved visual properties for an SVG node.
@@ -186,7 +188,9 @@ func applyProperties(s *Style, props map[string]string) {
 		case "font-family":
 			s.FontFamily = val
 		case "font-size":
-			if v, err := strconv.ParseFloat(strings.TrimSuffix(val, "px"), 64); err == nil {
+			// User units — px/pt suffixes are stripped, not converted,
+			// matching the width/height/r attribute policy in attrFloat.
+			if v, unit, ok := cssunit.Parse(val); ok && (unit == "" || unit == "px" || unit == "pt") {
 				s.FontSize = v
 			}
 		case "font-weight":

--- a/svg/svg_test.go
+++ b/svg/svg_test.go
@@ -968,6 +968,53 @@ func TestParse_NegativeDimensions(t *testing.T) {
 	s.Draw(stream, 0, 0, 100, 100)
 }
 
+func TestAttrFloat(t *testing.T) {
+	tests := []struct {
+		val  string
+		def  float64
+		want float64
+	}{
+		{"10", 0, 10},
+		{"10px", 0, 10},
+		{"10pt", 0, 10},
+		// Any other unit is rejected and the default is returned, same as
+		// the old TrimSuffix(px)/TrimSuffix(pt) chain never matching "em".
+		{"10em", 5, 5},
+		{"", 5, 5},
+	}
+	for _, tt := range tests {
+		node := &Node{Tag: "rect", Attrs: map[string]string{"width": tt.val}}
+		if tt.val == "" {
+			node.Attrs = map[string]string{}
+		}
+		if got := attrFloat(node, "width", tt.def); got != tt.want {
+			t.Errorf("attrFloat(%q, def=%v) = %v, want %v", tt.val, tt.def, got, tt.want)
+		}
+	}
+}
+
+func TestParseDimension(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"100px", 100},
+		{"10cm", 10},
+		{"50%", 50},
+		{"100", 100},
+		{"", 0},
+		// Multi-suffix garbage is no longer accepted: "px" strips once
+		// leaving "10em", "em" strips next leaving "10" — the sequential
+		// TrimSuffix loop used to fall through to a clean parse.
+		{"10empx", 0},
+	}
+	for _, tt := range tests {
+		if got := parseDimension(tt.input); got != tt.want {
+			t.Errorf("parseDimension(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestResolveStyle_UnrecognizedProperties(t *testing.T) {
 	// Unrecognized CSS properties in style attribute should not cause panic.
 	node := &Node{
@@ -981,6 +1028,31 @@ func TestResolveStyle_UnrecognizedProperties(t *testing.T) {
 		t.Fatal("Fill should not be nil after style with unrecognized properties")
 	}
 	assertColor(t, "fill with unrecognized props", *s.Fill, 1, 0, 0, 1)
+}
+
+func TestResolveStyle_FontSize(t *testing.T) {
+	tests := []struct {
+		style string
+		want  float64
+	}{
+		{"font-size:14px", 14},
+		{"font-size:14", 14},
+		// pt is now accepted as a user unit, matching the width/height/r
+		// attribute policy — previously only "px" parsed and a pt value
+		// silently left the inherited font size.
+		{"font-size:12pt", 12},
+		// Any other unit stays unhandled: the declaration is ignored and
+		// the parent's font size is inherited.
+		{"font-size:2em", 16},
+	}
+	for _, tt := range tests {
+		node := &Node{Tag: "text", Attrs: map[string]string{"style": tt.style}}
+		parent := defaultStyle()
+		s := resolveStyle(node, parent)
+		if s.FontSize != tt.want {
+			t.Errorf("resolveStyle(%q).FontSize = %v, want %v", tt.style, s.FontSize, tt.want)
+		}
+	}
 }
 
 func TestParseColor_RGBOverflow(t *testing.T) {


### PR DESCRIPTION
## Summary

Consolidates duplicated CSS length/unit parsing (html and svg each had their own) into a new `internal/cssunit` package. Sibling of the merged `internal/csscolor` consolidation.

## Change

- New `internal/cssunit`: `Parse(s) (value, unit, ok)` (px/pt/rem/em/mm/cm/in/% or bare number, exactly one suffix) and `PointsPerUnit(unit, fontSize)` (html's conversion table).
- `html/properties.go` (`parsePlainLength`) and the four svg sites (`attrFloat`, `parseGradientCoord`, the font-size style case, `parseDimension`) delegate tokenizing to `cssunit`, each keeping its own unit policy. `cssLength`/calc machinery untouched.

## Equivalence & intentional fixes (CHANGELOG → Fixed)

A byte-for-byte reproduction of the old html parser is asserted equal to `cssunit.Parse` over 21 inputs; existing html/svg tests pass with no assertion edits. Two documented SVG bug-fixes fall out of unification: multi-suffix garbage (`10empx`) is now rejected instead of silently stripped, and svg `font-size` now accepts `pt` values (previously only `px`).

golangci-lint clean.