### PR TITLE
html: number li::marker content with the implicit list-item counter (part of #378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CSS named colors now resolve to full-precision sRGB values in both `html` and `svg` output** — the two packages each carried an independent 148-entry named-color table stored as rounded decimal literals (3 decimals in `html`, 4 in `svg`), so the same keyword could render to different bytes depending on which package handled it. Both now share one table in `internal/csscolor` that computes each component as `x/255` at full `float64` precision, which changes the emitted bytes for named colors slightly versus the old decimal literals in both packages. `svg` color parsing also now accepts the full CSS color grammar (4/8-digit hex, CSS Color 4 space-separated `rgb()`, and `hsl()`/`hsla()`) that `html` already supported — previously-valid `svg` inputs are unaffected. As part of sharing the parser, malformed `svg` color literals (invalid hex digits, non-numeric `rgb()`/alpha components) are now treated leniently — the bad component defaults to 0 rather than rejecting the whole color, matching how `html` already handled them.
 
+### Fixed
+
+- **`li::marker { content: counter(list-item) }` now numbers list items** — `<li>` implicitly increments the CSS `list-item` counter and `<ul>`/`<ol>` implicitly reset it, per CSS Lists Module 3, so `::marker` content driven by `counter(list-item)` (or `counters(list-item, sep)` for nested lists) resolves correctly instead of always reading `0`. `::marker { font-style: italic }` is also now honored.
+
 ## [0.9.1] - 2026-06-10
 
 A rendering-correctness release across `border-radius` (#329), CSS paged media

--- a/html/converter_dispatch.go
+++ b/html/converter_dispatch.go
@@ -216,6 +216,14 @@ func (c *converter) convertNode(n *html.Node, parentStyle computedStyle) []layou
 func (c *converter) convertElement(n *html.Node, parentStyle computedStyle) []layout.Element {
 	style := c.computeElementStyle(n, parentStyle)
 
+	// UA default (CSS Lists 3 §6.1): every list root implicitly resets the
+	// "list-item" counter to 0, so counter(list-item) in ::marker numbers
+	// items and nested lists restart at 1. An explicit author counter-reset
+	// for "list-item" overrides this.
+	if n.DataAtom == atom.Ul || n.DataAtom == atom.Ol {
+		style.CounterReset = withImplicitListItemReset(style.CounterReset)
+	}
+
 	if style.Display == "none" {
 		return nil
 	}

--- a/html/converter_list.go
+++ b/html/converter_list.go
@@ -42,6 +42,13 @@ func (c *converter) convertList(n *html.Node, style computedStyle, ordered bool)
 						if fs > 0 {
 							list.SetMarkerFontSize(fs)
 						}
+					case "font-style":
+						if strings.EqualFold(strings.TrimSpace(d.value), "italic") {
+							markerStyle := style
+							markerStyle.FontStyle = "italic"
+							std, emb := c.resolveFontPair(markerStyle)
+							list.SetMarkerFont(std, emb)
+						}
 					}
 				}
 				break // only need to check the first <li>
@@ -139,6 +146,11 @@ func (c *converter) populateList(n *html.Node, list *layout.List, style computed
 		// the subtree. convertElement does this for the element path's block
 		// children, but the fast path and the li itself bypass it, so we mirror
 		// the reset-then-increment ordering here.
+		//
+		// UA default (CSS Lists 3 §6.1): every <li> implicitly increments
+		// "list-item" by 1. An explicit author counter-increment for
+		// "list-item" overrides this.
+		liStyle.CounterIncrement = withImplicitListItemIncrement(liStyle.CounterIncrement)
 		for _, cr := range liStyle.CounterReset {
 			c.resetCounter(cr.Name, cr.Value)
 		}
@@ -171,10 +183,13 @@ func (c *converter) populateList(n *html.Node, list *layout.List, style computed
 				}
 				// The fast path bypasses convertElement for the nested
 				// list, so apply the nested list's own counter-reset and
-				// counter-increment around the recursion. The element path's
-				// nested list goes through convertElement, which already
-				// handles both.
+				// counter-increment around the recursion, including the
+				// same implicit "list-item" reset convertElement applies
+				// (Step 2's equivalent) for nested lists reached here.
+				// The element path's nested list goes through
+				// convertElement, which already handles both.
 				nestedStyle := c.computeElementStyle(nestedList, style)
+				nestedStyle.CounterReset = withImplicitListItemReset(nestedStyle.CounterReset)
 				for _, cr := range nestedStyle.CounterReset {
 					c.resetCounter(cr.Name, cr.Value)
 				}

--- a/html/converter_style.go
+++ b/html/converter_style.go
@@ -551,6 +551,36 @@ func parseCounterEntries(val string, defaultVal int) []counterEntry {
 	return entries
 }
 
+// withImplicitListItemReset returns entries with an implicit "list-item"
+// counter-reset of 0 prepended, matching the CSS Lists 3 §6.1 user-agent
+// default (`ol, ul { counter-reset: list-item }`) that makes each list root
+// number its own items independently, including nested lists restarting at
+// 1. If the author already declared an explicit reset for "list-item",
+// theirs wins and no implicit entry is added.
+func withImplicitListItemReset(entries []counterEntry) []counterEntry {
+	for _, e := range entries {
+		if e.Name == "list-item" {
+			return entries
+		}
+	}
+	return append([]counterEntry{{Name: "list-item", Value: 0}}, entries...)
+}
+
+// withImplicitListItemIncrement returns entries with an implicit
+// "list-item" counter-increment of 1 prepended, matching the CSS Lists 3
+// §6.1 user-agent default (`li { counter-increment: list-item }`) — this is
+// what makes `content: counter(list-item)` in `::marker` number items
+// without any author counter-increment declaration. If the author already
+// declared an explicit increment for "list-item", theirs wins.
+func withImplicitListItemIncrement(entries []counterEntry) []counterEntry {
+	for _, e := range entries {
+		if e.Name == "list-item" {
+			return entries
+		}
+	}
+	return append([]counterEntry{{Name: "list-item", Value: 1}}, entries...)
+}
+
 // resetCounter pushes a new counter value onto the stack for the given name.
 func (c *converter) resetCounter(name string, value int) {
 	c.counters[name] = append(c.counters[name], value)

--- a/html/marker_list_item_counter_test.go
+++ b/html/marker_list_item_counter_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"strings"
+	"testing"
+)
+
+// The implicit "list-item" counter (CSS Lists 3 §6.1): every <li>
+// increments it by 1 and every <ul>/<ol> resets it to 0, so
+// `content: counter(list-item)` numbers items without any author
+// counter-reset/counter-increment declaration.
+
+// Regression test for issue #378 gap D: counter(list-item) previously always
+// resolved to 0 because the implicit reset/increment was never applied.
+func TestMarkerListItemCounterBasic(t *testing.T) {
+	htmlStr := `<style>
+		ul.notes li::marker { content: counter(list-item) ". "; }
+	</style>
+	<ul class="notes"><li>Alpha</li><li>Beta</li><li>Gamma</li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	for _, want := range []string{"(1.) Tj", "(2.) Tj", "(3.) Tj", "(Alpha) Tj", "(Beta) Tj", "(Gamma) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+	if strings.Contains(stream, "(0.) Tj") {
+		t.Errorf("marker still reads 0 — implicit list-item counter not applied\nstream:\n%s", stream)
+	}
+}
+
+// A nested list must restart list-item at 1 rather than continuing the
+// outer list's count, proving the implicit reset scopes per list root.
+func TestMarkerListItemCounterNestedRestarts(t *testing.T) {
+	htmlStr := `<style>
+		li::marker { content: counter(list-item) ". " }
+	</style>
+	<ol><li>Alpha<ol><li>Beta</li><li>Gamma</li></ol></li><li>Delta</li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	for _, want := range []string{"(1.) Tj", "(2.) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+	if strings.Contains(stream, "(3.) Tj") || strings.Contains(stream, "(4.) Tj") {
+		t.Errorf("nested list did not restart list-item at 1\nstream:\n%s", stream)
+	}
+}
+
+// counters(list-item, ".") composes the built-in counter across nesting
+// levels the same way an author-declared counter does.
+func TestMarkerListItemCounterMultiLevel(t *testing.T) {
+	htmlStr := `<style>
+		li::marker { content: counters(list-item, ".") ". " }
+	</style>
+	<ol><li>Alpha<ol><li>Beta</li><li>Gamma</li></ol></li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	for _, want := range []string{"(1.) Tj", "(1.1) Tj", "(1.2) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+}
+
+// An explicit author counter-increment for "list-item" must win over the
+// implicit +1 — no double counting.
+func TestMarkerListItemCounterExplicitIncrementWins(t *testing.T) {
+	htmlStr := `<style>
+		li { counter-increment: list-item 5 }
+		li::marker { content: counter(list-item) ". " }
+	</style>
+	<ol><li>A</li><li>B</li><li>C</li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	for _, want := range []string{"(5.) Tj", "(10.) Tj", "(15.) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+	if strings.Contains(stream, "(1.) Tj") || strings.Contains(stream, "(6.) Tj") {
+		t.Errorf("implicit +1 appears to have also applied (double counting)\nstream:\n%s", stream)
+	}
+}
+
+// An explicit author counter-reset for "list-item" on the list root must
+// win over the implicit reset to 0.
+func TestMarkerListItemCounterExplicitResetWins(t *testing.T) {
+	htmlStr := `<style>
+		ol { counter-reset: list-item 10 }
+		li::marker { content: counter(list-item) ". " }
+	</style>
+	<ol><li>A</li><li>B</li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	if !strings.Contains(stream, "(11.) Tj") {
+		t.Errorf("expected first marker to be 11. (10 + implicit +1)\nstream:\n%s", stream)
+	}
+	if strings.Contains(stream, "(1.) Tj") {
+		t.Errorf("explicit counter-reset: list-item 10 did not win over the implicit reset\nstream:\n%s", stream)
+	}
+}
+
+// Pin the nested-list fast path specifically: a plain inline <li> containing
+// a nested list with no box-model styles (the AddItemRunsWithSubList branch
+// in populateList). This is the path most likely to silently regress since
+// it bypasses convertElement entirely.
+func TestMarkerListItemCounterNestedFastPath(t *testing.T) {
+	htmlStr := `<style>
+		li::marker { content: counter(list-item) ". " }
+	</style>
+	<ul><li>Alpha<ul><li>Beta</li><li>Gamma</li></ul></li></ul>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	for _, want := range []string{"(1.) Tj", "(2.) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+	if strings.Contains(stream, "(3.) Tj") {
+		t.Errorf("nested fast-path list did not restart list-item at 1\nstream:\n%s", stream)
+	}
+}
+
+// The element path (an <li> with box-model styles, forcing addElementListItem
+// via a block child) must also number correctly.
+func TestMarkerListItemCounterElementPath(t *testing.T) {
+	htmlStr := `<style>
+		li::marker { content: counter(list-item) ") " }
+	</style>
+	<ol><li><p>First</p></li><li><p>Second</p></li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	for _, want := range []string{`(1\)) Tj`, `(2\)) Tj`, "(First) Tj", "(Second) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+}
+
+// Without any ::marker content, the implicit list-item counter must be
+// inert — the style-derived marker numbering (List.marker()/l.start) is
+// unaffected by the new counter plumbing.
+func TestMarkerListItemCounterInertWithoutMarkerContent(t *testing.T) {
+	htmlStr := `<ol><li>A</li><li>B</li></ol>`
+	elems, err := Convert(htmlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	for _, want := range []string{"(1.) Tj", "(2.) Tj", "(A) Tj", "(B) Tj"} {
+		if !strings.Contains(stream, want) {
+			t.Errorf("rendered stream missing %q\nstream:\n%s", want, stream)
+		}
+	}
+}

--- a/html/marker_test.go
+++ b/html/marker_test.go
@@ -4,6 +4,7 @@
 package html
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/carlos7ags/folio/layout"
@@ -74,6 +75,75 @@ func TestMarkerPseudoElementNoEffect(t *testing.T) {
 	if plan.Status != layout.LayoutFull {
 		t.Errorf("expected LayoutFull, got %v", plan.Status)
 	}
+}
+
+// font-style: italic on ::marker resolves through the same resolveFontPair
+// path used for regular text, giving the marker a distinct font resource
+// (the standard-font italic fallback, since no @font-face is registered)
+// from the body text's font.
+func TestMarkerPseudoElementFontStyleItalic(t *testing.T) {
+	src := `<style>li::marker { font-style: italic; content: "* "; }</style>
+	<ul><li>Alpha</li></ul>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+
+	markerFont := fontResourceBefore(t, stream, "(*) Tj")
+	bodyFont := fontResourceBefore(t, stream, "(Alpha) Tj")
+	if markerFont == "" || bodyFont == "" {
+		t.Fatalf("could not locate font resources in stream:\n%s", stream)
+	}
+	if markerFont == bodyFont {
+		t.Errorf("expected marker font-style: italic to use a different font resource than the body text, both used %q\nstream:\n%s", markerFont, stream)
+	}
+}
+
+// An unrecognized font-style value (anything but "italic") is a no-op: no
+// panic, and the marker keeps rendering with the list's default font.
+func TestMarkerPseudoElementFontStyleUnrecognizedIsNoop(t *testing.T) {
+	src := `<style>li::marker { font-style: oblique; content: "* "; }</style>
+	<ul><li>Alpha</li></ul>`
+	elems, err := Convert(src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(elems) == 0 {
+		t.Fatal("expected elements")
+	}
+	plan := elems[0].PlanLayout(layout.LayoutArea{Width: 400, Height: 1000})
+	if plan.Status != layout.LayoutFull {
+		t.Errorf("expected LayoutFull, got %v", plan.Status)
+	}
+
+	stream := renderStreamText(t, elems)
+	markerFont := fontResourceBefore(t, stream, "(*) Tj")
+	bodyFont := fontResourceBefore(t, stream, "(Alpha) Tj")
+	if markerFont != bodyFont {
+		t.Errorf("unrecognized font-style should be a no-op (marker keeps the list's default font), got marker=%q body=%q\nstream:\n%s", markerFont, bodyFont, stream)
+	}
+}
+
+// fontResourceBefore returns the PDF font resource name (e.g. "/F1") set by
+// the nearest preceding "Tf" operator before the given Tj text token.
+func fontResourceBefore(t *testing.T, stream, tjToken string) string {
+	t.Helper()
+	idx := strings.Index(stream, tjToken)
+	if idx < 0 {
+		t.Fatalf("token %q not found in stream", tjToken)
+	}
+	prefix := stream[:idx]
+	tfIdx := strings.LastIndex(prefix, "Tf")
+	if tfIdx < 0 {
+		return ""
+	}
+	lineStart := strings.LastIndex(prefix[:tfIdx], "\n") + 1
+	fields := strings.Fields(prefix[lineStart:tfIdx])
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 func TestMarkerPseudoElementTextUnaffected(t *testing.T) {

--- a/layout/list.go
+++ b/layout/list.go
@@ -31,10 +31,12 @@ type List struct {
 	fontSize       float64
 	indent         float64 // left indent for item text (points)
 	leading        float64
-	direction      Direction // text direction for list items
-	markerColor    *Color    // optional override color for markers
-	markerFontSize float64   // optional override font size for markers (0 = use list fontSize)
-	markerInside   bool      // CSS list-style-position: inside (marker flows inline)
+	direction      Direction          // text direction for list items
+	markerColor    *Color             // optional override color for markers
+	markerFontSize float64            // optional override font size for markers (0 = use list fontSize)
+	markerFont     *font.Standard     // optional override standard font for markers (nil = use list font)
+	markerEmbedded *font.EmbeddedFont // optional override embedded font for markers (nil = use list font)
+	markerInside   bool               // CSS list-style-position: inside (marker flows inline)
 
 	// start is the ordinal offset for marker numbering. The marker for the
 	// item at slice index i is numbered (i + 1 + start). It defaults to 0 so
@@ -172,6 +174,16 @@ func (l *List) SetMarkerColor(c Color) *List {
 // SetMarkerFontSize sets an override font size for list markers.
 func (l *List) SetMarkerFontSize(size float64) *List {
 	l.markerFontSize = size
+	return l
+}
+
+// SetMarkerFont sets an override font for list markers, independent of the
+// list's body font (used for CSS `::marker { font-style: italic }`).
+// Exactly one of std/emb should be non-nil, mirroring how the list itself
+// carries either a standard or an embedded font.
+func (l *List) SetMarkerFont(std *font.Standard, emb *font.EmbeddedFont) *List {
+	l.markerFont = std
+	l.markerEmbedded = emb
 	return l
 }
 
@@ -514,11 +526,15 @@ func (l *List) markerParagraph(index int) *Paragraph {
 	if l.markerFontSize > 0 {
 		markerSize = l.markerFontSize
 	}
+	stdFont, embFont := l.font, l.embedded
+	if l.markerFont != nil || l.markerEmbedded != nil {
+		stdFont, embFont = l.markerFont, l.markerEmbedded
+	}
 	var markerPara *Paragraph
-	if l.embedded != nil {
-		markerPara = NewParagraphEmbedded(marker, l.embedded, markerSize)
+	if embFont != nil {
+		markerPara = NewParagraphEmbedded(marker, embFont, markerSize)
 	} else {
-		markerPara = NewParagraph(marker, l.font, markerSize)
+		markerPara = NewParagraph(marker, stdFont, markerSize)
 	}
 	if l.markerColor != nil {
 		markerPara.runs[0].Color = *l.markerColor
@@ -863,6 +879,8 @@ func (l *List) cloneWithItems(items []listItem) *List {
 		direction:      l.direction,
 		markerColor:    l.markerColor,
 		markerFontSize: l.markerFontSize,
+		markerFont:     l.markerFont,
+		markerEmbedded: l.markerEmbedded,
 		markerInside:   l.markerInside,
 	}
 }

--- a/layout/list_test.go
+++ b/layout/list_test.go
@@ -125,6 +125,47 @@ func TestListImplementsElement(t *testing.T) {
 	var _ Element = NewList(font.Helvetica, 12)
 }
 
+// SetMarkerFont overrides the marker's font independently of the list's
+// body font (used for CSS ::marker { font-style: italic }); the body text
+// keeps the list's own font.
+func TestSetMarkerFont(t *testing.T) {
+	l := NewList(font.Helvetica, 12).
+		SetStyle(ListOrdered).
+		SetMarkerFont(font.HelveticaOblique, nil).
+		AddItem("Alpha")
+
+	marker := l.markerParagraph(0)
+	if marker.runs[0].Font != font.HelveticaOblique {
+		t.Errorf("expected marker font %v, got %v", font.HelveticaOblique, marker.runs[0].Font)
+	}
+
+	lines := l.Layout(400)
+	if len(lines) == 0 || len(lines[0].Words) == 0 {
+		t.Fatal("expected body text words")
+	}
+	if lines[0].Words[0].Font != font.Helvetica {
+		t.Errorf("expected body text to keep the list font %v, got %v", font.Helvetica, lines[0].Words[0].Font)
+	}
+}
+
+// cloneWithItems (used for page-break continuation) must copy the marker
+// font override, so a list split across a page keeps its marker font on the
+// continuation fragment.
+func TestCloneWithItemsCopiesMarkerFont(t *testing.T) {
+	l := NewList(font.Helvetica, 12).
+		SetMarkerFont(font.HelveticaOblique, nil).
+		AddItem("Alpha").
+		AddItem("Beta")
+
+	clone := l.cloneWithItems(l.items)
+	if clone.markerFont != font.HelveticaOblique {
+		t.Errorf("expected cloned list to carry the marker font override, got %v", clone.markerFont)
+	}
+	if clone.markerEmbedded != nil {
+		t.Errorf("expected nil markerEmbedded on clone, got %v", clone.markerEmbedded)
+	}
+}
+
 func TestHeadingImplementsElement(t *testing.T) {
 	var _ Element = NewHeading("Title", H1)
 }


### PR DESCRIPTION
## Summary

`ul li::marker { content: counter(list-item); }` had no effect: the `counter()`/`content` machinery existed, but the implicit CSS `list-item` counter (every `<li>` increments it, every `<ul>`/`<ol>` resets it) was never implemented, so `counter(list-item)` resolved to 0. Also `font-style` on `::marker` was unread. Part of #378 (the li::marker gap).

## Change

- Implicit `list-item` counter: `<ul>`/`<ol>` roots get an implicit `counter-reset: list-item 0` and each `<li>` an implicit `counter-increment: list-item 1` — but only if the author didn't declare their own, so `counter-reset/increment: list-item N` still wins.
- `::marker { font-style: italic }` now resolves an oblique font via the existing `resolveFontPair` and a new `layout.List.SetMarkerFont` (copied across page-break continuations).

## Tests

Basic numbering, nested-list restart-at-1, `counters(list-item, ".")` multi-level, explicit-increment/reset-wins, fast-path and element-path pins, marker font-style, and an inert-without-marker-content guard. Existing marker/counter suites stay green. golangci-lint + make check clean.