### PR TITLE
html: honor font-style/weight/family on @page margin boxes (part of #378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CSS named colors now resolve to full-precision sRGB values in both `html` and `svg` output** — the two packages each carried an independent 148-entry named-color table stored as rounded decimal literals (3 decimals in `html`, 4 in `svg`), so the same keyword could render to different bytes depending on which package handled it. Both now share one table in `internal/csscolor` that computes each component as `x/255` at full `float64` precision, which changes the emitted bytes for named colors slightly versus the old decimal literals in both packages. `svg` color parsing also now accepts the full CSS color grammar (4/8-digit hex, CSS Color 4 space-separated `rgb()`, and `hsl()`/`hsla()`) that `html` already supported — previously-valid `svg` inputs are unaffected. As part of sharing the parser, malformed `svg` color literals (invalid hex digits, non-numeric `rgb()`/alpha components) are now treated leniently — the bad component defaults to 0 rather than rejecting the whole color, matching how `html` already handled them.
 
+### Fixed
+
+- **`@page` margin boxes (`@top-*`/`@bottom-*`) now honor `font-style`, `font-weight`, and `font-family`** — previously only `font-size` and `color` were applied to generated margin-box content; `font-style: italic` and similar declarations were silently dropped (#378).
+
 ## [0.9.1] - 2026-06-10
 
 A rendering-correctness release across `border-radius` (#329), CSS paged media

--- a/document/html.go
+++ b/document/html.go
@@ -111,28 +111,28 @@ func (d *Document) AddConvertResult(result *foliohtml.ConvertResult) error {
 		if len(pc.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Font: mbc.Font, Embedded: mbc.Embedded}
 			}
 			d.SetMarginBoxes(boxes)
 		}
 		if pc.First != nil && len(pc.First.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.First.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Font: mbc.Font, Embedded: mbc.Embedded}
 			}
 			d.SetFirstMarginBoxes(boxes)
 		}
 		if pc.Left != nil && len(pc.Left.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.Left.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Font: mbc.Font, Embedded: mbc.Embedded}
 			}
 			d.SetLeftMarginBoxes(boxes)
 		}
 		if pc.Right != nil && len(pc.Right.MarginBoxes) > 0 {
 			boxes := make(map[string]layout.MarginBox)
 			for name, mbc := range pc.Right.MarginBoxes {
-				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Embedded: mbc.Embedded}
+				boxes[name] = layout.MarginBox{Content: mbc.Content, FontSize: mbc.FontSize, Color: mbc.Color, HasColor: mbc.HasColor, Font: mbc.Font, Embedded: mbc.Embedded}
 			}
 			d.SetRightMarginBoxes(boxes)
 		}

