### PR TITLE
perf: eliminate redundant image embedding and stream re-compression in the writer (#442)

### DIFF
--- a/core/stream.go
+++ b/core/stream.go
@@ -17,6 +17,8 @@ type PdfStream struct {
 	Dict     *PdfDictionary
 	Data     []byte
 	compress bool // if true, apply FlateDecode on WriteTo
+	levelSet bool // whether SetCompressLevel was called
+	level    int  // zlib level to use when levelSet is true
 }
 
 // NewPdfStream creates a stream with the given data (uncompressed).
@@ -44,6 +46,28 @@ func (s *PdfStream) SetCompress(enabled bool) {
 	s.compress = enabled
 }
 
+// SetCompressLevel selects the zlib level WriteTo uses when compressing
+// this stream (see compress/zlib level constants, e.g. zlib.BestSpeed,
+// zlib.DefaultCompression, zlib.NoCompression, zlib.HuffmanOnly). It has
+// no effect unless the stream is also set to compress (SetCompress(true)
+// or NewPdfStreamCompressed). Without a call to SetCompressLevel, WriteTo
+// uses zlib.BestCompression, matching historical behavior.
+func (s *PdfStream) SetCompressLevel(level int) {
+	s.levelSet = true
+	s.level = level
+}
+
+// effectiveLevel returns the zlib level WriteTo should use: the level set
+// via SetCompressLevel, or zlib.BestCompression by default. levelSet
+// (rather than a zero-value check) is required because 0 is itself a
+// valid zlib level (zlib.NoCompression).
+func (s *PdfStream) effectiveLevel() int {
+	if s.levelSet {
+		return s.level
+	}
+	return zlib.BestCompression
+}
+
 // WillCompress reports whether WriteTo will Flate-compress this stream's
 // payload before serializing. Useful for writer-side passes that want to
 // skip streams the writer is already going to compress at BestCompression.
@@ -61,7 +85,7 @@ func (s *PdfStream) WriteTo(w io.Writer) (int64, error) {
 	// Determine the actual bytes to write (compressed or raw)
 	streamData := s.Data
 	if s.compress {
-		compressed, err := DeflateStreamData(s.Data)
+		compressed, err := DeflateStreamDataLevel(s.Data, s.effectiveLevel())
 		if err != nil {
 			return 0, fmt.Errorf("core: flate compress: %w", err)
 		}
@@ -96,8 +120,15 @@ func (s *PdfStream) WriteTo(w io.Writer) (int64, error) {
 // for passes that need to produce FlateDecode payloads independently
 // of [PdfStream.WriteTo].
 func DeflateStreamData(data []byte) ([]byte, error) {
+	return DeflateStreamDataLevel(data, zlib.BestCompression)
+}
+
+// DeflateStreamDataLevel compresses data using zlib (RFC 1950) at the
+// given level (see compress/zlib level constants). It is the level-aware
+// primitive behind [DeflateStreamData] and [PdfStream.SetCompressLevel].
+func DeflateStreamDataLevel(data []byte, level int) ([]byte, error) {
 	var buf bytes.Buffer
-	w, err := zlib.NewWriterLevel(&buf, zlib.BestCompression)
+	w, err := zlib.NewWriterLevel(&buf, level)
 	if err != nil {
 		return nil, err
 	}

--- a/core/stream_test.go
+++ b/core/stream_test.go
@@ -4,6 +4,8 @@
 package core
 
 import (
+	"bytes"
+	"compress/zlib"
 	"io"
 	"testing"
 )
@@ -47,5 +49,87 @@ func TestStreamLengthIsDirect(t *testing.T) {
 					"depends on /Length never being indirect", length)
 			}
 		})
+	}
+}
+
+// TestDeflateStreamDataLevel verifies compressed output at a non-default
+// level still inflates back to the original bytes, and that the default
+// wrapper's output is byte-identical to explicitly requesting
+// zlib.BestCompression.
+func TestDeflateStreamDataLevel(t *testing.T) {
+	payload := bytes.Repeat([]byte("hello world, compress me please "), 50)
+
+	fast, err := DeflateStreamDataLevel(payload, zlib.BestSpeed)
+	if err != nil {
+		t.Fatalf("DeflateStreamDataLevel(BestSpeed): %v", err)
+	}
+	back, err := InflateStreamData(fast)
+	if err != nil {
+		t.Fatalf("InflateStreamData: %v", err)
+	}
+	if !bytes.Equal(back, payload) {
+		t.Error("BestSpeed round-trip did not reproduce the original payload")
+	}
+
+	viaDefault, err := DeflateStreamData(payload)
+	if err != nil {
+		t.Fatalf("DeflateStreamData: %v", err)
+	}
+	viaExplicit, err := DeflateStreamDataLevel(payload, zlib.BestCompression)
+	if err != nil {
+		t.Fatalf("DeflateStreamDataLevel(BestCompression): %v", err)
+	}
+	if !bytes.Equal(viaDefault, viaExplicit) {
+		t.Error("DeflateStreamData diverges from DeflateStreamDataLevel(_, zlib.BestCompression)")
+	}
+}
+
+// TestPdfStreamSetCompressLevel verifies SetCompressLevel changes the
+// level WriteTo uses, including the zlib.NoCompression edge case (0,
+// which collides with the PdfStream zero value and must not fall back
+// to BestCompression once SetCompressLevel has been called explicitly).
+func TestPdfStreamSetCompressLevel(t *testing.T) {
+	payload := bytes.Repeat([]byte("round trip through NoCompression "), 50)
+
+	s := NewPdfStreamCompressed(payload)
+	s.SetCompressLevel(zlib.NoCompression)
+
+	var buf bytes.Buffer
+	if _, err := s.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	// Re-inflate the stream body between "stream\n" and "\nendstream".
+	const marker = "\nstream\n"
+	idx := bytes.Index(buf.Bytes(), []byte(marker))
+	if idx < 0 {
+		t.Fatal("missing stream marker in output")
+	}
+	body := buf.Bytes()[idx+len(marker):]
+	body = bytes.TrimSuffix(body, []byte("\nendstream"))
+
+	back, err := InflateStreamData(body)
+	if err != nil {
+		t.Fatalf("InflateStreamData: %v", err)
+	}
+	if !bytes.Equal(back, payload) {
+		t.Error("NoCompression round-trip did not reproduce the original payload")
+	}
+
+	// Default (no SetCompressLevel call) must still behave as before:
+	// byte-identical to the historical BestCompression path.
+	plain := NewPdfStreamCompressed(payload)
+	var plainBuf bytes.Buffer
+	if _, err := plain.WriteTo(&plainBuf); err != nil {
+		t.Fatalf("WriteTo (default): %v", err)
+	}
+	explicit := NewPdfStreamCompressed(payload)
+	explicit.SetCompressLevel(zlib.BestCompression)
+	var explicitBuf bytes.Buffer
+	if _, err := explicit.WriteTo(&explicitBuf); err != nil {
+		t.Fatalf("WriteTo (explicit BestCompression): %v", err)
+	}
+	if !bytes.Equal(plainBuf.Bytes(), explicitBuf.Bytes()) {
+		t.Error("default level diverges from explicit zlib.BestCompression")
 	}
 }

