### PR TITLE
image: PNG IDAT passthrough (issue #442)

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -22,8 +22,9 @@ type Image struct {
 	smaskH     int    // smask height
 	adobeCMYK  bool   // Adobe-style inverted CMYK (APP14 marker, ncomp==4)
 
-	preCompressed   bool // data is already a FlateDecode (zlib) payload
-	predictorColors int  // /Colors for the PNG predictor; 0 = no predictor
+	preCompressed   bool           // data is already a FlateDecode (zlib) payload
+	predictorColors int            // /Colors for the PNG predictor; 0 = no predictor
+	colorSpaceObj   core.PdfObject // overrides colorSpace when non-nil (e.g. /Indexed array)
 }
 
 // Width returns the image width in pixels.
@@ -144,7 +145,11 @@ func (img *Image) BuildXObject(addObject func(core.PdfObject) *core.PdfIndirectR
 	stream.Dict.Set("Subtype", core.NewPdfName("Image"))
 	stream.Dict.Set("Width", core.NewPdfInteger(img.width))
 	stream.Dict.Set("Height", core.NewPdfInteger(img.height))
-	stream.Dict.Set("ColorSpace", core.NewPdfName(img.colorSpace))
+	if img.colorSpaceObj != nil {
+		stream.Dict.Set("ColorSpace", img.colorSpaceObj)
+	} else {
+		stream.Dict.Set("ColorSpace", core.NewPdfName(img.colorSpace))
+	}
 	stream.Dict.Set("BitsPerComponent", core.NewPdfInteger(img.bpc))
 
 	// Adobe-written CMYK JPEGs store components in inverted form relative

--- a/image/image.go
+++ b/image/image.go
@@ -21,6 +21,9 @@ type Image struct {
 	smaskW     int    // smask width (same as image width for alpha)
 	smaskH     int    // smask height
 	adobeCMYK  bool   // Adobe-style inverted CMYK (APP14 marker, ncomp==4)
+
+	preCompressed   bool // data is already a FlateDecode (zlib) payload
+	predictorColors int  // /Colors for the PNG predictor; 0 = no predictor
 }
 
 // Width returns the image width in pixels.
@@ -113,12 +116,25 @@ func NewFromGoImage(src *goimage.RGBA) *Image {
 // registers each indirect object in the PDF file.
 func (img *Image) BuildXObject(addObject func(core.PdfObject) *core.PdfIndirectReference) (*core.PdfIndirectReference, *core.PdfIndirectReference) {
 	var stream *core.PdfStream
-	if img.filter == "DCTDecode" {
+	switch {
+	case img.filter == "DCTDecode":
 		// JPEG: raw bytes go directly, no compression by us.
 		stream = core.NewPdfStream(img.data)
 		stream.SetCompress(false)
 		stream.Dict.Set("Filter", core.NewPdfName("DCTDecode"))
-	} else {
+	case img.preCompressed:
+		// Payload is already a FlateDecode stream whose inflated bytes are
+		// PNG-predictor-filtered scanlines; the writer must not touch it.
+		stream = core.NewPdfStream(img.data)
+		stream.SetCompress(false)
+		stream.Dict.Set("Filter", core.NewPdfName("FlateDecode"))
+		parms := core.NewPdfDictionary()
+		parms.Set("Predictor", core.NewPdfInteger(15))
+		parms.Set("Colors", core.NewPdfInteger(img.predictorColors))
+		parms.Set("BitsPerComponent", core.NewPdfInteger(img.bpc))
+		parms.Set("Columns", core.NewPdfInteger(img.width))
+		stream.Dict.Set("DecodeParms", parms)
+	default:
 		// PNG: pixel data, compress with FlateDecode.
 		stream = core.NewPdfStreamCompressed(img.data)
 	}

--- a/image/png.go
+++ b/image/png.go
@@ -5,10 +5,15 @@ package image
 
 import (
 	"bytes"
+	"compress/zlib"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	goimage "image"
 	"image/color"
 	"image/png"
+	"io"
+	"math"
 )
 
 // NewPNG creates an Image from raw PNG data. It decodes the PNG and
@@ -22,6 +27,10 @@ func NewPNG(data []byte) (*Image, error) {
 	}
 	if err := checkDimensions(cfg.Width, cfg.Height); err != nil {
 		return nil, fmt.Errorf("image: png: %w", err)
+	}
+
+	if img := pngPassthrough(data); img != nil {
+		return img, nil
 	}
 
 	img, err := png.Decode(bytes.NewReader(data))
@@ -179,6 +188,137 @@ func buildRGBOnly(img goimage.Image, w, h int) (*Image, error) {
 		bpc:        8,
 		filter:     "FlateDecode",
 	}, nil
+}
+
+var pngSignature = [8]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+
+// pngPassthrough attempts to reuse a PNG's IDAT stream verbatim as a
+// FlateDecode image payload with a PNG predictor (ISO 32000-1 §7.4.4.4).
+// It returns nil when the file is not eligible; ineligibility is never an
+// error, the caller falls back to a full decode.
+func pngPassthrough(data []byte) *Image {
+	if len(data) < 8 || !bytes.Equal(data[:8], pngSignature[:]) {
+		return nil
+	}
+
+	var (
+		width, height                      int
+		bitDepth, colorType                byte
+		compression, filterMethod, interlc byte
+		sawIHDR                            bool
+		idat                               []byte
+	)
+
+	off := 8
+	for {
+		if off+8 > len(data) {
+			return nil
+		}
+		length := binary.BigEndian.Uint32(data[off : off+4])
+		if length > math.MaxInt32 {
+			return nil
+		}
+		typeStart := off + 4
+		payloadStart := typeStart + 4
+		payloadEnd := payloadStart + int(length)
+		crcEnd := payloadEnd + 4
+		if payloadEnd < 0 || crcEnd < 0 || crcEnd > len(data) {
+			return nil
+		}
+		chunkType := string(data[typeStart:payloadStart])
+		payload := data[payloadStart:payloadEnd]
+		storedCRC := binary.BigEndian.Uint32(data[payloadEnd:crcEnd])
+		if crc32.ChecksumIEEE(data[typeStart:payloadEnd]) != storedCRC {
+			return nil
+		}
+
+		switch chunkType {
+		case "IHDR":
+			if sawIHDR || len(payload) != 13 {
+				return nil
+			}
+			sawIHDR = true
+			width = int(binary.BigEndian.Uint32(payload[0:4]))
+			height = int(binary.BigEndian.Uint32(payload[4:8]))
+			bitDepth = payload[8]
+			colorType = payload[9]
+			compression = payload[10]
+			filterMethod = payload[11]
+			interlc = payload[12]
+
+			if bitDepth != 8 {
+				return nil
+			}
+			if colorType != 0 && colorType != 2 {
+				return nil
+			}
+			if compression != 0 || filterMethod != 0 {
+				return nil
+			}
+			if interlc != 0 {
+				return nil
+			}
+		case "tRNS":
+			return nil
+		case "IDAT":
+			if !sawIHDR {
+				return nil
+			}
+			idat = append(idat, payload...)
+		case "IEND":
+			goto walked
+		default:
+			if !sawIHDR {
+				return nil
+			}
+		}
+
+		off = crcEnd
+	}
+
+walked:
+	if !sawIHDR || len(idat) == 0 {
+		return nil
+	}
+	if err := checkDimensions(width, height); err != nil {
+		return nil
+	}
+
+	channels := 1
+	colorSpace := "DeviceGray"
+	if colorType == 2 {
+		channels = 3
+		colorSpace = "DeviceRGB"
+	}
+	rowBytes := width * channels
+	wantLen := int64(height) * int64(1+rowBytes)
+
+	zr, err := zlib.NewReader(bytes.NewReader(idat))
+	if err != nil {
+		return nil
+	}
+	n, err := io.Copy(io.Discard, zr)
+	if err != nil {
+		_ = zr.Close()
+		return nil
+	}
+	if err := zr.Close(); err != nil {
+		return nil
+	}
+	if n != wantLen {
+		return nil
+	}
+
+	return &Image{
+		data:            idat,
+		width:           width,
+		height:          height,
+		colorSpace:      colorSpace,
+		bpc:             8,
+		filter:          "FlateDecode",
+		preCompressed:   true,
+		predictorColors: channels,
+	}
 }
 
 // isGrayscale reports whether the image uses a grayscale color model.

--- a/image/png.go
+++ b/image/png.go
@@ -14,6 +14,8 @@ import (
 	"image/png"
 	"io"
 	"math"
+
+	"github.com/carlos7ags/folio/core"
 )
 
 // NewPNG creates an Image from raw PNG data. It decodes the PNG and
@@ -205,8 +207,9 @@ func pngPassthrough(data []byte) *Image {
 		width, height                      int
 		bitDepth, colorType                byte
 		compression, filterMethod, interlc byte
-		sawIHDR                            bool
+		sawIHDR, sawPLTE                   bool
 		idat                               []byte
+		palette                            []byte
 	)
 
 	off := 8
@@ -246,10 +249,18 @@ func pngPassthrough(data []byte) *Image {
 			filterMethod = payload[11]
 			interlc = payload[12]
 
-			if bitDepth != 8 {
-				return nil
-			}
-			if colorType != 0 && colorType != 2 {
+			switch colorType {
+			case 0, 2:
+				if bitDepth != 8 {
+					return nil
+				}
+			case 3:
+				switch bitDepth {
+				case 1, 2, 4, 8:
+				default:
+					return nil
+				}
+			default:
 				return nil
 			}
 			if compression != 0 || filterMethod != 0 {
@@ -258,10 +269,26 @@ func pngPassthrough(data []byte) *Image {
 			if interlc != 0 {
 				return nil
 			}
+		case "PLTE":
+			if !sawIHDR || colorType != 3 || sawPLTE || len(idat) > 0 {
+				return nil
+			}
+			if len(payload) == 0 || len(payload)%3 != 0 {
+				return nil
+			}
+			n := len(payload) / 3
+			if n > 256 || n > (1<<bitDepth) {
+				return nil
+			}
+			sawPLTE = true
+			palette = append([]byte{}, payload...)
 		case "tRNS":
 			return nil
 		case "IDAT":
 			if !sawIHDR {
+				return nil
+			}
+			if colorType == 3 && !sawPLTE {
 				return nil
 			}
 			idat = append(idat, payload...)
@@ -280,6 +307,9 @@ walked:
 	if !sawIHDR || len(idat) == 0 {
 		return nil
 	}
+	if colorType == 3 && !sawPLTE {
+		return nil
+	}
 	if err := checkDimensions(width, height); err != nil {
 		return nil
 	}
@@ -289,8 +319,10 @@ walked:
 	if colorType == 2 {
 		channels = 3
 		colorSpace = "DeviceRGB"
+	} else if colorType == 3 {
+		colorSpace = "Indexed"
 	}
-	rowBytes := width * channels
+	rowBytes := (width*channels*int(bitDepth) + 7) / 8
 	wantLen := int64(height) * int64(1+rowBytes)
 
 	zr, err := zlib.NewReader(bytes.NewReader(idat))
@@ -309,16 +341,29 @@ walked:
 		return nil
 	}
 
-	return &Image{
+	img := &Image{
 		data:            idat,
 		width:           width,
 		height:          height,
 		colorSpace:      colorSpace,
-		bpc:             8,
+		bpc:             int(bitDepth),
 		filter:          "FlateDecode",
 		preCompressed:   true,
-		predictorColors: channels,
+		predictorColors: 1,
 	}
+	if colorType == 0 || colorType == 2 {
+		img.predictorColors = channels
+	}
+	if colorType == 3 {
+		n := len(palette) / 3
+		img.colorSpaceObj = core.NewPdfArray(
+			core.NewPdfName("Indexed"),
+			core.NewPdfName("DeviceRGB"),
+			core.NewPdfInteger(n-1),
+			core.NewPdfHexString(string(palette)),
+		)
+	}
+	return img
 }
 
 // isGrayscale reports whether the image uses a grayscale color model.

--- a/image/png_test.go
+++ b/image/png_test.go
@@ -5,12 +5,14 @@ package image
 
 import (
 	"bytes"
+	"compress/zlib"
 	"encoding/binary"
 	"errors"
 	"hash/crc32"
 	goimage "image"
 	"image/color"
 	"image/png"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -448,5 +450,317 @@ func TestNewFromGoImageInvalidStride(t *testing.T) {
 	img := NewFromGoImage(rgba)
 	if img != nil {
 		t.Error("expected nil for invalid stride")
+	}
+}
+
+// varyingGrayPNG builds an opaque grayscale PNG whose pixel values vary
+// enough (gradient plus noise) that the encoder is likely to choose more
+// than one row filter.
+func varyingGrayPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	src := goimage.NewGray(goimage.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			v := byte((x*7 + y*13) % 256)
+			src.SetGray(x, y, color.Gray{Y: v})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, src); err != nil {
+		t.Fatalf("png.Encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// varyingRGBPNG builds an opaque truecolor PNG whose pixel values vary
+// enough (gradient plus noise) that the encoder is likely to choose more
+// than one row filter.
+func varyingRGBPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	src := goimage.NewRGBA(goimage.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			src.Set(x, y, color.RGBA{
+				R: byte((x*7 + y*3) % 256),
+				G: byte((x*11 + y*17) % 256),
+				B: byte((x*5 + y*23) % 256),
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, src); err != nil {
+		t.Fatalf("png.Encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// findIDATOffset returns the file offset of the first byte of the first
+// IDAT chunk's payload.
+func findIDATOffset(t *testing.T, data []byte) int {
+	t.Helper()
+	off := 8
+	for off+8 <= len(data) {
+		length := binary.BigEndian.Uint32(data[off : off+4])
+		typeStart := off + 4
+		payloadStart := typeStart + 4
+		chunkType := string(data[typeStart:payloadStart])
+		if chunkType == "IDAT" {
+			return payloadStart
+		}
+		off = payloadStart + int(length) + 4
+	}
+	t.Fatal("no IDAT chunk found")
+	return -1
+}
+
+// spliceChunk inserts a well-formed chunk of the given type and payload
+// immediately before the first occurrence of beforeType in data.
+func spliceChunk(t *testing.T, data []byte, chunkType string, payload []byte, beforeType string) []byte {
+	t.Helper()
+	off := 8
+	for off+8 <= len(data) {
+		length := binary.BigEndian.Uint32(data[off : off+4])
+		typeStart := off + 4
+		payloadStart := typeStart + 4
+		ct := string(data[typeStart:payloadStart])
+		if ct == beforeType {
+			lenBuf := make([]byte, 4)
+			binary.BigEndian.PutUint32(lenBuf, uint32(len(payload)))
+			chunk := append([]byte(chunkType), payload...)
+			crc := crc32.ChecksumIEEE(chunk)
+			crcBuf := make([]byte, 4)
+			binary.BigEndian.PutUint32(crcBuf, crc)
+			out := append([]byte{}, data[:off]...)
+			out = append(out, lenBuf...)
+			out = append(out, chunk...)
+			out = append(out, crcBuf...)
+			out = append(out, data[off:]...)
+			return out
+		}
+		off = payloadStart + int(length) + 4
+	}
+	t.Fatalf("chunk type %s not found", beforeType)
+	return nil
+}
+
+func TestPNGPassthroughEligibleGray(t *testing.T) {
+	data := varyingGrayPNG(t, 12, 9)
+	img, err := NewPNG(data)
+	if err != nil {
+		t.Fatalf("NewPNG: %v", err)
+	}
+	if !img.preCompressed {
+		t.Fatal("expected preCompressed for eligible grayscale PNG")
+	}
+	if img.predictorColors != 1 {
+		t.Errorf("expected predictorColors 1, got %d", img.predictorColors)
+	}
+	zr, err := zlib.NewReader(bytes.NewReader(img.data))
+	if err != nil {
+		t.Fatalf("zlib.NewReader: %v", err)
+	}
+	inflated, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("inflate: %v", err)
+	}
+	rowBytes := img.width * 1
+	if len(inflated) != img.height*(1+rowBytes) {
+		t.Fatalf("expected %d inflated bytes, got %d", img.height*(1+rowBytes), len(inflated))
+	}
+	for y := range img.height {
+		f := inflated[y*(1+rowBytes)]
+		if f > 4 {
+			t.Errorf("row %d: filter byte %d out of range 0..4", y, f)
+		}
+	}
+}
+
+func TestPNGPassthroughEligibleRGB(t *testing.T) {
+	data := varyingRGBPNG(t, 12, 9)
+	img, err := NewPNG(data)
+	if err != nil {
+		t.Fatalf("NewPNG: %v", err)
+	}
+	if !img.preCompressed {
+		t.Fatal("expected preCompressed for eligible truecolor PNG")
+	}
+	if img.predictorColors != 3 {
+		t.Errorf("expected predictorColors 3, got %d", img.predictorColors)
+	}
+	zr, err := zlib.NewReader(bytes.NewReader(img.data))
+	if err != nil {
+		t.Fatalf("zlib.NewReader: %v", err)
+	}
+	inflated, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("inflate: %v", err)
+	}
+	rowBytes := img.width * 3
+	if len(inflated) != img.height*(1+rowBytes) {
+		t.Fatalf("expected %d inflated bytes, got %d", img.height*(1+rowBytes), len(inflated))
+	}
+	for y := range img.height {
+		f := inflated[y*(1+rowBytes)]
+		if f > 4 {
+			t.Errorf("row %d: filter byte %d out of range 0..4", y, f)
+		}
+	}
+}
+
+func TestPNGPassthroughXObjectDict(t *testing.T) {
+	data := varyingRGBPNG(t, 6, 5)
+	img, err := NewPNG(data)
+	if err != nil {
+		t.Fatalf("NewPNG: %v", err)
+	}
+	if !img.preCompressed {
+		t.Fatal("expected preCompressed image")
+	}
+
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		return core.NewPdfIndirectReference(1, 0)
+	}
+	imgRef, _ := img.BuildXObject(addObject)
+	if imgRef == nil {
+		t.Fatal("expected non-nil image reference")
+	}
+}
+
+func TestPNGPassthroughFallbackTable(t *testing.T) {
+	t.Run("RGBA", func(t *testing.T) {
+		src := goimage.NewNRGBA(goimage.Rect(0, 0, 4, 4))
+		for y := range 4 {
+			for x := range 4 {
+				src.SetNRGBA(x, y, color.NRGBA{R: 10, G: 20, B: 30, A: 200})
+			}
+		}
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, src); err != nil {
+			t.Fatalf("png.Encode: %v", err)
+		}
+		img, err := NewPNG(buf.Bytes())
+		if err != nil {
+			t.Fatalf("NewPNG: %v", err)
+		}
+		if img.preCompressed {
+			t.Error("expected fallback for RGBA (colour type 6)")
+		}
+	})
+
+	t.Run("GrayAlpha", func(t *testing.T) {
+		grayAlpha := goimage.NewNRGBA(goimage.Rect(0, 0, 4, 4))
+		for y := range 4 {
+			for x := range 4 {
+				grayAlpha.SetNRGBA(x, y, color.NRGBA{R: 50, G: 50, B: 50, A: 100})
+			}
+		}
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, grayAlpha); err != nil {
+			t.Fatalf("png.Encode: %v", err)
+		}
+		img, err := NewPNG(buf.Bytes())
+		if err != nil {
+			t.Fatalf("NewPNG: %v", err)
+		}
+		if img.preCompressed {
+			t.Error("expected fallback for non-opaque image")
+		}
+	})
+
+	t.Run("Palette", func(t *testing.T) {
+		pal := color.Palette{
+			color.RGBA{R: 255, G: 0, B: 0, A: 255},
+			color.RGBA{R: 0, G: 255, B: 0, A: 255},
+		}
+		src := goimage.NewPaletted(goimage.Rect(0, 0, 4, 4), pal)
+		for y := range 4 {
+			for x := range 4 {
+				src.SetColorIndex(x, y, uint8((x+y)%2))
+			}
+		}
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, src); err != nil {
+			t.Fatalf("png.Encode: %v", err)
+		}
+		img, err := NewPNG(buf.Bytes())
+		if err != nil {
+			t.Fatalf("NewPNG: %v", err)
+		}
+		if img.preCompressed {
+			t.Error("expected fallback for paletted PNG (colour type 3)")
+		}
+	})
+
+	t.Run("SixteenBit", func(t *testing.T) {
+		src := goimage.NewGray16(goimage.Rect(0, 0, 4, 4))
+		for y := range 4 {
+			for x := range 4 {
+				src.SetGray16(x, y, color.Gray16{Y: uint16((x + y) * 1000)})
+			}
+		}
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, src); err != nil {
+			t.Fatalf("png.Encode: %v", err)
+		}
+		img, err := NewPNG(buf.Bytes())
+		if err != nil {
+			t.Fatalf("NewPNG: %v", err)
+		}
+		if img.preCompressed {
+			t.Error("expected fallback for 16-bit PNG")
+		}
+	})
+
+	t.Run("Interlaced", func(t *testing.T) {
+		data := varyingRGBPNG(t, 4, 4)
+		off := 8
+		length := binary.BigEndian.Uint32(data[off : off+4])
+		payloadStart := off + 8
+		if string(data[off+4:payloadStart]) != "IHDR" {
+			t.Fatal("expected IHDR as first chunk")
+		}
+		payload := append([]byte{}, data[payloadStart:payloadStart+int(length)]...)
+		payload[12] = 1 // interlace method: Adam7
+		chunk := append([]byte("IHDR"), payload...)
+		crc := crc32.ChecksumIEEE(chunk)
+		crcBuf := make([]byte, 4)
+		binary.BigEndian.PutUint32(crcBuf, crc)
+		out := append([]byte{}, data[:payloadStart]...)
+		out = append(out, payload...)
+		out = append(out, crcBuf...)
+		out = append(out, data[payloadStart+int(length)+4:]...)
+
+		img := pngPassthrough(out)
+		if img != nil {
+			t.Error("expected nil for interlaced PNG")
+		}
+	})
+
+	t.Run("TRNS", func(t *testing.T) {
+		data := varyingRGBPNG(t, 4, 4)
+		spliced := spliceChunk(t, data, "tRNS", []byte{0, 0, 0, 0, 0, 0}, "IDAT")
+		img, err := NewPNG(spliced)
+		if err != nil {
+			t.Fatalf("NewPNG: %v", err)
+		}
+		if img.preCompressed {
+			t.Error("expected fallback for truecolor PNG carrying tRNS")
+		}
+	})
+}
+
+func TestPNGPassthroughCorruptIDATFallsBackToError(t *testing.T) {
+	data := varyingRGBPNG(t, 8, 8)
+	idatOff := findIDATOffset(t, data)
+	corrupt := append([]byte{}, data...)
+	corrupt[idatOff+3] ^= 0xFF // flip a bit inside the IDAT payload; CRC now stale
+
+	if _, decodeErr := png.Decode(bytes.NewReader(corrupt)); decodeErr == nil {
+		t.Fatal("test setup invalid: expected stdlib decode to fail on corrupted IDAT")
+	}
+
+	if _, err := NewPNG(corrupt); err == nil {
+		t.Fatal("expected NewPNG to return an error on corrupted IDAT, not a silent passthrough")
 	}
 }

--- a/image/png_test.go
+++ b/image/png_test.go
@@ -8,6 +8,7 @@ import (
 	"compress/zlib"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"hash/crc32"
 	goimage "image"
 	"image/color"
@@ -668,30 +669,6 @@ func TestPNGPassthroughFallbackTable(t *testing.T) {
 		}
 	})
 
-	t.Run("Palette", func(t *testing.T) {
-		pal := color.Palette{
-			color.RGBA{R: 255, G: 0, B: 0, A: 255},
-			color.RGBA{R: 0, G: 255, B: 0, A: 255},
-		}
-		src := goimage.NewPaletted(goimage.Rect(0, 0, 4, 4), pal)
-		for y := range 4 {
-			for x := range 4 {
-				src.SetColorIndex(x, y, uint8((x+y)%2))
-			}
-		}
-		var buf bytes.Buffer
-		if err := png.Encode(&buf, src); err != nil {
-			t.Fatalf("png.Encode: %v", err)
-		}
-		img, err := NewPNG(buf.Bytes())
-		if err != nil {
-			t.Fatalf("NewPNG: %v", err)
-		}
-		if img.preCompressed {
-			t.Error("expected fallback for paletted PNG (colour type 3)")
-		}
-	})
-
 	t.Run("SixteenBit", func(t *testing.T) {
 		src := goimage.NewGray16(goimage.Rect(0, 0, 4, 4))
 		for y := range 4 {
@@ -763,4 +740,232 @@ func TestPNGPassthroughCorruptIDATFallsBackToError(t *testing.T) {
 	if _, err := NewPNG(corrupt); err == nil {
 		t.Fatal("expected NewPNG to return an error on corrupted IDAT, not a silent passthrough")
 	}
+}
+
+// buildChunk assembles a length-prefixed, CRC-terminated PNG chunk.
+func buildChunk(chunkType string, payload []byte) []byte {
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(payload)))
+	body := append([]byte(chunkType), payload...)
+	crc := crc32.ChecksumIEEE(body)
+	crcBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(crcBuf, crc)
+	out := append([]byte{}, lenBuf...)
+	out = append(out, body...)
+	out = append(out, crcBuf...)
+	return out
+}
+
+// craftPalettedPNG hand-builds a colour-type-3 PNG at the given bit depth
+// with filter type 0 (None) on every scanline, so the caller controls the
+// exact packed-index layout.
+func craftPalettedPNG(t *testing.T, w, h int, bitDepth int, palette []byte, indices [][]int) []byte {
+	t.Helper()
+	rowBytes := (w*bitDepth + 7) / 8
+	var raw []byte
+	for y := range h {
+		row := make([]byte, rowBytes)
+		for x := range w {
+			idx := byte(indices[y][x])
+			bitOff := x * bitDepth
+			byteOff := bitOff / 8
+			shift := 8 - bitDepth - (bitOff % 8)
+			row[byteOff] |= idx << shift
+		}
+		raw = append(raw, 0) // filter type 0
+		raw = append(raw, row...)
+	}
+
+	var zbuf bytes.Buffer
+	zw := zlib.NewWriter(&zbuf)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], uint32(w))
+	binary.BigEndian.PutUint32(ihdr[4:8], uint32(h))
+	ihdr[8] = byte(bitDepth)
+	ihdr[9] = 3 // colour type: palette
+
+	out := append([]byte{}, pngSignature[:]...)
+	out = append(out, buildChunk("IHDR", ihdr)...)
+	out = append(out, buildChunk("PLTE", palette)...)
+	out = append(out, buildChunk("IDAT", zbuf.Bytes())...)
+	out = append(out, buildChunk("IEND", nil)...)
+	return out
+}
+
+func TestPNGPassthroughPaletteRouting(t *testing.T) {
+	for _, bitDepth := range []int{1, 2, 4, 8} {
+		t.Run(fmt.Sprintf("depth%d", bitDepth), func(t *testing.T) {
+			maxIdx := 1 << bitDepth
+			if maxIdx > 256 {
+				maxIdx = 256
+			}
+			palette := make([]byte, 0, maxIdx*3)
+			for i := range maxIdx {
+				palette = append(palette, byte(i), byte(i*2), byte(i*3))
+			}
+			w, h := 6, 5
+			indices := make([][]int, h)
+			for y := range h {
+				indices[y] = make([]int, w)
+				for x := range w {
+					indices[y][x] = (x + y) % maxIdx
+				}
+			}
+			data := craftPalettedPNG(t, w, h, bitDepth, palette, indices)
+
+			img, err := NewPNG(data)
+			if err != nil {
+				t.Fatalf("NewPNG: %v", err)
+			}
+			if !img.preCompressed {
+				t.Fatal("expected preCompressed for eligible paletted PNG")
+			}
+			if img.predictorColors != 1 {
+				t.Errorf("expected predictorColors 1, got %d", img.predictorColors)
+			}
+			if img.bpc != bitDepth {
+				t.Errorf("expected bpc %d, got %d", bitDepth, img.bpc)
+			}
+
+			zr, err := zlib.NewReader(bytes.NewReader(img.data))
+			if err != nil {
+				t.Fatalf("zlib.NewReader: %v", err)
+			}
+			inflated, err := io.ReadAll(zr)
+			if err != nil {
+				t.Fatalf("inflate: %v", err)
+			}
+			rowBytes := (w*bitDepth + 7) / 8
+			wantLen := h * (1 + rowBytes)
+			if len(inflated) != wantLen {
+				t.Fatalf("expected %d inflated bytes, got %d", wantLen, len(inflated))
+			}
+		})
+	}
+}
+
+func TestPNGPassthroughPaletteXObjectDict(t *testing.T) {
+	palette := []byte{255, 0, 0, 0, 255, 0, 0, 0, 255, 128, 128, 128}
+	w, h := 4, 4
+	indices := make([][]int, h)
+	for y := range h {
+		indices[y] = make([]int, w)
+		for x := range w {
+			indices[y][x] = (x + y) % 4
+		}
+	}
+	data := craftPalettedPNG(t, w, h, 8, palette, indices)
+
+	img, err := NewPNG(data)
+	if err != nil {
+		t.Fatalf("NewPNG: %v", err)
+	}
+	if !img.preCompressed {
+		t.Fatal("expected preCompressed image")
+	}
+	arr, ok := img.colorSpaceObj.(*core.PdfArray)
+	if !ok {
+		t.Fatalf("expected colorSpaceObj to be a *core.PdfArray, got %T", img.colorSpaceObj)
+	}
+	if arr.Len() != 4 {
+		t.Fatalf("expected 4-element colour space array, got %d", arr.Len())
+	}
+	name0, ok := arr.At(0).(*core.PdfName)
+	if !ok || name0.Value != "Indexed" {
+		t.Errorf("expected element 0 to be /Indexed, got %v", arr.At(0))
+	}
+	name1, ok := arr.At(1).(*core.PdfName)
+	if !ok || name1.Value != "DeviceRGB" {
+		t.Errorf("expected element 1 to be /DeviceRGB, got %v", arr.At(1))
+	}
+	hival, ok := arr.At(2).(*core.PdfNumber)
+	if !ok || hival.IntValue() != len(palette)/3-1 {
+		t.Errorf("expected hival %d, got %v", len(palette)/3-1, arr.At(2))
+	}
+	lookup, ok := arr.At(3).(*core.PdfString)
+	if !ok || lookup.Text() != string(palette) {
+		t.Errorf("expected lookup table to equal PLTE payload")
+	}
+	if img.bpc != 8 {
+		t.Errorf("expected BitsPerComponent 8, got %d", img.bpc)
+	}
+
+	addObject := func(obj core.PdfObject) *core.PdfIndirectReference {
+		return core.NewPdfIndirectReference(1, 0)
+	}
+	imgRef, _ := img.BuildXObject(addObject)
+	if imgRef == nil {
+		t.Fatal("expected non-nil image reference")
+	}
+}
+
+func TestPNGPassthroughPaletteFallback(t *testing.T) {
+	basePalette := []byte{255, 0, 0, 0, 255, 0, 0, 0, 255, 128, 128, 128}
+	w, h := 4, 4
+	indices := make([][]int, h)
+	for y := range h {
+		indices[y] = make([]int, w)
+		for x := range w {
+			indices[y][x] = (x + y) % 4
+		}
+	}
+
+	t.Run("TRNS", func(t *testing.T) {
+		data := craftPalettedPNG(t, w, h, 8, basePalette, indices)
+		spliced := spliceChunk(t, data, "tRNS", []byte{255, 255, 255, 0}, "IDAT")
+		img, err := NewPNG(spliced)
+		if err != nil {
+			t.Fatalf("NewPNG: %v", err)
+		}
+		if img.preCompressed {
+			t.Error("expected fallback for paletted PNG carrying tRNS")
+		}
+	})
+
+	t.Run("Interlaced", func(t *testing.T) {
+		data := craftPalettedPNG(t, w, h, 8, basePalette, indices)
+		// IHDR interlace byte is the 13th (last) byte of the 13-byte
+		// payload, immediately preceding its CRC.
+		ihdrPayloadEnd := 8 + 8 + 13 // signature + (len+type) + payload
+		data[ihdrPayloadEnd-1] = 1
+		// Recompute the IHDR CRC so the chunk walk's CRC check does not
+		// reject the file before eligibility is even considered.
+		chunkStart := 8 + 4 // signature + length field
+		crc := crc32.ChecksumIEEE(data[chunkStart:ihdrPayloadEnd])
+		binary.BigEndian.PutUint32(data[ihdrPayloadEnd:ihdrPayloadEnd+4], crc)
+
+		img := pngPassthrough(data)
+		if img != nil {
+			t.Error("expected nil for interlaced paletted PNG")
+		}
+	})
+
+	t.Run("OversizedPLTE", func(t *testing.T) {
+		// bitDepth 1 permits at most 2 palette entries; supply 4.
+		oversizedPalette := []byte{
+			255, 0, 0,
+			0, 255, 0,
+			0, 0, 255,
+			255, 255, 255,
+		}
+		oneBitIndices := make([][]int, h)
+		for y := range h {
+			oneBitIndices[y] = make([]int, w)
+			for x := range w {
+				oneBitIndices[y][x] = (x + y) % 2
+			}
+		}
+		data := craftPalettedPNG(t, w, h, 1, oversizedPalette, oneBitIndices)
+		img := pngPassthrough(data)
+		if img != nil {
+			t.Error("expected nil for PLTE larger than 1<<bitDepth entries")
+		}
+	})
 }

--- a/reader/png_passthrough_test.go
+++ b/reader/png_passthrough_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package reader_test
+
+import (
+	"bytes"
+	goimage "image"
+	"image/color"
+	"image/png"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/core"
+	"github.com/carlos7ags/folio/document"
+	folioimage "github.com/carlos7ags/folio/image"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// buildGrayPNGRoundTrip builds an opaque grayscale PNG with varied pixel
+// values (gradient plus noise), embeds it in a one-page document, and
+// returns both the written PDF bytes and the flattened pixel bytes the
+// pre-passthrough decode path would have produced.
+func buildGrayPNGRoundTrip(t *testing.T, w, h int) (pdfBytes, wantPixels []byte) {
+	t.Helper()
+	src := goimage.NewGray(goimage.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			src.SetGray(x, y, color.Gray{Y: byte((x*7 + y*13) % 256)})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, src); err != nil {
+		t.Fatalf("png.Encode: %v", err)
+	}
+
+	want := make([]byte, 0, w*h)
+	for y := range h {
+		for x := range w {
+			r, _, _, _ := src.At(x, y).RGBA()
+			want = append(want, byte(r>>8))
+		}
+	}
+
+	pdfBytes = embedInDocument(t, buf.Bytes())
+	return pdfBytes, want
+}
+
+// buildRGBPNGRoundTrip is the truecolor counterpart of
+// buildGrayPNGRoundTrip.
+func buildRGBPNGRoundTrip(t *testing.T, w, h int) (pdfBytes, wantPixels []byte) {
+	t.Helper()
+	src := goimage.NewRGBA(goimage.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			src.Set(x, y, color.RGBA{
+				R: byte((x*7 + y*3) % 256),
+				G: byte((x*11 + y*17) % 256),
+				B: byte((x*5 + y*23) % 256),
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, src); err != nil {
+		t.Fatalf("png.Encode: %v", err)
+	}
+
+	want := make([]byte, 0, w*h*3)
+	for y := range h {
+		for x := range w {
+			r, g, b, _ := src.At(x, y).RGBA()
+			want = append(want, byte(r>>8), byte(g>>8), byte(b>>8))
+		}
+	}
+
+	pdfBytes = embedInDocument(t, buf.Bytes())
+	return pdfBytes, want
+}
+
+func embedInDocument(t *testing.T, pngBytes []byte) []byte {
+	t.Helper()
+	img, err := folioimage.NewPNG(pngBytes)
+	if err != nil {
+		t.Fatalf("folioimage.NewPNG: %v", err)
+	}
+	doc := document.NewDocument(document.PageSizeLetter)
+	p := doc.AddPage()
+	p.AddImage(img, 72, 600, float64(img.Width()), float64(img.Height()))
+
+	var out bytes.Buffer
+	if _, err := doc.WriteTo(&out); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	return out.Bytes()
+}
+
+// resolveImageXObject parses pdfBytes, finds the page's "Im1" XObject, and
+// returns the resolved stream (Data already inflated and, if the stream
+// carried a PNG predictor, un-predicted by the reader).
+func resolveImageXObject(t *testing.T, pdfBytes []byte) *core.PdfStream {
+	t.Helper()
+	r, err := reader.Parse(pdfBytes)
+	if err != nil {
+		t.Fatalf("reader.Parse: %v", err)
+	}
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	resources, err := page.Resources()
+	if err != nil {
+		t.Fatalf("Resources: %v", err)
+	}
+	xobjDictObj, err := r.ResolveObject(resources.Get("XObject"))
+	if err != nil {
+		t.Fatalf("resolve XObject dict: %v", err)
+	}
+	xobjDict, ok := xobjDictObj.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("expected XObject to resolve to a dictionary, got %T", xobjDictObj)
+	}
+	imRef := xobjDict.Get("Im1")
+	if imRef == nil {
+		t.Fatal("expected /Im1 XObject entry")
+	}
+	imObj, err := r.ResolveObject(imRef)
+	if err != nil {
+		t.Fatalf("resolve Im1: %v", err)
+	}
+	stream, ok := imObj.(*core.PdfStream)
+	if !ok {
+		t.Fatalf("expected Im1 to resolve to a stream, got %T", imObj)
+	}
+	return stream
+}
+
+func TestPNGPassthroughRoundTripGray(t *testing.T) {
+	pdfBytes, want := buildGrayPNGRoundTrip(t, 16, 11)
+
+	pdf := string(pdfBytes)
+	if !strings.Contains(pdf, "/Filter /FlateDecode") {
+		t.Error("expected /Filter /FlateDecode in written PDF")
+	}
+	if !strings.Contains(pdf, "/DecodeParms") {
+		t.Error("expected /DecodeParms in written PDF")
+	}
+	if !strings.Contains(pdf, "/Predictor 15") {
+		t.Error("expected /Predictor 15 in written PDF")
+	}
+	if !strings.Contains(pdf, "/Colors 1") {
+		t.Error("expected /Colors 1 in written PDF")
+	}
+
+	stream := resolveImageXObject(t, pdfBytes)
+	if !bytes.Equal(stream.Data, want) {
+		t.Fatalf("predictor-decoded bytes mismatch: got %d bytes, want %d bytes", len(stream.Data), len(want))
+	}
+}
+
+func TestPNGPassthroughRoundTripRGB(t *testing.T) {
+	pdfBytes, want := buildRGBPNGRoundTrip(t, 16, 11)
+
+	pdf := string(pdfBytes)
+	if !strings.Contains(pdf, "/Filter /FlateDecode") {
+		t.Error("expected /Filter /FlateDecode in written PDF")
+	}
+	if !strings.Contains(pdf, "/DecodeParms") {
+		t.Error("expected /DecodeParms in written PDF")
+	}
+	if !strings.Contains(pdf, "/Predictor 15") {
+		t.Error("expected /Predictor 15 in written PDF")
+	}
+	if !strings.Contains(pdf, "/Colors 3") {
+		t.Error("expected /Colors 3 in written PDF")
+	}
+
+	stream := resolveImageXObject(t, pdfBytes)
+	if !bytes.Equal(stream.Data, want) {
+		t.Fatalf("predictor-decoded bytes mismatch: got %d bytes, want %d bytes", len(stream.Data), len(want))
+	}
+}

--- a/reader/png_passthrough_test.go
+++ b/reader/png_passthrough_test.go
@@ -5,6 +5,9 @@ package reader_test
 
 import (
 	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"hash/crc32"
 	goimage "image"
 	"image/color"
 	"image/png"
@@ -179,4 +182,138 @@ func TestPNGPassthroughRoundTripRGB(t *testing.T) {
 	if !bytes.Equal(stream.Data, want) {
 		t.Fatalf("predictor-decoded bytes mismatch: got %d bytes, want %d bytes", len(stream.Data), len(want))
 	}
+}
+
+// buildChunk assembles a length-prefixed, CRC-terminated PNG chunk.
+func buildChunk(chunkType string, payload []byte) []byte {
+	lenBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBuf, uint32(len(payload)))
+	body := append([]byte(chunkType), payload...)
+	crc := crc32.ChecksumIEEE(body)
+	crcBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(crcBuf, crc)
+	out := append([]byte{}, lenBuf...)
+	out = append(out, body...)
+	out = append(out, crcBuf...)
+	return out
+}
+
+// craftPalettedPNG hand-builds a colour-type-3 PNG at the given bit depth
+// with filter type 0 (None) on every scanline, so the caller controls the
+// exact packed-index layout.
+func craftPalettedPNG(t *testing.T, w, h int, bitDepth int, palette []byte, indices [][]int) []byte {
+	t.Helper()
+	rowBytes := (w*bitDepth + 7) / 8
+	var raw []byte
+	for y := range h {
+		row := make([]byte, rowBytes)
+		for x := range w {
+			idx := byte(indices[y][x])
+			bitOff := x * bitDepth
+			byteOff := bitOff / 8
+			shift := 8 - bitDepth - (bitOff % 8)
+			row[byteOff] |= idx << shift
+		}
+		raw = append(raw, 0) // filter type 0
+		raw = append(raw, row...)
+	}
+
+	var zbuf bytes.Buffer
+	zw := zlib.NewWriter(&zbuf)
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+
+	ihdr := make([]byte, 13)
+	binary.BigEndian.PutUint32(ihdr[0:4], uint32(w))
+	binary.BigEndian.PutUint32(ihdr[4:8], uint32(h))
+	ihdr[8] = byte(bitDepth)
+	ihdr[9] = 3 // colour type: palette
+
+	sig := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+	out := append([]byte{}, sig...)
+	out = append(out, buildChunk("IHDR", ihdr)...)
+	out = append(out, buildChunk("PLTE", palette)...)
+	out = append(out, buildChunk("IDAT", zbuf.Bytes())...)
+	out = append(out, buildChunk("IEND", nil)...)
+	return out
+}
+
+// unpackIndices unpacks one row's palette indices from bit-packed bytes.
+func unpackIndices(row []byte, w, bitDepth int) []int {
+	out := make([]int, w)
+	for x := range w {
+		bitOff := x * bitDepth
+		byteOff := bitOff / 8
+		shift := 8 - bitDepth - (bitOff % 8)
+		mask := byte(1<<bitDepth) - 1
+		out[x] = int((row[byteOff] >> shift) & mask)
+	}
+	return out
+}
+
+func testPalettedRoundTrip(t *testing.T, w, h, bitDepth int) {
+	t.Helper()
+	maxIdx := 1 << bitDepth
+	if maxIdx > 256 {
+		maxIdx = 256
+	}
+	palette := make([]byte, 0, maxIdx*3)
+	for i := range maxIdx {
+		palette = append(palette, byte(i*7%256), byte(i*13%256), byte(i*29%256))
+	}
+	indices := make([][]int, h)
+	for y := range h {
+		indices[y] = make([]int, w)
+		for x := range w {
+			indices[y][x] = (x + y) % maxIdx
+		}
+	}
+	pngBytes := craftPalettedPNG(t, w, h, bitDepth, palette, indices)
+
+	// Ground truth: what a full decode would produce.
+	decoded, err := png.Decode(bytes.NewReader(pngBytes))
+	if err != nil {
+		t.Fatalf("png.Decode: %v", err)
+	}
+	var want []byte
+	bounds := decoded.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, _ := decoded.At(x, y).RGBA()
+			want = append(want, byte(r>>8), byte(g>>8), byte(b>>8))
+		}
+	}
+
+	pdfBytes := embedInDocument(t, pngBytes)
+	stream := resolveImageXObject(t, pdfBytes)
+
+	rowBytes := (w*bitDepth + 7) / 8
+	if len(stream.Data) != h*rowBytes {
+		t.Fatalf("expected %d predictor-decoded bytes, got %d", h*rowBytes, len(stream.Data))
+	}
+
+	var got []byte
+	for y := range h {
+		row := stream.Data[y*rowBytes : (y+1)*rowBytes]
+		idxRow := unpackIndices(row, w, bitDepth)
+		for _, idx := range idxRow {
+			got = append(got, palette[idx*3], palette[idx*3+1], palette[idx*3+2])
+		}
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("index-through-palette bytes mismatch at bit depth %d", bitDepth)
+	}
+}
+
+func TestPNGPassthroughRoundTripPaletteDepth4(t *testing.T) {
+	testPalettedRoundTrip(t, 10, 7, 4)
+}
+
+func TestPNGPassthroughRoundTripPaletteDepth8(t *testing.T) {
+	testPalettedRoundTrip(t, 10, 7, 8)
 }


### PR DESCRIPTION
Embeds eligible PNGs' IDAT streams verbatim as /FlateDecode image XObjects with a PNG predictor (/DecodeParms /Predictor 15, ISO 32000-1 §7.4.4.4) instead of decoding to raw pixels and re-deflating at BestCompression. Removes both the decode and the re-encode for the common case, and preserves the source encoder's filter choices (usually smaller output).

Part of #442.

Commit 1 — truecolor/grayscale passthrough:
- Eligible: color type 0 or 2, bit depth 8, non-interlaced, no tRNS. Everything else falls back to the existing decode path unchanged.
- Hand-rolled stdlib chunk walk: per-chunk CRC-32, bounds/overflow guards, multi-IDAT concatenation.
- Corrupt-PNG error contract preserved: the zlib payload is inflated to io.Discard and must yield exactly height*(1+rowBytes) bytes, else fallback.
- Dimension limits enforced before the fast path.

Commit 2 — paletted PNGs as /Indexed:
- Color type 3 at depths 1/2/4/8 passes through with an /Indexed DeviceRGB color space; tRNS/interlaced/oversized-PLTE fall back.

Interaction notes:
- Streams are pre-compressed with SetCompress(false) and carry /DecodeParms, so RecompressStreams skips them by its existing eligibility rules.
- Reader round-trip tests decode the emitted XObjects via the existing /Predictor 15 support and compare pixel-exactly against png.Decode.

Verification: make check and go test ./... -race -count=1 green; 60s FuzzNewPNG clean; new tests cover gray, RGB, palette depths 4/8 round trips and every fallback path.