--- a/examples/html-to-pdf/main.go
+++ b/examples/html-to-pdf/main.go
@@ -52,6 +52,7 @@ const reportHTML = `<!DOCTYPE html>
       size: A4;
       margin: 0 0 24px 0;
       @bottom-center { content: "Page " counter(page) " of " counter(pages); }
+      @bottom-right { content: "CONFIDENTIAL"; font-size: 7pt; font-style: italic; font-weight: bold; color: #b91c1c; }
     }
     @page :first { @bottom-center { content: ""; } }
     body { font-family: Helvetica, Arial, sans-serif; margin: 0; padding: 0; color: #2d3748; font-size: 10pt; }

--- a/examples/html-to-pdf/main_test.go
+++ b/examples/html-to-pdf/main_test.go
@@ -91,11 +91,13 @@ func TestHTMLToPDFExampleMetadataFromHTML(t *testing.T) {
 // font-sharing fix landed in #300 (commit 61dc047). The example
 // styles body text as Helvetica and headings as Helvetica-Bold across
 // two pages; each variant must appear exactly once in the PDF, not
-// twice (pre-fix per-page embedding). The trailing space narrows the
-// match so /Helvetica does not falsely fire on /Helvetica-Bold.
+// twice (pre-fix per-page embedding). The trailing space narrows each
+// match so /Helvetica does not falsely fire on /Helvetica-Bold, and
+// /Helvetica-Bold does not falsely fire on /Helvetica-BoldOblique
+// (the margin-box footer's font).
 func TestHTMLToPDFExampleFontDedupAcrossPages(t *testing.T) {
 	pdf := string(examplePDFBytes())
-	for _, marker := range []string{"/BaseFont /Helvetica ", "/BaseFont /Helvetica-Bold"} {
+	for _, marker := range []string{"/BaseFont /Helvetica ", "/BaseFont /Helvetica-Bold "} {
 		if got := strings.Count(pdf, marker); got != 1 {
 			t.Errorf("count of %q = %d, want 1 (post-#300 single-embed-per-document)", marker, got)
 		}
@@ -117,5 +119,15 @@ func TestHTMLToPDFExampleLinkAnnotationTargetsRepo(t *testing.T) {
 	const wantURL = "https://github.com/carlos7ags/folio"
 	if !strings.Contains(pdf, wantURL) {
 		t.Errorf("link URI %q not present in PDF; check that the <a href> destination survives layout/serialization", wantURL)
+	}
+}
+
+// TestHTMLToPDFExampleMarginBoxFontStyleHonored pins issue #378 gap A: the
+// bottom-right footer declares font-style: italic; font-weight: bold and
+// must draw with Helvetica-BoldOblique, not plain Helvetica.
+func TestHTMLToPDFExampleMarginBoxFontStyleHonored(t *testing.T) {
+	pdf := string(examplePDFBytes())
+	if !strings.Contains(pdf, "/BaseFont /Helvetica-BoldOblique") {
+		t.Error("expected a Helvetica-BoldOblique font resource for the italic+bold margin box; font-style/font-weight were not honored")
 	}
 }

--- a/html/converter.go
+++ b/html/converter.go
@@ -224,11 +224,29 @@ type MarginBoxContent struct {
 	// margin-box rule. It lets the renderer distinguish an explicit
 	// `color: black` from an unset color (which defaults to gray).
 	HasColor bool
+	// FontStyle is the parsed font-style ("italic" or "normal"). Empty
+	// when the margin box declared none, in which case the box falls
+	// back to plain (non-italic) rather than inheriting <body>'s style —
+	// symmetric with how FontSize/Color already default rather than
+	// inherit.
+	FontStyle string
+	// FontWeight is the CSS Fonts L4 numeric weight (100-900). 0 means
+	// the margin box declared none (treated as 400).
+	FontWeight int
+	// FontFamily is the parsed font-family (lowercased, quotes/first-of-
+	// list stripped, see parseFontFamily). Empty when the margin box
+	// declared none.
+	FontFamily string
+	// Font is the resolved standard PDF font used when Embedded is nil,
+	// computed in resolveMarginBoxFont from FontStyle/FontWeight/
+	// FontFamily. nil until that resolution runs.
+	Font *font.Standard
 	// Embedded is the document's default body font, stamped during
 	// conversion so the renderer can draw the margin box with an embedded
 	// (PDF/A-safe) font instead of the non-embedded standard Helvetica.
-	// Nil when the document uses no embedded fonts. Font-family declared
-	// inside the margin box itself is not yet honoured (follow-up).
+	// Nil when the document uses no embedded fonts, or when the box's own
+	// font-style/font-weight/font-family resolves to a standard font
+	// instead (see resolveMarginBoxFont).
 	Embedded *font.EmbeddedFont
 }
 
@@ -392,13 +410,10 @@ func (pc *PageConfig) Resolve(defaultW, defaultH float64) (width, height float64
 	return width, height, autoHeight
 }
 
-// convertMarginBoxes converts html.MarginBoxContent to layout.MarginBox,
-// stamping the document's default body font (emb) onto each box so the
-// renderer draws running headers/footers with an embedded, PDF/A-safe font
-// instead of the non-embedded standard Helvetica (issue #328). emb may be
-// nil when the document has no embedded fonts; the renderer then falls back
-// to Helvetica, which is acceptable because such a document is not PDF/A.
-func convertMarginBoxes(src map[string]MarginBoxContent, emb *font.EmbeddedFont) map[string]layout.MarginBox {
+// convertMarginBoxes converts html.MarginBoxContent to layout.MarginBox. Each
+// box's Font/Embedded fields must already be resolved (see
+// resolveMarginBoxFonts) before this runs.
+func convertMarginBoxes(src map[string]MarginBoxContent) map[string]layout.MarginBox {
 	if len(src) == 0 {
 		return nil
 	}
@@ -409,19 +424,20 @@ func convertMarginBoxes(src map[string]MarginBoxContent, emb *font.EmbeddedFont)
 			FontSize: mbc.FontSize,
 			Color:    mbc.Color,
 			HasColor: mbc.HasColor,
-			Embedded: emb,
+			Font:     mbc.Font,
+			Embedded: mbc.Embedded,
 		}
 	}
 	return out
 }
 
-// stampMarginBoxFont writes emb onto the Embedded field of every
-// MarginBoxContent in src. It is used so the document.AddHTML path, which
-// reconstructs layout.MarginBox from PageConfig rather than from the
-// already-converted ConvertResult.MarginBoxes, embeds the same body font.
-func stampMarginBoxFont(src map[string]MarginBoxContent, emb *font.EmbeddedFont) {
+// resolveMarginBoxFonts fills in the Font/Embedded fields of every
+// MarginBoxContent in src via resolveMarginBoxFont (issue #378 gap A: a
+// box's own font-style/font-weight/font-family must be honored, not
+// just its color/font-size).
+func (c *converter) resolveMarginBoxFonts(src map[string]MarginBoxContent, bodyEmbedded *font.EmbeddedFont) {
 	for name, mbc := range src {
-		mbc.Embedded = emb
+		mbc.Font, mbc.Embedded = c.resolveMarginBoxFont(mbc, bodyEmbedded)
 		src[name] = mbc
 	}
 }
@@ -432,8 +448,9 @@ func stampMarginBoxFont(src map[string]MarginBoxContent, emb *font.EmbeddedFont)
 // matching @font-face is honoured) and resolves that style to an embedded
 // font. Returns nil when the document uses no embedded fonts (pure
 // standard-font document), in which case the renderer keeps the Helvetica
-// fallback. Font-family declared inside the margin box itself is not parsed
-// yet (deferred follow-up); the body font is the default per CSS GCPM.
+// fallback. Font-family declared inside the margin box itself is resolved
+// separately per box by resolveMarginBoxFont; this is only the fallback
+// default per CSS GCPM for boxes that declare none of their own.
 func (c *converter) defaultMarginBoxFont(doc *html.Node, root computedStyle) *font.EmbeddedFont {
 	if len(c.embeddedFonts) == 0 {
 		return nil
@@ -544,26 +561,28 @@ func ConvertFullWithContext(ctx context.Context, htmlStr string, opts *Options) 
 	result.PageConfig = pageConfig
 
 	// Build ready-to-use margin box maps so callers can pass them
-	// directly to doc.SetMarginBoxes without type conversion. The
-	// document's default body font is stamped onto each box (issue #328)
-	// and also onto the MarginBoxContent values in pageConfig so the
-	// document.AddHTML path (which rebuilds layout.MarginBox from
-	// pageConfig) embeds the same font.
+	// directly to doc.SetMarginBoxes without type conversion. Each box's
+	// own font-style/font-weight/font-family is resolved against the
+	// document's default body font (issue #328's inherited fallback for
+	// boxes that declare none of their own) so the resolved Font/Embedded
+	// values can also be copied onto the MarginBoxContent values in
+	// pageConfig, letting the document.AddHTML path (which rebuilds
+	// layout.MarginBox from pageConfig) draw with the same font.
 	if pageConfig != nil {
-		marginFont := c.defaultMarginBoxFont(doc, style)
-		stampMarginBoxFont(pageConfig.MarginBoxes, marginFont)
-		result.MarginBoxes = convertMarginBoxes(pageConfig.MarginBoxes, marginFont)
+		bodyEmbedded := c.defaultMarginBoxFont(doc, style)
+		c.resolveMarginBoxFonts(pageConfig.MarginBoxes, bodyEmbedded)
+		result.MarginBoxes = convertMarginBoxes(pageConfig.MarginBoxes)
 		if pageConfig.First != nil {
-			stampMarginBoxFont(pageConfig.First.MarginBoxes, marginFont)
-			result.FirstMarginBoxes = convertMarginBoxes(pageConfig.First.MarginBoxes, marginFont)
+			c.resolveMarginBoxFonts(pageConfig.First.MarginBoxes, bodyEmbedded)
+			result.FirstMarginBoxes = convertMarginBoxes(pageConfig.First.MarginBoxes)
 		}
 		if pageConfig.Left != nil {
-			stampMarginBoxFont(pageConfig.Left.MarginBoxes, marginFont)
-			result.LeftMarginBoxes = convertMarginBoxes(pageConfig.Left.MarginBoxes, marginFont)
+			c.resolveMarginBoxFonts(pageConfig.Left.MarginBoxes, bodyEmbedded)
+			result.LeftMarginBoxes = convertMarginBoxes(pageConfig.Left.MarginBoxes)
 		}
 		if pageConfig.Right != nil {
-			stampMarginBoxFont(pageConfig.Right.MarginBoxes, marginFont)
-			result.RightMarginBoxes = convertMarginBoxes(pageConfig.Right.MarginBoxes, marginFont)
+			c.resolveMarginBoxFonts(pageConfig.Right.MarginBoxes, bodyEmbedded)
+			result.RightMarginBoxes = convertMarginBoxes(pageConfig.Right.MarginBoxes)
 		}
 	}
 

--- a/html/converter_helpers.go
+++ b/html/converter_helpers.go
@@ -104,6 +104,35 @@ func (c *converter) resolveFontPair(style computedStyle) (*font.Standard, *font.
 	return resolveFont(style), nil
 }
 
+// resolveMarginBoxFont resolves the font for one margin box's own
+// declarations, reusing exactly the same nearest-weight/style matching
+// body text uses (resolveFontPair) so margin-box and body-text font
+// selection cannot silently diverge.
+//
+// When the box declares no font-style/font-weight/font-family of its
+// own, it keeps issue #328's behavior verbatim: it inherits bodyEmbedded,
+// the document's default body embedded font instance, with no standard
+// fallback. Otherwise its own declared properties are resolved against a
+// plain Helvetica/normal/400 base (unset properties default to plain,
+// not to <body>'s style), which may return either a standard PDF-14 font
+// or an @font-face-matched embedded font.
+func (c *converter) resolveMarginBoxFont(mbc MarginBoxContent, bodyEmbedded *font.EmbeddedFont) (*font.Standard, *font.EmbeddedFont) {
+	if mbc.FontFamily == "" && mbc.FontStyle == "" && mbc.FontWeight == 0 {
+		return nil, bodyEmbedded
+	}
+	style := computedStyle{FontFamily: "helvetica", FontWeight: 400, FontStyle: "normal"}
+	if mbc.FontFamily != "" {
+		style.FontFamily = mbc.FontFamily
+	}
+	if mbc.FontWeight != 0 {
+		style.FontWeight = mbc.FontWeight
+	}
+	if mbc.FontStyle != "" {
+		style.FontStyle = mbc.FontStyle
+	}
+	return c.resolveFontPair(style)
+}
+
 // matchEmbeddedFont returns the @font-face whose declared weight is the
 // nearest match for `desired` within the given family + style, per
 // CSS Fonts L4 §5.2:

--- a/html/marginbox_font_style_test.go
+++ b/html/marginbox_font_style_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import "testing"
+
+// TestMarginBoxItalicResolvesObliqueFont verifies that font-style: italic
+// on a margin box resolves to the standard oblique variant (issue #378
+// gap A), not the plain hard-coded Helvetica.
+func TestMarginBoxItalicResolvesObliqueFont(t *testing.T) {
+	src := `<!DOCTYPE html><html><head><style>
+@page { @bottom-right { content: "X"; font-style: italic; } }
+</style></head><body><p>Hi</p></body></html>`
+
+	result, err := ConvertFull(src, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box, ok := result.MarginBoxes["bottom-right"]
+	if !ok {
+		t.Fatalf("no bottom-right margin box; got %v", result.MarginBoxes)
+	}
+	if box.Font == nil {
+		t.Fatal("Font is nil, want Helvetica-Oblique")
+	}
+	if box.Font.Name() != "Helvetica-Oblique" {
+		t.Errorf("Font.Name() = %q, want Helvetica-Oblique", box.Font.Name())
+	}
+	if box.Embedded != nil {
+		t.Error("Embedded is non-nil, want nil for a document with no @font-face")
+	}
+}
+
+// TestMarginBoxBoldResolvesBoldFont verifies font-weight: bold resolves to
+// the standard bold variant.
+func TestMarginBoxBoldResolvesBoldFont(t *testing.T) {
+	src := `<!DOCTYPE html><html><head><style>
+@page { @bottom-right { content: "X"; font-weight: bold; } }
+</style></head><body><p>Hi</p></body></html>`
+
+	result, err := ConvertFull(src, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box, ok := result.MarginBoxes["bottom-right"]
+	if !ok {
+		t.Fatalf("no bottom-right margin box; got %v", result.MarginBoxes)
+	}
+	if box.Font == nil || box.Font.Name() != "Helvetica-Bold" {
+		t.Errorf("Font = %v, want Helvetica-Bold", box.Font)
+	}
+}
+
+// TestMarginBoxBoldItalicResolvesBoldObliqueFont exercises the issue's
+// exact repro shape: font-style, font-weight, color, and font-size
+// declared together on the same margin box must all be honored.
+func TestMarginBoxBoldItalicResolvesBoldObliqueFont(t *testing.T) {
+	src := `<!DOCTYPE html><html><head><style>
+@page { @bottom-right {
+	content: "CONFIDENTIAL";
+	font-size: 6pt;
+	font-style: italic;
+	font-weight: bold;
+	color: red;
+} }
+</style></head><body><p>Hi</p></body></html>`
+
+	result, err := ConvertFull(src, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box, ok := result.MarginBoxes["bottom-right"]
+	if !ok {
+		t.Fatalf("no bottom-right margin box; got %v", result.MarginBoxes)
+	}
+	if box.Font == nil || box.Font.Name() != "Helvetica-BoldOblique" {
+		t.Errorf("Font = %v, want Helvetica-BoldOblique", box.Font)
+	}
+	if !box.HasColor {
+		t.Error("HasColor = false, want true")
+	}
+	if box.Color != [3]float64{1, 0, 0} {
+		t.Errorf("Color = %v, want red {1,0,0}", box.Color)
+	}
+	if box.FontSize != 6.0 {
+		t.Errorf("FontSize = %v, want 6.0", box.FontSize)
+	}
+}
+
+// TestMarginBoxFontFamilyOverridesStandardFamily verifies font-family on
+// a margin box maps to the corresponding standard PDF family when no
+// matching @font-face is registered.
+func TestMarginBoxFontFamilyOverridesStandardFamily(t *testing.T) {
+	src := `<!DOCTYPE html><html><head><style>
+@page { @bottom-right { content: "X"; font-family: 'Courier New'; } }
+</style></head><body><p>Hi</p></body></html>`
+
+	result, err := ConvertFull(src, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box, ok := result.MarginBoxes["bottom-right"]
+	if !ok {
+		t.Fatalf("no bottom-right margin box; got %v", result.MarginBoxes)
+	}
+	if box.Font == nil || box.Font.Name() != "Courier" {
+		t.Errorf("Font = %v, want Courier", box.Font)
+	}
+}
+
+// TestMarginBoxNoFontDeclarationKeepsPlainHelvetica pins the "undeclared
+// box is unaffected" scope boundary: a box with only content/font-size/
+// color set must leave Font nil so the renderer falls back to plain
+// Helvetica, exactly as before this fix.
+func TestMarginBoxNoFontDeclarationKeepsPlainHelvetica(t *testing.T) {
+	src := `<!DOCTYPE html><html><head><style>
+@page { @bottom-right { content: "X"; font-size: 8pt; color: blue; } }
+</style></head><body><p>Hi</p></body></html>`
+
+	result, err := ConvertFull(src, nil)
+	if err != nil {
+		t.Fatalf("ConvertFull: %v", err)
+	}
+	box, ok := result.MarginBoxes["bottom-right"]
+	if !ok {
+		t.Fatalf("no bottom-right margin box; got %v", result.MarginBoxes)
+	}
+	if box.Font != nil {
+		t.Errorf("Font = %v, want nil (falls back to plain Helvetica)", box.Font)
+	}
+}

--- a/html/page.go
+++ b/html/page.go
@@ -210,7 +210,8 @@ func newSeededMargins(pc *PageConfig) *PageMargins {
 	return pm
 }
 
-// parseMarginBoxDecls extracts content, font-size, and color from margin box declarations.
+// parseMarginBoxDecls extracts content, font-size, color, and font-style/
+// font-weight/font-family from margin box declarations.
 func parseMarginBoxDecls(decls []cssDecl, defaultFontSize float64) MarginBoxContent {
 	var mbc MarginBoxContent
 	for _, d := range decls {
@@ -229,6 +230,12 @@ func parseMarginBoxDecls(decls []cssDecl, defaultFontSize float64) MarginBoxCont
 				mbc.Color = [3]float64{c.R, c.G, c.B}
 				mbc.HasColor = true
 			}
+		case "font-style":
+			mbc.FontStyle = parseFontStyle(val)
+		case "font-weight":
+			mbc.FontWeight = parseFontWeight(val, 400)
+		case "font-family":
+			mbc.FontFamily = parseFontFamily(val)
 		}
 	}
 	return mbc

--- a/layout/marginbox_font_style_test.go
+++ b/layout/marginbox_font_style_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// TestMarginBoxCustomFontRegistered verifies the renderer registers and
+// draws with a margin box's own resolved Font instead of the hard-coded
+// standard Helvetica (issue #378 gap A).
+func TestMarginBoxCustomFontRegistered(t *testing.T) {
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.Add(NewParagraph("Body", font.Helvetica, 12))
+	r.SetMarginBoxes(map[string]MarginBox{
+		"bottom-center": {Content: "X", FontSize: 9, Font: font.HelveticaOblique},
+	})
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("expected at least one page")
+	}
+	found := false
+	for _, fe := range pages[0].Fonts {
+		if fe.Standard != nil && fe.Standard.Name() == "Helvetica-Oblique" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a registered Helvetica-Oblique font resource, got %+v", pages[0].Fonts)
+	}
+}
+
+// TestMarginBoxNilFontDefaultsHelvetica verifies a nil Font (matching
+// every pre-existing caller) still falls back to plain Helvetica.
+func TestMarginBoxNilFontDefaultsHelvetica(t *testing.T) {
+	r := NewRenderer(612, 792, Margins{Top: 72, Right: 72, Bottom: 72, Left: 72})
+	r.Add(NewParagraph("Body", font.Helvetica, 12))
+	r.SetMarginBoxes(map[string]MarginBox{
+		"bottom-center": {Content: "X", FontSize: 9},
+	})
+	pages := r.Render()
+	if len(pages) == 0 {
+		t.Fatal("expected at least one page")
+	}
+	found := false
+	for _, fe := range pages[0].Fonts {
+		if fe.Standard != nil && fe.Standard.Name() == "Helvetica" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a registered plain Helvetica font resource, got %+v", pages[0].Fonts)
+	}
+}

--- a/layout/renderer.go
+++ b/layout/renderer.go
@@ -145,11 +145,16 @@ type MarginBox struct {
 	// from an unset color: when false the renderer applies the default
 	// gray; when true it honours Color verbatim (including pure black).
 	HasColor bool
+	// Font is the standard PDF font to draw with when Embedded is nil,
+	// resolved from the margin box's own font-style/font-weight/
+	// font-family declarations. nil falls back to plain Helvetica — the
+	// pre-fix behavior for a box with no font declarations of its own.
+	Font *font.Standard
 	// Embedded is the document's default body font, used to draw the
 	// margin-box text. When non-nil the renderer emits the text with this
 	// embedded font (Identity-H GID encoding), so the glyphs are subset
 	// and embedded — required for PDF/A. When nil the renderer falls back
-	// to the built-in standard Helvetica (acceptable for non-PDF/A docs).
+	// to Font, or plain Helvetica if Font is also nil.
 	Embedded *font.EmbeddedFont
 }
 
@@ -268,7 +273,6 @@ func (r *Renderer) drawMarginBoxes(ctx *DrawContext, pageIdx int, margins Margin
 		return
 	}
 
-	f := font.Helvetica
 	contentWidth := r.pageWidth - margins.Left - margins.Right
 
 	for _, name := range marginBoxOrder {
@@ -307,14 +311,19 @@ func (r *Renderer) drawMarginBoxes(ctx *DrawContext, pageIdx int, margins Margin
 
 		// Choose the drawing word: an embedded font (PDF/A-safe, Identity-H
 		// GID encoding) when one was stamped on the box, otherwise the
-		// built-in standard Helvetica. Width is measured with the same font
-		// so alignment math is consistent.
+		// box's own resolved standard font, falling back to plain
+		// Helvetica. Width is measured with the same font so alignment
+		// math is consistent.
 		word := Word{FontSize: fontSize, OriginalText: text, Text: text}
 		var textWidth float64
 		if box.Embedded != nil {
 			word.Embedded = box.Embedded
 			textWidth = box.Embedded.MeasureString(text, fontSize)
 		} else {
+			f := box.Font
+			if f == nil {
+				f = font.Helvetica
+			}
 			word.Font = f
 			textWidth = f.MeasureString(text, fontSize)
 		}


### PR DESCRIPTION
## Summary

CSS margin-box content (`@page { @bottom-right { ... } }`) applied `font-size` and `color` but silently dropped `font-style`, `font-weight`, and `font-family` — `parseMarginBoxDecls` had no cases for them, and `drawMarginBoxes` hard-coded `font.Helvetica`. Part of #378 (the margin-box-styling gap).

## Change

- `parseMarginBoxDecls` now parses `font-style/weight/family` into new `MarginBoxContent` fields (reusing the existing `parseFontStyle/Weight/Family`).
- New `resolveMarginBoxFont` builds a `computedStyle` from the box's own declarations and delegates to the existing `resolveFontPair` — the same path body text uses (so italic → oblique, bold → bold, custom family honored).
- `layout.MarginBox` gains a `Font` field; `drawMarginBoxes` uses it, falling back to Helvetica only when nil. All four `document/html.go` construction sites copy it.

## Preserves #328

A margin box with no font declarations of its own still inherits the exact same embedded body-font instance (early return), verified by the existing #328 tests staying green.

## Tests

Italic/bold/bold-italic/custom-family resolution and the no-declaration fallback, plus an `examples/html-to-pdf` margin box exercising the styling. golangci-lint + make check clean.