### PR TITLE
Fix xref repair scan, timestamped-PDF field loss, and e-invoice schema validity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y qpdf
 
       - name: Install libxml2-utils
+        if: runner.os == 'Linux'
         run: sudo apt-get install -y libxml2-utils
 
       - name: Format check
@@ -52,8 +53,91 @@ jobs:
       - name: Test
         run: go test ./... -race -coverprofile=coverage.out -count=1 -timeout 300s
 
+      # Downloads the UN/CEFACT Cross Industry Invoice (CII) D16B schema so
+      # the tagged XSD validation test below can run instead of skipping.
+      # Primary source is the official UNECE zip; UNECE has been observed
+      # to 403 non-browser clients from some networks, so this falls back
+      # to a pinned-commit mirror (ConnectingEurope/eInvoicing-EN16931,
+      # itself a verbatim re-publication of the UNECE-issued D16B SCRDM
+      # CII schema set) so the step still succeeds when that happens.
+      # Schemas are never committed to the repo — only downloaded into the
+      # runner's cache/workspace at CI time. A failed download is a
+      # network-flake, not a code regression: it degrades gracefully to a
+      # notice and the validation test below skips. If the schema *is*
+      # present, the validation test must still pass — that's the real
+      # gate.
+      - name: Cache UN/CEFACT CII schemas
+        if: runner.os == 'Linux'
+        id: xsd-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/xsd-schemas
+          key: xsd-schemas-cii-d16b-v1
+
+      - name: Download UN/CEFACT CII D16B schemas
+        if: runner.os == 'Linux' && steps.xsd-cache.outputs.cache-hit != 'true'
+        run: |
+          set -u
+          UNECE_URL="https://unece.org/fileadmin/DAM/cefact/xml_schemas/D16B_SCRDM__Subset__CII.zip"
+          # Pinned to a specific commit so the schema content used in CI
+          # cannot change out from under us. Upstream: UNECE-published
+          # D16B SCRDM (Subset) CII schema, "coupled clm" variant, as
+          # re-published verbatim by:
+          #   https://github.com/ConnectingEurope/eInvoicing-EN16931
+          MIRROR_SHA="b6c9e06a59812fb1a83585da40923b3678a649ad"
+          MIRROR_URL="https://github.com/ConnectingEurope/eInvoicing-EN16931/archive/${MIRROR_SHA}.zip"
+
+          work="$(mktemp -d)"
+          zip="$work/schemas.zip"
+          ok=0
+
+          if curl -fsSL --max-time 60 -o "$zip" "$UNECE_URL"; then
+            echo "downloaded from UNECE ($UNECE_URL)"
+            ok=1
+          else
+            echo "::notice::UNECE schema download failed, falling back to pinned mirror"
+            if curl -fsSL --max-time 60 -o "$zip" "$MIRROR_URL"; then
+              echo "downloaded from pinned mirror ($MIRROR_URL @ $MIRROR_SHA)"
+              ok=1
+            else
+              echo "::notice::UN/CEFACT CII schema download failed from both UNECE and the pinned mirror; XSD validation test will skip"
+            fi
+          fi
+
+          if [ "$ok" = "1" ]; then
+            extract="$work/extract"
+            mkdir -p "$extract"
+            if unzip -q "$zip" -d "$extract"; then
+              # Locate the "CII" schema root regardless of the archive's
+              # internal layout (the UNECE zip and the mirror's repo zip
+              # are not laid out identically) and normalize it to
+              # ~/xsd-schemas/CII/... which is what the tagged Go test
+              # expects under FOLIO_FACTURX_XSD_DIR.
+              cii_dir="$(find "$extract" -type d -name CII -path '*D16B*' -not -path '*uncoupled*' | head -1)"
+              if [ -z "$cii_dir" ]; then
+                cii_dir="$(find "$extract" -type d -name CII | head -1)"
+              fi
+              if [ -n "$cii_dir" ]; then
+                mkdir -p ~/xsd-schemas
+                rm -rf ~/xsd-schemas/CII
+                cp -R "$cii_dir" ~/xsd-schemas/CII
+                echo "installed schemas to ~/xsd-schemas/CII"
+              else
+                echo "::notice::could not locate a CII schema directory in the downloaded archive; XSD validation test will skip"
+              fi
+            else
+              echo "::notice::failed to extract downloaded schema archive; XSD validation test will skip"
+            fi
+          fi
+
+          rm -rf "$work"
+
       - name: ZUGFeRD XSD validation
