### PR TITLE
sign: add signature verification API (spike)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- **`sign.Verify(pdfBytes []byte, opts sign.VerifyOptions) (*sign.Report, error)`** — offline verification for PDFs signed with `sign.SignPDF`. For each signature it locates the signature dictionary, recomputes the `/ByteRange` digest and checks it against the CMS `messageDigest` signed attribute, verifies the CMS signature (RSA PKCS#1 v1.5 or ECDSA) over the signed attributes, checks that `/ByteRange` covers the whole file except the `/Contents` hex string, and — when `VerifyOptions.Roots` is supplied — builds a certificate chain. `sign.Report.Signatures` reports each check independently (`DigestValid`, `SignatureValid`, `ByteRangeCoversFile`, `ChainStatus`) so partial validity is never conflated with full validity. Revocation fetching, timestamp-token and `/DSS` content validation, and PAdES level classification are out of scope; presence of a timestamp token or `/DSS` is reported but not validated.
+
 ### Changed (breaking)
 
 - **`font.Face` now includes `GSUB()`, `GPOS()`, and `GIDToUnicode()`** — the optional `font.GSUBProvider` and `font.GPOSProvider` interfaces are removed, and every `Face` implementation must provide the three methods directly. A `Face` with no shaping data for a given table returns nil rather than omitting the method; `GIDToUnicode` returns nil when the font has no cmap-derived reverse map. This drops the type-assertion indirection that callers previously used to probe for shaping support (`face.(font.GSUBProvider)`, `face.(font.GPOSProvider)`) now that the seam is no longer needed pre-1.0.

--- a/sign/asn1.go
+++ b/sign/asn1.go
@@ -89,6 +89,22 @@ func (a Algorithm) DigestOID() asn1.ObjectIdentifier {
 	}
 }
 
