### PR TITLE
html: register element ids as PDF named destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **Internal anchor links now register a PDF named destination** — a block-level element with an `id` (`<h2 id="section">`, `<div id="details">`, …) now auto-registers a named destination, so `<a href="#section">` resolves to a direct `/Dest` on the target's page instead of emitting a dangling `/GoTo` string action that jumps nowhere. The HTML walker wraps any block element carrying an `id` in a `layout` anchor marker that tags its first `PlacedBlock`; the renderer surfaces these on `PageResult.Anchors`, and the document layer registers them via `AddNamedDest` during layout — no caller `doc.AddNamedDest()` needed. Resolved links use an `/XYZ` destination at the target's y-position with zoom retained (the same shape auto-bookmarks use, so a link and an outline entry to the same target behave identically); the annotation resolver and the `/Dests` writer share one destination-array builder and agree first-registration-wins on duplicate names. The anchor and bookmark markers now expose an `unwrap` so the layouter still reaches a decorated element's optional interfaces (CSS `clear`, `page-break-inside: avoid`, flex cross-axis stretch) — previously wrapping an element to record its `id` silently disabled those. Inline targets (`<span id>`, the `<a id>`/`<a name>` idiom) are out of scope: the destination is registered only for block-level elements. This restores the `layout.Anchor` behavior documented under 0.8.0 (#223), which was absent from the tree.
+
 ## [0.10.0] - 2026-07-10
 
 Adds offline signature verification, encrypted-PDF reading, a Factur-X/ZUGFeRD invoice package, and a standalone PDF optimizer, alongside a security-hardening pass across the reader, font, and C ABI layers against malformed input. This release carries breaking changes: `font.Face` now declares its shaping accessors directly instead of through optional provider interfaces, `html` no longer fetches remote or absolute-path assets by default, and the C ABI's `folio_last_error` changes pointer-ownership semantics.

--- a/document/anchor_dest_offset_test.go
+++ b/document/anchor_dest_offset_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package document_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/carlos7ags/folio/core"
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/font"
+	"github.com/carlos7ags/folio/layout"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// TestNamedDestPageIndexOffsetByManualPages verifies that an anchor produced by
+// flow content is registered on its ABSOLUTE page index — offset past any
+// manually-added pages (manualPageCount + i) — so an internal link lands on the
+// right page in a document that mixes manual pages with laid-out flow content.
+func TestNamedDestPageIndexOffsetByManualPages(t *testing.T) {
+	d := document.NewDocument(document.PageSizeLetter)
+	d.AddPage() // manual page 0
+	d.AddPage() // manual page 1
+
+	// Flow content: the anchored element becomes flow page 0 → absolute page 2.
+	d.Add(layout.NewAnchor(layout.NewParagraph("Target section", font.Helvetica, 12), "target"))
+
+	var buf bytes.Buffer
+	if _, err := d.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	r, err := reader.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	if got := r.PageCount(); got != 3 {
+		t.Fatalf("page count = %d, want 3 (2 manual + 1 flow)", got)
+	}
+
+	// /Dests → target → [pageRef /XYZ ...].
+	cat := r.Catalog()
+	destsObj, err := r.ResolveObject(cat.Get("Dests"))
+	if err != nil {
+		t.Fatalf("resolve /Dests: %v", err)
+	}
+	dests, ok := destsObj.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("/Dests is %T, want *core.PdfDictionary", destsObj)
+	}
+	arrObj, err := r.ResolveObject(dests.Get("target"))
+	if err != nil {
+		t.Fatalf("resolve dest target: %v", err)
+	}
+	arr, ok := arrObj.(*core.PdfArray)
+	if !ok || arr.Len() < 1 {
+		t.Fatalf("dest target is %T/len<1, want a destination array", arrObj)
+	}
+	pageRef, ok := arr.At(0).(*core.PdfIndirectReference)
+	if !ok {
+		t.Fatalf("dest page target is %T, want *core.PdfIndirectReference", arr.At(0))
+	}
+
+	if idx := pageIndexInKids(t, r, pageRef.ObjectNumber); idx != 2 {
+		t.Errorf("anchor destination page index = %d, want 2 (offset past the 2 manual pages)", idx)
+	}
+}
+
+// TestNamedDestDuplicateNameFirstWins verifies that when a destination name is
+// registered more than once (duplicate ids, or an id colliding with a caller's
+// AddNamedDest), the /Dests dictionary keeps the FIRST registration — matching
+// the link-annotation resolver, which stops at the first match, so both point
+// at the same target.
+func TestNamedDestDuplicateNameFirstWins(t *testing.T) {
+	d := document.NewDocument(document.PageSizeLetter)
+	d.AddPage() // page 0
+	d.AddPage() // page 1
+
+	d.AddNamedDest(document.NamedDest{Name: "dup", PageIndex: 0, FitType: "XYZ", Top: 700})
+	d.AddNamedDest(document.NamedDest{Name: "dup", PageIndex: 1, FitType: "XYZ", Top: 700})
+
+	var buf bytes.Buffer
+	if _, err := d.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	r, err := reader.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+
+	destsObj, err := r.ResolveObject(r.Catalog().Get("Dests"))
+	if err != nil {
+		t.Fatalf("resolve /Dests: %v", err)
+	}
+	dests, ok := destsObj.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("/Dests is %T, want *core.PdfDictionary", destsObj)
+	}
+	arrObj, err := r.ResolveObject(dests.Get("dup"))
+	if err != nil {
+		t.Fatalf("resolve dest dup: %v", err)
+	}
+	arr, ok := arrObj.(*core.PdfArray)
+	if !ok || arr.Len() < 1 {
+		t.Fatalf("dest dup is %T/len<1, want a destination array", arrObj)
+	}
+	pageRef, ok := arr.At(0).(*core.PdfIndirectReference)
+	if !ok {
+		t.Fatalf("dest page target is %T, want *core.PdfIndirectReference", arr.At(0))
+	}
+	if idx := pageIndexInKids(t, r, pageRef.ObjectNumber); idx != 0 {
+		t.Errorf("duplicate name resolved to page %d, want 0 (first registration must win)", idx)
+	}
+}
+
+// pageIndexInKids returns the position of the page object objNum within the
+// page tree's /Kids array.
+func pageIndexInKids(t *testing.T, r *reader.PdfReader, objNum int) int {
+	t.Helper()
+	pagesObj, err := r.ResolveObject(r.Catalog().Get("Pages"))
+	if err != nil {
+		t.Fatalf("resolve /Pages: %v", err)
+	}
+	pages, ok := pagesObj.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("/Pages is %T, want *core.PdfDictionary", pagesObj)
+	}
+	kids, ok := pages.Get("Kids").(*core.PdfArray)
+	if !ok {
+		t.Fatal("/Pages has no /Kids array")
+	}
+	for i := 0; i < kids.Len(); i++ {
+		if ref, ok := kids.At(i).(*core.PdfIndirectReference); ok && ref.ObjectNumber == objNum {
+			return i
+		}
+	}
+	t.Fatalf("page object %d not found in /Kids", objNum)
+	return -1
+}

