### PR TITLE
zugferd: add Factur-X/ZUGFeRD e-invoice package (spike)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`zugferd` package** — generates Factur-X/ZUGFeRD hybrid e-invoices: a typed `Invoice` renders EN 16931 UN/CEFACT Cross-Industry Invoice (CII) XML and `Invoice.Attach` embeds it into a `document.Document` as a PDF/A-3B associated file with the matching Factur-X XMP schema, keeping the attachment filename, `AFRelationship`, and XMP conformance level in sync. Covers the MINIMUM and BASIC Factur-X 1.0 profiles, with hand-written field-presence and totals-arithmetic validation (`Invoice.Validate`) and a fixed-point `Amount` type so money never touches a float. `examples/zugferd` is ported onto it. See `docs/design-zugferd.md` for profile coverage and known limitations.
 - **`html.Options.AllowRemoteFetch`** — opt-in for fetching `http(s)` assets referenced by the document. Default false.
 - **`html.Options.AllowAbsolutePaths`** — opt-in for reading absolute filesystem paths named in document content when `BaseFS` is nil. Default false; reads are size-capped like the HTTP path.
 - **`html.DenyInternalHosts`** — a `URLPolicy` that blocks non-http(s) schemes and targets resolving to loopback, private (RFC1918 / ULA), link-local, unspecified, or multicast addresses (plus carrier-grade NAT, and IPv4-compatible / NAT64 IPv6 forms that embed such addresses). Applied by default when `AllowRemoteFetch` is true and `URLPolicy` is nil, and re-checked on every redirect hop.