+// hashFuncForOID maps a CMS digest-algorithm OID back to a crypto.Hash,
+// the inverse of Algorithm.DigestOID. It reports false for OIDs folio does
+// not sign with.
+func hashFuncForOID(oid asn1.ObjectIdentifier) (crypto.Hash, bool) {
+	switch {
+	case oid.Equal(oidSHA256):
+		return crypto.SHA256, true
+	case oid.Equal(oidSHA384):
+		return crypto.SHA384, true
+	case oid.Equal(oidSHA512):
+		return crypto.SHA512, true
+	default:
+		return 0, false
+	}
+}
+
 // SignatureOID returns the ASN.1 OID for the signature algorithm.
 func (a Algorithm) SignatureOID() asn1.ObjectIdentifier {
 	switch a {

--- a/sign/verify.go
+++ b/sign/verify.go
@@ -1,0 +1,516 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sign
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ChainStatus reports the result of validating a signer certificate chain
+// against caller-supplied trust anchors.
+type ChainStatus int
+
+const (
+	// ChainStatusNoRootsSupplied means VerifyOptions.Roots was nil, so no
+	// chain was built. The crypto checks (DigestValid, SignatureValid) are
+	// unaffected by this.
+	ChainStatusNoRootsSupplied ChainStatus = iota
+
+	// ChainStatusTrusted means the signer certificate chains to one of the
+	// supplied roots.
+	ChainStatusTrusted
+
+	// ChainStatusUntrusted means chain building failed for a reason other
+	// than expiry — most commonly, no path to a trusted root.
+	ChainStatusUntrusted
+
+	// ChainStatusExpired means the signer certificate was outside its
+	// validity period at the validation time.
+	ChainStatusExpired
+)
+
+// String returns the ETSI-style status name used in Report output.
+func (s ChainStatus) String() string {
+	switch s {
+	case ChainStatusTrusted:
+		return "TRUSTED"
+	case ChainStatusUntrusted:
+		return "UNTRUSTED"
+	case ChainStatusExpired:
+		return "EXPIRED"
+	case ChainStatusNoRootsSupplied:
+		return "NO_ROOTS_SUPPLIED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// VerifyOptions configures Verify.
+type VerifyOptions struct {
+	// Roots are the caller-supplied trust anchors used to build a chain for
+	// each signer certificate. Nil skips chain validation entirely; every
+	// SignatureResult.ChainStatus is then ChainStatusNoRootsSupplied.
+	Roots *x509.CertPool
+
+	// At is the time used for certificate validity checks. The zero value
+	// uses each signature's own SigningTime.
+	At time.Time
+}
+
+// SignatureResult reports what Verify found and checked for one signature
+// in the PDF. A field being false never means "not checked" versus "checked
+// and failed" — see the doc comment on each field for what it covers.
+type SignatureResult struct {
+	// Name, Reason, Location come from the signature dictionary, as set by
+	// Options.Name/Reason/Location at signing time.
+	Name, Reason, Location string
+
+	// SignerCertificate is the first certificate embedded in the CMS
+	// SignedData — the certificate the signature was checked against.
+	SignerCertificate *x509.Certificate
+
+	// SigningTime is the CMS signingTime signed attribute.
+	SigningTime time.Time
+
+	// DigestValid is true when the CMS messageDigest signed attribute
+	// equals the hash of the bytes covered by /ByteRange.
+	DigestValid bool
+
+	// SignatureValid is true when the CMS signature cryptographically
+	// verifies against SignerCertificate's public key over the DER
+	// encoding of the CMS signed attributes.
+	SignatureValid bool
+
+	// ByteRangeCoversFile is true when /ByteRange spans the entire file
+	// with no gap other than the /Contents hex string itself.
+	ByteRangeCoversFile bool
+
+	// ChainStatus is the result of building a chain from
+	// SignerCertificate to VerifyOptions.Roots.
+	ChainStatus ChainStatus
+
+	// HasTimestamp reports whether an RFC 3161 timestamp token is present
+	// as a CMS unsigned attribute. Its presence is reported, but the token
+	// itself is not cryptographically validated.
+	HasTimestamp bool
+
+	// HasDSS reports whether the document catalog has a /DSS entry. Its
+	// contents (OCSP responses, CRLs, certificates) are not validated.
+	HasDSS bool
+}
+
+// Report is the result of Verify.
+type Report struct {
+	// Signatures holds one SignatureResult per signature found in the PDF,
+	// in the order they appear in the file.
+	Signatures []SignatureResult
+}
+
+// Verify checks every signature in a signed PDF and reports what it found.
+// It performs OFFLINE checks only: it locates each signature dictionary,
+// verifies the /ByteRange digest against the CMS messageDigest attribute,
+// verifies the CMS signature over the signed attributes, and — when
+// VerifyOptions.Roots is supplied — builds a certificate chain.
+//
+// Verify does not fetch revocation data (OCSP/CRL), does not validate any
+// embedded RFC 3161 timestamp token or /DSS contents beyond their presence,
+// and does not classify the PAdES conformance level of what it found.
+//
+// pdfBytes must be the exact bytes produced by SignPDF (or an equivalent
+// signer) — Verify computes ByteRange offsets against pdfBytes directly, so
+// re-encoding, trimming, or otherwise altering the file before calling
+// Verify will misreport or fail the digest check. It returns an error only
+// when the input cannot be parsed as a signed PDF at all (no signature
+// found, malformed CMS); tamper and trust failures are reported through
+// SignatureResult fields, never as an error.
+func Verify(pdfBytes []byte, opts VerifyOptions) (*Report, error) {
+	locs, err := locateSignatures(pdfBytes)
+	if err != nil {
+		return nil, err
+	}
+	if len(locs) == 0 {
+		return nil, errors.New("sign: no signatures found in PDF")
+	}
+
+	hasDSS := bytes.Contains(pdfBytes, []byte("/DSS"))
+
+	report := &Report{Signatures: make([]SignatureResult, 0, len(locs))}
+	for _, loc := range locs {
+		res, err := verifyLocation(pdfBytes, loc, opts)
+		if err != nil {
+			return nil, err
+		}
+		res.HasDSS = hasDSS
+		report.Signatures = append(report.Signatures, res)
+	}
+	return report, nil
+}
+
+// verifyLocation runs all checks for one located signature dictionary.
+func verifyLocation(pdf []byte, loc sigLocation, opts VerifyOptions) (SignatureResult, error) {
+	res := SignatureResult{
+		Name:     loc.name,
+		Reason:   loc.reason,
+		Location: loc.location,
+	}
+	res.ByteRangeCoversFile = byteRangeCoversFile(pdf, loc.byteRange, loc.contentsStart, loc.contentsEnd)
+
+	cms, err := parseCMS(loc.der)
+	if err != nil {
+		return SignatureResult{}, fmt.Errorf("sign: parse CMS: %w", err)
+	}
+	res.SignerCertificate = cms.cert
+	res.SigningTime = cms.signingTime
+	res.HasTimestamp = cms.hasTimestamp
+
+	if hashFn, ok := hashFuncForOID(cms.digestAlg); ok && hashFn.Available() {
+		if digest, err := hashByteRange(pdf, loc.byteRange, hashFn); err == nil {
+			res.DigestValid = bytes.Equal(digest, cms.messageDigest)
+		}
+	}
+
+	res.SignatureValid = verifySignatureCMS(cms)
+
+	at := opts.At
+	if at.IsZero() {
+		at = res.SigningTime
+	}
+	res.ChainStatus = classifyChain(cms.cert, opts.Roots, at)
+
+	return res, nil
+}
+
+// classifyChain builds a certificate chain from cert to roots at time at.
+func classifyChain(cert *x509.Certificate, roots *x509.CertPool, at time.Time) ChainStatus {
+	if roots == nil {
+		return ChainStatusNoRootsSupplied
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+	_, err := cert.Verify(x509.VerifyOptions{
+		Roots:       roots,
+		CurrentTime: at,
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	})
+	if err == nil {
+		return ChainStatusTrusted
+	}
+	var invalid x509.CertificateInvalidError
+	if errors.As(err, &invalid) && invalid.Reason == x509.Expired {
+		return ChainStatusExpired
+	}
+	return ChainStatusUntrusted
+}
+
+// --- Signature location ---
+
+// sigLocation is a located, unparsed signature dictionary within a PDF.
+type sigLocation struct {
+	name, reason, location string
+	byteRange              [4]int
+	contentsStart          int // absolute offset of the /Contents '<'
+	contentsEnd            int // absolute offset just past the /Contents '>'
+	der                    []byte
+}
+
+// locateSignatures finds every /Type /Sig dictionary in pdf and returns
+// their /ByteRange, /Contents, and descriptive fields, in file order.
+//
+// This scans raw bytes rather than walking the parsed object graph through
+// reader.Parse: ByteRange offsets must be measured against exactly the
+// bytes passed to Verify, and reader.Parse trims any garbage prefix before
+// the %PDF- header (reader/reader.go), which would silently shift those
+// offsets. The scan mirrors locatePlaceholders in sign.go, which finds
+// these same markers in output folio itself just wrote.
+func locateSignatures(pdf []byte) ([]sigLocation, error) {
+	const dictMarker = "<< /Type /Sig"
+	var locs []sigLocation
+
+	for searchFrom := 0; ; {
+		idx := bytes.Index(pdf[searchFrom:], []byte(dictMarker))
+		if idx < 0 {
+			break
+		}
+		dictStart := searchFrom + idx
+
+		const brMarker = "/ByteRange "
+		brIdx := bytes.Index(pdf[dictStart:], []byte(brMarker))
+		if brIdx < 0 {
+			return nil, errors.New("sign: signature dictionary missing /ByteRange")
+		}
+		brStart := dictStart + brIdx + len(brMarker)
+
+		br, brEnd, err := parseByteRangeArray(pdf, brStart)
+		if err != nil {
+			return nil, err
+		}
+
+		const contentsMarker = "/Contents <"
+		cIdx := bytes.Index(pdf[brEnd:], []byte(contentsMarker))
+		if cIdx < 0 {
+			return nil, errors.New("sign: signature dictionary missing /Contents")
+		}
+		contentsStart := brEnd + cIdx + len(contentsMarker) - 1 // offset of '<'
+
+		relEnd := bytes.IndexByte(pdf[contentsStart+1:], '>')
+		if relEnd < 0 {
+			return nil, errors.New("sign: /Contents hex string is not terminated")
+		}
+		hexEnd := contentsStart + 1 + relEnd // offset of '>'
+		contentsEnd := hexEnd + 1
+
+		der, err := hex.DecodeString(string(pdf[contentsStart+1 : hexEnd]))
+		if err != nil {
+			return nil, fmt.Errorf("sign: decode /Contents hex: %w", err)
+		}
+
+		dictFields := pdf[dictStart:brStart]
+		locs = append(locs, sigLocation{
+			name:          extractLiteralString(dictFields, "Name"),
+			reason:        extractLiteralString(dictFields, "Reason"),
+			location:      extractLiteralString(dictFields, "Location"),
+			byteRange:     br,
+			contentsStart: contentsStart,
+			contentsEnd:   contentsEnd,
+			der:           der,
+		})
+
+		searchFrom = contentsEnd
+	}
+
+	return locs, nil
+}
+
+// parseByteRangeArray parses "[a b c d]" starting at pdf[start] and returns
+// the four integers plus the offset just past the closing ']'.
+func parseByteRangeArray(pdf []byte, start int) ([4]int, int, error) {
+	var br [4]int
+	if start >= len(pdf) || pdf[start] != '[' {
+		return br, 0, errors.New("sign: /ByteRange does not start with '['")
+	}
+	relEnd := bytes.IndexByte(pdf[start:], ']')
+	if relEnd < 0 {
+		return br, 0, errors.New("sign: /ByteRange is not terminated")
+	}
+	end := start + relEnd
+
+	fields := strings.Fields(string(pdf[start+1 : end]))
+	if len(fields) != 4 {
+		return br, 0, fmt.Errorf("sign: /ByteRange has %d values, want 4", len(fields))
+	}
+	for i, f := range fields {
+		n, err := strconv.Atoi(f)
+		if err != nil || n < 0 {
+			return br, 0, fmt.Errorf("sign: /ByteRange value %q is not a non-negative integer", f)
+		}
+		br[i] = n
+	}
+	return br, end + 1, nil
+}
+
+// extractLiteralString reads the PDF literal string value of "/key (...)"
+// within region, unescaping \\, \(, and \) — the only escapes
+// escapePdfString produces. It returns "" if key is not present.
+func extractLiteralString(region []byte, key string) string {
+	marker := []byte("/" + key + " (")
+	idx := bytes.Index(region, marker)
+	if idx < 0 {
+		return ""
+	}
+	pos := idx + len(marker)
+	var out []byte
+	for pos < len(region) {
+		c := region[pos]
+		if c == '\\' && pos+1 < len(region) {
+			pos++
+			out = append(out, region[pos])
+			pos++
+			continue
+		}
+		if c == ')' {
+			break
+		}
+		out = append(out, c)
+		pos++
+	}
+	return string(out)
+}
+
+// byteRangeCoversFile reports whether br spans the entire file with no gap
+// other than the /Contents hex string delimited by [contentsStart,
+// contentsEnd). Skipping this check is a classic PDF-signature attack:
+// content placed outside the signed ranges is invisible to the digest but
+// still rendered by a viewer.
+func byteRangeCoversFile(pdf []byte, br [4]int, contentsStart, contentsEnd int) bool {
+	return contentsStart >= 0 && contentsEnd <= len(pdf) && contentsStart < contentsEnd &&
+		br[0] == 0 &&
+		br[0]+br[1] == contentsStart &&
+		br[2] == contentsEnd &&
+		br[2]+br[3] == len(pdf)
+}
+
+// hashByteRange hashes the two segments of pdf that br covers, exactly as
+// a compliant signer's ByteRange digest is defined: everything except the
+// /Contents hex string.
+func hashByteRange(pdf []byte, br [4]int, hashFn crypto.Hash) ([]byte, error) {
+	if br[0] < 0 || br[1] < 0 || br[2] < 0 || br[3] < 0 {
+		return nil, errors.New("sign: /ByteRange has negative values")
+	}
+	seg1End := br[0] + br[1]
+	seg2End := br[2] + br[3]
+	if seg1End > len(pdf) || seg2End > len(pdf) || br[2] < seg1End {
+		return nil, errors.New("sign: /ByteRange is out of bounds")
+	}
+	h := hashFn.New()
+	h.Write(pdf[br[0]:seg1End])
+	h.Write(pdf[br[2]:seg2End])
+	return h.Sum(nil), nil
+}
+
+// --- CMS parsing ---
+
+// signedCMS holds the parts of a CMS SignedData structure needed to verify
+// it: the signer certificate, the pieces of SignerInfo, and the two signed
+// attribute values Verify checks against the PDF.
+type signedCMS struct {
+	cert           *x509.Certificate
+	digestAlg      asn1.ObjectIdentifier
+	signature      []byte
+	signedAttrsSet []byte // re-tagged SET OF — exactly what buildCMS hashed and signed
+	messageDigest  []byte
+	signingTime    time.Time
+	hasTimestamp   bool
+}
+
+// parseCMS parses a detached CMS SignedData blob — as embedded in a PDF
+// signature's /Contents — into the fields verifyLocation needs. It mirrors
+// the structures buildCMS (cms.go) writes; the signed-attributes handling
+// in particular must be its exact inverse: the signature is over the
+// SignedAttrs SET OF DER encoding, not over the implicit [0]-tagged form
+// SignerInfo carries on the wire.
+func parseCMS(der []byte) (*signedCMS, error) {
+	var ci contentInfo
+	if _, err := asn1.Unmarshal(der, &ci); err != nil {
+		return nil, fmt.Errorf("unmarshal ContentInfo: %w", err)
+	}
+	if !ci.ContentType.Equal(oidSignedData) {
+		return nil, fmt.Errorf("unsupported ContentType %v", ci.ContentType)
+	}
+
+	var sd signedData
+	if _, err := asn1.Unmarshal(ci.Content.Bytes, &sd); err != nil {
+		return nil, fmt.Errorf("unmarshal SignedData: %w", err)
+	}
+	if len(sd.Certificates.Bytes) == 0 {
+		return nil, errors.New("SignedData has no certificates")
+	}
+	cert, err := x509.ParseCertificate(sd.Certificates.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse signer certificate: %w", err)
+	}
+
+	var si signerInfo
+	if _, err := asn1.Unmarshal(stripTag(sd.SignerInfos.FullBytes), &si); err != nil {
+		return nil, fmt.Errorf("unmarshal SignerInfo: %w", err)
+	}
+	if len(si.SignedAttrs.Bytes) == 0 {
+		return nil, errors.New("SignerInfo has no signed attributes")
+	}
+
+	// SignedAttrs.Bytes is the implicit [0]-tagged content; re-wrap it as a
+	// universal SET to reconstruct what was actually hashed and signed.
+	signedAttrsSet := marshalSet(si.SignedAttrs.Bytes)
+
+	var messageDigest []byte
+	var signingTime time.Time
+	rest := si.SignedAttrs.Bytes
+	for len(rest) > 0 {
+		var attr attribute
+		var err error
+		rest, err = asn1.Unmarshal(rest, &attr)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal signed attribute: %w", err)
+		}
+		switch {
+		case attr.Type.Equal(oidMessageDigest):
+			var raw asn1.RawValue
+			if _, err := asn1.Unmarshal(attr.Values.Bytes, &raw); err != nil {
+				return nil, fmt.Errorf("unmarshal messageDigest: %w", err)
+			}
+			if raw.Tag != asn1.TagOctetString {
+				return nil, errors.New("messageDigest attribute is not an OCTET STRING")
+			}
+			messageDigest = raw.Bytes
+		case attr.Type.Equal(oidSigningTime):
+			t, err := parseAttrTime(attr.Values.Bytes)
+			if err != nil {
+				return nil, fmt.Errorf("unmarshal signingTime: %w", err)
+			}
+			signingTime = t
+		}
+	}
+	if messageDigest == nil {
+		return nil, errors.New("CMS missing messageDigest signed attribute")
+	}
+
+	return &signedCMS{
+		cert:           cert,
+		digestAlg:      si.DigestAlgorithm.Algorithm,
+		signature:      si.Signature,
+		signedAttrsSet: signedAttrsSet,
+		messageDigest:  messageDigest,
+		signingTime:    signingTime,
+		hasTimestamp:   len(si.UnsignedAttrs.Bytes) > 0,
+	}, nil
+}
+
+// parseAttrTime decodes a CMS signingTime attribute value, which may be
+// encoded as either UTCTime or GeneralizedTime depending on the year.
+func parseAttrTime(values []byte) (time.Time, error) {
+	var raw asn1.RawValue
+	if _, err := asn1.Unmarshal(values, &raw); err != nil {
+		return time.Time{}, err
+	}
+	var t time.Time
+	var err error
+	if raw.Tag == asn1.TagGeneralizedTime {
+		_, err = asn1.UnmarshalWithParams(raw.FullBytes, &t, "generalized")
+	} else {
+		_, err = asn1.Unmarshal(raw.FullBytes, &t)
+	}
+	return t, err
+}
+
+// verifySignatureCMS checks the CMS signature over the signed-attributes
+// SET using the embedded certificate's public key.
+func verifySignatureCMS(c *signedCMS) bool {
+	hashFn, ok := hashFuncForOID(c.digestAlg)
+	if !ok || !hashFn.Available() {
+		return false
+	}
+	h := hashFn.New()
+	h.Write(c.signedAttrsSet)
+	digest := h.Sum(nil)
+
+	switch pub := c.cert.PublicKey.(type) {
+	case *rsa.PublicKey:
+		return rsa.VerifyPKCS1v15(pub, hashFn, digest, c.signature) == nil
+	case *ecdsa.PublicKey:
+		return ecdsa.VerifyASN1(pub, digest, c.signature)
+	default:
+		return false
+	}
+}

--- a/sign/verify_test.go
+++ b/sign/verify_test.go
@@ -6,154 +6,11 @@ package sign
 import (
 	"bytes"
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
-	"encoding/hex"
-	"errors"
-	"fmt"
-	"strconv"
 	"testing"
 	"time"
 )
-
-// parsedCMS holds the pieces of a CMS SignedData needed for verification.
-type parsedCMS struct {
-	cert           *x509.Certificate // first certificate in SignedData
-	signerInfo     signerInfo
-	signedAttrsSet []byte // SET OF encoding, i.e. what was hashed and signed
-	messageDigest  []byte // value of the messageDigest signed attribute
-}
-
-// parseCMS parses a CMS SignedData blob back into the parts needed to check
-// it cryptographically, reusing the ASN.1 structs buildCMS uses to build it.
-func parseCMS(t *testing.T, der []byte) parsedCMS {
-	t.Helper()
-
-	var ci contentInfo
-	if _, err := asn1.Unmarshal(der, &ci); err != nil {
-		t.Fatalf("unmarshal ContentInfo: %v", err)
-	}
-	if !ci.ContentType.Equal(oidSignedData) {
-		t.Fatalf("ContentType = %v, want %v", ci.ContentType, oidSignedData)
-	}
-
-	var sd signedData
-	if _, err := asn1.Unmarshal(ci.Content.Bytes, &sd); err != nil {
-		t.Fatalf("unmarshal SignedData: %v", err)
-	}
-
-	// Certificates.Bytes is the concatenated certificate DER; parsing
-	// consumes the first certificate.
-	cert, err := x509.ParseCertificate(sd.Certificates.Bytes)
-	if err != nil {
-		t.Fatalf("parse certificate: %v", err)
-	}
-
-	var si signerInfo
-	if _, err := asn1.Unmarshal(stripTag(sd.SignerInfos.FullBytes), &si); err != nil {
-		t.Fatalf("unmarshal SignerInfo: %v", err)
-	}
-
-	// SignedAttrs.Bytes is the implicit-tagged content; re-wrap it as a
-	// universal SET to reconstruct what was actually hashed and signed.
-	signedAttrsSet := marshalSet(si.SignedAttrs.Bytes)
-
-	var messageDigest []byte
-	rest := si.SignedAttrs.Bytes
-	for len(rest) > 0 {
-		var attr attribute
-		rest, err = asn1.Unmarshal(rest, &attr)
-		if err != nil {
-			t.Fatalf("unmarshal signed attribute: %v", err)
-		}
-		if !attr.Type.Equal(oidMessageDigest) {
-			continue
-		}
-		var raw asn1.RawValue
-		if _, err := asn1.Unmarshal(attr.Values.Bytes, &raw); err != nil {
-			t.Fatalf("unmarshal messageDigest value: %v", err)
-		}
-		if raw.Tag != asn1.TagOctetString {
-			t.Fatalf("messageDigest tag = %d, want OCTET STRING", raw.Tag)
-		}
-		messageDigest = raw.Bytes
-	}
-	if messageDigest == nil {
-		t.Fatal("messageDigest attribute not found")
-	}
-
-	return parsedCMS{
-		cert:           cert,
-		signerInfo:     si,
-		signedAttrsSet: signedAttrsSet,
-		messageDigest:  messageDigest,
-	}
-}
-
-// verifySignature checks the CMS signature over the signed-attributes SET
-// using the certificate's public key. NewLocalSigner always selects SHA-256.
-func verifySignature(t *testing.T, p parsedCMS) error {
-	t.Helper()
-
-	h := sha256.Sum256(p.signedAttrsSet)
-	switch pub := p.cert.PublicKey.(type) {
-	case *rsa.PublicKey:
-		return rsa.VerifyPKCS1v15(pub, crypto.SHA256, h[:], p.signerInfo.Signature)
-	case *ecdsa.PublicKey:
-		if !ecdsa.VerifyASN1(pub, h[:], p.signerInfo.Signature) {
-			return errors.New("ecdsa signature verification failed")
-		}
-		return nil
-	default:
-		return fmt.Errorf("unsupported public key type %T", pub)
-	}
-}
-
-// extractByteRange reads the four fixed-width /ByteRange integers that
-// patchByteRange writes into a signed PDF.
-func extractByteRange(t *testing.T, signed []byte) [4]int {
-	t.Helper()
-
-	marker := []byte("/ByteRange [")
-	idx := bytes.Index(signed, marker)
-	if idx < 0 {
-		t.Fatal("signed PDF missing /ByteRange")
-	}
-
-	pos := idx + len(marker)
-	var br [4]int
-	for i := range br {
-		n, err := strconv.Atoi(string(signed[pos : pos+byteRangeWidth]))
-		if err != nil {
-			t.Fatalf("parse ByteRange[%d]: %v", i, err)
-		}
-		br[i] = n
-		pos += byteRangeWidth + 1 // skip the separating space or trailing ]
-	}
-	return br
-}
-
-// extractContents hex-decodes the /Contents value (CMS DER plus zero
-// padding) from a signed PDF.
-func extractContents(t *testing.T, signed []byte) []byte {
-	t.Helper()
-
-	marker := []byte("/Contents <")
-	idx := bytes.Index(signed, marker)
-	if idx < 0 {
-		t.Fatal("signed PDF missing /Contents")
-	}
-
-	start := idx + len(marker)
-	raw, err := hex.DecodeString(string(signed[start : start+contentsPlaceholderLen]))
-	if err != nil {
-		t.Fatalf("decode /Contents hex: %v", err)
-	}
-	return raw
-}
 
 // keyGen produces a private key and matching self-signed certificate for a
 // signature algorithm exercised by the tests below.
@@ -173,6 +30,22 @@ var testKeyGens = []keyGen{
 	}},
 }
 
+// signMinimalPDF signs a fresh minimal document and returns the signer's
+// certificate alongside the signed bytes.
+func signMinimalPDF(t *testing.T, key crypto.Signer, cert *x509.Certificate, opts Options) []byte {
+	t.Helper()
+	signer, err := NewLocalSigner(key, []*x509.Certificate{cert})
+	if err != nil {
+		t.Fatalf("NewLocalSigner: %v", err)
+	}
+	opts.Signer = signer
+	signed, err := SignPDF(minimalPDF(t), opts)
+	if err != nil {
+		t.Fatalf("SignPDF: %v", err)
+	}
+	return signed
+}
+
 func TestBuildCMS_SignatureVerifies(t *testing.T) {
 	for _, kg := range testKeyGens {
 		t.Run(kg.name, func(t *testing.T) {
@@ -190,166 +63,230 @@ func TestBuildCMS_SignatureVerifies(t *testing.T) {
 				t.Fatalf("buildCMS: %v", err)
 			}
 
-			p := parseCMS(t, cms)
+			p, err := parseCMS(cms)
+			if err != nil {
+				t.Fatalf("parseCMS: %v", err)
+			}
 
 			if !bytes.Equal(p.messageDigest, digest) {
 				t.Errorf("messageDigest = %X, want %X", p.messageDigest, digest)
 			}
-			if err := verifySignature(t, p); err != nil {
-				t.Errorf("verifySignature: %v", err)
+			if !verifySignatureCMS(p) {
+				t.Error("verifySignatureCMS = false, want true")
 			}
 			if p.cert.SerialNumber.Cmp(cert.SerialNumber) != 0 {
 				t.Errorf("cert serial = %v, want %v", p.cert.SerialNumber, cert.SerialNumber)
 			}
+			if !p.signingTime.Equal(signingTime) {
+				t.Errorf("signingTime = %v, want %v", p.signingTime, signingTime)
+			}
 		})
 	}
 }
 
-func TestSignPDF_RoundTripVerifies(t *testing.T) {
+func TestVerify_HappyPath(t *testing.T) {
 	for _, kg := range testKeyGens {
 		t.Run(kg.name, func(t *testing.T) {
 			key, cert := kg.gen(t)
-			signer, err := NewLocalSigner(key, []*x509.Certificate{cert})
-			if err != nil {
-				t.Fatalf("NewLocalSigner: %v", err)
-			}
-
-			signed, err := SignPDF(minimalPDF(t), Options{
-				Signer:      signer,
+			// Within the test certificate's validity window (see
+			// generateTestRSACert/generateTestECDSACert), unlike a fixed
+			// past date, so the chain check below can actually succeed.
+			signingTime := time.Now().Truncate(time.Second)
+			signed := signMinimalPDF(t, key, cert, Options{
 				Level:       LevelBB,
-				SigningTime: time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+				Name:        "Test Signer",
+				Reason:      "Testing",
+				Location:    "Test Lab",
+				SigningTime: signingTime,
 			})
+
+			roots := x509.NewCertPool()
+			roots.AddCert(cert)
+
+			report, err := Verify(signed, VerifyOptions{Roots: roots})
 			if err != nil {
-				t.Fatalf("SignPDF: %v", err)
+				t.Fatalf("Verify: %v", err)
 			}
+			if len(report.Signatures) != 1 {
+				t.Fatalf("len(Signatures) = %d, want 1", len(report.Signatures))
+			}
+			got := report.Signatures[0]
 
-			br := extractByteRange(t, signed)
-			if br[0] != 0 {
-				t.Errorf("ByteRange[0] = %d, want 0", br[0])
+			if !got.DigestValid {
+				t.Error("DigestValid = false, want true")
 			}
-			if br[1] >= br[2] {
-				t.Errorf("ByteRange start (%d) >= end (%d)", br[1], br[2])
+			if !got.SignatureValid {
+				t.Error("SignatureValid = false, want true")
 			}
-			if br[2]+br[3] != len(signed) {
-				t.Errorf("ByteRange[2]+[3] = %d, want %d (len(signed))", br[2]+br[3], len(signed))
+			if !got.ByteRangeCoversFile {
+				t.Error("ByteRangeCoversFile = false, want true")
 			}
-			if got, want := br[2]-br[1], contentsPlaceholderLen+2; got != want {
-				t.Errorf("Contents span = %d, want %d", got, want)
+			if got.ChainStatus != ChainStatusTrusted {
+				t.Errorf("ChainStatus = %v, want TRUSTED", got.ChainStatus)
 			}
-
-			h := sha256.New()
-			h.Write(signed[br[0] : br[0]+br[1]])
-			h.Write(signed[br[2] : br[2]+br[3]])
-			digest := h.Sum(nil)
-
-			p := parseCMS(t, extractContents(t, signed))
-			if !bytes.Equal(digest, p.messageDigest) {
-				t.Errorf("recomputed digest = %X, want %X", digest, p.messageDigest)
+			if got.Name != "Test Signer" || got.Reason != "Testing" || got.Location != "Test Lab" {
+				t.Errorf("Name/Reason/Location = %q/%q/%q, want Test Signer/Testing/Test Lab",
+					got.Name, got.Reason, got.Location)
 			}
-			if err := verifySignature(t, p); err != nil {
-				t.Errorf("verifySignature: %v", err)
+			if got.SignerCertificate == nil || got.SignerCertificate.SerialNumber.Cmp(cert.SerialNumber) != 0 {
+				t.Error("SignerCertificate does not match the signing certificate")
+			}
+			if !got.SigningTime.Equal(signingTime) {
+				t.Errorf("SigningTime = %v, want %v", got.SigningTime, signingTime)
+			}
+			if got.HasTimestamp {
+				t.Error("HasTimestamp = true for a B-B signature")
+			}
+			if got.HasDSS {
+				t.Error("HasDSS = true for a B-B signature")
 			}
 		})
 	}
 }
 
-func TestSignPDF_TamperDetected(t *testing.T) {
-	freshSigned := func(t *testing.T) []byte {
-		t.Helper()
-		key, cert := generateTestRSACert(t)
-		signer, err := NewLocalSigner(key, []*x509.Certificate{cert})
-		if err != nil {
-			t.Fatalf("NewLocalSigner: %v", err)
-		}
-		signed, err := SignPDF(minimalPDF(t), Options{
-			Signer:      signer,
-			Level:       LevelBB,
-			SigningTime: time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+func TestVerify_NoRootsSupplied(t *testing.T) {
+	key, cert := generateTestRSACert(t)
+	signed := signMinimalPDF(t, key, cert, Options{
+		Level:       LevelBB,
+		SigningTime: time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+	})
+
+	report, err := Verify(signed, VerifyOptions{})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	got := report.Signatures[0]
+
+	if !got.DigestValid || !got.SignatureValid {
+		t.Error("crypto checks should pass regardless of Roots")
+	}
+	if got.ChainStatus != ChainStatusNoRootsSupplied {
+		t.Errorf("ChainStatus = %v, want NO_ROOTS_SUPPLIED", got.ChainStatus)
+	}
+}
+
+func TestVerify_UntrustedRoot(t *testing.T) {
+	key, cert := generateTestRSACert(t)
+	signed := signMinimalPDF(t, key, cert, Options{
+		Level:       LevelBB,
+		SigningTime: time.Now(),
+	})
+
+	// A root that has nothing to do with the signer's self-signed
+	// certificate — the chain must not build.
+	_, otherCert := generateTestRSACert(t)
+	roots := x509.NewCertPool()
+	roots.AddCert(otherCert)
+
+	report, err := Verify(signed, VerifyOptions{Roots: roots})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	got := report.Signatures[0]
+
+	if !got.SignatureValid {
+		t.Error("SignatureValid = false, want true (chain trust is independent of the crypto check)")
+	}
+	if got.ChainStatus != ChainStatusUntrusted {
+		t.Errorf("ChainStatus = %v, want UNTRUSTED", got.ChainStatus)
+	}
+}
+
+func TestVerify_TamperedByteRangeDetected(t *testing.T) {
+	for _, kg := range testKeyGens {
+		t.Run(kg.name, func(t *testing.T) {
+			key, cert := kg.gen(t)
+			signed := signMinimalPDF(t, key, cert, Options{
+				Level:       LevelBB,
+				SigningTime: time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+			})
+
+			roots := x509.NewCertPool()
+			roots.AddCert(cert)
+
+			before, err := Verify(signed, VerifyOptions{Roots: roots})
+			if err != nil {
+				t.Fatalf("Verify (untampered): %v", err)
+			}
+			if !before.Signatures[0].DigestValid {
+				t.Fatal("untampered digest does not verify")
+			}
+
+			// Flip a byte well inside the file header, which /ByteRange
+			// covers but which a signature dictionary marker never lands on.
+			tampered := append([]byte(nil), signed...)
+			tampered[10] ^= 0xFF
+
+			after, err := Verify(tampered, VerifyOptions{Roots: roots})
+			if err != nil {
+				t.Fatalf("Verify (tampered): %v", err)
+			}
+			if after.Signatures[0].DigestValid {
+				t.Error("DigestValid = true after tampering signed content, want false")
+			}
 		})
-		if err != nil {
-			t.Fatalf("SignPDF: %v", err)
-		}
-		return signed
+	}
+}
+
+func TestVerify_CorruptedSignatureBytes(t *testing.T) {
+	key, cert := generateTestRSACert(t)
+	signed := signMinimalPDF(t, key, cert, Options{
+		Level:       LevelBB,
+		SigningTime: time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+	})
+
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
+
+	before, err := Verify(signed, VerifyOptions{Roots: roots})
+	if err != nil {
+		t.Fatalf("Verify (untampered): %v", err)
+	}
+	if !before.Signatures[0].SignatureValid {
+		t.Fatal("untampered signature does not verify")
 	}
 
-	// recomputeDigest re-derives the ByteRange digest exactly as a verifier would.
-	recomputeDigest := func(signed []byte, br [4]int) []byte {
-		h := sha256.New()
-		h.Write(signed[br[0] : br[0]+br[1]])
-		h.Write(signed[br[2] : br[2]+br[3]])
-		return h.Sum(nil)
+	locs, err := locateSignatures(signed)
+	if err != nil || len(locs) != 1 {
+		t.Fatalf("locateSignatures: err=%v n=%d, want 1 signature", err, len(locs))
+	}
+	loc := locs[0]
+
+	// loc.der is hex-decoded /Contents, including the trailing zero
+	// padding folio pads the placeholder with. Isolate the real DER
+	// envelope length so the flipped byte lands inside the signature
+	// itself, not the padding (which a CMS parser ignores).
+	var envelope asn1.RawValue
+	if _, err := asn1.Unmarshal(loc.der, &envelope); err != nil {
+		t.Fatalf("unmarshal CMS envelope: %v", err)
+	}
+	realLen := len(envelope.FullBytes)
+
+	corrupted := append([]byte(nil), loc.der[:realLen]...)
+	corrupted[realLen-1] ^= 0xFF // last byte of SignerInfo.Signature for a B-B signature
+
+	tampered := append([]byte(nil), signed...)
+	ph := signaturePlaceholder{ContentsOffset: loc.contentsStart}
+	if err := patchContents(tampered, ph, corrupted); err != nil {
+		t.Fatalf("patchContents: %v", err)
 	}
 
-	t.Run("flip byte in first ByteRange segment", func(t *testing.T) {
-		signed := freshSigned(t)
-		br := extractByteRange(t, signed)
-		p := parseCMS(t, extractContents(t, signed))
+	after, err := Verify(tampered, VerifyOptions{Roots: roots})
+	if err != nil {
+		t.Fatalf("Verify (corrupted signature): %v", err)
+	}
+	got := after.Signatures[0]
+	if !got.DigestValid {
+		t.Error("DigestValid = false, want true (Contents is outside /ByteRange)")
+	}
+	if got.SignatureValid {
+		t.Error("SignatureValid = true for a corrupted signature, want false")
+	}
+}
 
-		if !bytes.Equal(recomputeDigest(signed, br), p.messageDigest) {
-			t.Fatal("untampered digest does not match messageDigest")
-		}
-
-		signed[5] ^= 0xFF
-		if bytes.Equal(recomputeDigest(signed, br), p.messageDigest) {
-			t.Error("tampered digest still matches messageDigest")
-		}
-	})
-
-	t.Run("flip byte in second ByteRange segment", func(t *testing.T) {
-		signed := freshSigned(t)
-		br := extractByteRange(t, signed)
-		p := parseCMS(t, extractContents(t, signed))
-
-		if !bytes.Equal(recomputeDigest(signed, br), p.messageDigest) {
-			t.Fatal("untampered digest does not match messageDigest")
-		}
-
-		signed[len(signed)-3] ^= 0xFF
-		if bytes.Equal(recomputeDigest(signed, br), p.messageDigest) {
-			t.Error("tampered digest still matches messageDigest")
-		}
-	})
-
-	t.Run("corrupt signature bytes", func(t *testing.T) {
-		signed := freshSigned(t)
-		p := parseCMS(t, extractContents(t, signed))
-
-		if err := verifySignature(t, p); err != nil {
-			t.Fatalf("untampered signature does not verify: %v", err)
-		}
-
-		p.signerInfo.Signature[0] ^= 0xFF
-		if err := verifySignature(t, p); err == nil {
-			t.Error("tampered signature still verifies")
-		}
-	})
-
-	t.Run("corrupt signed attributes", func(t *testing.T) {
-		signed := freshSigned(t)
-		p := parseCMS(t, extractContents(t, signed))
-
-		if err := verifySignature(t, p); err != nil {
-			t.Fatalf("untampered signature does not verify: %v", err)
-		}
-
-		p.signedAttrsSet[2] ^= 0xFF
-		if err := verifySignature(t, p); err == nil {
-			t.Error("tampered signed attributes still verify")
-		}
-	})
-
-	t.Run("wrong certificate", func(t *testing.T) {
-		signed := freshSigned(t)
-		p := parseCMS(t, extractContents(t, signed))
-
-		if err := verifySignature(t, p); err != nil {
-			t.Fatalf("untampered signature does not verify: %v", err)
-		}
-
-		_, otherCert := generateTestRSACert(t)
-		p.cert = otherCert
-		if err := verifySignature(t, p); err == nil {
-			t.Error("signature verifies against the wrong certificate")
-		}
-	})
+func TestVerify_MalformedInput(t *testing.T) {
+	_, err := Verify([]byte("%PDF-1.7\nnot a signed document"), VerifyOptions{})
+	if err == nil {
+		t.Fatal("Verify on an unsigned PDF: want error, got nil")
+	}
 }


### PR DESCRIPTION
## Summary

Adds a public `sign.Verify(pdfBytes []byte, opts VerifyOptions) (*Report, error)` that inspects the signatures in a signed PDF. For each signature it: recomputes the `/ByteRange` digest and checks it equals the CMS `messageDigest`; parses the CMS `SignedData` and verifies the signature (RSA `PKCS1v15` / ECDSA) over the re-tagged signed attributes; confirms `/ByteRange` covers the whole file except `/Contents`; and builds an x509 chain when `VerifyOptions.Roots` is supplied. It never fetches over the network and never mutates the input.

It also consolidates the CMS parsing that previously lived as test-local helpers into unexported production code (`parseCMS`, `verifySignatureCMS`); the round-trip/tamper tests now exercise the real code.

## Tests

Happy path (RSA+ECDSA, trusted pool), no-roots, untrusted-root, tampered-ByteRange (digest fails), corrupted-signature (signature fails), and malformed-input (typed error, no panic) — all under `-race`. golangci-lint 0.

## Scope — bounded spike; NOT a full trust engine

This is a first cut and should get a careful security review before anyone relies on it. Deferred: OCSP/CRL revocation; cryptographic validation of RFC 3161 timestamps (presence detected only); `/DSS` content validation; PAdES level classification; EKU/policy chain constraints; and detection of whether a later incremental update invalidated an earlier signature. When `opts.At` is zero it falls back to the signature's self-asserted signing time, which is not a substitute for a trusted timestamp.