-        run: go test -tags xsdvalidate ./zugferd/ -run TestXSDValidation -v
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ] && [ -d "$HOME/xsd-schemas" ]; then
+            export FOLIO_FACTURX_XSD_DIR="$HOME/xsd-schemas"
+          fi
+          go test -tags xsdvalidate ./zugferd/ -run TestXSDValidation -v
 
       - name: Check no competitor references in source
         if: runner.os == 'Linux'

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -332,7 +332,7 @@ func repairXref(data []byte) (*xrefTable, error) {
 			continue
 		}
 		t3 := tok.Next()
-		if t3.Type != TokenKeyword && t3.Value != "obj" {
+		if t3.Type != TokenKeyword || t3.Value != "obj" {
 			continue
 		}
 		// Found "N G obj" at position pos.

--- a/reader/reader_malformed_test.go
+++ b/reader/reader_malformed_test.go
@@ -327,7 +327,7 @@ func buildMinimalPDFWithBadXref() []byte {
 			"trailer\n" +
 			"<< /Size 3 /Root 1 0 R >>\n" +
 			"startxref\n" +
-			"95\n" + // offset to "xref" keyword
+			"110\n" + // offset to "xref" keyword
 			"%%EOF\n")
 }
 

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -938,3 +938,52 @@ func TestMemoryLimitsDefaults(t *testing.T) {
 
 // Use core import to avoid unused import error.
 var _ = core.NewPdfNull
+
+// TestRepairXrefSkipsIndirectReferences ensures the tolerant xref repair
+// scan only records genuine "N G obj" headers, not "N G R" indirect
+// references (e.g. inside a trailer dictionary), which happen to share the
+// same "N G <keyword>" token shape.
+func TestRepairXrefSkipsIndirectReferences(t *testing.T) {
+	// Object 1's real header is written first. A "1 0 R" indirect
+	// reference to it (inside the trailer, which is scanned afterwards)
+	// must NOT overwrite the entry recorded for the real header.
+	pdf := "%PDF-1.4\n" +
+		"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n" +
+		"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n" +
+		"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n" +
+		"trailer\n<< /Root 1 0 R /Size 4 >>\n"
+	data := []byte(pdf)
+
+	wantOffset := int64(bytes.Index(data, []byte("1 0 obj")))
+	if wantOffset < 0 {
+		t.Fatalf("test setup: could not locate real object 1 header")
+	}
+	badOffset := int64(bytes.Index(data, []byte("1 0 R")))
+	if badOffset < 0 {
+		t.Fatalf("test setup: could not locate '1 0 R' reference in trailer")
+	}
+	if badOffset <= wantOffset {
+		t.Fatalf("test setup: expected the '1 0 R' reference to appear after the real header")
+	}
+
+	table, err := repairXref(data)
+	if err != nil {
+		t.Fatalf("repairXref: %v", err)
+	}
+	entry, ok := table.entries[1]
+	if !ok {
+		t.Fatalf("repairXref: object 1 missing from reconstructed xref")
+	}
+	// The recorded offset should land near the real "1 0 obj" header, not
+	// near the "1 0 R" reference inside the trailer (which appears much
+	// later in the file). A small tolerance absorbs repairXref's own
+	// (pre-existing, unrelated) token-boundary rounding of the recorded
+	// offset; it must not be anywhere close to badOffset.
+	const tolerance = 16
+	if entry.offset < wantOffset-tolerance || entry.offset > wantOffset+tolerance {
+		t.Errorf("repairXref: object 1 offset = %d (want near %d, the real 'obj' header); "+
+			"got something near the '1 0 R' reference (offset %d) instead, meaning the scan "+
+			"misidentified an indirect reference as an object header",
+			entry.offset, wantOffset, badOffset)
+	}
+}

--- a/sign/doctimestamp.go
+++ b/sign/doctimestamp.go
@@ -113,7 +113,7 @@ func AddDocumentTimestamp(pdfBytes []byte, tsaClient *TSAClient, hashFunc crypto
 	acroFormObjNum := nextObjNum + 2
 
 	// Build updated AcroForm that adds the timestamp field.
-	acroFormDict := buildAcroFormWithExisting(catalog, tsFieldObjNum)
+	acroFormDict := buildAcroFormWithExisting(r, catalog, tsFieldObjNum)
 
 	// Build updated catalog with new AcroForm.
 	updatedCatalog := cloneCatalogWithAcroForm(catalog, acroFormObjNum)
@@ -177,24 +177,31 @@ func buildDocTimestampField(objNum, tsDictObjNum int) *core.PdfDictionary {
 
 // buildAcroFormWithExisting creates an AcroForm dict that preserves existing
 // fields and adds a new signature field reference.
-func buildAcroFormWithExisting(catalog *core.PdfDictionary, newFieldObjNum int) *core.PdfDictionary {
+func buildAcroFormWithExisting(r *reader.PdfReader, catalog *core.PdfDictionary, newFieldObjNum int) *core.PdfDictionary {
 	d := core.NewPdfDictionary()
 
-	// Try to get existing AcroForm fields.
+	// Try to get existing AcroForm fields. The catalog's /AcroForm entry may
+	// be a direct dictionary or (more commonly, for signed PDFs) an indirect
+	// reference that must be resolved before its /Fields can be read.
 	var existingFields []core.PdfObject
-	if acroFormObj := catalog.Get("AcroForm"); acroFormObj != nil {
-		if acroFormDict, ok := acroFormObj.(*core.PdfDictionary); ok {
-			if fieldsObj := acroFormDict.Get("Fields"); fieldsObj != nil {
-				if fieldsArr, ok := fieldsObj.(*core.PdfArray); ok {
-					for _, f := range fieldsArr.All() {
-						existingFields = append(existingFields, f)
-					}
+	acroFormObj := catalog.Get("AcroForm")
+	if ref, ok := acroFormObj.(*core.PdfIndirectReference); ok && r != nil {
+		if resolved, err := r.ResolveObject(ref); err == nil {
+			acroFormObj = resolved
+		}
+	}
+	if acroFormDict, ok := acroFormObj.(*core.PdfDictionary); ok {
+		if fieldsObj := acroFormDict.Get("Fields"); fieldsObj != nil {
+			if ref, ok := fieldsObj.(*core.PdfIndirectReference); ok && r != nil {
+				if resolved, err := r.ResolveObject(ref); err == nil {
+					fieldsObj = resolved
 				}
 			}
-		} else if acroFormRef, ok := acroFormObj.(*core.PdfIndirectReference); ok {
-			// Existing AcroForm is an indirect reference — we can't resolve it
-			// here, so we include it as-is and add our field.
-			_ = acroFormRef
+			if fieldsArr, ok := fieldsObj.(*core.PdfArray); ok {
+				for _, f := range fieldsArr.All() {
+					existingFields = append(existingFields, f)
+				}
+			}
 		}
 	}
 

--- a/sign/doctimestamp_test.go
+++ b/sign/doctimestamp_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/carlos7ags/folio/core"
 	"github.com/carlos7ags/folio/reader"
 )
 
@@ -73,28 +74,98 @@ func TestAddDocumentTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
-	if len(rep.Signatures) == 0 {
-		t.Fatal("expected at least one signature result")
+	// buildAcroFormWithExisting resolves the catalog's /AcroForm entry
+	// (typically an indirect reference for a signed PDF) and carries the
+	// original /Fields into the rebuilt AcroForm alongside the new
+	// DocTimeStamp field, so both the original signature and the new
+	// document timestamp remain reachable via the AcroForm graph.
+	if len(rep.Signatures) != 2 {
+		t.Fatalf("len(rep.Signatures) = %d, want 2", len(rep.Signatures))
 	}
-	// The original signature is the first one located. Note: with the
-	// object-graph-based locateSignaturesGraph, the DocTimeStamp field also
-	// carries /FT /Sig, so it is picked up as a second (unverifiable, since
-	// its /Contents holds an RFC3161 token rather than a CMS SignedData)
-	// signature location. The plan (written against the pre-graph
-	// byte-scan locateSignatures, which only matched "/Type /Sig") expected
-	// exactly one result; the object-graph rework changed that. We assert
-	// on the first result — the original signature — which is what this
-	// test is actually guarding.
-	orig := rep.Signatures[0]
-	if !orig.DigestValid {
-		t.Error("original signature DigestValid = false, want true")
+
+	var sawSignature, sawTimestamp bool
+	for _, s := range rep.Signatures {
+		if s.IsDocTimeStamp {
+			sawTimestamp = true
+			if !s.DigestValid {
+				t.Error("document timestamp DigestValid = false, want true")
+			}
+			if !s.ByteRangeCoversFile {
+				t.Error("document timestamp ByteRangeCoversFile = false, want true")
+			}
+		} else {
+			sawSignature = true
+			if !s.DigestValid {
+				t.Error("original signature DigestValid = false, want true")
+			}
+			if !s.SignatureValid {
+				t.Error("original signature SignatureValid = false, want true")
+			}
+		}
 	}
-	if !orig.SignatureValid {
-		t.Error("original signature SignatureValid = false, want true")
+	if !sawSignature {
+		t.Error("expected one signature entry with IsDocTimeStamp = false (the original signature)")
 	}
-	if !orig.ByteRangeCoversFile {
-		t.Error("original signature ByteRangeCoversFile = false, want true")
+	if !sawTimestamp {
+		t.Error("expected one signature entry with IsDocTimeStamp = true (the document timestamp)")
 	}
+}
+
+// TestAddDocumentTimestamp_DirectAcroFormDict covers the case where the
+// catalog's /AcroForm entry is a direct dictionary rather than an indirect
+// reference, ensuring buildAcroFormWithExisting also preserves fields in
+// that shape.
+func TestAddDocumentTimestamp_DirectAcroFormDict(t *testing.T) {
+	signed := signMinimalPDFForLTV(t)
+
+	r, err := reader.Parse(signed)
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	catalog := r.Catalog()
+	if catalog == nil {
+		t.Fatal("catalog is nil")
+	}
+
+	acroFormObj := catalog.Get("AcroForm")
+	if _, isRef := acroFormObj.(*core.PdfIndirectReference); !isRef {
+		t.Skip("catalog's /AcroForm is not an indirect reference in this fixture")
+	}
+	resolved, err := r.ResolveObject(acroFormObj)
+	if err != nil {
+		t.Fatalf("ResolveObject(AcroForm): %v", err)
+	}
+	acroFormDict, ok := resolved.(*core.PdfDictionary)
+	if !ok {
+		t.Fatal("resolved AcroForm is not a dictionary")
+	}
+
+	newFieldObjNum := r.MaxObjectNumber() + 100
+	result := buildAcroFormWithExisting(nil, catalogWithDirectAcroForm(catalog, acroFormDict), newFieldObjNum)
+
+	fieldsObj := result.Get("Fields")
+	fieldsArr, ok := fieldsObj.(*core.PdfArray)
+	if !ok {
+		t.Fatal("Fields is not an array")
+	}
+	if fieldsArr.Len() < 2 {
+		t.Fatalf("Fields array has %d entries, want at least 2 (existing + new)", fieldsArr.Len())
+	}
+}
+
+// catalogWithDirectAcroForm returns a copy of catalog with /AcroForm set to
+// the given dictionary directly (not an indirect reference), for testing the
+// direct-dictionary code path of buildAcroFormWithExisting.
+func catalogWithDirectAcroForm(catalog *core.PdfDictionary, acroForm *core.PdfDictionary) *core.PdfDictionary {
+	d := core.NewPdfDictionary()
+	for key, value := range catalog.All() {
+		if key == "AcroForm" {
+			continue
+		}
+		d.Set(key, value)
+	}
+	d.Set("AcroForm", acroForm)
+	return d
 }
 
 func TestAddDocumentTimestamp_NilClient(t *testing.T) {

--- a/sign/verify.go
+++ b/sign/verify.go
@@ -116,6 +116,18 @@ type SignatureResult struct {
 	// falling back to a raw "/DSS" byte scan otherwise. Its contents (OCSP
 	// responses, CRLs, certificates) are not validated.
 	HasDSS bool
+
+	// IsDocTimeStamp is true when this entry is a document timestamp
+	// (added by AddDocumentTimestamp) rather than an author or approval
+	// signature: its /V dictionary has /Type /DocTimeStamp or /SubFilter
+	// /ETSI.RFC3161. Both share the AcroForm /FT /Sig field type, so
+	// locateSignaturesGraph reports both kinds; callers that only care
+	// about author/approval signatures should filter on this field. The
+	// /Contents of a document timestamp holds an RFC 3161 token rather
+	// than a CMS SignedData signing this document's ByteRange, so
+	// DigestValid, SignatureValid, and ChainStatus are not meaningful
+	// verdicts on the document's authorship for these entries.
+	IsDocTimeStamp bool
 }
 
 // OK reports the aggregate verdict for this signature: the ByteRange digest
@@ -205,6 +217,7 @@ func verifyLocation(pdf []byte, loc sigLocation, opts VerifyOptions) ([]Signatur
 			Reason:              loc.reason,
 			Location:            loc.location,
 			ByteRangeCoversFile: byteRangeOK,
+			IsDocTimeStamp:      loc.isDocTimeStamp,
 		}
 		res.SignerCertificate = cms.cert
 		res.SigningTime = cms.signingTime
@@ -272,6 +285,7 @@ type sigLocation struct {
 	contentsStart          int // absolute offset of the /Contents '<'
 	contentsEnd            int // absolute offset just past the /Contents '>'
 	der                    []byte
+	isDocTimeStamp         bool // /V dict is /Type /DocTimeStamp or /SubFilter /ETSI.RFC3161
 }
 
 // locateSignaturesGraph finds signatures by walking the parsed object
@@ -471,14 +485,29 @@ func sigLocationFromDict(pdf []byte, sd *core.PdfDictionary) (sigLocation, error
 	}
 
 	return sigLocation{
-		name:          pdfStringField(sd, "Name"),
-		reason:        pdfStringField(sd, "Reason"),
-		location:      pdfStringField(sd, "Location"),
-		byteRange:     br,
-		contentsStart: contentsStart,
-		contentsEnd:   contentsEnd,
-		der:           der,
+		name:           pdfStringField(sd, "Name"),
+		reason:         pdfStringField(sd, "Reason"),
+		location:       pdfStringField(sd, "Location"),
+		byteRange:      br,
+		contentsStart:  contentsStart,
+		contentsEnd:    contentsEnd,
+		der:            der,
+		isDocTimeStamp: isDocTimeStampDict(sd),
 	}, nil
+}
+
+// isDocTimeStampDict reports whether sd (a resolved /V dictionary) is a
+// document timestamp rather than an author/approval signature, per
+// ISO 32000-2 §12.8.3.3: /Type /DocTimeStamp or /SubFilter
+// /ETSI.RFC3161. AddDocumentTimestamp (doctimestamp.go) sets both.
+func isDocTimeStampDict(sd *core.PdfDictionary) bool {
+	if typeName, ok := sd.Get("Type").(*core.PdfName); ok && typeName.Value == "DocTimeStamp" {
+		return true
+	}
+	if sf, ok := sd.Get("SubFilter").(*core.PdfName); ok && sf.Value == "ETSI.RFC3161" {
+		return true
+	}
+	return false
 }
 
 // pdfStringField reads a string-valued dictionary entry, returning "" if

--- a/zugferd/xml.go
+++ b/zugferd/xml.go
@@ -56,10 +56,20 @@ type ciiFormattedDate struct {
 }
 
 type ciiTransaction struct {
-	LineItems  []ciiLineItem `xml:"ram:IncludedSupplyChainTradeLineItem,omitempty"`
-	Agreement  ciiAgreement  `xml:"ram:ApplicableHeaderTradeAgreement"`
-	Settlement ciiSettlement `xml:"ram:ApplicableHeaderTradeSettlement"`
+	LineItems  []ciiLineItem     `xml:"ram:IncludedSupplyChainTradeLineItem,omitempty"`
+	Agreement  ciiAgreement      `xml:"ram:ApplicableHeaderTradeAgreement"`
+	Delivery   ciiHeaderDelivery `xml:"ram:ApplicableHeaderTradeDelivery"`
+	Settlement ciiSettlement     `xml:"ram:ApplicableHeaderTradeSettlement"`
 }
+
+// ciiHeaderDelivery is the header-level ram:ApplicableHeaderTradeDelivery
+// element. The CII schema requires the element itself (minOccurs="1" on
+// ApplicableHeaderTradeDelivery within SupplyChainTradeTransactionType),
+// but every child of HeaderTradeDeliveryType is optional, so an empty
+// element (no known delivery date) is schema-valid. Folio does not
+// currently model a delivery/despatch date, so this is always emitted
+// empty.
+type ciiHeaderDelivery struct{}
 
 type ciiAgreement struct {
 	Seller ciiTradeParty `xml:"ram:SellerTradeParty"`

--- a/zugferd/xsd_test.go
+++ b/zugferd/xsd_test.go
@@ -12,37 +12,78 @@ import (
 	"testing"
 )
 
-// TestXSDValidation validates generated CII output against the official
-// Factur-X XSD for each supported profile using xmllint (libxml2).
+// TestXSDValidation validates generated CII output against an XSD schema
+// using xmllint (libxml2). FOLIO_FACTURX_XSD_DIR must point at a local,
+// pre-extracted schema directory; the test skips (not fails) when the env
+// var is unset or xmllint is unavailable.
 //
-// The official Factur-X/ZUGFeRD schema package is not committed to this
-// repository: its redistribution terms could not be confirmed (the
-// FNFE-MPE download is email-gated and the page states "All Rights
-// Reserved" with no explicit redistribution grant — see
-// plans/zugferd-20260813-xsd-validation.md STOP conditions). Point
-// FOLIO_FACTURX_XSD_DIR at a local checkout of the schema package to run
-// this test; each entry in root below is resolved relative to that
-// directory. The test skips (not fails) when the env var is unset or
-// xmllint is unavailable.
+// Two schema layouts are supported, tried in order for each profile via
+// facturXPaths below:
+//
+//  1. The official Factur-X/ZUGFeRD package (e.g.
+//     "Factur-X_1.0.7_MINIMUM/Schema/Factur-X_1.07_MINIMUM.xsd"). Not
+//     committed to this repo: its redistribution terms could not be
+//     confirmed (the FNFE-MPE download is email-gated and the page states
+//     "All Rights Reserved" with no explicit redistribution grant).
+//     Factur-X profile XSDs are restrictions of plain CII (they add
+//     profile-specific cardinality/business rules on top of the base UN/
+//     CEFACT model), so validating against them is the stronger check.
+//
+//  2. The plain UN/CEFACT Cross Industry Invoice (CII) D16B schema
+//     (SCRDM, "coupled" codelists), published by UNECE and mirrored
+//     verbatim by third parties (e.g. ConnectingEurope/eInvoicing-EN16931
+//     on GitHub). Its root is
+//     "CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd"
+//     under the schema dir, used for both MINIMUM and BASIC profiles
+//     since CII has no Factur-X-specific profile restrictions. This is a
+//     weaker check than (1): it validates that the XML is well-formed CII
+//     (correct elements, types, structure) but not the tighter
+//     profile-specific business rules Factur-X layers on top (e.g. which
+//     elements are mandatory/forbidden per profile).
 //
 // Run with: FOLIO_FACTURX_XSD_DIR=/path/to/schemas go test -tags xsdvalidate ./zugferd/
 func TestXSDValidation(t *testing.T) {
 	xsdDir := os.Getenv("FOLIO_FACTURX_XSD_DIR")
 	if xsdDir == "" {
-		t.Skip("FOLIO_FACTURX_XSD_DIR not set; the Factur-X schema package is not committed to this repo (unclear redistribution terms) — see plans/zugferd-20260813-xsd-validation.md")
+		t.Skip("FOLIO_FACTURX_XSD_DIR not set; no XSD schema package is committed to this repo — see zugferd/xsd_test.go for supported layouts")
 	}
 	if _, err := exec.LookPath("xmllint"); err != nil {
 		t.Skip("xmllint not installed")
 	}
+
+	const cii100pD16B = "CII/uncefact/data/standard/CrossIndustryInvoice_100pD16B.xsd"
+
 	cases := []struct {
 		profile Profile
-		xsd     string // root XSD relative to FOLIO_FACTURX_XSD_DIR
+		// candidates are tried in order; the first that exists under
+		// FOLIO_FACTURX_XSD_DIR is used. This lets FOLIO_FACTURX_XSD_DIR
+		// point at either a Factur-X package checkout or a plain UNECE
+		// CII D16B schema extraction.
+		candidates []string
 	}{
-		{ProfileMinimum, "Factur-X_1.0.7_MINIMUM/Schema/Factur-X_1.07_MINIMUM.xsd"},
-		{ProfileBasic, "Factur-X_1.0.7_BASIC/Schema/Factur-X_1.07_BASIC.xsd"},
+		{ProfileMinimum, []string{
+			"Factur-X_1.0.7_MINIMUM/Schema/Factur-X_1.07_MINIMUM.xsd",
+			cii100pD16B,
+		}},
+		{ProfileBasic, []string{
+			"Factur-X_1.0.7_BASIC/Schema/Factur-X_1.07_BASIC.xsd",
+			cii100pD16B,
+		}},
 	}
 	for _, tc := range cases {
-		t.Run(tc.xsd, func(t *testing.T) {
+		t.Run(tc.candidates[0], func(t *testing.T) {
+			var schema string
+			for _, c := range tc.candidates {
+				p := filepath.Join(xsdDir, c)
+				if _, err := os.Stat(p); err == nil {
+					schema = p
+					break
+				}
+			}
+			if schema == "" {
+				t.Skipf("no schema found under %s among candidates %v", xsdDir, tc.candidates)
+			}
+
 			xml, err := sampleInvoice().XML(tc.profile)
 			if err != nil {
 				t.Fatalf("XML: %v", err)
@@ -51,13 +92,9 @@ func TestXSDValidation(t *testing.T) {
 			if err := os.WriteFile(f, xml, 0o644); err != nil {
 				t.Fatal(err)
 			}
-			schema := filepath.Join(xsdDir, tc.xsd)
-			if _, err := os.Stat(schema); err != nil {
-				t.Skipf("schema not found at %s: %v", schema, err)
-			}
 			out, err := exec.Command("xmllint", "--noout", "--schema", schema, f).CombinedOutput()
 			if err != nil {
-				t.Errorf("XSD validation failed:\n%s", out)
+				t.Errorf("XSD validation failed against %s:\n%s", schema, out)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Three bug fixes surfaced during the hardening pass, plus CI-side schema validation for e-invoices.

### reader
- The tolerant xref repair scan matched any `N G <keyword>` sequence as an object header, so an indirect reference like `1 0 R` in scanned content corrupted the reconstructed xref map (one-character bug: `&&` for `||`). The scan now requires the `obj` keyword. A malformed-input test fixture whose `startxref` offset made it pass for the wrong reason is also corrected.

### sign
- `AddDocumentTimestamp` dropped a document's pre-existing AcroForm fields whenever `/AcroForm` was an indirect reference (the normal case), so the original signature field vanished from the form tree of a timestamped PDF. Indirect references are now resolved and fields carried over.
- `SignatureResult` gains `IsDocTimeStamp`, classified from the `/V` dictionary (`/Type /DocTimeStamp` or `ETSI.RFC3161` subfilter), so document timestamps are no longer reported as ordinary signatures. `Verify` on a signed-then-timestamped PDF now reports both entries, correctly classified.

### zugferd
- Generated CII XML omitted the required `ram:ApplicableHeaderTradeDelivery` element (minOccurs=1), making every Factur-X invoice schema-invalid against the official CII XSDs. It is now always emitted. Found by running the new schema validation.
- XSD validation (behind the `xsdvalidate` build tag) accepts both the Factur-X package layout and the plain UN/CEFACT CII D16B layout.

### ci
- Downloads and caches the UN/CEFACT CII D16B schemas at build time (unece.org first, pinned GitHub mirror `ConnectingEurope/eInvoicing-EN16931@b6c9e06` as fallback — schemas are never committed to the repo) and runs the XSD validation test; all schema steps guarded to Linux so the OS matrix legs are unaffected.

## Test plan
- `go build ./...`, `go vet ./...` clean; `go test ./...` green
- New tests: `TestRepairXrefSkipsIndirectReferences`, `TestAddDocumentTimestamp` (now asserts 2 correctly-classified entries), `TestAddDocumentTimestamp_DirectAcroFormDict`, XSD validation passing (not skipping) against downloaded schemas locally