--- a/docs/design-zugferd.md
+++ b/docs/design-zugferd.md
@@ -1,0 +1,295 @@
+# zugferd: Factur-X/ZUGFeRD e-invoice generation
+
+Package `github.com/carlos7ags/folio/zugferd` turns a typed `Invoice`
+into an EN 16931 UN/CEFACT Cross-Industry Invoice (CII) XML document
+and attaches it to a `document.Document` as a PDF/A-3B associated
+file — the Factur-X/ZUGFeRD hybrid e-invoice format. It builds on two
+primitives folio already ships: PDF/A-3 conformance with custom XMP
+extension schemas (`document/pdfa.go`) and embedded files with
+`/AFRelationship` (`document/attachment.go`).
+
+## Standards background
+
+Factur-X 1.0 (France) and ZUGFeRD 2.x (Germany) are the same
+technical standard under two names. The embedded XML is UN/CEFACT
+Cross-Industry Invoice (CII) D16B; EN 16931 defines the semantic
+data model the XML carries. The standard defines five ascending
+profiles: MINIMUM, BASIC WL, BASIC, EN 16931 (COMFORT), EXTENDED.
+The guideline URN in `ExchangedDocumentContext` names the profile a
+given document conforms to; a validator reads that URN and checks the
+document against the matching rule set.
+
+Three consistency rules span the PDF, the XMP metadata, and the XML,
+and a hand-rolled string template cannot enforce any of them: the
+attachment filename must be `factur-x.xml` (or `zugferd-invoice.xml`
+for older ZUGFeRD 1.x), `AFRelationship` must be `Alternative` or
+`Data` depending on profile, and the XMP `fx:ConformanceLevel` value
+must match the profile encoded in the XML's guideline URN. `Invoice.Attach`
+exists to keep those three in lockstep from one call site.
+
+## Package API
+
+```go
+package zugferd
+
+type Profile int
+
+const (
+	ProfileMinimum Profile = iota
+	ProfileBasic
+)
+
+type Party struct {
+	Name  string
+	VATID string
+}
+
+type LineItem struct {
+	ID              string
+	Description     string
+	Quantity        string
+	UnitCode        string
+	UnitPrice       Amount
+	LineTotal       Amount
+	TaxCategoryCode string
+	TaxRatePercent  string
+}
+
+type TaxBreakdown struct {
+	CategoryCode  string
+	RatePercent   string
+	TaxableAmount Amount
+	TaxAmount     Amount
+}
+
+type MonetarySummation struct {
+	LineTotal        Amount
+	TaxBasisTotal    Amount
+	TaxTotal         Amount
+	GrandTotal       Amount
+	DuePayableAmount Amount
+}
+
+type Invoice struct {
+	Number       string
+	TypeCode     string
+	IssueDate    time.Time
+	Currency     string
+	Seller, Buyer Party
+	Lines        []LineItem
+	TaxTotals    []TaxBreakdown
+	Totals       MonetarySummation
+	PaymentTerms string
+}
+
+func (inv *Invoice) Validate(p Profile) error
+func (inv *Invoice) XML(p Profile) ([]byte, error)
+func (inv *Invoice) Attach(doc *document.Document, p Profile) error
+```
+
+This matches the shape sketched when the package was scoped, with two
+adjustments the prototype forced:
+
+**Amount is a minor-units integer type, not a string or a decimal
+dependency.** `type Amount int64` stores cents; `NewAmount(units,
+cents)` and `ParseAmount("401.63")` construct one, `.String()` renders
+the fixed two-decimal form CII expects, `.Add` composes totals. This
+keeps every money computation exact and keeps `Amount.String()`
+output byte-stable, at the cost of only supporting two-decimal
+currencies (EUR, USD, GBP, ...) — three-decimal (BHD) and zero-decimal
+(JPY) currencies are out of scope for this spike. A plain validated
+string was the other option considered; it was rejected because it
+gives up the `.Add` arithmetic the totals-consistency validation rule
+needs, without saving meaningful complexity over the minor-units type.
+
+**CII XML uses struct tags with literal prefixed local names, not a
+manual token-stream encoder.** A field tag like `` `xml:"rsm:ExchangedDocumentContext"` ``
+has no space before the colon, so `encoding/xml`'s encoder treats the
+whole string as an opaque local name and writes it verbatim — it never
+tries to resolve `rsm` as a namespace prefix itself. The root element
+separately declares `xmlns:rsm`, `xmlns:ram`, `xmlns:udt` as literal
+attributes (tagged `xml:"xmlns:rsm,attr"`), so the emitted document is
+namespace-valid XML even though the encoder isn't aware it's producing
+namespaced elements. Decoding is the interesting asymmetry: `encoding/xml`'s
+*decoder* is genuinely namespace-aware, so parsing this same output back
+resolves `<rsm:ExchangedDocumentContext>` to `XMLName{Space: nsRSM, Local:
+"ExchangedDocumentContext"}` — the prefix is stripped and the URI is
+resolved for real. `zugferd/xml_test.go`'s semantic-equivalence test
+relies on exactly this: it decodes both the old hand-rolled XML and the
+package's output into a generic namespace-aware node tree and compares
+by `(Space, Local)` identity, which is prefix-agnostic by construction.
+No `xml.Encoder`/token-stream fallback was needed — struct tags produced
+correct output on the first attempt, so the stdlib namespace-prefix
+limitation flagged as a risk when this package was scoped did not
+materialize for CII's three-namespace, non-mixed-content structure.
+
+**`Attach` owns `SetPdfA` outright; it does not attempt to merge with a
+caller's existing `PdfAConfig`.** `document.SetPdfA` takes a whole
+`PdfAConfig` value and replaces whatever was there
+(`d.pdfA = &config`), so `Attach` calling it a second time after the
+caller's own call would silently discard the caller's `XMPSchemas`/
+`XMPProperties`. A merge is possible in principle — concatenate the
+`XMPSchemas` and `XMPProperties` slices, keep the caller's
+`ICCProfile`/`OutputCondition` if set — but it requires `Document` to
+expose its current `*PdfAConfig` (it doesn't; the field is unexported),
+and doing that merge blind, without knowing whether the caller's schema
+list already has a same-prefixed `fx` entry, risks producing invalid
+duplicate schema declarations. For this spike `Attach` documents the
+overwrite behavior in its doc comment and requires callers who need
+both to call `SetPdfA` again *after* `Attach`, repeating the Factur-X
+block themselves. A `PdfAConfig`-merging helper, or an `Attach` variant
+that takes the caller's extra `XMPSchemas`/`XMPProperties` as
+arguments, is open-question material (see below) rather than something
+this spike hacks around.
+
+## Profile strategy
+
+Only MINIMUM and BASIC are implemented. Field-presence matrix:
+
+| Field | MINIMUM | BASIC |
+|---|---|---|
+| `Number`, `IssueDate`, `Currency`, `Seller.Name`, `Buyer.Name` | required | required |
+| `Totals` (`TaxBasisTotal`, `TaxTotal`, `GrandTotal`) | required, arithmetic-checked | required, arithmetic-checked |
+| `Lines` | ignored even if set | required, ≥1 entry |
+| `TaxTotals` | ignored even if set | required, ≥1 entry, sum must equal `Totals.TaxTotal` |
+| `PaymentTerms` | optional | optional |
+
+Guideline URNs (Factur-X 1.0):
+
+| Profile | URN |
+|---|---|
+| MINIMUM | `urn:factur-x.eu:1p0:minimum` |
+| BASIC | `urn:factur-x.eu:1p0:basic` |
+
+`Attach` sets `fx:ConformanceLevel` to `p.String()` ("MINIMUM" /
+"BASIC"), matching the profile passed to it — this is one of the three
+consistency rules `Attach` exists to hold together.
+
+## Validation strategy
+
+Three options were on the table: (a) no validation — garbage in,
+garbage out; (b) hand-written struct validation covering required
+fields and totals arithmetic; (c) full XSD/Schematron validation
+against the official Factur-X schema set.
+
+(c) is rejected outright — it needs a schema-validation dependency,
+and the repo's dependency invariant limits this module to
+`golang.org/x/{image,net,text}` plus the stdlib. (a) produces XML that
+silently violates a validator's required-field rules, defeating the
+whole point of a typed package over the string-template status quo.
+
+The package implements (b), in `Invoice.Validate`, with this exact
+rule list:
+
+- `Number`, `Currency` (3-letter, uppercase, ISO-4217-shaped —
+  regex-checked, not looked up against the ISO 4217 table),
+  `Seller.Name`, `Buyer.Name` non-empty; `IssueDate` non-zero — for
+  both profiles.
+- `Totals.TaxBasisTotal + Totals.TaxTotal == Totals.GrandTotal` —
+  for both profiles.
+- BASIC only: `Lines` non-empty; each line's `Description`,
+  `Quantity`, `TaxRatePercent` non-empty; `TaxTotals` non-empty; sum
+  of `TaxTotals[].TaxAmount == Totals.TaxTotal`.
+
+Deliberately **not** validated in this spike: `Quantity * UnitPrice ==
+LineTotal` arithmetic (Quantity is a caller-supplied decimal string,
+not a typed decimal — see Open questions), currency-code lookup
+against the real ISO 4217 list (regex shape only), and any
+cross-field EN 16931 business rule beyond the two arithmetic checks
+above (e.g. the full BR-CO series). This is explicitly the "schema-lite"
+tier — enough to catch the mistakes a copy-paste string template
+invites, not a Schematron replacement. `ValidationError` names the
+`Profile` and the offending `Field` so a caller (or a test) can act on
+the specific failure rather than pattern-matching an error string.
+
+## Determinism
+
+`Invoice.XML` output is byte-identical across repeated calls with the
+same `Invoice` value: field order comes from Go struct field order
+(fixed at compile time, not map iteration), `Amount.String()` is a
+pure function of the integer minor-units value, and no field is
+sourced from wall-clock time — `IssueDate` is caller-supplied.
+`zugferd/xml_test.go`'s `TestXMLDeterministic` asserts this directly
+by generating twice and comparing bytes. This preserves the
+deterministic-output invariant the rest of folio's document output
+already holds (see `document/deterministic_test.go`).
+
+## Honest demand note
+
+This package's priority is inferred from the EU/German B2B e-invoicing
+regulatory trend (Factur-X/ZUGFeRD adoption, and the broader mandatory
+e-invoicing rollout across several European jurisdictions), not from
+measured user demand — folio has not received a feature request for
+this. It was built because the PDF-side primitives (PDF/A-3, custom
+XMP schemas, associated files) were already done and tested, and the
+only existing e-invoice code path (`examples/zugferd/main.go`) was a
+37-line hand-rolled XML string that any consuming project would have
+had to copy and get right on their own. Treat the profile scope
+(MINIMUM/BASIC only) and the validation depth as a starting point sized
+to that inferred need, not a commitment shaped by real integration
+feedback.
+
+## Open questions
+
+- **XRechnung**: German public-sector e-invoicing uses CII with a
+  different (stricter) guideline URN and additional mandatory fields
+  (e.g. a "Leitweg-ID" routing identifier). Does it belong in this
+  package as another `Profile` constant, or is it different enough
+  (different validation rule set, different mandatory fields) to
+  warrant its own type?
+- **Order-X / Delivery-X**: the same PDF/A-3 + embedded-XML hybrid
+  mechanism, applied to purchase orders and delivery notes instead of
+  invoices. If those are added, does the package name `zugferd`
+  survive, or should the package be renamed to something
+  document-type-agnostic (e.g. `einvoice`) with Factur-X as the first
+  supported format? Renaming after a public release is a breaking
+  change, so this should be decided before this package's first
+  tagged release.
+- **Validation depth**: is the hand-written rule list in `Validate`
+  worth extending toward full EN 16931 business-rule coverage (the
+  BR-CO/BR-S/BR-* series), or should the package stay schema-lite
+  permanently and document a pointer to an external validator (e.g.
+  running the official Schematron rules out-of-process) for callers
+  who need certainty?
+- **Profile roadmap**: EN 16931 (COMFORT) and EXTENDED are the
+  natural next profiles. COMFORT adds delivery information, multiple
+  payment means, and allowance/charge lines; EXTENDED adds further
+  optional business terms. Who actually needs them, and does adding
+  them require new `Invoice` fields that are unpopulated (and
+  therefore silently absent from the XML) for existing MINIMUM/BASIC
+  callers — i.e. is the field addition additive-only, or does it risk
+  reshaping fields like `LineItem` in a breaking way?
+- **Guideline URN pinning**: the package hard-codes the Factur-X 1.0
+  URNs (`urn:factur-x.eu:1p0:*`). Should the guideline URN become
+  caller-overridable (e.g. an `Invoice.GuidelineURN` override field)
+  for forward compatibility with a future Factur-X/ZUGFeRD revision,
+  or does that just let callers produce XML whose URN and structure
+  disagree?
+- **`Attach`'s ownership of `SetPdfA`**: covered above under Package
+  API — does the package need a merge-aware variant, or an `Attach`
+  overload that accepts the caller's additional `XMPSchemas`/
+  `XMPProperties` to fold in, once `document.Document` exposes a way
+  to read back its current `PdfAConfig`?
+- **Reading side**: extracting and parsing `factur-x.xml` back out of
+  a received invoice PDF needs embedded-file extraction on the reader
+  side, which does not exist yet (`reader.PdfReader` has no
+  `EmbeddedFiles()`/`Attachments()` accessor — `zugferd/attach_test.go`
+  had to walk `Catalog()["AF"]` by hand via `ResolveObject` to test the
+  write side). This is a separate, larger piece of work: a generic
+  `reader` attachment-extraction API that `zugferd` could then build a
+  CII-XML-parsing layer on top of.
+
+## Spike limitations (not open questions — known gaps in this pass)
+
+- Two-decimal currencies only (`Amount` assumes cents; JPY/BHD-style
+  currencies are unsupported).
+- `LineItem.Quantity` is an unvalidated decimal string; `Quantity *
+  UnitPrice == LineTotal` is not checked.
+- Currency codes are shape-validated (3 uppercase letters), not looked
+  up against the real ISO 4217 list.
+- No delivery-party/delivery-date block (`ApplicableHeaderTradeDelivery`)
+  is emitted — invoices with a distinct ship-to party need it and this
+  package doesn't produce it yet.
+- No support for multiple tax breakdown entries interacting with
+  allowances/charges (BR-CO discount rules) — `TaxBreakdown` entries
+  are summed and checked against the header tax total, nothing more.

--- a/examples/zugferd/main.go
+++ b/examples/zugferd/main.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // ZUGFeRD demonstrates creating a PDF/A-3B compliant invoice with an
-// embedded Factur-X/ZUGFeRD XML file attachment.
+// embedded Factur-X/ZUGFeRD XML file attachment via the zugferd package.
 //
 // PDF/A-3B is the only PDF/A level that permits file attachments
 // (ISO 19005-3 §6.4). This makes it the standard for hybrid e-invoice
@@ -11,8 +11,8 @@
 //
 // The example generates a minimal invoice PDF with:
 //   - PDF/A-3B compliance with sRGB output intent
-//   - An embedded XML attachment with AFRelationship "Alternative"
-//   - XMP metadata declaring the Factur-X schema
+//   - An embedded Factur-X CII XML attachment, built and attached by
+//     [github.com/carlos7ags/folio/zugferd.Invoice.Attach]
 //   - Invoice content rendered via the HTML converter (auto-embeds fonts)
 //
 // Usage:
@@ -24,10 +24,12 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/carlos7ags/folio/document"
 	"github.com/carlos7ags/folio/html"
 	"github.com/carlos7ags/folio/layout"
+	"github.com/carlos7ags/folio/zugferd"
 )
 
 func main() {
@@ -115,79 +117,34 @@ hr { margin: 8px 0; border: none; border-top: 1px solid #ccc; }
 		doc.Add(e)
 	}
 
-	// --- PDF/A-3B with Factur-X XMP schema ---
-	doc.SetPdfA(document.PdfAConfig{
-		Level: document.PdfA3B,
-		XMPSchemas: []document.XMPSchema{{
-			Schema:       "Factur-X PDFA Extension Schema",
-			NamespaceURI: "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#",
-			Prefix:       "fx",
-			Properties: []document.XMPSchemaProperty{
-				{Name: "DocumentFileName", ValueType: "Text", Category: "external", Description: "Name of the embedded XML invoice file"},
-				{Name: "DocumentType", ValueType: "Text", Category: "external", Description: "Type of the hybrid document"},
-				{Name: "Version", ValueType: "Text", Category: "external", Description: "Version of the Factur-X standard"},
-				{Name: "ConformanceLevel", ValueType: "Text", Category: "external", Description: "Factur-X conformance level"},
-			},
-		}},
-		XMPProperties: []document.XMPPropertyBlock{{
-			Namespace: "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#",
-			Prefix:    "fx",
-			Properties: []document.XMPProperty{
-				{Name: "DocumentFileName", Value: "factur-x.xml"},
-				{Name: "DocumentType", Value: "INVOICE"},
-				{Name: "Version", Value: "1.0"},
-				{Name: "ConformanceLevel", Value: "BASIC"},
-			},
-		}},
-	})
-
-	// --- Attach Factur-X XML ---
-	// Minimal CrossIndustryInvoice matching the PDF content.
-	xmlData := []byte(`<?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryInvoice
-  xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-  xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
-  xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
-  <rsm:ExchangedDocumentContext>
-    <ram:GuidelineSpecifiedDocumentContextParameter>
-      <ram:ID>urn:factur-x.eu:1p0:basic</ram:ID>
-    </ram:GuidelineSpecifiedDocumentContextParameter>
-  </rsm:ExchangedDocumentContext>
-  <rsm:ExchangedDocument>
-    <ram:ID>2024-001</ram:ID>
-    <ram:TypeCode>380</ram:TypeCode>
-    <ram:IssueDateTime>
-      <udt:DateTimeString format="102">20240115</udt:DateTimeString>
-    </ram:IssueDateTime>
-  </rsm:ExchangedDocument>
-  <rsm:SupplyChainTradeTransaction>
-    <ram:ApplicableHeaderTradeAgreement>
-      <ram:SellerTradeParty>
-        <ram:Name>ACME Corp</ram:Name>
-      </ram:SellerTradeParty>
-      <ram:BuyerTradeParty>
-        <ram:Name>Example GmbH</ram:Name>
-      </ram:BuyerTradeParty>
-    </ram:ApplicableHeaderTradeAgreement>
-    <ram:ApplicableHeaderTradeSettlement>
-      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
-      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
-        <ram:TaxBasisTotalAmount>337.50</ram:TaxBasisTotalAmount>
-        <ram:TaxTotalAmount currencyID="EUR">64.13</ram:TaxTotalAmount>
-        <ram:GrandTotalAmount>401.63</ram:GrandTotalAmount>
-        <ram:DuePayableAmount>401.63</ram:DuePayableAmount>
-      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
-    </ram:ApplicableHeaderTradeSettlement>
-  </rsm:SupplyChainTradeTransaction>
-</rsm:CrossIndustryInvoice>`)
-
-	doc.AttachFile(document.FileAttachment{
-		FileName:       "factur-x.xml",
-		MIMEType:       "application/xml",
-		Description:    "Factur-X XML Invoice Data (BASIC profile)",
-		AFRelationship: "Alternative",
-		Data:           xmlData,
-	})
+	// --- Factur-X: PDF/A-3B, XMP schema, and embedded CII XML ---
+	// Attach derives all three from the invoice and wires them onto doc
+	// in one call, matching the rendered content above.
+	invoice := &zugferd.Invoice{
+		Number:    "2024-001",
+		IssueDate: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+		Currency:  "EUR",
+		Seller:    zugferd.Party{Name: "ACME Corp", VATID: "DE123456789"},
+		Buyer:     zugferd.Party{Name: "Example GmbH", VATID: "DE987654321"},
+		Lines: []zugferd.LineItem{
+			{Description: "Widget A - Standard", Quantity: "10", UnitPrice: zugferd.NewAmount(5, 0), LineTotal: zugferd.NewAmount(50, 0), TaxRatePercent: "19.00"},
+			{Description: "Widget B - Premium", Quantity: "3", UnitPrice: zugferd.NewAmount(12, 50), LineTotal: zugferd.NewAmount(37, 50), TaxRatePercent: "19.00"},
+			{Description: "Consulting Service", Quantity: "1", UnitPrice: zugferd.NewAmount(250, 0), LineTotal: zugferd.NewAmount(250, 0), TaxRatePercent: "19.00"},
+		},
+		TaxTotals: []zugferd.TaxBreakdown{
+			{RatePercent: "19.00", TaxableAmount: zugferd.NewAmount(337, 50), TaxAmount: zugferd.NewAmount(64, 13)},
+		},
+		Totals: zugferd.MonetarySummation{
+			LineTotal:     zugferd.NewAmount(337, 50),
+			TaxBasisTotal: zugferd.NewAmount(337, 50),
+			TaxTotal:      zugferd.NewAmount(64, 13),
+			GrandTotal:    zugferd.NewAmount(401, 63),
+		},
+		PaymentTerms: "30 days net",
+	}
+	if err := invoice.Attach(doc, zugferd.ProfileBasic); err != nil {
+		return nil, fmt.Errorf("zugferd: %w", err)
+	}
 
 	return doc, nil
 }

