### PR TITLE
document: add debug MediaBox outline toggle (closes #376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`sign.Verify(pdfBytes []byte, opts sign.VerifyOptions) (*sign.Report, error)`** — offline verification for PDFs signed with `sign.SignPDF`. For each signature it locates the signature dictionary, recomputes the `/ByteRange` digest and checks it against the CMS `messageDigest` signed attribute, verifies the CMS signature (RSA PKCS#1 v1.5 or ECDSA) over the signed attributes, checks that `/ByteRange` covers the whole file except the `/Contents` hex string, and — when `VerifyOptions.Roots` is supplied — builds a certificate chain. `sign.Report.Signatures` reports each check independently (`DigestValid`, `SignatureValid`, `ByteRangeCoversFile`, `ChainStatus`) so partial validity is never conflated with full validity. Revocation fetching, timestamp-token and `/DSS` content validation, and PAdES level classification are out of scope; presence of a timestamp token or `/DSS` is reported but not validated.
+- **`document.Page.SetDebugMediaBox` / `document.Document.SetDebugMediaBox`** — strokes a rectangle around a page's true MediaBox for visual layout debugging (#376). Drawn last, on top of all other page content including the watermark. A page-level call overrides the document-wide default for that page.
 
 ### Changed (breaking)
 

--- a/document/boxes_test.go
+++ b/document/boxes_test.go
@@ -76,3 +76,52 @@ func TestBoxQpdfCheck(t *testing.T) {
 
 	runQpdfCheck(t, buf.Bytes())
 }
+
+func TestPageDebugMediaBox(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	p := doc.AddPage()
+	p.SetDebugMediaBox([3]float64{1, 0, 0}, 2)
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	cs := decompressedContentStreams(t, buf.Bytes())
+
+	for _, want := range []string{"2 w", "1 0 0 RG", "0 0 612 792 re", "S"} {
+		if !strings.Contains(cs, want) {
+			t.Errorf("expected content stream to contain %q, got:\n%s", want, cs)
+		}
+	}
+}
+
+func TestPageDebugMediaBoxOverridesDocument(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.SetDebugMediaBox([3]float64{0, 0, 1}, 1) // document default: blue
+	p := doc.AddPage()
+	p.SetDebugMediaBox([3]float64{1, 0, 0}, 2) // page override: red
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	cs := decompressedContentStreams(t, buf.Bytes())
+
+	if strings.Contains(cs, "0 0 1 RG") {
+		t.Error("page-level SetDebugMediaBox should override the document default, but blue stroke color was found")
+	}
+	if !strings.Contains(cs, "1 0 0 RG") {
+		t.Error("expected page-level red stroke color in content stream")
+	}
+}
+
+func TestPageDebugMediaBoxNegativeLineWidthPanics(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	p := doc.AddPage()
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic for negative line width")
+		}
+	}()
+	p.SetDebugMediaBox([3]float64{0, 0, 0}, -1)
+}

--- a/document/debugmediabox.go
+++ b/document/debugmediabox.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document
+
+import "fmt"
+
+// debugMediaBoxConfig holds the stroke color and line width for a debug
+// MediaBox outline.
+type debugMediaBoxConfig struct {
+	color     [3]float64
+	lineWidth float64
+}
+
+// SetDebugMediaBox strokes a rectangle around this page's MediaBox — the
+// exact page geometry PDF viewers use — for visual layout debugging.
+// Overrides any document-wide SetDebugMediaBox for this page.
+// color is [R, G, B] in [0, 1]. Panics if lineWidth is negative.
+func (p *Page) SetDebugMediaBox(color [3]float64, lineWidth float64) *Page {
+	if lineWidth < 0 {
+		panic(fmt.Sprintf("document.Page.SetDebugMediaBox: negative line width %v", lineWidth))
+	}
+	p.debugMediaBox = &debugMediaBoxConfig{color: color, lineWidth: lineWidth}
+	return p
+}
+
+// SetDebugMediaBox strokes a rectangle around every page's MediaBox for
+// visual layout debugging. A page with its own Page.SetDebugMediaBox
+// keeps that per-page setting instead. color is [R, G, B] in [0, 1].
+// Panics if lineWidth is negative.
+func (d *Document) SetDebugMediaBox(color [3]float64, lineWidth float64) {
+	if lineWidth < 0 {
+		panic(fmt.Sprintf("document.Document.SetDebugMediaBox: negative line width %v", lineWidth))
+	}
+	d.debugMediaBox = &debugMediaBoxConfig{color: color, lineWidth: lineWidth}
+}
+
+// applyDebugMediaBox draws the MediaBox outline for one page, if either the
+// page or the document has a debug config set (page config wins). Must run
+// after every other content mutation in buildAllPages so the outline is the
+// last thing drawn — on top of headers, footers, absolutes, and watermark.
+func (d *Document) applyDebugMediaBox(p *Page) {
+	cfg := p.debugMediaBox
+	if cfg == nil {
+		cfg = d.debugMediaBox
+	}
+	if cfg == nil {
+		return
+	}
+	ps := p.effectiveSize()
+	p.AddRect(0, 0, ps.Width, ps.Height, cfg.lineWidth, cfg.color)
+}

