### PR TITLE
reader: guard page tree walk against cycles and excessive depth

### DIFF
--- a/reader/reader.go
+++ b/reader/reader.go
@@ -464,7 +464,7 @@ func (r *PdfReader) parsePageTree() error {
 	}
 
 	r.pages = nil
-	return r.collectPages(pagesDict, inherited{})
+	return r.collectPages(pagesDict, inherited{}, map[*core.PdfDictionary]struct{}{}, 0)
 }
 
 // inherited carries inheritable page tree attributes down the tree.
@@ -477,8 +477,37 @@ type inherited struct {
 	rotate    *core.PdfNumber
 }
 
+// maxPageTreeDepth caps page tree recursion. Real documents nest a
+// handful of levels; a tree deeper than this is malformed or hostile,
+// and following it would overflow the goroutine stack — an unrecoverable
+// fatal error rather than a catchable panic.
+const maxPageTreeDepth = 256
+
 // collectPages recursively collects leaf pages from the page tree.
-func (r *PdfReader) collectPages(node *core.PdfDictionary, inh inherited) error {
+//
+// visited holds the Pages nodes on the current root-to-node path so a
+// /Kids entry pointing back at an ancestor is caught instead of recursed
+// into forever. It is path-scoped, not walk-scoped: a node is removed on
+// the way back up, so a node legitimately reachable through two separate
+// branches is still expanded both times.
+//
+// Under StrictnessTolerant a cycle or over-deep branch is skipped and the
+// remaining pages are still collected; under StrictnessStrict it is an
+// error.
+func (r *PdfReader) collectPages(node *core.PdfDictionary, inh inherited, visited map[*core.PdfDictionary]struct{}, depth int) error {
+	if _, cycle := visited[node]; cycle {
+		if r.strictness == StrictnessStrict {
+			return fmt.Errorf("reader: page tree contains a cycle")
+		}
+		return nil
+	}
+	if depth > maxPageTreeDepth {
+		if r.strictness == StrictnessStrict {
+			return fmt.Errorf("reader: page tree deeper than %d levels", maxPageTreeDepth)
+		}
+		return nil
+	}
+
 	// Update inheritable attributes from this node.
 	if mb := node.Get("MediaBox"); mb != nil {
 		if arr, ok := mb.(*core.PdfArray); ok {
@@ -523,6 +552,11 @@ func (r *PdfReader) collectPages(node *core.PdfDictionary, inh inherited) error 
 		return fmt.Errorf("reader: /Kids is not an array")
 	}
 
+	// Mark this node for the duration of the subtree walk only, so the
+	// check above sees ancestors but not already-finished siblings.
+	visited[node] = struct{}{}
+	defer delete(visited, node)
+
 	for _, kidRef := range kids.All() {
 		kidObj, err := r.resolver.ResolveDeep(kidRef)
 		if err != nil {
@@ -532,7 +566,7 @@ func (r *PdfReader) collectPages(node *core.PdfDictionary, inh inherited) error 
 		if !ok {
 			continue
 		}
-		if err := r.collectPages(kidDict, inh); err != nil {
+		if err := r.collectPages(kidDict, inh, visited, depth+1); err != nil {
 			return err
 		}
 	}

--- a/reader/reader_malformed_test.go
+++ b/reader/reader_malformed_test.go
@@ -4,6 +4,7 @@
 package reader
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -401,4 +402,116 @@ func TestMalformedXrefStreamHugeW(t *testing.T) {
 		_, err := Parse(buildPDFWithXrefStreamW("[1000000000 3 1]"))
 		return err
 	})
+}
+
+// buildPDFFromObjects assembles a minimal PDF whose body is objs[i] for
+// object number i+1, with a catalog expected at object 1.
+func buildPDFFromObjects(objs []string) []byte {
+	body := "%PDF-1.7\n"
+	offsets := make([]int, 0, len(objs))
+	for i, o := range objs {
+		offsets = append(offsets, len(body))
+		body += strconv.Itoa(i+1) + " 0 obj\n" + o + "\nendobj\n"
+	}
+	xrefOff := len(body)
+	body += "xref\n0 " + strconv.Itoa(len(objs)+1) + "\n0000000000 65535 f \n"
+	for _, off := range offsets {
+		body += fmt.Sprintf("%010d 00000 n \n", off)
+	}
+	body += "trailer\n<< /Size " + strconv.Itoa(len(objs)+1) + " /Root 1 0 R >>\n" +
+		"startxref\n" + strconv.Itoa(xrefOff) + "\n%%EOF\n"
+	return []byte(body)
+}
+
+// TestPageTreeSelfReference covers a /Pages node listing itself in
+// /Kids. Walking it without a cycle guard recurses until the goroutine
+// stack overflows, which is a fatal error the caller cannot recover
+// from — so this test crashes the process on regression rather than
+// merely failing.
+func TestPageTreeSelfReference(t *testing.T) {
+	data := buildPDFFromObjects([]string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [2 0 R] /Count 1 /MediaBox [0 0 612 792] >>",
+	})
+	r, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := r.PageCount(); got != 0 {
+		t.Errorf("PageCount() = %d, want 0 (cyclic tree has no leaf pages)", got)
+	}
+}
+
+// TestPageTreeMutualCycle covers a two-node cycle: A lists B, B lists A.
+// The real page under A must still be collected.
+func TestPageTreeMutualCycle(t *testing.T) {
+	data := buildPDFFromObjects([]string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [4 0 R 3 0 R] /Count 2 /MediaBox [0 0 612 792] >>",
+		"<< /Type /Pages /Kids [2 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R >>",
+	})
+	r, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := r.PageCount(); got != 1 {
+		t.Errorf("PageCount() = %d, want 1 (cycle skipped, real page kept)", got)
+	}
+}
+
+// TestPageTreeCycleStrict checks that strict mode reports the cycle
+// instead of silently returning a short page list.
+func TestPageTreeCycleStrict(t *testing.T) {
+	data := buildPDFFromObjects([]string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [2 0 R] /Count 1 /MediaBox [0 0 612 792] >>",
+	})
+	_, err := ParseWithOptions(data, ReadOptions{Strictness: StrictnessStrict})
+	if err == nil {
+		t.Fatal("ParseWithOptions(strict) = nil error, want a cycle error")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error = %q, want it to mention a cycle", err)
+	}
+}
+
+// TestPageTreeSharedNode guards the cycle check against over-reach: a
+// Pages node reachable through two sibling branches is not a cycle, and
+// its pages must be collected once per reference.
+func TestPageTreeSharedNode(t *testing.T) {
+	data := buildPDFFromObjects([]string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 612 792] >>",
+		"<< /Type /Pages /Kids [5 0 R] /Count 1 >>",
+		"<< /Type /Pages /Kids [5 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R >>",
+	})
+	r, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := r.PageCount(); got != 2 {
+		t.Errorf("PageCount() = %d, want 2 (shared node expanded under both parents)", got)
+	}
+}
+
+// TestPageTreeExcessiveDepth covers an acyclic but pathologically deep
+// chain, which overflows the stack just as a cycle would.
+func TestPageTreeExcessiveDepth(t *testing.T) {
+	const depth = maxPageTreeDepth + 50
+	objs := []string{"<< /Type /Catalog /Pages 2 0 R >>"}
+	for i := range depth {
+		kid := strconv.Itoa(i + 3)
+		objs = append(objs, "<< /Type /Pages /Kids ["+kid+" 0 R] /Count 1 /MediaBox [0 0 612 792] >>")
+	}
+	objs = append(objs, "<< /Type /Page >>")
+
+	r, err := Parse(buildPDFFromObjects(objs))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := r.PageCount(); got != 0 {
+		t.Errorf("PageCount() = %d, want 0 (branch abandoned past the depth cap)", got)
+	}
 }