--- a/document/deterministic_test.go
+++ b/document/deterministic_test.go
@@ -150,3 +150,58 @@ func TestDeterministicNonPdfAGainsID(t *testing.T) {
 		t.Fatal("expected deterministic plain-document output to be reproducible")
 	}
 }
+
+// TestDeterministicTeeAcrossOptionSets verifies the /ID tee produces
+// byte-stable output for Deterministic with and without UseXRefStream —
+// the two code paths that call finishID from different trailer writers.
+func TestDeterministicTeeAcrossOptionSets(t *testing.T) {
+	cases := []struct {
+		name string
+		opts WriteOptions
+	}{
+		{"traditional trailer", WriteOptions{Deterministic: true}},
+		{"xref stream trailer", WriteOptions{Deterministic: true, UseXRefStream: true}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := writeOpts(t, newPdfADoc, c.opts)
+			b := writeOpts(t, newPdfADoc, c.opts)
+			if !bytes.Equal(a, b) {
+				t.Fatalf("expected byte-identical output for %s", c.name)
+			}
+		})
+	}
+}
+
+// TestDeterministicTeeObjectStreamsPath verifies the /ID tee also covers
+// the object-stream writer path (writeXRefStreamWithObjStms), which has
+// its own finishID call site.
+func TestDeterministicTeeObjectStreamsPath(t *testing.T) {
+	opts := WriteOptions{Deterministic: true, UseXRefStream: true, UseObjectStreams: true}
+	a := writeOpts(t, newPdfADoc, opts)
+	b := writeOpts(t, newPdfADoc, opts)
+	if !bytes.Equal(a, b) {
+		t.Fatal("expected byte-identical output on the object-stream path")
+	}
+	if !bytes.Contains(a, []byte("/ID")) {
+		t.Fatal("expected trailer to contain /ID on the object-stream path")
+	}
+}
+
+// TestSetFileIDOverridesDeterministicObjectStreamsPath is
+// TestSetFileIDOverridesDeterministic's counterpart for the object-stream
+// writer path: an explicit /ID must still win over the tee-derived digest.
+func TestSetFileIDOverridesDeterministicObjectStreamsPath(t *testing.T) {
+	id := bytes.Repeat([]byte{0xCD}, 16)
+	build := func() *Document {
+		doc := newPdfADoc()
+		doc.SetFileID(id)
+		return doc
+	}
+	out := writeOpts(t, build, WriteOptions{Deterministic: true, UseXRefStream: true, UseObjectStreams: true})
+
+	wantHex := fmt.Sprintf("<%X>", id)
+	if !bytes.Contains(out, []byte("/ID ["+wantHex+" "+wantHex+"]")) {
+		t.Fatalf("expected explicit /ID %s to override the derived digest on the object-stream path", wantHex)
+	}
+}