--- a/document/document.go
+++ b/document/document.go
@@ -87,6 +87,7 @@ type Document struct {
 	headerElem       ElementDecorator
 	footerElem       ElementDecorator
 	watermark        *WatermarkConfig
+	debugMediaBox    *debugMediaBoxConfig
 	encryption       *EncryptionConfig
 	tagged           bool        // if true, produce tagged PDF with structure tree
 	actualText       bool        // if true (default), wrap shaped Arabic words in /ActualText markers
@@ -510,6 +511,12 @@ func (d *Document) buildAllPages(ctx context.Context) (all []*Page, structTags [
 		for _, p := range all {
 			d.applyWatermark(p)
 		}
+	}
+
+	// Apply debug MediaBox outline last so it renders on top of everything,
+	// including the watermark.
+	for _, p := range all {
+		d.applyDebugMediaBox(p)
 	}
 
 	return all, structTags, nil

--- a/document/document_test.go
+++ b/document/document_test.go
@@ -1018,6 +1018,45 @@ func TestWatermarkMultiplePages(t *testing.T) {
 	}
 }
 
+func TestDocumentDebugMediaBoxAllPages(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.SetDebugMediaBox([3]float64{0, 1, 0}, 1.5)
+	doc.AddPage()
+	doc.AddPage()
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	cs := decompressedContentStreams(t, buf.Bytes())
+
+	if got := strings.Count(cs, "0 1 0 RG"); got != 2 {
+		t.Errorf("expected 2 outline stroke colors (one per page), got %d", got)
+	}
+}
+
+func TestDocumentDebugMediaBoxDrawnAfterWatermark(t *testing.T) {
+	doc := NewDocument(PageSizeLetter)
+	doc.SetWatermark("DRAFT")
+	doc.SetDebugMediaBox([3]float64{1, 0, 0}, 1)
+	doc.AddPage()
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+	cs := decompressedContentStreams(t, buf.Bytes())
+
+	wmIdx := strings.Index(cs, "(DRAFT) Tj")
+	outlineIdx := strings.LastIndex(cs, "1 0 0 RG")
+	if wmIdx == -1 || outlineIdx == -1 {
+		t.Fatalf("missing expected operators: watermark=%d outline=%d", wmIdx, outlineIdx)
+	}
+	if outlineIdx < wmIdx {
+		t.Error("debug MediaBox outline must be drawn after (on top of) the watermark")
+	}
+}
+
 func TestPageDefaultSize(t *testing.T) {
 	// Verify that a page without SetSize uses the document's page size.
 	doc := NewDocument(PageSizeLetter)

--- a/document/page.go
+++ b/document/page.go
@@ -126,6 +126,8 @@ type Page struct {
 	bleedBox *[4]float64 // bleed region for production
 	trimBox  *[4]float64 // intended finished page dimensions
 	artBox   *[4]float64 // meaningful content area
+
+	debugMediaBox *debugMediaBoxConfig // per-page debug MediaBox outline (nil = use document default)
 }
 
 // boxToArray converts a [4]float64 to a PdfArray.


### PR DESCRIPTION
## Summary

Adds an opt-in debug outline stroked around each page's MediaBox, so HTML/CSS layout can be checked against true page geometry without hand-rolling a fixed-position debug div. Closes #376.

## API

- `func (p *Page) SetDebugMediaBox(color [3]float64, lineWidth float64) *Page` — chains, matching the other geometry-box setters.
- `func (d *Document) SetDebugMediaBox(color [3]float64, lineWidth float64)` — void return, matching every other `Document.Set*` (no chaining precedent on `Document`).
- A page-level call overrides the document-level default for that page. Negative `lineWidth` panics (consistent with `SetLineWidth`).

## Draw order

The outline is applied in `buildAllPages` immediately after the watermark step, appending `SaveState/SetLineWidth/SetStrokeColorRGB/Rectangle/Stroke/RestoreState` onto the page stream — so it's always drawn last, on top of headers/footers/absolutes/watermark. A regression test asserts the outline's stroke op comes strictly after the watermark's.

## Tests

Page + document level tests, override precedence, negative-width panic, and the draw-order regression. golangci-lint + make check clean.