--- a/zugferd/amount.go
+++ b/zugferd/amount.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zugferd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Amount is a monetary value stored as an integer number of minor
+// units (cents), never a float, so invoice totals stay exact and
+// XML output stays byte-stable across runs. It assumes a two-decimal
+// currency (EUR, USD, GBP, ...); currencies with a different minor-unit
+// scale (e.g. JPY, BHD) are not supported by this spike.
+type Amount int64
+
+// NewAmount builds an Amount from a whole-unit and cents part, e.g.
+// NewAmount(401, 63) is 401.63.
+func NewAmount(units, cents int64) Amount {
+	if units < 0 {
+		return Amount(units*100 - cents)
+	}
+	return Amount(units*100 + cents)
+}
+
+// ParseAmount parses a fixed-point decimal string (e.g. "401.63",
+// "50", "-12.5") into an Amount. It rejects scientific notation and
+// more than two fractional digits.
+func ParseAmount(s string) (Amount, error) {
+	neg := strings.HasPrefix(s, "-")
+	unsigned := strings.TrimPrefix(s, "-")
+	whole, frac, hasFrac := strings.Cut(unsigned, ".")
+	if whole == "" || (hasFrac && frac == "") || len(frac) > 2 {
+		return 0, fmt.Errorf("zugferd: invalid amount %q", s)
+	}
+	for _, r := range whole + frac {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("zugferd: invalid amount %q", s)
+		}
+	}
+	for len(frac) < 2 {
+		frac += "0"
+	}
+	w, err := strconv.ParseInt(whole, 10, 63)
+	if err != nil {
+		return 0, fmt.Errorf("zugferd: invalid amount %q: %w", s, err)
+	}
+	c, err := strconv.ParseInt(frac, 10, 63)
+	if err != nil {
+		return 0, fmt.Errorf("zugferd: invalid amount %q: %w", s, err)
+	}
+	minor := w*100 + c
+	if neg {
+		minor = -minor
+	}
+	return Amount(minor), nil
+}
+
+// Add returns a + b.
+func (a Amount) Add(b Amount) Amount {
+	return a + b
+}
+
+// String renders the amount as a fixed two-decimal string (e.g. "401.63"),
+// the format CII expects for ram:*Amount elements.
+func (a Amount) String() string {
+	neg := a < 0
+	v := int64(a)
+	if neg {
+		v = -v
+	}
+	s := fmt.Sprintf("%d.%02d", v/100, v%100)
+	if neg {
+		s = "-" + s
+	}
+	return s
+}