--- a/document/document.go
+++ b/document/document.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/carlos7ags/folio/core"
 	"github.com/carlos7ags/folio/font"
+	folioimage "github.com/carlos7ags/folio/image"
 	"github.com/carlos7ags/folio/layout"
 )
 
@@ -757,6 +758,7 @@ func (d *Document) WriteToWithContext(ctx context.Context, w io.Writer, opts Wri
 	// the font program is embedded exactly once per document.
 	embeddedFontRefs := make(map[*font.EmbeddedFont]*core.PdfIndirectReference)
 	standardFontRefs := make(map[*font.Standard]*core.PdfIndirectReference)
+	imageXObjectRefs := map[*folioimage.Image]*core.PdfIndirectReference{}
 
 	// First pass: build page objects.
 	for pageIdx, page := range allPages {
@@ -817,7 +819,11 @@ func (d *Document) WriteToWithContext(ctx context.Context, w io.Writer, opts Wri
 		if len(page.images) > 0 || len(page.formXObjects) > 0 {
 			xobjDict := core.NewPdfDictionary()
 			for _, entry := range page.images {
-				imgRef, _ := entry.image.BuildXObject(writer.AddObject)
+				imgRef, ok := imageXObjectRefs[entry.image]
+				if !ok {
+					imgRef, _ = entry.image.BuildXObject(writer.AddObject)
+					imageXObjectRefs[entry.image] = imgRef
+				}
 				xobjDict.Set(entry.name, imgRef)
 			}
 			for _, entry := range page.formXObjects {

--- a/document/image_test.go
+++ b/document/image_test.go
@@ -185,6 +185,64 @@ func TestImageLayoutElementQpdfCheck(t *testing.T) {
 	runQpdfCheck(t, buf.Bytes())
 }
 
+func TestImageXObjectReusedAcrossPages(t *testing.T) {
+	src := goimage.NewRGBA(goimage.Rect(0, 0, 10, 10))
+	for y := range 10 {
+		for x := range 10 {
+			a := uint8(255)
+			if x == 0 && y == 0 {
+				a = 128 // one non-opaque pixel forces an SMask.
+			}
+			src.Set(x, y, color.RGBA{R: 0, G: 128, B: 255, A: a})
+		}
+	}
+	img := folioimage.NewFromGoImage(src)
+
+	doc := NewDocument(PageSizeLetter)
+	for range 3 {
+		p := doc.AddPage()
+		p.AddImage(img, 72, 600, 100, 100)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	got := strings.Count(buf.String(), "/Subtype /Image")
+	if got != 2 {
+		t.Errorf("/Subtype /Image count = %d, want 2 (one image + one SMask)", got)
+	}
+}
+
+func TestImageXObjectDistinctImagesNotShared(t *testing.T) {
+	src1 := goimage.NewRGBA(goimage.Rect(0, 0, 10, 10))
+	src2 := goimage.NewRGBA(goimage.Rect(0, 0, 10, 10))
+	for y := range 10 {
+		for x := range 10 {
+			src1.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+			src2.Set(x, y, color.RGBA{R: 0, G: 255, B: 0, A: 255})
+		}
+	}
+	img1 := folioimage.NewFromGoImage(src1)
+	img2 := folioimage.NewFromGoImage(src2)
+
+	doc := NewDocument(PageSizeLetter)
+	p := doc.AddPage()
+	p.AddImage(img1, 72, 600, 100, 100)
+	p.AddImage(img2, 72, 400, 100, 100)
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	got := strings.Count(buf.String(), "/Subtype /Image")
+	if got != 2 {
+		t.Errorf("/Subtype /Image count = %d, want 2 (two distinct opaque images)", got)
+	}
+}
+
 func TestMixedContentQpdfCheck(t *testing.T) {
 	jpegData := createTestJPEG(t, 150, 100)
 	jpegImg, err := folioimage.NewJPEG(jpegData)

--- a/document/writer_dedup.go
+++ b/document/writer_dedup.go
@@ -6,6 +6,7 @@ package document
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 
 	"github.com/carlos7ags/folio/core"
 )
@@ -73,12 +74,17 @@ func (w *Writer) deduplicateObjects() {
 	// cannot collide with any real hash so they never group with
 	// anything else.
 	//
-	// Side effect: hashing a *PdfStream calls its WriteTo, which sets
-	// /Length on the stream's dictionary (and /Filter when the stream
-	// was constructed with NewPdfStreamCompressed). Both are inserted
-	// at deterministic positions and re-running WriteTo produces
-	// byte-identical output, so the hash is stable across calls and
-	// the writer's later serialization sees the same dictionary state.
+	// Streams are hashed from their current Dict bytes, a compress-flag
+	// tag, and the raw Data — never by compressing Data to reproduce
+	// WriteTo's output. Two streams are mergeable iff their WriteTo
+	// outputs would be byte-identical; matching Dict bytes + compress
+	// flag + raw Data is a sufficient (if conservative) proxy for that,
+	// since /Length and /Filter injection at final serialization is a
+	// deterministic function of the flag and the data. A pair that would
+	// serialize identically but whose current dicts differ (e.g. one
+	// already carries /Filter /FlateDecode) is not merged; that is safe,
+	// just less than maximally deduped, and does not occur for
+	// writer-built documents.
 	type hashedSlot struct {
 		idx  int    // index into w.objects
 		hash string // hex SHA-256 of canonical bytes; "" means "do not dedup"
@@ -88,6 +94,26 @@ func (w *Writer) deduplicateObjects() {
 	for i, obj := range w.objects {
 		hashed[i].idx = i
 		if skip[obj.ObjectNumber] {
+			continue
+		}
+		if s, ok := obj.Object.(*core.PdfStream); ok {
+			h := sha256.New()
+			// Domain separation: dict bytes, then a tag byte for the
+			// compress flag, then raw payload. Length prefixes prevent
+			// dict/data boundary ambiguity.
+			buf.Reset()
+			if _, err := s.Dict.WriteTo(&buf); err != nil {
+				continue
+			}
+			var meta [9]byte // 8-byte dict length + 1 flag byte
+			binary.BigEndian.PutUint64(meta[:8], uint64(buf.Len()))
+			if s.WillCompress() {
+				meta[8] = 1
+			}
+			h.Write(buf.Bytes())
+			h.Write(meta[:])
+			h.Write(s.Data)
+			hashed[i].hash = string(h.Sum(nil))
 			continue
 		}
 		buf.Reset()

--- a/document/writer_dedup_test.go
+++ b/document/writer_dedup_test.go
@@ -661,3 +661,88 @@ func TestDeduplicateObjects_DropsObjectShrinksSerializedOutput(t *testing.T) {
 			withDedup.Len(), noDedup.Len())
 	}
 }
+
+func TestDeduplicateObjects_SameDataDifferentDictNotMerged(t *testing.T) {
+	// Two streams with identical raw Data but different Dict entries
+	// (e.g. different /Subtype) must not be merged: their WriteTo
+	// output would differ.
+	w := minimalCatalogWriter(t)
+	payload := bytes.Repeat([]byte("shared "), 100)
+
+	s1 := core.NewPdfStream(payload)
+	s1.Dict.Set("Subtype", core.NewPdfName("Image"))
+	r1 := w.AddObject(s1)
+
+	s2 := core.NewPdfStream(payload)
+	s2.Dict.Set("Subtype", core.NewPdfName("Form"))
+	r2 := w.AddObject(s2)
+
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("A", r1)
+	root.Set("B", r2)
+
+	preCount := len(w.objects)
+	w.deduplicateObjects()
+
+	if len(w.objects) != preCount {
+		t.Errorf("dedup merged streams with different dicts: %d → %d", preCount, len(w.objects))
+	}
+	if r1.Num() == r2.Num() {
+		t.Error("streams with different dicts share an object number after dedup")
+	}
+}
+
+func TestDeduplicateObjects_SameDataAndDictDifferentCompressNotMerged(t *testing.T) {
+	// Same Data and same Dict entries, but one stream compresses
+	// (NewPdfStreamCompressed) and the other does not (NewPdfStream).
+	// Their WriteTo output differs (/Filter presence and payload
+	// bytes), so they must not be merged.
+	w := minimalCatalogWriter(t)
+	payload := bytes.Repeat([]byte("compressible payload "), 100)
+
+	s1 := core.NewPdfStream(payload)
+	r1 := w.AddObject(s1)
+
+	s2 := core.NewPdfStreamCompressed(payload)
+	r2 := w.AddObject(s2)
+
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("A", r1)
+	root.Set("B", r2)
+
+	preCount := len(w.objects)
+	w.deduplicateObjects()
+
+	if len(w.objects) != preCount {
+		t.Errorf("dedup merged streams with different compress flags: %d → %d", preCount, len(w.objects))
+	}
+	if r1.Num() == r2.Num() {
+		t.Error("streams with different compress flags share an object number after dedup")
+	}
+}
+
+func TestDeduplicateObjects_EqualCompressedStreamsMerge(t *testing.T) {
+	// Two NewPdfStreamCompressed streams with equal data and equal
+	// dicts must still merge under the new identity scheme.
+	w := minimalCatalogWriter(t)
+	payload := bytes.Repeat([]byte("compressible payload "), 100)
+
+	s1 := core.NewPdfStreamCompressed(payload)
+	r1 := w.AddObject(s1)
+	s2 := core.NewPdfStreamCompressed(payload)
+	r2 := w.AddObject(s2)
+
+	root := w.objects[0].Object.(*core.PdfDictionary)
+	root.Set("A", r1)
+	root.Set("B", r2)
+
+	preCount := len(w.objects)
+	w.deduplicateObjects()
+
+	if len(w.objects) != preCount-1 {
+		t.Errorf("expected 1 object dropped, pre=%d post=%d", preCount, len(w.objects))
+	}
+	if r1.Num() != r2.Num() {
+		t.Errorf("equal compressed streams not merged: A=%d B=%d", r1.Num(), r2.Num())
+	}
+}

--- a/document/writer_objstm.go
+++ b/document/writer_objstm.go
@@ -61,7 +61,7 @@ type packedObjStm struct {
 // Phase 1 refuses encryption: §7.5.7 forbids per-object encryption of
 // objects inside an /ObjStm, and the safe interaction with the standard
 // security handler is large enough to defer.
-func (w *Writer) writeXRefStreamWithObjStms(cw *countingWriter, opts WriteOptions) error {
+func (w *Writer) writeXRefStreamWithObjStms(cw *countingWriter, opts WriteOptions, finishID func()) error {
 	// The encryption refusal also lives in WriteToWithOptions, ahead of
 	// the encryption walk; this is defense in depth in case a future
 	// caller bypasses WriteToWithOptions.
@@ -211,6 +211,7 @@ func (w *Writer) writeXRefStreamWithObjStms(cw *countingWriter, opts WriteOption
 		Field2: uint64(xrefStreamOffset),
 	}
 
+	finishID()
 	extras := w.buildTrailerDict()
 	subsections := []core.XRefStreamSubsection{{First: 0, Entries: entries}}
 	stream, err := core.BuildXRefStream(subsections, size, extras)

--- a/document/writer_test.go
+++ b/document/writer_test.go
@@ -5,6 +5,7 @@ package document
 
 import (
 	"bytes"
+	"compress/zlib"
 	"os"
 	"strings"
 	"testing"
@@ -204,4 +205,32 @@ func TestDocumentQpdfCheck(t *testing.T) {
 		t.Fatalf("WriteTo failed: %v", err)
 	}
 	runQpdfCheck(t, buf.Bytes())
+}
+
+// TestWriteOptionsCompressionLevel checks that a document written with
+// default WriteOptions and one written with CompressionLevel set to
+// zlib.BestSpeed both parse, and that the BestSpeed output is byte-stable
+// across two renders of the same input.
+func TestWriteOptionsCompressionLevel(t *testing.T) {
+	build := func() *Document { return buildSampleDocument(5) }
+
+	def, err := build().ToBytes()
+	if err != nil {
+		t.Fatalf("default ToBytes: %v", err)
+	}
+	runQpdfCheck(t, def)
+
+	fastA, err := build().ToBytesWithOptions(WriteOptions{CompressionLevel: zlib.BestSpeed})
+	if err != nil {
+		t.Fatalf("BestSpeed ToBytesWithOptions: %v", err)
+	}
+	runQpdfCheck(t, fastA)
+
+	fastB, err := build().ToBytesWithOptions(WriteOptions{CompressionLevel: zlib.BestSpeed})
+	if err != nil {
+		t.Fatalf("BestSpeed ToBytesWithOptions (second render): %v", err)
+	}
+	if !bytes.Equal(fastA, fastB) {
+		t.Error("CompressionLevel: zlib.BestSpeed output not byte-stable across renders")
+	}
 }

--- a/document/writer_xref_stream.go
+++ b/document/writer_xref_stream.go
@@ -142,6 +142,13 @@ type WriteOptions struct {
 	// file identifier and derives the encryption key from it (§7.6.3.3), so
 	// their output is never byte-stable; the /ID is left to the handler.
 	Deterministic bool
+
+	// CompressionLevel selects the zlib level for streams the writer
+	// compresses at serialization time (zlib constants; e.g.
+	// zlib.BestSpeed). Zero value keeps the default, zlib.BestCompression.
+	// Does not affect RecompressStreams, which is BestCompression by
+	// definition. Determinism is preserved at any fixed level.
+	CompressionLevel int
 }
 
 // WriteToWithOptions is the option-aware variant of WriteTo. WriteTo is
@@ -210,6 +217,18 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 	}
 	if opts.RecompressStreams {
 		w.recompressStreams()
+	}
+
+	// Apply the requested compression level to every stream the writer
+	// will compress at serialization time. Runs after the optimizer
+	// passes above (which may register or recompress streams) and before
+	// encryption, so it never touches ciphertext.
+	if opts.CompressionLevel != 0 {
+		for _, obj := range w.objects {
+			if s, ok := obj.Object.(*core.PdfStream); ok && s.WillCompress() {
+				s.SetCompressLevel(opts.CompressionLevel)
+			}
+		}
 	}
 
 	// Encrypt all user objects in place. Done before serialization so

--- a/document/writer_xref_stream.go
+++ b/document/writer_xref_stream.go
@@ -243,9 +243,9 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 	}
 
 	// Deterministic /ID: when requested and no explicit identifier was set
-	// (via SetFileID), derive a stable /ID from the bytes actually written
-	// before the trailer — header, object bodies, and (on the traditional
-	// path) the xref table — via a hashing tee on the output writer. This
+	// (via SetFileID), derive a stable /ID from the bytes written before
+	// finishID runs — the header and object bodies (each trailer writer
+	// calls finishID first) — via a hashing tee on the output writer. This
 	// needs no extra serialization pass: identical inputs still produce
 	// byte-identical output, since the digest covers exactly the
 	// deterministic content the writer emits. Encryption supplies its own

--- a/document/writer_xref_stream.go
+++ b/document/writer_xref_stream.go
@@ -6,6 +6,7 @@ package document
 import (
 	"crypto/md5"
 	"fmt"
+	"hash"
 	"io"
 
 	"github.com/carlos7ags/folio/core"
@@ -223,19 +224,29 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 	}
 
 	// Deterministic /ID: when requested and no explicit identifier was set
-	// (via SetFileID), derive a stable /ID from the final object set — after
-	// the optimization passes above have settled object content and numbers
-	// — so identical inputs yield byte-identical output. Encryption supplies
-	// its own random /ID and key, so deterministic output is unavailable for
-	// encrypted documents and the derivation is skipped there.
+	// (via SetFileID), derive a stable /ID from the bytes actually written
+	// before the trailer — header, object bodies, and (on the traditional
+	// path) the xref table — via a hashing tee on the output writer. This
+	// needs no extra serialization pass: identical inputs still produce
+	// byte-identical output, since the digest covers exactly the
+	// deterministic content the writer emits. Encryption supplies its own
+	// random /ID and key, so deterministic output is unavailable for
+	// encrypted documents and the tee is skipped there.
+	var h hash.Hash
 	if opts.Deterministic && len(w.fileID) == 0 && w.encryptor == nil {
-		w.fileID = w.deterministicFileID()
+		h = md5.New()
+		out = io.MultiWriter(out, h)
+	}
+	finishID := func() {
+		if h != nil && len(w.fileID) == 0 {
+			w.fileID = h.Sum(nil)
+		}
 	}
 
 	cw := &countingWriter{w: out}
 
 	if opts.UseObjectStreams {
-		return cw.n, w.writeXRefStreamWithObjStms(cw, opts)
+		return cw.n, w.writeXRefStreamWithObjStms(cw, opts, finishID)
 	}
 
 	if err := writeHeader(cw, w.version); err != nil {
@@ -248,9 +259,9 @@ func (w *Writer) WriteToWithOptions(out io.Writer, opts WriteOptions) (int64, er
 	}
 
 	if opts.UseXRefStream {
-		return cw.n, w.writeXRefStreamTrailer(cw, offsets)
+		return cw.n, w.writeXRefStreamTrailer(cw, offsets, finishID)
 	}
-	return cw.n, w.writeTraditionalTrailer(cw, offsets)
+	return cw.n, w.writeTraditionalTrailer(cw, offsets, finishID)
 }
 
 // writeHeader emits the PDF version header and the four-byte binary
@@ -292,7 +303,7 @@ func (w *Writer) writeObjectBodies(cw *countingWriter) ([]int64, error) {
 
 // writeTraditionalTrailer emits a §7.5.4 cross-reference table and a
 // §7.5.5 trailer dictionary followed by startxref and EOF.
-func (w *Writer) writeTraditionalTrailer(cw *countingWriter, offsets []int64) error {
+func (w *Writer) writeTraditionalTrailer(cw *countingWriter, offsets []int64, finishID func()) error {
 	xrefOffset := cw.n
 	if _, err := fmt.Fprint(cw, "xref\n"); err != nil {
 		return err
@@ -309,6 +320,7 @@ func (w *Writer) writeTraditionalTrailer(cw *countingWriter, offsets []int64) er
 		}
 	}
 
+	finishID()
 	trailer := w.buildTrailerDict()
 	trailer.Set("Size", core.NewPdfInteger(len(w.objects)+1))
 	if _, err := fmt.Fprint(cw, "trailer\n"); err != nil {
@@ -329,7 +341,7 @@ func (w *Writer) writeTraditionalTrailer(cw *countingWriter, offsets []int64) er
 // always the last object in the file, so its own offset is known
 // before any compression happens and the field-width calculation can
 // observe the maximum offset directly — no chicken-and-egg.
-func (w *Writer) writeXRefStreamTrailer(cw *countingWriter, offsets []int64) error {
+func (w *Writer) writeXRefStreamTrailer(cw *countingWriter, offsets []int64, finishID func()) error {
 	xrefStreamObjNum := len(w.objects) + 1
 	xrefStreamOffset := cw.n
 	size := xrefStreamObjNum + 1 // covers object numbers 0..xrefStreamObjNum
@@ -349,6 +361,7 @@ func (w *Writer) writeXRefStreamTrailer(cw *countingWriter, offsets []int64) err
 		Field3: 0,
 	}
 
+	finishID()
 	extras := w.buildTrailerDict()
 	subsections := []core.XRefStreamSubsection{{First: 0, Entries: entries}}
 	stream, err := core.BuildXRefStream(subsections, size, extras)
@@ -389,22 +402,4 @@ func (w *Writer) buildTrailerDict() *core.PdfDictionary {
 		d.Set("ID", core.NewPdfArray(id, id))
 	}
 	return d
-}
-
-// deterministicFileID derives a stable 16-byte file identifier by hashing
-// the serialized form of every registered object in order. Because the
-// object set, object numbers, and each object's serialization are fully
-// determined by the document content — PdfDictionary preserves insertion
-// order, so there is no map-iteration nondeterminism — identical input
-// documents produce an identical identifier. MD5 yields exactly the 16
-// bytes a /ID entry expects (ISO 32000-1 §14.4); it is used here only as a
-// content digest, not for any security property.
-func (w *Writer) deterministicFileID() []byte {
-	h := md5.New()
-	for _, obj := range w.objects {
-		_, _ = fmt.Fprintf(h, "%d %d obj\n", obj.ObjectNumber, obj.GenerationNumber)
-		_, _ = obj.Object.WriteTo(h)
-		_, _ = io.WriteString(h, "\nendobj\n")
-	}
-	return h.Sum(nil)
 }

--- a/image/png.go
+++ b/image/png.go
@@ -316,10 +316,11 @@ walked:
 
 	channels := 1
 	colorSpace := "DeviceGray"
-	if colorType == 2 {
+	switch colorType {
+	case 2:
 		channels = 3
 		colorSpace = "DeviceRGB"
-	} else if colorType == 3 {
+	case 3:
 		colorSpace = "Indexed"
 	}
 	rowBytes := (width*channels*int(bitDepth) + 7) / 8


### PR DESCRIPTION
Fixes the size and time complaints in #442 for default WriteOptions and the DeduplicateObjects path. Complements #444 (PNG IDAT passthrough).

Commits:
1. document: cache image XObjects across pages — the same *image.Image used on N pages now embeds once (fonts already cached; images missed the pattern). Fixes the 20+ MB default-output case in #442 directly.
2. document: hash stream identity without compressing in dedup — deduplicateObjects no longer Flate-compresses every stream payload just to hash it; identity is dict bytes + compress flag + raw data (conservative, provably safe). Removes the pprof hotspot reported in #442.
3. document: derive deterministic /ID from written bytes — the Deterministic option's /ID now comes from an MD5 tee over the real output instead of a second full serialization pass. Note: the derived /ID value changes vs v0.10.x (determinism itself is preserved; /ID is opaque per ISO 32000-1 §14.4).
4. core, document: configurable Flate compression level — WriteOptions.CompressionLevel (zlib constants; default remains BestCompression). RecompressStreams stays BestCompression by contract.
5. image: tagged switch on colorType — staticcheck QF1003 fix for the post-merge lint failure on main from #444.
6. document: comment correction on the /ID digest coverage.

Verification: full go test ./... -race -count=1 green, make check green (vet, gofmt, export sync) at head. New tests: cross-page image reuse counts /Subtype /Image occurrences; dedup no-false-merge on dict/flag differences plus merge-still-happens; /ID determinism across xref-table, xref-stream, and object-stream paths plus SetFileID precedence; compression-level round-trips including NoCompression, and byte-stability at BestSpeed.