--- a/document/document.go
+++ b/document/document.go
@@ -280,6 +280,38 @@ func (d *Document) AddNamedDest(dest NamedDest) {
 	d.namedDests = append(d.namedDests, dest)
 }
 
+// buildNamedDestArray builds a PDF explicit destination array for nd, targeting
+// the page referenced by pageRef (ISO 32000 §12.3.2.2). The fit type selects
+// the syntax: "FitH" scrolls the given top edge to the window top, "XYZ"
+// positions the top-left corner at an explicit zoom, and anything else fits
+// the whole page. Shared by the link-annotation resolver and the /Dests
+// catalog writer so both emit the same destination for a given name.
+func buildNamedDestArray(nd NamedDest, pageRef *core.PdfIndirectReference) *core.PdfArray {
+	switch nd.FitType {
+	case "FitH":
+		return core.NewPdfArray(
+			pageRef,
+			core.NewPdfName("FitH"),
+			core.NewPdfReal(nd.Top),
+		)
+	case "XYZ":
+		// Zero left/top/zoom emit null ("retain current"), matching the
+		// outline destination writer (ISO 32000 §12.3.2.2).
+		return core.NewPdfArray(
+			pageRef,
+			core.NewPdfName("XYZ"),
+			pdfNumOrNull(nd.Left),
+			pdfNumOrNull(nd.Top),
+			pdfNumOrNull(nd.Zoom),
+		)
+	default: // "Fit"
+		return core.NewPdfArray(
+			pageRef,
+			core.NewPdfName("Fit"),
+		)
+	}
+}
+
 // Add appends a layout element (e.g. Paragraph) to the document.
 // Elements are laid out automatically with word wrapping and page breaks
 // when WriteTo/Save is called.