--- a/zugferd/amount_test.go
+++ b/zugferd/amount_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zugferd
+
+import "testing"
+
+func TestAmountString(t *testing.T) {
+	tests := []struct {
+		amount Amount
+		want   string
+	}{
+		{NewAmount(401, 63), "401.63"},
+		{NewAmount(0, 0), "0.00"},
+		{NewAmount(5, 0), "5.00"},
+		{NewAmount(-12, 50), "-12.50"},
+	}
+	for _, tt := range tests {
+		if got := tt.amount.String(); got != tt.want {
+			t.Errorf("Amount(%d).String() = %q, want %q", int64(tt.amount), got, tt.want)
+		}
+	}
+}
+
+func TestParseAmount(t *testing.T) {
+	tests := []struct {
+		in   string
+		want Amount
+	}{
+		{"401.63", NewAmount(401, 63)},
+		{"50", NewAmount(50, 0)},
+		{"12.5", NewAmount(12, 50)},
+		{"-12.50", NewAmount(-12, 50)},
+		{"0.00", 0},
+	}
+	for _, tt := range tests {
+		got, err := ParseAmount(tt.in)
+		if err != nil {
+			t.Errorf("ParseAmount(%q) error: %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseAmount(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseAmountInvalid(t *testing.T) {
+	tests := []string{"", ".", "1.234", "abc", "1.2.3", "1e10", "-", "1."}
+	for _, in := range tests {
+		if _, err := ParseAmount(in); err == nil {
+			t.Errorf("ParseAmount(%q) = nil error, want error", in)
+		}
+	}
+}
+
+func TestAmountRoundTrip(t *testing.T) {
+	for _, s := range []string{"401.63", "0.00", "999999.99", "-42.10"} {
+		a, err := ParseAmount(s)
+		if err != nil {
+			t.Fatalf("ParseAmount(%q): %v", s, err)
+		}
+		if got := a.String(); got != s {
+			t.Errorf("ParseAmount(%q).String() = %q, want %q", s, got, s)
+		}
+	}
+}
+
+func TestAmountAdd(t *testing.T) {
+	a := NewAmount(337, 50)
+	b := NewAmount(64, 13)
+	if got, want := a.Add(b), NewAmount(401, 63); got != want {
+		t.Errorf("Add = %v, want %v", got, want)
+	}
+}

--- a/zugferd/attach.go
+++ b/zugferd/attach.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zugferd
+
+import (
+	"fmt"
+
+	"github.com/carlos7ags/folio/document"
+)
+
+// factur-x.xml is the fixed attachment filename Factur-X validators
+// look for (ISO 19005-3 §6.4 associated file mechanism).
+const attachmentFileName = "factur-x.xml"
+
+// facturXNamespaceURI is the Factur-X PDF/A XMP extension schema
+// namespace, declared under the "fx" prefix.
+const facturXNamespaceURI = "urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#"
+
+// Attach validates the invoice, renders its CII XML for the given
+// profile, and wires it into doc as a PDF/A-3B associated file: it
+// calls [document.Document.SetPdfA] with the Factur-X XMP extension
+// schema and calls [document.Document.AttachFile] with the resulting
+// XML, keeping the three Factur-X consistency rules (attachment
+// filename, AFRelationship, and XMP conformance level) in one place.
+//
+// Attach always calls SetPdfA with PdfA3B, which replaces any PDF/A
+// configuration doc already had — Attach owns PDF/A conformance for
+// the document rather than merging with a caller-supplied PdfAConfig.
+// Call Attach before configuring unrelated PDF/A settings, or add
+// custom XMPSchemas/XMPProperties by calling SetPdfA again afterward
+// (SetPdfA replaces wholesale, so the caller's second call must repeat
+// the Factur-X schema block if it still wants both).
+func (inv *Invoice) Attach(doc *document.Document, p Profile) error {
+	xmlData, err := inv.XML(p)
+	if err != nil {
+		return err
+	}
+
+	doc.SetPdfA(document.PdfAConfig{
+		Level: document.PdfA3B,
+		XMPSchemas: []document.XMPSchema{{
+			Schema:       "Factur-X PDFA Extension Schema",
+			NamespaceURI: facturXNamespaceURI,
+			Prefix:       "fx",
+			Properties: []document.XMPSchemaProperty{
+				{Name: "DocumentFileName", ValueType: "Text", Category: "external", Description: "Name of the embedded XML invoice file"},
+				{Name: "DocumentType", ValueType: "Text", Category: "external", Description: "Type of the hybrid document"},
+				{Name: "Version", ValueType: "Text", Category: "external", Description: "Version of the Factur-X standard"},
+				{Name: "ConformanceLevel", ValueType: "Text", Category: "external", Description: "Factur-X conformance level"},
+			},
+		}},
+		XMPProperties: []document.XMPPropertyBlock{{
+			Namespace: facturXNamespaceURI,
+			Prefix:    "fx",
+			Properties: []document.XMPProperty{
+				{Name: "DocumentFileName", Value: attachmentFileName},
+				{Name: "DocumentType", Value: "INVOICE"},
+				{Name: "Version", Value: "1.0"},
+				{Name: "ConformanceLevel", Value: p.String()},
+			},
+		}},
+	})
+
+	doc.AttachFile(document.FileAttachment{
+		FileName:       attachmentFileName,
+		MIMEType:       "application/xml",
+		Description:    fmt.Sprintf("Factur-X XML Invoice Data (%s profile)", p),
+		AFRelationship: "Alternative",
+		Data:           xmlData,
+	})
+
+	return nil
+}

--- a/zugferd/attach_test.go
+++ b/zugferd/attach_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zugferd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/core"
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// buildAndParse runs Attach on a fresh document, writes it, and
+// parses the bytes back with reader.Parse — the write-then-parse round
+// trip the package's PDF/A-3 output must survive.
+func buildAndParse(t *testing.T, inv *Invoice, p Profile) (*reader.PdfReader, []byte) {
+	t.Helper()
+	doc := document.NewDocument(document.PageSizeA4)
+	doc.Info.Title = "Factur-X Attach Test"
+	if err := inv.Attach(doc, p); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	r, err := reader.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	return r, buf.Bytes()
+}
+
+// findEmbeddedFile walks the catalog's /AF array to the first
+// Filespec's embedded /EF /F stream, decoding it the same way
+// reader.PageInfo.ContentStream decodes page content streams
+// (ResolveObject follows the indirect reference and decompresses).
+// Returns the filespec dictionary and the decoded file bytes.
+func findEmbeddedFile(t *testing.T, r *reader.PdfReader) (*core.PdfDictionary, []byte) {
+	t.Helper()
+	catalog := r.Catalog()
+	afObj := catalog.Get("AF")
+	if afObj == nil {
+		t.Fatal("catalog has no /AF entry")
+	}
+	resolved, err := r.ResolveObject(afObj)
+	if err != nil {
+		t.Fatalf("resolve /AF: %v", err)
+	}
+	afArray, ok := resolved.(*core.PdfArray)
+	if !ok || afArray.Len() == 0 {
+		t.Fatalf("/AF is not a non-empty array: %T", resolved)
+	}
+
+	fsObj, err := r.ResolveObject(afArray.At(0))
+	if err != nil {
+		t.Fatalf("resolve filespec: %v", err)
+	}
+	fsDict, ok := fsObj.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("filespec is not a dictionary: %T", fsObj)
+	}
+
+	efHolderObj, err := r.ResolveObject(fsDict.Get("EF"))
+	if err != nil {
+		t.Fatalf("resolve /EF: %v", err)
+	}
+	efHolder, ok := efHolderObj.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("/EF is not a dictionary: %T", efHolderObj)
+	}
+
+	streamObj, err := r.ResolveObject(efHolder.Get("F"))
+	if err != nil {
+		t.Fatalf("resolve embedded file stream: %v", err)
+	}
+	stream, ok := streamObj.(*core.PdfStream)
+	if !ok {
+		t.Fatalf("/EF /F is not a stream: %T", streamObj)
+	}
+
+	return fsDict, stream.Data
+}
+
+// TestAttachEmbedsExactXML is the round-trip acceptance test: it
+// writes a document via Attach, re-parses the PDF bytes, extracts and
+// decompresses the embedded file stream through the same path
+// reader.PageInfo.ContentStream uses for page content, and asserts
+// the decoded bytes are byte-identical to what Invoice.XML produces
+// independently — proving the attachment carries the exact Factur-X
+// XML, not merely a filename that says so.
+func TestAttachEmbedsExactXML(t *testing.T) {
+	inv := sampleInvoice()
+	wantXML, err := inv.XML(ProfileBasic)
+	if err != nil {
+		t.Fatalf("XML: %v", err)
+	}
+
+	r, _ := buildAndParse(t, inv, ProfileBasic)
+	fsDict, gotXML := findEmbeddedFile(t, r)
+
+	if !bytes.Equal(gotXML, wantXML) {
+		t.Errorf("embedded file bytes differ from Invoice.XML output:\ngot:\n%s\nwant:\n%s", gotXML, wantXML)
+	}
+
+	if name, ok := fsDict.Get("F").(*core.PdfString); !ok || name.Text() != attachmentFileName {
+		t.Errorf("filespec /F = %v, want %q", fsDict.Get("F"), attachmentFileName)
+	}
+	if name, ok := fsDict.Get("UF").(*core.PdfString); !ok || name.Text() != attachmentFileName {
+		t.Errorf("filespec /UF = %v, want %q", fsDict.Get("UF"), attachmentFileName)
+	}
+	if rel, ok := fsDict.Get("AFRelationship").(*core.PdfName); !ok || rel.Value != "Alternative" {
+		t.Errorf("filespec /AFRelationship = %v, want /Alternative", fsDict.Get("AFRelationship"))
+	}
+}
+
+// TestAttachSetsPdfA3BConformance asserts Attach configures PDF/A-3B
+// (the only PDF/A level permitting file attachments) with the
+// Factur-X XMP extension schema and a conformance level matching the
+// profile.
+func TestAttachSetsPdfA3BConformance(t *testing.T) {
+	_, pdfBytes := buildAndParse(t, sampleInvoice(), ProfileBasic)
+	pdf := string(pdfBytes)
+
+	if !strings.Contains(pdf, "<pdfaid:part>3</pdfaid:part>") {
+		t.Error("expected PDF/A part 3 (PDF/A-3) in XMP")
+	}
+	if !strings.Contains(pdf, "<pdfaid:conformance>B</pdfaid:conformance>") {
+		t.Error("expected PDF/A conformance B in XMP")
+	}
+	if !strings.Contains(pdf, "Factur-X PDFA Extension Schema") {
+		t.Error("expected Factur-X XMP extension schema declaration")
+	}
+	if !strings.Contains(pdf, "<fx:ConformanceLevel>BASIC</fx:ConformanceLevel>") {
+		t.Error("expected fx:ConformanceLevel BASIC")
+	}
+	if !strings.Contains(pdf, "<fx:DocumentFileName>"+attachmentFileName+"</fx:DocumentFileName>") {
+		t.Error("expected fx:DocumentFileName factur-x.xml")
+	}
+}
+
+// TestAttachMinimumConformanceLevel asserts the XMP fx:ConformanceLevel
+// tracks the profile passed to Attach.
+func TestAttachMinimumConformanceLevel(t *testing.T) {
+	inv := sampleInvoice()
+	inv.Lines = nil
+	inv.TaxTotals = nil
+	_, pdfBytes := buildAndParse(t, inv, ProfileMinimum)
+	if !strings.Contains(string(pdfBytes), "<fx:ConformanceLevel>MINIMUM</fx:ConformanceLevel>") {
+		t.Error("expected fx:ConformanceLevel MINIMUM")
+	}
+}
+
+// TestAttachRejectsInvalidInvoice asserts Attach surfaces validation
+// errors instead of embedding a broken invoice.
+func TestAttachRejectsInvalidInvoice(t *testing.T) {
+	inv := sampleInvoice()
+	inv.Number = ""
+	doc := document.NewDocument(document.PageSizeA4)
+	doc.Info.Title = "Invalid Invoice"
+	if err := inv.Attach(doc, ProfileBasic); err == nil {
+		t.Error("Attach with missing Number = nil error, want error")
+	}
+}
+
+// TestAttachPageCountAndTitlePreserved asserts Attach only adds PDF/A
+// and attachment metadata — it does not touch page content or Info
+// beyond what the caller already set.
+func TestAttachPageCountAndTitlePreserved(t *testing.T) {
+	r, _ := buildAndParse(t, sampleInvoice(), ProfileBasic)
+	if got := r.PageCount(); got != 0 {
+		t.Errorf("PageCount = %d, want 0 (test builds no page content; Attach must not add any)", got)
+	}
+	title, _, _, _, _ := r.Info()
+	if title != "Factur-X Attach Test" {
+		t.Errorf("/Info Title = %q, want %q", title, "Factur-X Attach Test")
+	}
+}

--- a/zugferd/invoice.go
+++ b/zugferd/invoice.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package zugferd generates Factur-X/ZUGFeRD hybrid e-invoices: a
+// typed [Invoice] renders to UN/CEFACT Cross-Industry Invoice (CII)
+// XML and attaches to a [github.com/carlos7ags/folio/document.Document]
+// as a PDF/A-3 embedded file, using the primitives in that package
+// ([document.FileAttachment], [document.PdfAConfig]).
+//
+// Only the MINIMUM and BASIC Factur-X 1.0 profiles are supported.
+// EN 16931 (COMFORT) and EXTENDED are not implemented.
+package zugferd
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+)
+
+// Profile selects the Factur-X conformance profile, which determines
+// the guideline URN written into the XML and which Invoice fields
+// are required.
+type Profile int
+
+const (
+	// ProfileMinimum carries only header-level identification and
+	// totals; no line items or tax breakdown are required.
+	ProfileMinimum Profile = iota
+
+	// ProfileBasic adds line items and a tax breakdown to MINIMUM.
+	ProfileBasic
+)
+
+// String returns the profile's conformance-level name as used in the
+// Factur-X XMP extension schema (e.g. "MINIMUM", "BASIC").
+func (p Profile) String() string {
+	switch p {
+	case ProfileMinimum:
+		return "MINIMUM"
+	case ProfileBasic:
+		return "BASIC"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// guidelineURN returns the Factur-X 1.0 guideline URN written into
+// ram:GuidelineSpecifiedDocumentContextParameter/ram:ID for the profile.
+func (p Profile) guidelineURN() (string, error) {
+	switch p {
+	case ProfileMinimum:
+		return "urn:factur-x.eu:1p0:minimum", nil
+	case ProfileBasic:
+		return "urn:factur-x.eu:1p0:basic", nil
+	default:
+		return "", fmt.Errorf("zugferd: unknown profile %d", int(p))
+	}
+}
+
+// Party is a seller or buyer trade party.
+type Party struct {
+	// Name is the party's registered name. Required.
+	Name string
+
+	// VATID is the party's VAT identification number (e.g.
+	// "DE123456789"). Optional; omitted from the XML when empty.
+	VATID string
+}
+
+// LineItem is one invoice line (CII ram:IncludedSupplyChainTradeLineItem).
+// Required for ProfileBasic; ProfileMinimum ignores Lines entirely.
+type LineItem struct {
+	// ID is the line number (e.g. "1"). If empty, XML assigns the
+	// 1-based position in Lines.
+	ID string
+
+	// Description is the billed product or service name. Required.
+	Description string
+
+	// Quantity is the billed quantity as a plain decimal string (e.g.
+	// "10", "2.5"). Required. Not validated arithmetically against
+	// UnitPrice/LineTotal — see package-level limitations.
+	Quantity string
+
+	// UnitCode is the UN/ECE Recommendation 20 unit code (e.g. "C62"
+	// for "piece", "HUR" for hour). Defaults to "C62" when empty.
+	UnitCode string
+
+	// UnitPrice is the net price per unit.
+	UnitPrice Amount
+
+	// LineTotal is the net line total (Quantity x UnitPrice,
+	// pre-computed by the caller — not derived). Required.
+	LineTotal Amount
+
+	// TaxCategoryCode is the UNTDID 5305 category code (e.g. "S" for
+	// standard rate). Defaults to "S" when empty.
+	TaxCategoryCode string
+
+	// TaxRatePercent is the VAT rate as a decimal string (e.g. "19.00").
+	// Required.
+	TaxRatePercent string
+}
+
+// TaxBreakdown is one entry in the header tax summary (CII
+// ram:ApplicableTradeTax), grouping line items by rate and category.
+// Required (at least one entry) for ProfileBasic.
+type TaxBreakdown struct {
+	// CategoryCode is the UNTDID 5305 category code (e.g. "S").
+	// Defaults to "S" when empty.
+	CategoryCode string
+
+	// RatePercent is the VAT rate as a decimal string (e.g. "19.00").
+	RatePercent string
+
+	// TaxableAmount is the taxable basis for this rate/category.
+	TaxableAmount Amount
+
+	// TaxAmount is the tax due for this rate/category.
+	TaxAmount Amount
+}
+
+// MonetarySummation is the header-level totals block (CII
+// ram:SpecifiedTradeSettlementHeaderMonetarySummation).
+type MonetarySummation struct {
+	// LineTotal is the sum of all line net totals. Only meaningful
+	// (and emitted) when Lines is non-empty.
+	LineTotal Amount
+
+	// TaxBasisTotal is the total taxable amount (sum of TaxTotals'
+	// TaxableAmount, or the invoice net total for MINIMUM).
+	TaxBasisTotal Amount
+
+	// TaxTotal is the total tax due.
+	TaxTotal Amount
+
+	// GrandTotal is TaxBasisTotal + TaxTotal.
+	GrandTotal Amount
+
+	// DuePayableAmount is the amount still owed. Defaults to
+	// GrandTotal when zero (no prior payments/prepayments modeled).
+	DuePayableAmount Amount
+}
+
+// Invoice is a Factur-X/ZUGFeRD invoice: enough structured data to
+// render EN 16931 CII XML and attach it to a PDF/A-3 document via
+// [Invoice.Attach]. The rendered PDF content (the human-readable
+// invoice) is the caller's responsibility — Invoice only produces the
+// machine-readable counterpart.
+type Invoice struct {
+	// Number is the invoice number (CII ExchangedDocument/ID). Required.
+	Number string
+
+	// TypeCode is the UNTDID 1001 document type code. Defaults to
+	// "380" (commercial invoice) when empty.
+	TypeCode string
+
+	// IssueDate is the invoice issue date. Required (non-zero).
+	IssueDate time.Time
+
+	// Currency is the ISO 4217 currency code (e.g. "EUR"). Required.
+	Currency string
+
+	// Seller and Buyer are the trade parties. Both Name fields are required.
+	Seller, Buyer Party
+
+	// Lines is the invoice line items. Empty is only valid for
+	// ProfileMinimum; ProfileBasic requires at least one line.
+	Lines []LineItem
+
+	// TaxTotals is the header tax breakdown. Empty is only valid for
+	// ProfileMinimum; ProfileBasic requires at least one entry, and
+	// the sum of TaxAmount must equal Totals.TaxTotal.
+	TaxTotals []TaxBreakdown
+
+	// Totals is the header monetary summation. Required; TaxBasisTotal
+	// + TaxTotal must equal GrandTotal.
+	Totals MonetarySummation
+
+	// PaymentTerms is a free-text payment terms description (e.g.
+	// "30 days net"). Optional.
+	PaymentTerms string
+}
+
+// ValidationError names the invoice field and profile that failed
+// validation.
+type ValidationError struct {
+	Profile Profile
+	Field   string
+	Reason  string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("zugferd: profile %s: %s: %s", e.Profile, e.Field, e.Reason)
+}
+
+var currencyPattern = regexp.MustCompile(`^[A-Z]{3}$`)
+
+// Validate checks the invoice against the field-presence and
+// arithmetic-consistency rules for the given profile. It does not
+// validate Quantity/UnitPrice/LineTotal arithmetic (see package docs)
+// or perform full EN 16931 Schematron-equivalent validation.
+func (inv *Invoice) Validate(p Profile) error {
+	if inv.Number == "" {
+		return &ValidationError{p, "Number", "required"}
+	}
+	if inv.IssueDate.IsZero() {
+		return &ValidationError{p, "IssueDate", "required"}
+	}
+	if !currencyPattern.MatchString(inv.Currency) {
+		return &ValidationError{p, "Currency", "required, must be a 3-letter ISO 4217 code"}
+	}
+	if inv.Seller.Name == "" {
+		return &ValidationError{p, "Seller.Name", "required"}
+	}
+	if inv.Buyer.Name == "" {
+		return &ValidationError{p, "Buyer.Name", "required"}
+	}
+
+	if p == ProfileBasic {
+		if len(inv.Lines) == 0 {
+			return &ValidationError{p, "Lines", "at least one line item is required for profile BASIC"}
+		}
+		for i, line := range inv.Lines {
+			if line.Description == "" {
+				return &ValidationError{p, fmt.Sprintf("Lines[%d].Description", i), "required"}
+			}
+			if line.Quantity == "" {
+				return &ValidationError{p, fmt.Sprintf("Lines[%d].Quantity", i), "required"}
+			}
+			if line.TaxRatePercent == "" {
+				return &ValidationError{p, fmt.Sprintf("Lines[%d].TaxRatePercent", i), "required"}
+			}
+		}
+		if len(inv.TaxTotals) == 0 {
+			return &ValidationError{p, "TaxTotals", "at least one entry is required for profile BASIC"}
+		}
+		var taxSum Amount
+		for _, tt := range inv.TaxTotals {
+			if tt.RatePercent == "" {
+				return &ValidationError{p, "TaxTotals[].RatePercent", "required"}
+			}
+			taxSum = taxSum.Add(tt.TaxAmount)
+		}
+		if taxSum != inv.Totals.TaxTotal {
+			return &ValidationError{p, "TaxTotals", "sum of TaxAmount must equal Totals.TaxTotal"}
+		}
+	}
+
+	if inv.Totals.TaxBasisTotal.Add(inv.Totals.TaxTotal) != inv.Totals.GrandTotal {
+		return &ValidationError{p, "Totals", "TaxBasisTotal + TaxTotal must equal GrandTotal"}
+	}
+
+	return nil
+}
+
+// typeCode returns inv.TypeCode, defaulting to "380" (commercial invoice).
+func (inv *Invoice) typeCode() string {
+	if inv.TypeCode == "" {
+		return "380"
+	}
+	return inv.TypeCode
+}
+
+// duePayable returns Totals.DuePayableAmount, defaulting to GrandTotal.
+func (inv *Invoice) duePayable() Amount {
+	if inv.Totals.DuePayableAmount == 0 {
+		return inv.Totals.GrandTotal
+	}
+	return inv.Totals.DuePayableAmount
+}

--- a/zugferd/invoice_test.go
+++ b/zugferd/invoice_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zugferd
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestValidateSampleInvoiceOK(t *testing.T) {
+	if err := sampleInvoice().Validate(ProfileBasic); err != nil {
+		t.Fatalf("Validate(BASIC) = %v, want nil", err)
+	}
+	if err := sampleInvoice().Validate(ProfileMinimum); err != nil {
+		t.Fatalf("Validate(MINIMUM) = %v, want nil", err)
+	}
+}
+
+func TestValidateMinimumAllowsEmptyLines(t *testing.T) {
+	inv := sampleInvoice()
+	inv.Lines = nil
+	inv.TaxTotals = nil
+	if err := inv.Validate(ProfileMinimum); err != nil {
+		t.Errorf("ProfileMinimum with no Lines/TaxTotals: Validate() = %v, want nil", err)
+	}
+}
+
+func TestValidateBasicRejectsEmptyLines(t *testing.T) {
+	inv := sampleInvoice()
+	inv.Lines = nil
+	err := inv.Validate(ProfileBasic)
+	var verr *ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("Validate() = %v, want *ValidationError", err)
+	}
+	if verr.Field != "Lines" {
+		t.Errorf("ValidationError.Field = %q, want %q", verr.Field, "Lines")
+	}
+}
+
+func TestValidateMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*Invoice)
+		wantField string
+	}{
+		{"number", func(inv *Invoice) { inv.Number = "" }, "Number"},
+		{"issue date", func(inv *Invoice) { inv.IssueDate = time.Time{} }, "IssueDate"},
+		{"currency empty", func(inv *Invoice) { inv.Currency = "" }, "Currency"},
+		{"currency lowercase", func(inv *Invoice) { inv.Currency = "eur" }, "Currency"},
+		{"currency too long", func(inv *Invoice) { inv.Currency = "EURO" }, "Currency"},
+		{"seller name", func(inv *Invoice) { inv.Seller.Name = "" }, "Seller.Name"},
+		{"buyer name", func(inv *Invoice) { inv.Buyer.Name = "" }, "Buyer.Name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv := sampleInvoice()
+			tt.mutate(inv)
+			err := inv.Validate(ProfileBasic)
+			var verr *ValidationError
+			if !errors.As(err, &verr) {
+				t.Fatalf("Validate() = %v, want *ValidationError", err)
+			}
+			if verr.Field != tt.wantField {
+				t.Errorf("ValidationError.Field = %q, want %q", verr.Field, tt.wantField)
+			}
+		})
+	}
+}
+
+func TestValidateBasicLineFieldsRequired(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*LineItem)
+	}{
+		{"description", func(l *LineItem) { l.Description = "" }},
+		{"quantity", func(l *LineItem) { l.Quantity = "" }},
+		{"tax rate", func(l *LineItem) { l.TaxRatePercent = "" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv := sampleInvoice()
+			tt.mutate(&inv.Lines[0])
+			err := inv.Validate(ProfileBasic)
+			var verr *ValidationError
+			if !errors.As(err, &verr) {
+				t.Fatalf("Validate() = %v, want *ValidationError", err)
+			}
+			if verr.Profile != ProfileBasic {
+				t.Errorf("ValidationError.Profile = %v, want ProfileBasic", verr.Profile)
+			}
+		})
+	}
+}
+
+func TestValidateBasicRequiresTaxTotals(t *testing.T) {
+	inv := sampleInvoice()
+	inv.TaxTotals = nil
+	err := inv.Validate(ProfileBasic)
+	var verr *ValidationError
+	if !errors.As(err, &verr) || verr.Field != "TaxTotals" {
+		t.Fatalf("Validate() = %v, want *ValidationError on TaxTotals", err)
+	}
+}
+
+func TestValidateTaxTotalMismatch(t *testing.T) {
+	inv := sampleInvoice()
+	inv.TaxTotals[0].TaxAmount = NewAmount(1, 0) // no longer sums to Totals.TaxTotal
+	err := inv.Validate(ProfileBasic)
+	var verr *ValidationError
+	if !errors.As(err, &verr) || verr.Field != "TaxTotals" {
+		t.Fatalf("Validate() = %v, want *ValidationError on TaxTotals (sum mismatch)", err)
+	}
+}
+
+func TestValidateTotalsArithmeticMismatch(t *testing.T) {
+	inv := sampleInvoice()
+	inv.Totals.GrandTotal = NewAmount(999, 99)
+	err := inv.Validate(ProfileMinimum)
+	var verr *ValidationError
+	if !errors.As(err, &verr) || verr.Field != "Totals" {
+		t.Fatalf("Validate() = %v, want *ValidationError on Totals", err)
+	}
+}
+
+func TestValidationErrorMessage(t *testing.T) {
+	err := &ValidationError{Profile: ProfileBasic, Field: "Lines", Reason: "at least one line item is required for profile BASIC"}
+	want := "zugferd: profile BASIC: Lines: at least one line item is required for profile BASIC"
+	if got := err.Error(); got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestDuePayableDefaultsToGrandTotal(t *testing.T) {
+	inv := sampleInvoice()
+	inv.Totals.DuePayableAmount = 0
+	if got := inv.duePayable(); got != inv.Totals.GrandTotal {
+		t.Errorf("duePayable() = %v, want GrandTotal %v", got, inv.Totals.GrandTotal)
+	}
+}
+
+func TestTypeCodeDefault(t *testing.T) {
+	inv := sampleInvoice()
+	inv.TypeCode = ""
+	if got := inv.typeCode(); got != "380" {
+		t.Errorf("typeCode() = %q, want \"380\"", got)
+	}
+	inv.TypeCode = "381" // credit note
+	if got := inv.typeCode(); got != "381" {
+		t.Errorf("typeCode() = %q, want \"381\"", got)
+	}
+}
+
+func TestProfileString(t *testing.T) {
+	if got := ProfileMinimum.String(); got != "MINIMUM" {
+		t.Errorf("ProfileMinimum.String() = %q, want \"MINIMUM\"", got)
+	}
+	if got := ProfileBasic.String(); got != "BASIC" {
+		t.Errorf("ProfileBasic.String() = %q, want \"BASIC\"", got)
+	}
+}

--- a/zugferd/testdata_test.go
+++ b/zugferd/testdata_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zugferd
+
+import "time"
+
+// sampleInvoice returns the invoice used across tests. Its header
+// values (number, date, parties, totals) mirror the ones the old
+// examples/zugferd/main.go example hand-rolled into a CII XML string
+// literal, so xml_test.go can assert semantic equivalence against
+// that literal. Lines and TaxTotals are populated (the old example
+// had neither) because ProfileBasic requires them; the sums are
+// chosen to stay consistent with the shared totals.
+func sampleInvoice() *Invoice {
+	return &Invoice{
+		Number:    "2024-001",
+		IssueDate: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+		Currency:  "EUR",
+		Seller:    Party{Name: "ACME Corp", VATID: "DE123456789"},
+		Buyer:     Party{Name: "Example GmbH", VATID: "DE987654321"},
+		Lines: []LineItem{
+			{Description: "Widget A - Standard", Quantity: "10", UnitPrice: NewAmount(5, 0), LineTotal: NewAmount(50, 0), TaxRatePercent: "19.00"},
+			{Description: "Widget B - Premium", Quantity: "3", UnitPrice: NewAmount(12, 50), LineTotal: NewAmount(37, 50), TaxRatePercent: "19.00"},
+			{Description: "Consulting Service", Quantity: "1", UnitPrice: NewAmount(250, 0), LineTotal: NewAmount(250, 0), TaxRatePercent: "19.00"},
+		},
+		TaxTotals: []TaxBreakdown{
+			{RatePercent: "19.00", TaxableAmount: NewAmount(337, 50), TaxAmount: NewAmount(64, 13)},
+		},
+		Totals: MonetarySummation{
+			LineTotal:     NewAmount(337, 50),
+			TaxBasisTotal: NewAmount(337, 50),
+			TaxTotal:      NewAmount(64, 13),
+			GrandTotal:    NewAmount(401, 63),
+		},
+		PaymentTerms: "30 days net",
+	}
+}

--- a/zugferd/xml.go
+++ b/zugferd/xml.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zugferd
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// CII element namespaces (UN/CEFACT Cross-Industry Invoice D16B), as
+// declared on the rsm:CrossIndustryInvoice root element.
+const (
+	nsRSM = "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+	nsRAM = "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+	nsUDT = "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
+)
+
+// The element tags below spell out their CII namespace prefix
+// ("rsm:", "ram:", "udt:") directly in the Go struct tag's local name.
+// encoding/xml treats an unspaced tag as an opaque local name, so it
+// writes the prefix verbatim without needing to manage a prefix-to-URI
+// binding itself; the xmlns:* declarations are emitted as ordinary
+// attributes on the root element below.
+
+type ciiInvoice struct {
+	XMLName  xml.Name `xml:"rsm:CrossIndustryInvoice"`
+	XMLNSRSM string   `xml:"xmlns:rsm,attr"`
+	XMLNSRAM string   `xml:"xmlns:ram,attr"`
+	XMLNSUDT string   `xml:"xmlns:udt,attr"`
+
+	Context     ciiDocumentContext `xml:"rsm:ExchangedDocumentContext"`
+	Document    ciiDocument        `xml:"rsm:ExchangedDocument"`
+	Transaction ciiTransaction     `xml:"rsm:SupplyChainTradeTransaction"`
+}
+
+type ciiDocumentContext struct {
+	GuidelineID string `xml:"ram:GuidelineSpecifiedDocumentContextParameter>ram:ID"`
+}
+
+type ciiDocument struct {
+	ID            string          `xml:"ram:ID"`
+	TypeCode      string          `xml:"ram:TypeCode"`
+	IssueDateTime ciiIssueDateTag `xml:"ram:IssueDateTime"`
+}
+
+type ciiIssueDateTag struct {
+	DateTimeString ciiFormattedDate `xml:"udt:DateTimeString"`
+}
+
+// ciiFormattedDate is udt:DateTimeString with a format="102" attribute
+// (CII format 102 = YYYYMMDD, ISO 8601 basic date).
+type ciiFormattedDate struct {
+	Format string `xml:"format,attr"`
+	Value  string `xml:",chardata"`
+}
+
+type ciiTransaction struct {
+	LineItems  []ciiLineItem `xml:"ram:IncludedSupplyChainTradeLineItem,omitempty"`
+	Agreement  ciiAgreement  `xml:"ram:ApplicableHeaderTradeAgreement"`
+	Settlement ciiSettlement `xml:"ram:ApplicableHeaderTradeSettlement"`
+}
+
+type ciiAgreement struct {
+	Seller ciiTradeParty `xml:"ram:SellerTradeParty"`
+	Buyer  ciiTradeParty `xml:"ram:BuyerTradeParty"`
+}
+
+type ciiTradeParty struct {
+	Name            string              `xml:"ram:Name"`
+	TaxRegistration *ciiTaxRegistration `xml:"ram:SpecifiedTaxRegistration,omitempty"`
+}
+
+type ciiTaxRegistration struct {
+	ID ciiSchemedID `xml:"ram:ID"`
+}
+
+// ciiSchemedID is a ram:ID with a schemeID attribute, e.g.
+// <ram:ID schemeID="VA">DE123456789</ram:ID> for a VAT number.
+type ciiSchemedID struct {
+	SchemeID string `xml:"schemeID,attr"`
+	Value    string `xml:",chardata"`
+}
+
+type ciiSettlement struct {
+	InvoiceCurrencyCode string             `xml:"ram:InvoiceCurrencyCode"`
+	ApplicableTradeTax  []ciiHeaderTax     `xml:"ram:ApplicableTradeTax,omitempty"`
+	PaymentTerms        *ciiPaymentTerms   `xml:"ram:SpecifiedTradePaymentTerms,omitempty"`
+	MonetarySummation   ciiMonetarySummary `xml:"ram:SpecifiedTradeSettlementHeaderMonetarySummation"`
+}
+
+type ciiHeaderTax struct {
+	CalculatedAmount      string `xml:"ram:CalculatedAmount"`
+	TypeCode              string `xml:"ram:TypeCode"`
+	BasisAmount           string `xml:"ram:BasisAmount"`
+	CategoryCode          string `xml:"ram:CategoryCode"`
+	RateApplicablePercent string `xml:"ram:RateApplicablePercent"`
+}
+
+type ciiPaymentTerms struct {
+	Description string `xml:"ram:Description"`
+}
+
+type ciiMonetarySummary struct {
+	LineTotalAmount     string            `xml:"ram:LineTotalAmount,omitempty"`
+	TaxBasisTotalAmount string            `xml:"ram:TaxBasisTotalAmount"`
+	TaxTotalAmount      ciiCurrencyAmount `xml:"ram:TaxTotalAmount"`
+	GrandTotalAmount    string            `xml:"ram:GrandTotalAmount"`
+	DuePayableAmount    string            `xml:"ram:DuePayableAmount"`
+}
+
+// ciiCurrencyAmount is an amount with a currencyID attribute, e.g.
+// <ram:TaxTotalAmount currencyID="EUR">64.13</ram:TaxTotalAmount>.
+type ciiCurrencyAmount struct {
+	CurrencyID string `xml:"currencyID,attr"`
+	Value      string `xml:",chardata"`
+}
+
+type ciiLineItem struct {
+	LineDocument ciiLineDocument   `xml:"ram:AssociatedDocumentLineDocument"`
+	Product      ciiTradeProduct   `xml:"ram:SpecifiedTradeProduct"`
+	Agreement    ciiLineAgreement  `xml:"ram:SpecifiedLineTradeAgreement"`
+	Delivery     ciiLineDelivery   `xml:"ram:SpecifiedLineTradeDelivery"`
+	Settlement   ciiLineSettlement `xml:"ram:SpecifiedLineTradeSettlement"`
+}
+
+type ciiLineDocument struct {
+	LineID string `xml:"ram:LineID"`
+}
+
+type ciiTradeProduct struct {
+	Name string `xml:"ram:Name"`
+}
+
+type ciiLineAgreement struct {
+	NetPrice ciiNetPrice `xml:"ram:NetPriceProductTradePrice"`
+}
+
+type ciiNetPrice struct {
+	ChargeAmount string `xml:"ram:ChargeAmount"`
+}
+
+type ciiLineDelivery struct {
+	BilledQuantity ciiQuantity `xml:"ram:BilledQuantity"`
+}
+
+// ciiQuantity is a quantity with a unitCode attribute (UN/ECE
+// Recommendation 20), e.g. <ram:BilledQuantity unitCode="C62">10</ram:BilledQuantity>.
+type ciiQuantity struct {
+	UnitCode string `xml:"unitCode,attr"`
+	Value    string `xml:",chardata"`
+}
+
+type ciiLineSettlement struct {
+	ApplicableTradeTax ciiLineTax             `xml:"ram:ApplicableTradeTax"`
+	MonetarySummation  ciiLineMonetarySummary `xml:"ram:SpecifiedTradeSettlementLineMonetarySummation"`
+}
+
+type ciiLineTax struct {
+	TypeCode              string `xml:"ram:TypeCode"`
+	CategoryCode          string `xml:"ram:CategoryCode"`
+	RateApplicablePercent string `xml:"ram:RateApplicablePercent"`
+}
+
+type ciiLineMonetarySummary struct {
+	LineTotalAmount string `xml:"ram:LineTotalAmount"`
+}
+
+// dateFormat102 renders a date in CII format 102 (YYYYMMDD).
+func dateFormat102(inv *Invoice) string {
+	return inv.IssueDate.Format("20060102")
+}
+
+// XML renders the invoice as EN 16931 CII XML for the given profile.
+// The output is deterministic: field order is fixed by the struct
+// layout and no data is sourced from map iteration or wall-clock time.
+func (inv *Invoice) XML(p Profile) ([]byte, error) {
+	if err := inv.Validate(p); err != nil {
+		return nil, err
+	}
+	guideline, err := p.guidelineURN()
+	if err != nil {
+		return nil, err
+	}
+
+	doc := ciiInvoice{
+		XMLNSRSM: nsRSM,
+		XMLNSRAM: nsRAM,
+		XMLNSUDT: nsUDT,
+		Context: ciiDocumentContext{
+			GuidelineID: guideline,
+		},
+		Document: ciiDocument{
+			ID:       inv.Number,
+			TypeCode: inv.typeCode(),
+			IssueDateTime: ciiIssueDateTag{
+				DateTimeString: ciiFormattedDate{Format: "102", Value: dateFormat102(inv)},
+			},
+		},
+		Transaction: ciiTransaction{
+			Agreement: ciiAgreement{
+				Seller: tradeParty(inv.Seller),
+				Buyer:  tradeParty(inv.Buyer),
+			},
+			Settlement: ciiSettlement{
+				InvoiceCurrencyCode: inv.Currency,
+				MonetarySummation: ciiMonetarySummary{
+					TaxBasisTotalAmount: inv.Totals.TaxBasisTotal.String(),
+					TaxTotalAmount:      ciiCurrencyAmount{CurrencyID: inv.Currency, Value: inv.Totals.TaxTotal.String()},
+					GrandTotalAmount:    inv.Totals.GrandTotal.String(),
+					DuePayableAmount:    inv.duePayable().String(),
+				},
+			},
+		},
+	}
+
+	if inv.PaymentTerms != "" {
+		doc.Transaction.Settlement.PaymentTerms = &ciiPaymentTerms{Description: inv.PaymentTerms}
+	}
+
+	if p == ProfileBasic {
+		doc.Transaction.Settlement.MonetarySummation.LineTotalAmount = inv.Totals.LineTotal.String()
+
+		for _, tt := range inv.TaxTotals {
+			category := tt.CategoryCode
+			if category == "" {
+				category = "S"
+			}
+			doc.Transaction.Settlement.ApplicableTradeTax = append(doc.Transaction.Settlement.ApplicableTradeTax, ciiHeaderTax{
+				CalculatedAmount:      tt.TaxAmount.String(),
+				TypeCode:              "VAT",
+				BasisAmount:           tt.TaxableAmount.String(),
+				CategoryCode:          category,
+				RateApplicablePercent: tt.RatePercent,
+			})
+		}
+
+		for i, line := range inv.Lines {
+			doc.Transaction.LineItems = append(doc.Transaction.LineItems, lineItemXML(i, line))
+		}
+	}
+
+	out, err := xml.MarshalIndent(&doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("zugferd: marshal CII XML: %w", err)
+	}
+	return append([]byte(xml.Header), out...), nil
+}
+
+func tradeParty(party Party) ciiTradeParty {
+	tp := ciiTradeParty{Name: party.Name}
+	if party.VATID != "" {
+		tp.TaxRegistration = &ciiTaxRegistration{ID: ciiSchemedID{SchemeID: "VA", Value: party.VATID}}
+	}
+	return tp
+}
+
+func lineItemXML(index int, line LineItem) ciiLineItem {
+	id := line.ID
+	if id == "" {
+		id = fmt.Sprintf("%d", index+1)
+	}
+	unitCode := line.UnitCode
+	if unitCode == "" {
+		unitCode = "C62"
+	}
+	category := line.TaxCategoryCode
+	if category == "" {
+		category = "S"
+	}
+	return ciiLineItem{
+		LineDocument: ciiLineDocument{LineID: id},
+		Product:      ciiTradeProduct{Name: line.Description},
+		Agreement: ciiLineAgreement{
+			NetPrice: ciiNetPrice{ChargeAmount: line.UnitPrice.String()},
+		},
+		Delivery: ciiLineDelivery{
+			BilledQuantity: ciiQuantity{UnitCode: unitCode, Value: line.Quantity},
+		},
+		Settlement: ciiLineSettlement{
+			ApplicableTradeTax: ciiLineTax{
+				TypeCode:              "VAT",
+				CategoryCode:          category,
+				RateApplicablePercent: line.TaxRatePercent,
+			},
+			MonetarySummation: ciiLineMonetarySummary{
+				LineTotalAmount: line.LineTotal.String(),
+			},
+		},
+	}
+}

--- a/zugferd/xml_test.go
+++ b/zugferd/xml_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package zugferd
+
+import (
+	"bytes"
+	"encoding/xml"
+	"strings"
+	"testing"
+)
+
+// oldExampleXML is the hand-rolled CII XML literal that
+// examples/zugferd/main.go embedded before it was ported onto this
+// package (see git history). It carries no line items and no tax
+// breakdown — TestXMLSemanticEquivalenceWithOldExample compares the
+// package's BASIC-profile output against it on the fields the two
+// have in common, and separately asserts the package's additions.
+const oldExampleXML = `<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice
+  xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+  xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+  xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:factur-x.eu:1p0:basic</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>2024-001</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20240115</udt:DateTimeString>
+    </ram:IssueDateTime>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+        <ram:Name>ACME Corp</ram:Name>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:Name>Example GmbH</ram:Name>
+      </ram:BuyerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:TaxBasisTotalAmount>337.50</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">64.13</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>401.63</ram:GrandTotalAmount>
+        <ram:DuePayableAmount>401.63</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>`
+
+// xnode is a generic, namespace-aware XML node tree used to compare
+// documents by element identity (namespace + local name) and text
+// content rather than by raw bytes — indentation and attribute/prefix
+// spelling differences are not semantic.
+type xnode struct {
+	XMLName  xml.Name
+	Attrs    []xml.Attr `xml:",any,attr"`
+	Chardata string     `xml:",chardata"`
+	Children []xnode    `xml:",any"`
+}
+
+func parseXNode(t *testing.T, data []byte) *xnode {
+	t.Helper()
+	var n xnode
+	if err := xml.Unmarshal(data, &n); err != nil {
+		t.Fatalf("xml.Unmarshal: %v", err)
+	}
+	return &n
+}
+
+// child returns the first direct child element with the given local
+// name, regardless of namespace, or nil.
+func (n *xnode) child(local string) *xnode {
+	for i := range n.Children {
+		if n.Children[i].XMLName.Local == local {
+			return &n.Children[i]
+		}
+	}
+	return nil
+}
+
+// children returns all direct child elements with the given local name.
+func (n *xnode) children(local string) []*xnode {
+	var out []*xnode
+	for i := range n.Children {
+		if n.Children[i].XMLName.Local == local {
+			out = append(out, &n.Children[i])
+		}
+	}
+	return out
+}
+
+// at navigates a dotted path of local names from n, failing the test
+// if any segment is missing.
+func (n *xnode) at(t *testing.T, path string) *xnode {
+	t.Helper()
+	cur := n
+	for _, seg := range strings.Split(path, ".") {
+		next := cur.child(seg)
+		if next == nil {
+			t.Fatalf("missing element %q under path %q", seg, path)
+		}
+		cur = next
+	}
+	return cur
+}
+
+func (n *xnode) text() string {
+	return strings.TrimSpace(n.Chardata)
+}
+
+func (n *xnode) attr(local string) string {
+	for _, a := range n.Attrs {
+		if a.Name.Local == local {
+			return a.Value
+		}
+	}
+	return ""
+}
+
+// TestXMLSemanticEquivalenceWithOldExample is the spike's acceptance
+// test (see package doc): it asserts the package's BASIC-profile CII
+// output carries the same values, in the same structural positions,
+// as the string literal examples/zugferd/main.go used to hand-roll
+// before it was ported onto this package. Byte equality is not
+// required — only element identity (namespace + local name) and
+// text/attribute content, which is what a validator actually checks.
+func TestXMLSemanticEquivalenceWithOldExample(t *testing.T) {
+	got, err := sampleInvoice().XML(ProfileBasic)
+	if err != nil {
+		t.Fatalf("XML: %v", err)
+	}
+
+	oldRoot := parseXNode(t, []byte(oldExampleXML))
+	newRoot := parseXNode(t, got)
+
+	// --- Common subset: every field the old literal carried. ---
+	if got, want := oldRoot.at(t, "ExchangedDocumentContext.GuidelineSpecifiedDocumentContextParameter.ID").text(),
+		newRoot.at(t, "ExchangedDocumentContext.GuidelineSpecifiedDocumentContextParameter.ID").text(); got != want {
+		t.Errorf("GuidelineID = %q, want %q", want, got)
+	}
+	if got, want := oldRoot.at(t, "ExchangedDocument.ID").text(), newRoot.at(t, "ExchangedDocument.ID").text(); got != want {
+		t.Errorf("ExchangedDocument.ID = %q, want %q", want, got)
+	}
+	if got, want := oldRoot.at(t, "ExchangedDocument.TypeCode").text(), newRoot.at(t, "ExchangedDocument.TypeCode").text(); got != want {
+		t.Errorf("TypeCode = %q, want %q", want, got)
+	}
+	oldDate := oldRoot.at(t, "ExchangedDocument.IssueDateTime.DateTimeString")
+	newDate := newRoot.at(t, "ExchangedDocument.IssueDateTime.DateTimeString")
+	if oldDate.text() != newDate.text() {
+		t.Errorf("IssueDateTime text = %q, want %q", newDate.text(), oldDate.text())
+	}
+	if oldDate.attr("format") != newDate.attr("format") {
+		t.Errorf("IssueDateTime format = %q, want %q", newDate.attr("format"), oldDate.attr("format"))
+	}
+
+	oldAgreement := oldRoot.at(t, "SupplyChainTradeTransaction.ApplicableHeaderTradeAgreement")
+	newAgreement := newRoot.at(t, "SupplyChainTradeTransaction.ApplicableHeaderTradeAgreement")
+	if got, want := oldAgreement.at(t, "SellerTradeParty.Name").text(), newAgreement.at(t, "SellerTradeParty.Name").text(); got != want {
+		t.Errorf("SellerTradeParty.Name = %q, want %q", want, got)
+	}
+	if got, want := oldAgreement.at(t, "BuyerTradeParty.Name").text(), newAgreement.at(t, "BuyerTradeParty.Name").text(); got != want {
+		t.Errorf("BuyerTradeParty.Name = %q, want %q", want, got)
+	}
+
+	oldSettlement := oldRoot.at(t, "SupplyChainTradeTransaction.ApplicableHeaderTradeSettlement")
+	newSettlement := newRoot.at(t, "SupplyChainTradeTransaction.ApplicableHeaderTradeSettlement")
+	if got, want := oldSettlement.at(t, "InvoiceCurrencyCode").text(), newSettlement.at(t, "InvoiceCurrencyCode").text(); got != want {
+		t.Errorf("InvoiceCurrencyCode = %q, want %q", want, got)
+	}
+
+	oldTotals := oldSettlement.at(t, "SpecifiedTradeSettlementHeaderMonetarySummation")
+	newTotals := newSettlement.at(t, "SpecifiedTradeSettlementHeaderMonetarySummation")
+	for _, field := range []string{"TaxBasisTotalAmount", "GrandTotalAmount", "DuePayableAmount"} {
+		if got, want := oldTotals.at(t, field).text(), newTotals.at(t, field).text(); got != want {
+			t.Errorf("%s = %q, want %q", field, want, got)
+		}
+	}
+	oldTax := oldTotals.at(t, "TaxTotalAmount")
+	newTax := newTotals.at(t, "TaxTotalAmount")
+	if oldTax.text() != newTax.text() {
+		t.Errorf("TaxTotalAmount = %q, want %q", newTax.text(), oldTax.text())
+	}
+	if oldTax.attr("currencyID") != newTax.attr("currencyID") {
+		t.Errorf("TaxTotalAmount currencyID = %q, want %q", newTax.attr("currencyID"), oldTax.attr("currencyID"))
+	}
+
+	// --- Additions: BASIC-profile elements the old literal lacked. ---
+	if newTotals.child("LineTotalAmount") == nil {
+		t.Error("new XML missing LineTotalAmount (BASIC addition over the old MINIMUM-ish example)")
+	}
+	newTransaction := newRoot.at(t, "SupplyChainTradeTransaction")
+	if got := len(newTransaction.children("IncludedSupplyChainTradeLineItem")); got != 3 {
+		t.Errorf("IncludedSupplyChainTradeLineItem count = %d, want 3 (old example had none)", got)
+	}
+	if got := len(newSettlement.children("ApplicableTradeTax")); got != 1 {
+		t.Errorf("ApplicableTradeTax count = %d, want 1 (old example had none)", got)
+	}
+}
+
+// TestXMLDeterministic asserts two generations from the same Invoice
+// produce byte-identical XML — required so folio's deterministic
+// document output isn't broken by embedding this attachment.
+func TestXMLDeterministic(t *testing.T) {
+	inv := sampleInvoice()
+	a, err := inv.XML(ProfileBasic)
+	if err != nil {
+		t.Fatalf("XML: %v", err)
+	}
+	b, err := inv.XML(ProfileBasic)
+	if err != nil {
+		t.Fatalf("XML: %v", err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Error("two XML generations from the same Invoice differ")
+	}
+}
+
+// TestXMLDateFormat102 asserts IssueDateTime uses CII format 102
+// (YYYYMMDD).
+func TestXMLDateFormat102(t *testing.T) {
+	inv := sampleInvoice()
+	out, err := inv.XML(ProfileBasic)
+	if err != nil {
+		t.Fatalf("XML: %v", err)
+	}
+	if !strings.Contains(string(out), `format="102">20240115<`) {
+		t.Errorf("expected format=\"102\">20240115< in output, got:\n%s", out)
+	}
+}
+
+// TestXMLMinimumProfileOmitsLinesAndTax asserts ProfileMinimum ignores
+// Lines/TaxTotals entirely, even when present on the Invoice, and uses
+// the MINIMUM guideline URN.
+func TestXMLMinimumProfileOmitsLinesAndTax(t *testing.T) {
+	out, err := sampleInvoice().XML(ProfileMinimum)
+	if err != nil {
+		t.Fatalf("XML: %v", err)
+	}
+	root := parseXNode(t, out)
+	if got := root.at(t, "ExchangedDocumentContext.GuidelineSpecifiedDocumentContextParameter.ID").text(); got != "urn:factur-x.eu:1p0:minimum" {
+		t.Errorf("GuidelineID = %q, want the MINIMUM URN", got)
+	}
+	transaction := root.at(t, "SupplyChainTradeTransaction")
+	if n := len(transaction.children("IncludedSupplyChainTradeLineItem")); n != 0 {
+		t.Errorf("IncludedSupplyChainTradeLineItem count = %d, want 0 for ProfileMinimum", n)
+	}
+	settlement := transaction.at(t, "ApplicableHeaderTradeSettlement")
+	if n := len(settlement.children("ApplicableTradeTax")); n != 0 {
+		t.Errorf("ApplicableTradeTax count = %d, want 0 for ProfileMinimum", n)
+	}
+}


### PR DESCRIPTION
## Summary

New `zugferd/` package for generating structured Factur-X / ZUGFeRD e-invoices: a typed `Invoice` model (parties, lines, tax breakdown, monetary summation), an `Amount` type backed by minor-units `int64` (no floats), `Invoice.XML(profile)` for the CII XML, and `Invoice.Attach(doc, profile)` which embeds the XML and sets PDF/A-3B conformance. Targets Factur-X 1.0 MINIMUM and BASIC profiles.

## Tests

- Semantic (namespace-aware) XML equivalence against the previous hand-rolled example XML, plus the BASIC-profile additions.
- A write→re-parse round trip that walks the catalog `/AF` tree to the embedded file stream and asserts the bytes are byte-identical to `Invoice.XML`, with correct `/F`/`/UF`/`/AFRelationship`.
- PDF/A-3B markers (`pdfaid:part 3`, `conformance B`, Factur-X XMP schema). Determinism test. golangci-lint 0.

`examples/zugferd` is ported onto the package (its existing test still passes). Design notes and scope/limitations in `docs/design-zugferd.md`.

## Scope — bounded spike

MINIMUM/BASIC only (EN 16931/EXTENDED/XRechnung deferred); two-decimal currencies; shape-validated currency codes; `Attach` overwrites rather than merges a pre-existing PDF/A config. All documented.