### PR DESCRIPTION
## Problem

`reader.collectPages` walks `/Kids` with no record of which `Pages` nodes it has already entered. A document whose `Pages` node references itself — directly, or around a longer loop — recurses until the goroutine stack overflows.

That is worse than a hang: a stack overflow is a `fatal error`, not a catchable panic, so `recover()` cannot contain it. Any service parsing untrusted PDFs is killed by a file like this one:

```
1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
2 0 obj << /Type /Pages /Kids [2 0 R] /Count 1 /MediaBox [0 0 612 792] >> endobj
```

Against `main`:

```
fatal error: stack overflow
runtime.(*resolver).Resolve       resolver.go:88
runtime.(*PdfReader).collectPages reader.go:527
```

The resolver's circular-reference detection does not cover this. It guards a single in-flight `Resolve` call via `r.resolving`; by the time the walk comes back around, the object is in the resolver cache and returns immediately without re-entering that check.

## Fix

Track the `Pages` nodes on the current root-to-node path and refuse to re-enter one.

The set is **path-scoped, not walk-scoped** — a node is removed on the way back up. A `Pages` node legitimately reachable through two sibling branches is not a cycle, and must still be expanded under both parents; a walk-scoped set would silently drop every page under the second reference. `TestPageTreeSharedNode` pins that distinction.

Recursion is also capped at 256 levels. A chain deeper than that is malformed or hostile, and it overflows the stack for exactly the same reason a cycle does without ever repeating a node. Real documents nest a handful of levels.

Both conditions follow the reader's existing strictness contract:

- `StrictnessTolerant` (default) abandons the offending branch and collects the remaining pages.
- `StrictnessStrict` returns an error.

## Tests

Five cases in `reader/reader_malformed_test.go`, all built from in-repo PDFs — no network, no fixtures:

| Test | Covers |
| --- | --- |
| `TestPageTreeSelfReference` | node listing itself in `/Kids` |
| `TestPageTreeMutualCycle` | two-node loop; the real page under it is still collected |
| `TestPageTreeCycleStrict` | strict mode reports the cycle instead of a short page list |
| `TestPageTreeSharedNode` | shared node expanded under both parents (guards against over-reach) |
| `TestPageTreeExcessiveDepth` | acyclic chain past the depth cap |

Verified non-vacuous: with the guard removed, `TestPageTreeSelfReference` brings down the test binary with `fatal error: stack overflow`. With it, the package passes.

`gofmt`, `go vet`, and `go test ./...` are clean.