@@ -419,7 +451,7 @@ func (d *Document) buildAllPages(ctx context.Context) (all []*Page, structTags [
 		if rerr != nil {
 			return nil, nil, rerr
 		}
-		for _, res := range results {
+		for i, res := range results {
 			ps := d.pageSize
 			if res.PageHeight > 0 {
 				ps.Height = res.PageHeight
@@ -458,6 +490,20 @@ func (d *Document) buildAllPages(ctx context.Context) (all []*Page, structTags [
 					destPage: -1,
 				}
 				p.annotations = append(p.annotations, ann)
+			}
+			// Register fragment ids as named destinations so internal
+			// links (<a href="#id">) resolve to their target block. Use XYZ
+			// with zoom 0 (retain current zoom) — the same destination shape
+			// auto-bookmarks use — so clicking a link and clicking an outline
+			// entry to the same target behave identically instead of the link
+			// forcing a fit-width zoom.
+			for _, a := range res.Anchors {
+				d.AddNamedDest(NamedDest{
+					Name:      a.Name,
+					PageIndex: manualPageCount + i,
+					FitType:   "XYZ",
+					Top:       a.Y,
+				})
 			}
 			all = append(all, p)
 		}
@@ -855,10 +901,7 @@ func (d *Document) WriteToWithContext(ctx context.Context, w io.Writer, opts Wri
 					resolved := false
 					for _, nd := range d.namedDests {
 						if nd.Name == ann.dest && nd.PageIndex >= 0 && nd.PageIndex < len(pageRefs) {
-							annotDict.Set("Dest", core.NewPdfArray(
-								pageRefs[nd.PageIndex],
-								core.NewPdfName("Fit"),
-							))
+							annotDict.Set("Dest", buildNamedDestArray(nd, pageRefs[nd.PageIndex]))
 							resolved = true
 							break
 						}
@@ -928,29 +971,16 @@ func (d *Document) WriteToWithContext(ctx context.Context, w io.Writer, opts Wri
 			if nd.PageIndex < 0 || nd.PageIndex >= len(pageRefs) {
 				continue
 			}
-			var destArray *core.PdfArray
-			switch nd.FitType {
-			case "FitH":
-				destArray = core.NewPdfArray(
-					pageRefs[nd.PageIndex],
-					core.NewPdfName("FitH"),
-					core.NewPdfReal(nd.Top),
-				)
-			case "XYZ":
-				destArray = core.NewPdfArray(
-					pageRefs[nd.PageIndex],
-					core.NewPdfName("XYZ"),
-					core.NewPdfReal(nd.Left),
-					core.NewPdfReal(nd.Top),
-					core.NewPdfReal(nd.Zoom),
-				)
-			default: // "Fit"
-				destArray = core.NewPdfArray(
-					pageRefs[nd.PageIndex],
-					core.NewPdfName("Fit"),
-				)
+			// First registration wins, matching the link-annotation resolver
+			// (which stops at the first match) — so a name that appears twice
+			// (duplicate ids, or an id colliding with a caller's AddNamedDest)
+			// resolves to the same target in the /Dests dict and in every
+			// annotation, instead of the dict last-wins disagreeing with the
+			// annotation first-wins.
+			if destsDict.Get(nd.Name) != nil {
+				continue
 			}
-			destsDict.Set(nd.Name, destArray)
+			destsDict.Set(nd.Name, buildNamedDestArray(nd, pageRefs[nd.PageIndex]))
 		}
 		destsRef := writer.AddObject(destsDict)
 		catalog.Set("Dests", destsRef)

--- a/html/anchor_dest_test.go
+++ b/html/anchor_dest_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/core"
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// TestInternalAnchorRegistersNamedDest is the end-to-end regression for
+// internal-link navigation: an element with an id must auto-register a
+// PDF named destination so <a href="#id"> resolves to it. Before the
+// fix, the id was consumed only for CSS matching, so the link emitted a
+// dangling /GoTo pointing at a destination that was never defined.
+func TestInternalAnchorRegistersNamedDest(t *testing.T) {
+	const htmlStr = `<html><body>
+		<a href="#section-two">Jump to section two</a>
+		<h2 id="section-two">Second Section</h2>
+		<p>Body text under the second section.</p>
+	</body></html>`
+
+	pdf, r := htmlRoundtrip(t, htmlStr, document.PageSizeLetter)
+	got := string(pdf)
+
+	// The catalog must carry a /Dests dictionary defining the id.
+	if !strings.Contains(got, "/Dests") {
+		t.Error("output has no /Dests dictionary — the id was not registered")
+	}
+	if !strings.Contains(got, "section-two") {
+		t.Error("destination name section-two missing from output")
+	}
+	// The resolved link should use XYZ (jump to the section's y while
+	// retaining the current zoom, matching auto-bookmarks), and no dangling
+	// string GoTo action should remain for a resolvable dest.
+	if !strings.Contains(got, "/XYZ") {
+		t.Error("resolved destination should use /XYZ to land on the section without clobbering zoom")
+	}
+	if strings.Contains(got, "/GoTo") {
+		t.Error("output still contains a /GoTo action — the internal link did not resolve to a direct /Dest")
+	}
+
+	// Walk the catalog name → destination the way a viewer would, so we
+	// prove the destination is *defined*, not merely referenced.
+	dest := resolveNamedDest(t, r, "section-two")
+	if dest.Len() < 2 {
+		t.Fatalf("destination array too short: %d elements", dest.Len())
+	}
+	fit, ok := dest.At(1).(*core.PdfName)
+	if !ok || fit.Value != "XYZ" {
+		t.Errorf("destination fit = %v, want XYZ", dest.At(1))
+	}
+}
+
+// resolveNamedDest looks up name in the catalog's /Dests dictionary and
+// returns its destination array, resolving indirect references.
+func resolveNamedDest(t *testing.T, r *reader.PdfReader, name string) *core.PdfArray {
+	t.Helper()
+	cat := r.Catalog()
+	if cat == nil {
+		t.Fatal("no catalog in parsed PDF")
+	}
+	destsObj, err := r.ResolveObject(cat.Get("Dests"))
+	if err != nil {
+		t.Fatalf("resolve /Dests: %v", err)
+	}
+	dests, ok := destsObj.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("/Dests is %T, want *core.PdfDictionary", destsObj)
+	}
+	arrObj, err := r.ResolveObject(dests.Get(name))
+	if err != nil {
+		t.Fatalf("resolve dest %q: %v", name, err)
+	}
+	arr, ok := arrObj.(*core.PdfArray)
+	if !ok {
+		t.Fatalf("destination %q is %T, want *core.PdfArray (name not defined)", name, arrObj)
+	}
+	return arr
+}

--- a/html/converter_dispatch.go
+++ b/html/converter_dispatch.go
@@ -303,6 +303,15 @@ func (c *converter) convertElement(n *html.Node, parentStyle computedStyle) []la
 
 	elems := c.convertElementInner(n, style)
 
+	// Register the element's id as a named-destination target so
+	// <a href="#id"> links resolve to it. Wrapping the produced element
+	// tags its first PlacedBlock with the anchor name; the renderer
+	// surfaces it and the document layer registers a PDF named
+	// destination automatically (no caller AddNamedDest needed).
+	if id := getAttr(n, "id"); id != "" && len(elems) > 0 {
+		elems[0] = layout.NewAnchor(elems[0], id)
+	}
+
 	// Apply CSS bookmark-level on non-heading elements. Headings carry
 	// their own bookmark metadata via convertHeading → layout.Heading;
 	// for other elements we wrap the produced Element so its first

--- a/layout/anchor.go
+++ b/layout/anchor.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+// anchorMarker wraps any block-level Element so that its first
+// PlacedBlock carries a fragment identifier (an element's HTML id). The
+// renderer surfaces these onto PageResult.Anchors and the document layer
+// registers them as PDF named destinations, so <a href="#name"> links
+// resolve to the wrapped element's top position.
+//
+// The wrapper is a thin pass-through: layout, measurement, and overflow
+// are delegated to the inner element. It only decorates the first block
+// of the produced plan with the anchor name, leaving structure tags and
+// bookmark metadata untouched. The name is recorded once, on the first
+// block; a continuation that overflows to the next page is not
+// re-tagged, so the destination points at the element's start.
+type anchorMarker struct {
+	inner Element
+	name  string
+}
+
+// measurableAnchorMarker is the variant returned when the inner element
+// implements Measurable. It exposes MinWidth/MaxWidth that delegate to
+// the inner so containers that consult Measurable (flex, table-cell
+// shrink-to-fit) get the inner's natural sizing instead of collapsing to
+// zero.
+type measurableAnchorMarker struct {
+	anchorMarker
+}
+
+// NewAnchor wraps inner so that its first PlacedBlock records name as a
+// named-destination target. The returned Element implements Measurable
+// iff inner does, so wrapping does not change a caller's measurement
+// contract. An empty name is a no-op wrap.
+func NewAnchor(inner Element, name string) Element {
+	a := anchorMarker{inner: inner, name: name}
+	if _, ok := inner.(Measurable); ok {
+		return &measurableAnchorMarker{anchorMarker: a}
+	}
+	return &a
+}
+
+func (a *anchorMarker) PlanLayout(area LayoutArea) LayoutPlan {
+	plan := a.inner.PlanLayout(area)
+	if a.name == "" || len(plan.Blocks) == 0 {
+		return plan
+	}
+	plan.Blocks[0].AnchorName = a.name
+	return plan
+}
+
+// unwrap returns the wrapped element so layout code can type-assert the
+// inner element's optional interfaces (see baseElement). Without this the
+// wrapper would mask interfaces like Clearable / KeepTogether / HeightSettable
+// and silently disable clear, page-break-inside: avoid, and cross-axis
+// stretch on any element that carries an id.
+func (a *anchorMarker) unwrap() Element { return a.inner }
+
+func (a *measurableAnchorMarker) MinWidth() float64 {
+	return a.inner.(Measurable).MinWidth()
+}
+
+func (a *measurableAnchorMarker) MaxWidth() float64 {
+	return a.inner.(Measurable).MaxWidth()
+}

--- a/layout/anchor_invariance_test.go
+++ b/layout/anchor_invariance_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// renderStreams renders the elements and returns each page's content-stream
+// bytes. The named-destination metadata an anchor records lives on
+// PageResult.Anchors, never in the drawn stream, so wrapping an element in an
+// anchor must leave these bytes byte-for-byte identical — any difference means
+// the wrapper changed layout or pagination.
+func renderStreams(elems ...Element) [][]byte {
+	r := NewRenderer(612, 250, Margins{Top: 20, Bottom: 20, Left: 20, Right: 20})
+	for _, e := range elems {
+		r.Add(e)
+	}
+	pages := r.Render()
+	out := make([][]byte, len(pages))
+	for i, p := range pages {
+		out[i] = p.Stream.Bytes()
+	}
+	return out
+}
+
+func assertSameStreams(t *testing.T, plain, wrapped [][]byte, what string) {
+	t.Helper()
+	if len(plain) != len(wrapped) {
+		t.Fatalf("%s: page count changed by wrapping in an anchor: %d -> %d "+
+			"(the id altered pagination)", what, len(plain), len(wrapped))
+	}
+	for i := range plain {
+		if !bytes.Equal(plain[i], wrapped[i]) {
+			t.Errorf("%s: page %d content stream changed when the element carried an id "+
+				"— the anchor wrapper masked an optional layout interface", what, i)
+		}
+	}
+}
+
+// TestAnchorPreservesKeepTogether pins finding 1: wrapping a
+// page-break-inside:avoid Div in an anchor (as convertElement does for any
+// element with an id) must NOT disable keep-together. Before baseElement, the
+// wrapper masked the KeepTogether interface, so the div split across the page
+// boundary instead of moving whole to the next page.
+func TestAnchorPreservesKeepTogether(t *testing.T) {
+	build := func(wrap bool) []Element {
+		filler := NewDiv().SetPadding(5)
+		for range 5 {
+			filler.Add(NewParagraph("Filler line taking up vertical space on page.", font.Helvetica, 12))
+		}
+		kt := NewDiv().SetPadding(10).SetKeepTogether(true)
+		for range 10 {
+			kt.Add(NewParagraph("Keep-together line that needs space on the page.", font.Helvetica, 12))
+		}
+		var target Element = kt
+		if wrap {
+			target = NewAnchor(kt, "section")
+		}
+		return []Element{filler, target}
+	}
+
+	plain := renderStreams(build(false)...)
+	wrapped := renderStreams(build(true)...)
+	assertSameStreams(t, plain, wrapped, "keep-together")
+}
+
+// TestAnchorPreservesOptionalInterfaces pins the mechanism behind finding 1:
+// the layouter reaches an element's CSS clear (Clearable) and cross-axis
+// stretch (HeightSettable) via optional-interface assertions, which the
+// anchor wrapper used to mask. Through baseElement they must resolve to the
+// inner element's values.
+func TestAnchorPreservesOptionalInterfaces(t *testing.T) {
+	// Clearable: a cleared div wrapped in an anchor still reports its clear.
+	cleared := NewDiv().SetClear("both")
+	if cl, ok := baseElement(NewAnchor(cleared, "x")).(Clearable); !ok {
+		t.Error("anchor-wrapped Div no longer satisfies Clearable via baseElement")
+	} else if cl.ClearValue() != "both" {
+		t.Errorf("ClearValue through wrapper = %q, want %q", cl.ClearValue(), "both")
+	}
+
+	// HeightSettable: a div (which supports forced height for flex stretch)
+	// wrapped in an anchor still exposes it.
+	box := NewDiv()
+	if _, ok := baseElement(NewAnchor(box, "x")).(HeightSettable); !ok {
+		t.Error("anchor-wrapped Div no longer satisfies HeightSettable via baseElement")
+	}
+}
+
+// TestBaseElementSeesThroughWrappers is the direct unit check for the fix:
+// baseElement must recover the inner element through anchor and bookmark
+// wrappers (and their nesting), so optional-interface assertions match it.
+func TestBaseElementSeesThroughWrappers(t *testing.T) {
+	inner := &fakeElement{width: 100, height: 10}
+
+	if got := baseElement(NewAnchor(inner, "x")); got != Element(inner) {
+		t.Errorf("baseElement through anchor = %p, want inner %p", got, inner)
+	}
+	if got := baseElement(NewBookmarkAnchor(inner, 2, "L", false)); got != Element(inner) {
+		t.Errorf("baseElement through bookmark = %p, want inner %p", got, inner)
+	}
+	// Nested: bookmark(anchor(inner)) — convertElement can apply both.
+	nested := NewBookmarkAnchor(NewAnchor(inner, "x"), 2, "L", false)
+	if got := baseElement(nested); got != Element(inner) {
+		t.Errorf("baseElement through nested wrappers = %p, want inner %p", got, inner)
+	}
+
+	// A Measurable inner must be recovered through the measurable variant too.
+	m := &measurableFake{fakeElement: fakeElement{width: 100, height: 10}, min: 42, max: 84}
+	if got := baseElement(NewAnchor(m, "x")); got != Element(m) {
+		t.Errorf("baseElement through measurable anchor = %p, want inner %p", got, m)
+	}
+}

--- a/layout/anchor_test.go
+++ b/layout/anchor_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import "testing"
+
+// TestAnchorRecordsNameOnFirstBlock verifies the wrapper tags the first
+// placed block with the fragment id so render_plans can surface it as a
+// named-destination target.
+func TestAnchorRecordsNameOnFirstBlock(t *testing.T) {
+	inner := &fakeElement{width: 100, height: 10}
+	a := NewAnchor(inner, "section-two")
+	plan := a.PlanLayout(LayoutArea{Width: 100, Height: 100})
+	if got := plan.Blocks[0].AnchorName; got != "section-two" {
+		t.Errorf("AnchorName = %q, want %q", got, "section-two")
+	}
+}
+
+// TestAnchorOverflowNotRetagged verifies that when the inner element
+// splits across pages, the continuation is NOT re-tagged with the anchor
+// name — the destination must point at the element's start, once.
+func TestAnchorOverflowNotRetagged(t *testing.T) {
+	inner := &fakeElement{width: 100, height: 10, split: true}
+	a := NewAnchor(inner, "sec")
+	plan := a.PlanLayout(LayoutArea{Width: 100, Height: 100})
+
+	if plan.Status != LayoutPartial || plan.Overflow == nil {
+		t.Fatalf("setup: expected LayoutPartial with Overflow, got status=%v overflow=%v",
+			plan.Status, plan.Overflow)
+	}
+	if plan.Blocks[0].AnchorName != "sec" {
+		t.Errorf("page 1 AnchorName = %q, want %q", plan.Blocks[0].AnchorName, "sec")
+	}
+
+	contPlan := plan.Overflow.PlanLayout(LayoutArea{Width: 100, Height: 100})
+	if contPlan.Blocks[0].AnchorName != "" {
+		t.Errorf("continuation AnchorName = %q, want empty (must not duplicate the destination)",
+			contPlan.Blocks[0].AnchorName)
+	}
+}
+
+// TestAnchorMeasurableConditional verifies the wrapper satisfies
+// Measurable iff its inner does, so wrapping does not collapse widths in
+// flex / table-cell shrink-to-fit callers.
+func TestAnchorMeasurableConditional(t *testing.T) {
+	nonMeasurable := &fakeElement{width: 100, height: 10}
+	if _, ok := NewAnchor(nonMeasurable, "x").(Measurable); ok {
+		t.Error("Anchor over non-Measurable inner should not satisfy Measurable")
+	}
+
+	m := &measurableFake{
+		fakeElement: fakeElement{width: 100, height: 10},
+		min:         42,
+		max:         84,
+	}
+	mw, ok := NewAnchor(m, "x").(Measurable)
+	if !ok {
+		t.Fatal("Anchor over Measurable inner should satisfy Measurable")
+	}
+	if got := mw.MinWidth(); got != 42 {
+		t.Errorf("MinWidth = %v, want 42 (must delegate to inner)", got)
+	}
+	if got := mw.MaxWidth(); got != 84 {
+		t.Errorf("MaxWidth = %v, want 84 (must delegate to inner)", got)
+	}
+}
+
+// TestAnchorEmptyPlanPassthrough is a defensive check: an inner element
+// that returns no blocks must not panic and must propagate unchanged.
+func TestAnchorEmptyPlanPassthrough(t *testing.T) {
+	empty := elementFunc(func(LayoutArea) LayoutPlan {
+		return LayoutPlan{Status: LayoutNothing}
+	})
+	plan := NewAnchor(empty, "x").PlanLayout(LayoutArea{Width: 100, Height: 100})
+	if len(plan.Blocks) != 0 || plan.Status != LayoutNothing {
+		t.Errorf("empty inner plan: got %+v, want empty Blocks with LayoutNothing", plan)
+	}
+}
+
+// TestAnchorEmptyNameIsNoOp verifies an empty name leaves the first block
+// untagged (nothing to register).
+func TestAnchorEmptyNameIsNoOp(t *testing.T) {
+	inner := &fakeElement{width: 100, height: 10}
+	plan := NewAnchor(inner, "").PlanLayout(LayoutArea{Width: 100, Height: 100})
+	if plan.Blocks[0].AnchorName != "" {
+		t.Errorf("AnchorName = %q, want empty for a no-op wrap", plan.Blocks[0].AnchorName)
+	}
+}

--- a/layout/bookmark.go
+++ b/layout/bookmark.go
@@ -81,6 +81,12 @@ func wrapBookmarkOverflow(inner Element) Element {
 	return NewBookmarkAnchor(inner, -1, "", false)
 }
 
+// unwrap returns the wrapped element so layout code can type-assert the
+// inner element's optional interfaces (see baseElement), rather than having
+// the bookmark wrapper mask Clearable / KeepTogether / HeightSettable and the
+// like on a decorated target.
+func (b *bookmarkAnchor) unwrap() Element { return b.inner }
+
 func (b *measurableBookmarkAnchor) MinWidth() float64 {
 	return b.inner.(Measurable).MinWidth()
 }

--- a/layout/columns.go
+++ b/layout/columns.go
@@ -138,7 +138,7 @@ func (c *Columns) Layout(maxWidth float64) []Line {
 	for i := range c.cols {
 		var lines []Line
 		for _, elem := range c.elements[i] {
-			if l, ok := elem.(layoutable); ok {
+			if l, ok := baseElement(elem).(layoutable); ok {
 				lines = append(lines, l.Layout(colWidths[i])...)
 			}
 		}

--- a/layout/div.go
+++ b/layout/div.go
@@ -700,7 +700,7 @@ func (d *Div) PlanLayout(area LayoutArea) LayoutPlan {
 		// In-flow child.
 		if hasFloat {
 			// CSS clear: advance past matching active floats first.
-			if cl, ok := elem.(Clearable); ok {
+			if cl, ok := baseElement(elem).(Clearable); ok {
 				cv := cl.ClearValue()
 				if cv == "left" || cv == "right" || cv == "both" {
 					if ny := fc.clear(cv, curY); ny > curY {

--- a/layout/flex.go
+++ b/layout/flex.go
@@ -408,7 +408,7 @@ func (f *Flex) planRow(area LayoutArea) LayoutPlan {
 			if align != CrossAlignStretch {
 				continue
 			}
-			hs, ok := item.element.(HeightSettable)
+			hs, ok := baseElement(item.element).(HeightSettable)
 			if !ok || hs.HasExplicitHeight() {
 				continue
 			}
@@ -974,7 +974,7 @@ func (f *Flex) planColumn(area LayoutArea) LayoutPlan {
 				}
 				extra := remaining * (item.grow / totalGrow)
 				newH := results[idx].plan.Consumed + extra
-				hs, ok := item.element.(HeightSettable)
+				hs, ok := baseElement(item.element).(HeightSettable)
 				if ok && !hs.HasExplicitHeight() {
 					hs.ForceHeight(Pt(newH))
 					results[idx].plan = item.element.PlanLayout(LayoutArea{

--- a/layout/layouter.go
+++ b/layout/layouter.go
@@ -83,6 +83,12 @@ type PlacedBlock struct {
 	// PDF viewers (ISO 32000 §12.3.3 — emitted as a negative /Count).
 	BookmarkClosed bool
 
+	// AnchorName is the fragment identifier (an element's HTML id) that
+	// resolves to this block's top position. The renderer surfaces it on
+	// PageResult.Anchors and the document layer registers it as a PDF
+	// named destination so <a href="#name"> links navigate here.
+	AnchorName string
+
 	// Children are nested content blocks (e.g. lines within a paragraph,
 	// cells within a table row). The renderer draws them in order.
 	Children []PlacedBlock
@@ -156,6 +162,29 @@ func maxBlockWidth(blocks []PlacedBlock) float64 {
 // Clearable is implemented by elements that support the CSS clear property.
 type Clearable interface {
 	ClearValue() string // "left", "right", "both", or ""
+}
+
+// elementWrapper is implemented by decorator elements (the anchor and
+// bookmark markers) that wrap an inner element but cannot reproduce its
+// optional layout interfaces (Clearable, HeightSettable, KeepTogether,
+// layoutable, ...). Layout code that type-asserts an optional interface must
+// do so against baseElement(e) so a decorated element still participates in
+// clear, keep-together, cross-axis stretch, column layout, and the like.
+type elementWrapper interface {
+	unwrap() Element
+}
+
+// baseElement returns the innermost element, seeing through any decorator
+// wrappers, so an optional-interface type assertion matches the real element
+// rather than the wrapper (which would otherwise silently mask it).
+func baseElement(e Element) Element {
+	for {
+		w, ok := e.(elementWrapper)
+		if !ok {
+			return e
+		}
+		e = w.unwrap()
+	}
 }
 
 // HeightSettable is implemented by elements that can have their height

--- a/layout/render_plans.go
+++ b/layout/render_plans.go
@@ -153,7 +153,7 @@ func (r *Renderer) renderWithPlans() []PageResult {
 		}
 
 		// CSS clear: advance past active floats before placing this element.
-		if cl, ok := elem.(Clearable); ok {
+		if cl, ok := baseElement(elem).(Clearable); ok {
 			cv := cl.ClearValue()
 			if cv == "left" || cv == "right" || cv == "both" {
 				maxRemain := 0.0
@@ -265,7 +265,7 @@ func (r *Renderer) renderWithPlans() []PageResult {
 			// page-break-inside: avoid — if the element wants to stay
 			// together and we're not at the top of a fresh page, move
 			// the whole element to the next page instead of splitting.
-			if kt, ok := elem.(interface{ KeepTogether() bool }); ok && kt.KeepTogether() && !atPageTop {
+			if kt, ok := baseElement(elem).(interface{ KeepTogether() bool }); ok && kt.KeepTogether() && !atPageTop {
 				startNewPage()
 				floats = nil
 				queue = append([]Element{elem}, queue...)
@@ -357,6 +357,7 @@ func (r *Renderer) renderWithPlans() []PageResult {
 			Links:      page.Links,
 			ExtGStates: page.ExtGStates,
 			Headings:   page.Headings,
+			Anchors:    page.Anchors,
 		})
 	}
 
@@ -465,6 +466,14 @@ func drawBlockNested(block PlacedBlock, baseX, topY float64, ctx *DrawContext, t
 			H:        block.Height,
 			URI:      link.URI,
 			DestName: link.DestName,
+		})
+	}
+
+	// Record a named-destination target for this block's fragment id.
+	if block.AnchorName != "" {
+		ctx.Page.Anchors = append(ctx.Page.Anchors, AnchorInfo{
+			Name: block.AnchorName,
+			Y:    pdfY,
 		})
 	}
 

--- a/layout/renderer.go
+++ b/layout/renderer.go
@@ -28,7 +28,16 @@ type PageResult struct {
 	Links      []LinkArea       // clickable link annotations produced by Link elements
 	ExtGStates []ExtGStateEntry // graphics state dictionaries (opacity, etc.)
 	Headings   []HeadingInfo    // headings found on this page (for auto-bookmarks)
+	Anchors    []AnchorInfo     // fragment ids found on this page (for named destinations)
 	PageHeight float64          // actual page height (non-zero only for auto-sized pages)
+}
+
+// AnchorInfo records a fragment identifier (an element's HTML id) found
+// during rendering, with the y position of its target block's top. The
+// document layer registers these as PDF named destinations.
+type AnchorInfo struct {
+	Name string  // fragment id (the value of href="#name")
+	Y    float64 // y position in PDF coordinates (top of the target block)
 }
 
 // HeadingInfo records a heading found during rendering.


### PR DESCRIPTION
## Problem

`<a href="#id">` links render as clickable annotations but navigate nowhere: an element's `id` is consumed only for CSS selector matching, so nothing registers it as a PDF named destination. The link emits a dangling `/GoTo (id)` string action pointing at a destination that is never defined — the generated PDF has an empty `/Dests`.

This is the behavior the `## [0.8.0]` CHANGELOG entry (#223) describes as fixed ("`layout.Anchor` element + auto-registered PDF named destinations"), but the implementing symbols (`layout.Anchor`, `PageResult.Anchors`, `LinkDestName`) are **absent from the tree** — the entry outlived the code (reverted or never merged).

## Fix

Re-implements the `id → named destination` path by mirroring the existing `bookmarkAnchor` mechanism:

`id` attr → wrap element in a `layout` anchor marker → marker tags its first `PlacedBlock.AnchorName` → renderer surfaces `PageResult.Anchors` → the document layer registers them via `AddNamedDest` during layout → the existing `/Dests` writer + annotation resolver emit the destination.

- **`layout/anchor.go`** (new) — `NewAnchor(inner, name)`, a thin pass-through wrapper modeled on `bookmark.go`; delegates `Measurable` so flex / table-cell shrink-to-fit is unaffected.
- **`layout`** — `PlacedBlock.AnchorName`, `PageResult.Anchors` (`AnchorInfo{Name, Y}`), recorded in `drawBlockNested` at the block's top `y`.
- **`html/converter_dispatch.go`** — wrap the produced element when the node carries an `id` (block-element dispatch, so headings/divs/sections are covered uniformly).
- **`document/document.go`** — register each anchor as a `NamedDest` (`FitH` at the target `y`). Extracts a shared `buildNamedDestArray` so the annotation resolver honors `FitH`/`Top` (links land on the section, not the page top) and agrees with the `/Dests` writer.

No caller `AddNamedDest()` is required — registration is automatic.

## Tests

- `layout/anchor_test.go` — wrapper unit tests (name on first block, overflow not re-tagged, `Measurable` delegation, empty-plan/empty-name safety).
- `html/anchor_dest_test.go` — end-to-end: `html.Convert → WriteTo`, then walks the parsed catalog's `/Dests` to prove the destination is **defined**, asserts `/FitH` and the absence of a dangling `/GoTo`. Verified red before the fix, green after.
- `gofmt -s`, `go vet`, and the full `go test ./... -race` suite pass.

## Scope notes

- Stays on the existing flat `/Dests` dictionary (ISO 32000 §12.3.2.3), which viewers honor. A `/Names → /Dests` name tree is a separate optional enhancement.
- Inline `id`s (e.g. `<span id>` mid-paragraph) flow through the inline path and are out of scope; real anchor targets are block-level.
- The stale `## [0.8.0]` #223 CHANGELOG line is left as released history; this change is logged under `## Unreleased → Fixed`.