### PR TITLE
Fix letter-spacing gaps and wasm renderSettings (orientation, margins, custom fonts)

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -8,25 +8,13 @@ package main
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"syscall/js"
 
+	"github.com/carlos7ags/folio/cmd/wasm/settings"
 	"github.com/carlos7ags/folio/document"
 	"github.com/carlos7ags/folio/html"
 	"github.com/carlos7ags/folio/layout"
 )
-
-type renderSettings struct {
-	PageSize             string `json:"pageSize"`
-	MediaType            string `json:"mediaType"`
-	PdfProfile           string `json:"pdfProfile"`
-	PdfTitle             string `json:"pdfTitle"`
-	IgnoreResourceErrors bool   `json:"ignoreResourceErrors"`
-	CssDpi               int    `json:"cssDpi"`
-	Watermark            string `json:"watermark,omitempty"`  // optional watermark text
-	HeaderHTML           string `json:"headerHtml,omitempty"` // HTML for page header
-	FooterHTML           string `json:"footerHtml,omitempty"` // HTML for page footer
-}
 
 func renderHTML(_ js.Value, args []js.Value) any {
 	if len(args) < 2 {
@@ -36,24 +24,22 @@ func renderHTML(_ js.Value, args []js.Value) any {
 	htmlStr := args[0].String()
 	settingsJSON := args[1].String()
 
-	var settings renderSettings
-	if err := json.Unmarshal([]byte(settingsJSON), &settings); err != nil {
+	set, err := settings.Parse(settingsJSON)
+	if err != nil {
 		return map[string]any{"error": "invalid settings JSON: " + err.Error()}
 	}
 
-	pageSize := document.PageSizeLetter
-	switch settings.PageSize {
-	case "a4":
-		pageSize = document.PageSizeA4
-	case "legal":
-		pageSize = document.PageSizeLegal
-	case "a3":
-		pageSize = document.PageSizeA3
-	}
+	// Named page size plus orientation (landscape swaps the dimensions).
+	pageSize := set.ResolvePageSize()
 
 	opts := &html.Options{
 		PageWidth:  pageSize.Width,
 		PageHeight: pageSize.Height,
+	}
+	// Asset resolution: baseDir → BaseFS, allowAbsolutePaths, fallback font
+	// from path or inline base64 data.
+	if err := set.ApplyOptions(opts); err != nil {
+		return map[string]any{"error": err.Error()}
 	}
 
 	result, err := html.ConvertFull(htmlStr, opts)
@@ -102,6 +88,16 @@ func renderHTML(_ js.Value, args []js.Value) any {
 		}
 	}
 
+	// Explicit margins from renderSettings (points) override @page margins.
+	if set.Margins != nil {
+		doc.SetMargins(layout.Margins{
+			Top:    set.Margins.Top,
+			Right:  set.Margins.Right,
+			Bottom: set.Margins.Bottom,
+			Left:   set.Margins.Left,
+		})
+	}
+
 	// Apply margin boxes from @page rules (e.g. page numbers).
 	if result.MarginBoxes != nil {
 		doc.SetMarginBoxes(result.MarginBoxes)
@@ -124,9 +120,18 @@ func renderHTML(_ js.Value, args []js.Value) any {
 		doc.Info.Author = result.Metadata.Author
 	}
 
-	// Override title if user specified one
-	if settings.PdfTitle != "" {
-		doc.Info.Title = settings.PdfTitle
+	// Overrides / additions from renderSettings.
+	if set.PdfTitle != "" {
+		doc.Info.Title = set.PdfTitle
+	}
+	if set.PdfAuthor != "" {
+		doc.Info.Author = set.PdfAuthor
+	}
+	if set.PdfSubject != "" {
+		doc.Info.Subject = set.PdfSubject
+	}
+	if set.PdfKeywords != "" {
+		doc.Info.Keywords = set.PdfKeywords
 	}
 
 	for _, e := range result.Elements {
@@ -144,9 +149,9 @@ func renderHTML(_ js.Value, args []js.Value) any {
 	}
 
 	// Optional watermark (requested by caller, e.g. playground).
-	if settings.Watermark != "" {
+	if set.Watermark != "" {
 		doc.SetWatermarkConfig(document.WatermarkConfig{
-			Text:     settings.Watermark,
+			Text:     set.Watermark,
 			FontSize: 54,
 			ColorR:   0.001,
 			ColorG:   0.001,
@@ -157,8 +162,8 @@ func renderHTML(_ js.Value, args []js.Value) any {
 	}
 
 	// Header/footer from HTML.
-	if settings.HeaderHTML != "" {
-		headerElems, err := html.Convert(settings.HeaderHTML, nil)
+	if set.HeaderHTML != "" {
+		headerElems, err := html.Convert(set.HeaderHTML, nil)
 		if err == nil && len(headerElems) > 0 {
 			doc.SetHeaderElement(func(_ document.PageContext) layout.Element {
 				if len(headerElems) == 1 {
@@ -172,8 +177,8 @@ func renderHTML(_ js.Value, args []js.Value) any {
 			})
 		}
 	}
-	if settings.FooterHTML != "" {
-		footerElems, err := html.Convert(settings.FooterHTML, nil)
+	if set.FooterHTML != "" {
+		footerElems, err := html.Convert(set.FooterHTML, nil)
 		if err == nil && len(footerElems) > 0 {
 			doc.SetFooterElement(func(_ document.PageContext) layout.Element {
 				if len(footerElems) == 1 {
@@ -189,7 +194,7 @@ func renderHTML(_ js.Value, args []js.Value) any {
 	}
 
 	// PDF profiles
-	switch settings.PdfProfile {
+	switch set.PdfProfile {
 	case "pdfa1b":
 		doc.SetPdfA(document.PdfAConfig{Level: document.PdfA1B})
 	case "pdfa1a":

--- a/cmd/wasm/settings/settings.go
+++ b/cmd/wasm/settings/settings.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package settings parses the renderSettings JSON accepted by the wasm
+// entrypoint (cmd/wasm). It is a separate, build-tag-free package so the
+// parsing logic can be unit-tested on the host toolchain.
+package settings
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/html"
+)
+
+// Margins holds page margins in PDF points. It unmarshals from either a
+// single JSON number (applied to all four sides) or an object with any of
+// top/right/bottom/left.
+type Margins struct {
+	Top    float64 `json:"top"`
+	Right  float64 `json:"right"`
+	Bottom float64 `json:"bottom"`
+	Left   float64 `json:"left"`
+}
+
+// UnmarshalJSON accepts 36 or {"top":36,"left":18,...}.
+func (m *Margins) UnmarshalJSON(b []byte) error {
+	var n float64
+	if err := json.Unmarshal(b, &n); err == nil {
+		m.Top, m.Right, m.Bottom, m.Left = n, n, n, n
+		return nil
+	}
+	type plain Margins // avoid recursion
+	var p plain
+	if err := json.Unmarshal(b, &p); err != nil {
+		return fmt.Errorf("margins must be a number or an object with top/right/bottom/left: %w", err)
+	}
+	*m = Margins(p)
+	return nil
+}
+
+// Settings is the renderSettings JSON accepted by folioRender.
+type Settings struct {
+	PageSize    string   `json:"pageSize"`    // named size, e.g. "a4", "letter" (default letter)
+	Orientation string   `json:"orientation"` // "portrait" (default) or "landscape"
+	Margins     *Margins `json:"margins,omitempty"`
+
+	MediaType            string `json:"mediaType"`
+	PdfProfile           string `json:"pdfProfile"`
+	PdfTitle             string `json:"pdfTitle"`
+	PdfAuthor            string `json:"pdfAuthor,omitempty"`
+	PdfSubject           string `json:"pdfSubject,omitempty"`
+	PdfKeywords          string `json:"pdfKeywords,omitempty"`
+	IgnoreResourceErrors bool   `json:"ignoreResourceErrors"`
+	CssDpi               int    `json:"cssDpi"`
+	Watermark            string `json:"watermark,omitempty"`  // optional watermark text
+	HeaderHTML           string `json:"headerHtml,omitempty"` // HTML for page header
+	FooterHTML           string `json:"footerHtml,omitempty"` // HTML for page footer
+
+	// Asset / font resolution (issue #426).
+	AllowAbsolutePaths bool   `json:"allowAbsolutePaths"`         // permit absolute OS paths in the document (default false)
+	BaseDir            string `json:"baseDir,omitempty"`          // directory used as BaseFS root for relative asset paths
+	FallbackFontPath   string `json:"fallbackFontPath,omitempty"` // Unicode fallback font path (BaseFS-relative or absolute)
+	FallbackFontData   string `json:"fallbackFontData,omitempty"` // base64-encoded TTF/OTF used as the Unicode fallback font
+}
+
+// Parse decodes the renderSettings JSON.
+func Parse(jsonStr string) (Settings, error) {
+	var s Settings
+	if err := json.Unmarshal([]byte(jsonStr), &s); err != nil {
+		return Settings{}, err
+	}
+	return s, nil
+}
+
+var pageSizes = map[string]document.PageSize{
+	"a0":        document.PageSizeA0,
+	"a1":        document.PageSizeA1,
+	"a2":        document.PageSizeA2,
+	"a3":        document.PageSizeA3,
+	"a4":        document.PageSizeA4,
+	"a5":        document.PageSizeA5,
+	"a6":        document.PageSizeA6,
+	"b4":        document.PageSizeB4,
+	"b5":        document.PageSizeB5,
+	"letter":    document.PageSizeLetter,
+	"legal":     document.PageSizeLegal,
+	"tabloid":   document.PageSizeTabloid,
+	"ledger":    document.PageSizeLedger,
+	"executive": document.PageSizeExecutive,
+}
+
+// ResolvePageSize maps the named page size (defaulting to US Letter) and
+// applies the orientation, swapping dimensions for landscape.
+func (s Settings) ResolvePageSize() document.PageSize {
+	ps, ok := pageSizes[strings.ToLower(s.PageSize)]
+	if !ok {
+		ps = document.PageSizeLetter
+	}
+	switch strings.ToLower(s.Orientation) {
+	case "landscape":
+		if ps.Height > ps.Width {
+			ps.Width, ps.Height = ps.Height, ps.Width
+		}
+	case "portrait":
+		if ps.Width > ps.Height {
+			ps.Width, ps.Height = ps.Height, ps.Width
+		}
+	}
+	return ps
+}
+
+// fallbackFontName is the synthetic BaseFS path used when the fallback font
+// is supplied inline via fallbackFontData.
+const fallbackFontName = "__folio_fallback_font__"
+
+// ApplyOptions wires the asset-resolution settings into html.Options:
+// baseDir becomes BaseFS (via os.DirFS), allowAbsolutePaths is passed
+// through, and the fallback font is set from fallbackFontData (base64,
+// takes precedence) or fallbackFontPath. Defaults stay safe: with no
+// settings, BaseFS is nil and absolute paths are denied.
+func (s Settings) ApplyOptions(opts *html.Options) error {
+	opts.AllowAbsolutePaths = s.AllowAbsolutePaths
+	if s.BaseDir != "" {
+		opts.BaseFS = os.DirFS(s.BaseDir)
+	}
+	if s.FallbackFontPath != "" {
+		opts.FallbackFontPath = s.FallbackFontPath
+	}
+	if s.FallbackFontData != "" {
+		data, err := base64.StdEncoding.DecodeString(s.FallbackFontData)
+		if err != nil {
+			return fmt.Errorf("invalid fallbackFontData: %w", err)
+		}
+		opts.BaseFS = overlayFS{
+			extra: map[string][]byte{fallbackFontName: data},
+			base:  opts.BaseFS,
+		}
+		opts.FallbackFontPath = fallbackFontName
+	}
+	return nil
+}
+
+// overlayFS serves a small in-memory file set, falling back to base (which
+// may be nil) for everything else.
+type overlayFS struct {
+	extra map[string][]byte
+	base  fs.FS
+}
+
+func (o overlayFS) Open(name string) (fs.File, error) {
+	if data, ok := o.extra[name]; ok {
+		return &memFile{name: name, r: bytes.NewReader(data), size: int64(len(data))}, nil
+	}
+	if o.base != nil {
+		return o.base.Open(name)
+	}
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+}
+
+type memFile struct {
+	name string
+	r    *bytes.Reader
+	size int64
+}
+
+func (f *memFile) Read(p []byte) (int, error) { return f.r.Read(p) }
+func (f *memFile) Close() error               { return nil }
+func (f *memFile) Stat() (fs.FileInfo, error) { return memInfo{name: f.name, size: f.size}, nil }
+
+type memInfo struct {
+	name string
+	size int64
+}
+
+func (i memInfo) Name() string       { return i.name }
+func (i memInfo) Size() int64        { return i.size }
+func (i memInfo) Mode() fs.FileMode  { return 0o444 }
+func (i memInfo) ModTime() time.Time { return time.Time{} }
+func (i memInfo) IsDir() bool        { return false }
+func (i memInfo) Sys() any           { return nil }

--- a/cmd/wasm/settings/settings_test.go
+++ b/cmd/wasm/settings/settings_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package settings
+
+import (
+	"encoding/base64"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/carlos7ags/folio/html"
+)
+
+func TestResolvePageSizeOrientation(t *testing.T) {
+	tests := []struct {
+		name          string
+		json          string
+		width, height float64
+	}{
+		{"default letter", `{}`, 612, 792},
+		{"a4 portrait", `{"pageSize":"a4","orientation":"portrait"}`, 595.28, 841.89},
+		{"a4 landscape", `{"pageSize":"a4","orientation":"landscape"}`, 841.89, 595.28},
+		{"letter landscape", `{"pageSize":"letter","orientation":"landscape"}`, 792, 612},
+		{"ledger already landscape", `{"pageSize":"ledger","orientation":"landscape"}`, 1224, 792},
+		{"ledger forced portrait", `{"pageSize":"ledger","orientation":"portrait"}`, 792, 1224},
+		{"tabloid", `{"pageSize":"tabloid"}`, 792, 1224},
+		{"case-insensitive", `{"pageSize":"A4","orientation":"Landscape"}`, 841.89, 595.28},
+		{"unknown size falls back to letter", `{"pageSize":"bogus"}`, 612, 792},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := Parse(tt.json)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ps := s.ResolvePageSize()
+			if ps.Width != tt.width || ps.Height != tt.height {
+				t.Errorf("got %gx%g, want %gx%g", ps.Width, ps.Height, tt.width, tt.height)
+			}
+		})
+	}
+}
+
+func TestMarginsNumber(t *testing.T) {
+	s, err := Parse(`{"margins":36}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := s.Margins
+	if m == nil || m.Top != 36 || m.Right != 36 || m.Bottom != 36 || m.Left != 36 {
+		t.Errorf("got %+v, want uniform 36", m)
+	}
+}
+
+func TestMarginsObject(t *testing.T) {
+	s, err := Parse(`{"margins":{"top":10,"right":20,"bottom":30,"left":40}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := s.Margins
+	if m == nil || m.Top != 10 || m.Right != 20 || m.Bottom != 30 || m.Left != 40 {
+		t.Errorf("got %+v", m)
+	}
+}
+
+func TestMarginsPartialObject(t *testing.T) {
+	s, err := Parse(`{"margins":{"left":18}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := s.Margins
+	if m == nil || m.Left != 18 || m.Top != 0 {
+		t.Errorf("got %+v", m)
+	}
+}
+
+func TestMarginsOmitted(t *testing.T) {
+	s, err := Parse(`{}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Margins != nil {
+		t.Errorf("expected nil margins, got %+v", s.Margins)
+	}
+}
+
+func TestMarginsInvalid(t *testing.T) {
+	if _, err := Parse(`{"margins":"big"}`); err == nil {
+		t.Error("expected error for string margins")
+	}
+}
+
+func TestApplyOptionsDefaultsAreSafe(t *testing.T) {
+	s, _ := Parse(`{}`)
+	var opts html.Options
+	if err := s.ApplyOptions(&opts); err != nil {
+		t.Fatal(err)
+	}
+	if opts.BaseFS != nil || opts.AllowAbsolutePaths || opts.FallbackFontPath != "" {
+		t.Errorf("defaults not safe: %+v", opts)
+	}
+}
+
+func TestApplyOptionsBaseDirAndFlags(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "x.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Parse(`{"baseDir":` + jsonStr(dir) + `,"allowAbsolutePaths":true,"fallbackFontPath":"fonts/f.ttf"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var opts html.Options
+	if err := s.ApplyOptions(&opts); err != nil {
+		t.Fatal(err)
+	}
+	if !opts.AllowAbsolutePaths {
+		t.Error("allowAbsolutePaths not applied")
+	}
+	if opts.FallbackFontPath != "fonts/f.ttf" {
+		t.Errorf("fallbackFontPath = %q", opts.FallbackFontPath)
+	}
+	data, err := fs.ReadFile(opts.BaseFS, "x.txt")
+	if err != nil || string(data) != "hi" {
+		t.Errorf("BaseFS read: %q, %v", data, err)
+	}
+}
+
+func TestApplyOptionsFallbackFontData(t *testing.T) {
+	fontBytes := []byte{0, 1, 0, 0, 0xde, 0xad}
+	s := Settings{FallbackFontData: base64.StdEncoding.EncodeToString(fontBytes)}
+	var opts html.Options
+	if err := s.ApplyOptions(&opts); err != nil {
+		t.Fatal(err)
+	}
+	if opts.FallbackFontPath != fallbackFontName {
+		t.Errorf("FallbackFontPath = %q", opts.FallbackFontPath)
+	}
+	got, err := fs.ReadFile(opts.BaseFS, fallbackFontName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(fontBytes) {
+		t.Errorf("font bytes mismatch")
+	}
+	// Anything else is not found (no base FS).
+	if _, err := opts.BaseFS.Open("other"); err == nil {
+		t.Error("expected not-exist for other files")
+	}
+}
+
+func TestApplyOptionsFontDataOverlaysBaseDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "img.png"), []byte("png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := Settings{
+		BaseDir:          dir,
+		FallbackFontData: base64.StdEncoding.EncodeToString([]byte("font")),
+	}
+	var opts html.Options
+	if err := s.ApplyOptions(&opts); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := fs.ReadFile(opts.BaseFS, fallbackFontName); err != nil || string(b) != "font" {
+		t.Errorf("overlay font: %q, %v", b, err)
+	}
+	if b, err := fs.ReadFile(opts.BaseFS, "img.png"); err != nil || string(b) != "png" {
+		t.Errorf("base passthrough: %q, %v", b, err)
+	}
+}
+
+func TestApplyOptionsBadFontData(t *testing.T) {
+	s := Settings{FallbackFontData: "not base64!!!"}
+	var opts html.Options
+	if err := s.ApplyOptions(&opts); err == nil {
+		t.Error("expected error for invalid base64")
+	}
+}
+
+func TestParseMetadataFields(t *testing.T) {
+	s, err := Parse(`{"pdfTitle":"T","pdfAuthor":"A","pdfSubject":"S","pdfKeywords":"k1,k2"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.PdfTitle != "T" || s.PdfAuthor != "A" || s.PdfSubject != "S" || s.PdfKeywords != "k1,k2" {
+		t.Errorf("got %+v", s)
+	}
+}
+
+// jsonStr encodes a Go string as a JSON string literal (handles backslashes
+// in Windows-style temp paths).
+func jsonStr(s string) string {
+	b := []byte{'"'}
+	for _, r := range s {
+		switch r {
+		case '"', '\\':
+			b = append(b, '\\', byte(r))
+		default:
+			b = append(b, string(r)...)
+		}
+	}
+	return string(append(b, '"'))
+}

--- a/html/converter_paragraph.go
+++ b/html/converter_paragraph.go
@@ -392,13 +392,11 @@ func (c *converter) collectListItemRuns(li *html.Node, style computedStyle) []la
 				continue
 			}
 			stdFont, embFont := c.resolveFontForText(style, text)
-			runs = append(runs, layout.TextRun{
-				Text:     text,
-				Font:     stdFont,
-				Embedded: embFont,
-				FontSize: style.FontSize,
-				Color:    style.Color,
-			})
+			run := c.makeTextRun(text, stdFont, embFont, style)
+			// The li's own background paints as a block background, not a
+			// per-word text highlight.
+			run.BackgroundColor = nil
+			runs = append(runs, run)
 		case html.ElementNode:
 			childStyle := c.computeElementStyle(child, style)
 			childRuns := c.collectRuns(child, childStyle)

--- a/html/letter_spacing_repro_test.go
+++ b/html/letter_spacing_repro_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// tdXPositions extracts the x coordinate of every "x y Td" operator in a
+// content stream, in order of appearance.
+func tdXPositions(t *testing.T, stream string) []float64 {
+	t.Helper()
+	re := regexp.MustCompile(`(?m)^([\d.+-]+) [\d.+-]+ Td$`)
+	var xs []float64
+	for _, m := range re.FindAllStringSubmatch(stream, -1) {
+		x, err := strconv.ParseFloat(m[1], 64)
+		if err != nil {
+			t.Fatalf("bad Td x %q: %v", m[1], err)
+		}
+		xs = append(xs, x)
+	}
+	return xs
+}
+
+// Regression test for issue #429: CSS letter-spacing must affect both the
+// drawn output (Tc character-spacing operator) and word placement (the
+// measured word widths and inter-word gap used by line layout).
+func TestLetterSpacingAffectsOutput(t *testing.T) {
+	render := func(src string) string {
+		elems, err := Convert(src, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return renderStreamText(t, elems)
+	}
+
+	plain := render(`<div>Hello World</div>`)
+	spaced := render(`<div style="letter-spacing: 10px;">Hello World</div>`)
+
+	// 10px = 7.5pt must be emitted as PDF character spacing.
+	if !strings.Contains(spaced, "7.5 Tc") {
+		t.Fatalf("spaced stream missing '7.5 Tc':\n%s", spaced)
+	}
+	if strings.Contains(plain, "Tc") {
+		t.Fatalf("plain stream unexpectedly sets character spacing:\n%s", plain)
+	}
+
+	// Word placement must use the spaced widths: the gap from "Hello" to
+	// "World" grows by 4 intra-word gaps ("H-e", "e-l", "l-l", "l-o") plus
+	// the 2 boundaries around the space = 6 * 7.5pt = 45pt.
+	px, sx := tdXPositions(t, plain), tdXPositions(t, spaced)
+	if len(px) < 2 || len(sx) < 2 {
+		t.Fatalf("expected two positioned words, got %d plain / %d spaced", len(px), len(sx))
+	}
+	plainGap := px[1] - px[0]
+	spacedGap := sx[1] - sx[0]
+	const want = 6 * 7.5
+	if got := spacedGap - plainGap; got < want-0.01 || got > want+0.01 {
+		t.Fatalf("advance Hello->World grew by %.3f pt, want %.1f (plain %.3f, spaced %.3f)",
+			got, float64(want), plainGap, spacedGap)
+	}
+}
+
+// Line breaking must use letter-spaced word widths: at a width that fits
+// "aa bb" only without spacing, adding letter-spacing must wrap onto two
+// lines (two distinct baseline y positions).
+func TestLetterSpacingAffectsLineBreaking(t *testing.T) {
+	countLines := func(src string) int {
+		elems, err := Convert(src, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		stream := renderStreamText(t, elems)
+		re := regexp.MustCompile(`(?m)^[\d.+-]+ ([\d.+-]+) Td$`)
+		ys := map[string]bool{}
+		for _, m := range re.FindAllStringSubmatch(stream, -1) {
+			ys[m[1]] = true
+		}
+		return len(ys)
+	}
+
+	if n := countLines(`<div style="width: 40px">aa bb</div>`); n != 1 {
+		t.Fatalf("plain text should fit one line, got %d", n)
+	}
+	if n := countLines(`<div style="width: 40px; letter-spacing: 8px">aa bb</div>`); n != 2 {
+		t.Fatalf("letter-spaced text should wrap to two lines, got %d", n)
+	}
+}
+
+// List item text inherits letter-spacing (previously dropped by
+// collectListItemRuns building bare TextRuns).
+func TestLetterSpacingListItems(t *testing.T) {
+	elems, err := Convert(`<ul style="letter-spacing: 4px"><li>Hello</li></ul>`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream := renderStreamText(t, elems)
+	if !strings.Contains(stream, "3 Tc") { // 4px = 3pt
+		t.Fatalf("list item stream missing '3 Tc':\n%s", stream)
+	}
+}

--- a/layout/paragraph.go
+++ b/layout/paragraph.go
@@ -319,7 +319,11 @@ func (p *Paragraph) Layout(maxWidth float64) []Line {
 		glueAdjacentRuns(measured, p.runs, i)
 
 		measurer := runMeasurer(run)
-		spaceW := measurer.MeasureString(" ", run.FontSize) + run.WordSpacing
+		// Letter-spacing applies between every pair of adjacent characters,
+		// including across the space separating two words (per CSS Text §8.2
+		// there are two such boundaries around a single space), so widen the
+		// inter-word gap by 2× the spacing.
+		spaceW := measurer.MeasureString(" ", run.FontSize) + run.WordSpacing + 2*run.LetterSpacing
 		words := splitWords(run.Text)
 
 		nextLineBreak := nextLineBreakFromBr

--- a/layout/paragraph_measure.go
+++ b/layout/paragraph_measure.go
@@ -133,7 +133,7 @@ func inlineSpaceAfter(measured []Word, runs []TextRun, currentIdx int) float64 {
 		if r.InlineElement != nil {
 			continue
 		}
-		return runMeasurer(r).MeasureString(" ", r.FontSize) + r.WordSpacing
+		return runMeasurer(r).MeasureString(" ", r.FontSize) + r.WordSpacing + 2*r.LetterSpacing
 	}
 	// No text context at all — flush spacing.
 	return 0
@@ -179,7 +179,7 @@ func (p *Paragraph) MaxWidth() float64 {
 		}
 		measurer := runMeasurer(run)
 		words := splitWords(run.Text)
-		spaceW := measurer.MeasureString(" ", run.FontSize)
+		spaceW := measurer.MeasureString(" ", run.FontSize) + 2*run.LetterSpacing
 		for i, w := range words {
 			ww := measurer.MeasureString(w, run.FontSize)
 			if run.LetterSpacing != 0 {
@@ -295,7 +295,9 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 		glueAdjacentRuns(measured, p.runs, i)
 
 		measurer := runMeasurer(run)
-		spaceW := measurer.MeasureString(" ", run.FontSize) + run.WordSpacing
+		// Letter-spacing also widens the inter-word gap: a single space has
+		// two adjacent-character boundaries (before and after it).
+		spaceW := measurer.MeasureString(" ", run.FontSize) + run.WordSpacing + 2*run.LetterSpacing
 		text := run.Text
 
 		// If the run starts with punctuation (no leading space) and we


### PR DESCRIPTION
## Summary
- Fixes #429 — letter-spacing now applies at inter-word boundaries (CSS applies it at every adjacent-character boundary, including around spaces): placement, justification, nowrap/fit-content measurement, and line breaking all use spaced widths. List items previously dropped letter-spacing (and other run styling) entirely; they now go through the shared run builder.
- Fixes #428 — wasm renderSettings now honors `orientation`, `margins` (number or `{top,right,bottom,left}`), an extended page-size table (a0–a6, b4/b5, letter, legal, tabloid, ledger, executive), and `pdfAuthor`/`pdfSubject`/`pdfKeywords`.
- Fixes #426 — wasm can embed custom fonts again: `allowAbsolutePaths`, `baseDir` (wired to `BaseFS` via `os.DirFS`, served by node's wasm_exec fs shims), `fallbackFontPath`, and `fallbackFontData` (base64 font layered as an in-memory FS). Defaults stay safe: absolute paths remain denied unless opted in.
- Settings parsing factored into a build-tag-free `cmd/wasm/settings` package so it is testable on the host.

## Test plan
- Regression tests for the exact #429 repro: `7.5 Tc` emitted, Hello→World advance grows by exactly 6×7.5pt, spacing forces a wrap, `<li>` text emits `Tc`.
- 13 new host-side tests for wasm settings: orientation/size resolution, margin forms, safe defaults, baseDir wiring, font-data overlay + precedence, invalid base64, metadata.
- `go build ./...`, `GOOS=js GOARCH=wasm go build ./cmd/wasm`, `go test -count=1 ./...` all green.