### PR TITLE
html: emit a destination for internal anchors in inline flow

### DIFF
--- a/html/anchor_inline_dest_test.go
+++ b/html/anchor_inline_dest_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/core"
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// linkAnnot is a parsed /Link annotation, reduced to the parts that decide
+// whether a viewer can follow it.
+type linkAnnot struct {
+	uri      string // /A << /S /URI /URI (...) >>
+	destName string // /A << /S /GoTo /D (name) >>
+	hasDest  bool   // /Dest [ pageRef /XYZ ... ] — a resolved direct destination
+	destPage core.PdfObject
+}
+
+// followable reports whether the annotation actually navigates somewhere:
+// either a direct /Dest array or a /GoTo naming a destination.
+func (a linkAnnot) followable() bool {
+	return a.hasDest || a.destName != "" || (a.uri != "" && !strings.HasPrefix(a.uri, "#"))
+}
+
+// collectLinkAnnots walks the page tree and returns every /Link annotation,
+// in page order. Assertions run against parsed objects rather than a byte
+// scan so a link that is present but points nowhere cannot pass.
+func collectLinkAnnots(t *testing.T, r *reader.PdfReader) []linkAnnot {
+	t.Helper()
+	var out []linkAnnot
+	cat := r.Catalog()
+	if cat == nil {
+		t.Fatal("no catalog in parsed PDF")
+	}
+	pagesObj, err := r.ResolveObject(cat.Get("Pages"))
+	if err != nil {
+		t.Fatalf("resolve /Pages: %v", err)
+	}
+	pages, ok := pagesObj.(*core.PdfDictionary)
+	if !ok {
+		t.Fatalf("/Pages is %T, want *core.PdfDictionary", pagesObj)
+	}
+	kidsObj, err := r.ResolveObject(pages.Get("Kids"))
+	if err != nil {
+		t.Fatalf("resolve /Kids: %v", err)
+	}
+	kids, ok := kidsObj.(*core.PdfArray)
+	if !ok {
+		t.Fatalf("/Kids is %T, want *core.PdfArray", kidsObj)
+	}
+	for i := range kids.Len() {
+		pageObj, err := r.ResolveObject(kids.At(i))
+		if err != nil {
+			t.Fatalf("resolve page %d: %v", i, err)
+		}
+		page, ok := pageObj.(*core.PdfDictionary)
+		if !ok {
+			continue
+		}
+		annotsObj, err := r.ResolveObject(page.Get("Annots"))
+		if err != nil {
+			continue
+		}
+		annots, ok := annotsObj.(*core.PdfArray)
+		if !ok {
+			continue
+		}
+		for j := range annots.Len() {
+			annObj, err := r.ResolveObject(annots.At(j))
+			if err != nil {
+				continue
+			}
+			ann, ok := annObj.(*core.PdfDictionary)
+			if !ok {
+				continue
+			}
+			if sub, ok := ann.Get("Subtype").(*core.PdfName); !ok || sub.Value != "Link" {
+				continue
+			}
+			la := linkAnnot{}
+			if dest, ok := ann.Get("Dest").(*core.PdfArray); ok && dest.Len() > 0 {
+				la.hasDest = true
+				la.destPage = dest.At(0)
+			}
+			if actObj, err := r.ResolveObject(ann.Get("A")); err == nil {
+				if act, ok := actObj.(*core.PdfDictionary); ok {
+					s, _ := act.Get("S").(*core.PdfName)
+					switch {
+					case s != nil && s.Value == "URI":
+						if v, ok := act.Get("URI").(*core.PdfString); ok {
+							la.uri = v.Text()
+						}
+					case s != nil && s.Value == "GoTo":
+						if v, ok := act.Get("D").(*core.PdfString); ok {
+							la.destName = v.Text()
+						}
+					}
+				}
+			}
+			out = append(out, la)
+		}
+	}
+	return out
+}
+
+// assertNoFragmentURI fails if any annotation carries a /URI action whose
+// value is a bare fragment. Such an action resolves to nothing in every
+// viewer, so the link is dead even though it looks present.
+func assertNoFragmentURI(t *testing.T, annots []linkAnnot) {
+	t.Helper()
+	for i, a := range annots {
+		if strings.HasPrefix(a.uri, "#") {
+			t.Errorf("annotation %d: /URI (%s) — a bare fragment is not a URI; "+
+				"an internal anchor must emit a destination, not a /URI action", i, a.uri)
+		}
+	}
+}
+
+// TestInlineInternalAnchorEmitsDestination is the regression for internal
+// anchors that flow inline. <a href="#id"> is display:inline by default, so
+// in a heading, a paragraph, a list item or a table cell it is converted as
+// part of the surrounding text rather than as its own element. Those paths
+// used to copy the raw href onto the text run's link URI, producing a
+// /URI (#id) action that navigates nowhere. Every one of them must resolve
+// to the registered destination instead.
+func TestInlineInternalAnchorEmitsDestination(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"heading", `<h2>Section <a href="#section-two">jump link</a> here</h2>`},
+		{"paragraph", `<p>Lead text <a href="#section-two">jump link</a> trailing text.</p>`},
+		{"list item", `<ul><li>Item with <a href="#section-two">jump link</a>.</li></ul>`},
+		{"table cell", `<table><tr><td>Cell with <a href="#section-two">jump link</a></td></tr></table>`},
+		// The control: an <a> forced to display:block is dispatched as its
+		// own element and has always worked. It proves the boundary.
+		{"block control", `<a href="#section-two" style="display:block">jump link</a>`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			htmlStr := `<html><body>` + tc.body + `
+				<h2 id="section-two">Second Section</h2>
+				<p>Body text under the second section.</p>
+			</body></html>`
+
+			pdf, r := htmlRoundtrip(t, htmlStr, document.PageSizeLetter)
+
+			annots := collectLinkAnnots(t, r)
+			assertNoFragmentURI(t, annots)
+
+			if len(annots) == 0 {
+				t.Fatal("no /Link annotation emitted — the anchor produced no clickable region")
+			}
+			for i, a := range annots {
+				if !a.followable() {
+					t.Errorf("annotation %d navigates nowhere (uri=%q destName=%q hasDest=%v)",
+						i, a.uri, a.destName, a.hasDest)
+				}
+			}
+
+			// The destination must be resolvable, not merely referenced.
+			if !strings.Contains(string(pdf), "/Dests") {
+				t.Fatal("output has no /Dests dictionary — the id was not registered")
+			}
+			dest := resolveNamedDest(t, r, "section-two")
+			if dest.Len() < 2 {
+				t.Fatalf("destination array too short: %d elements", dest.Len())
+			}
+			if fit, ok := dest.At(1).(*core.PdfName); !ok || fit.Value != "XYZ" {
+				t.Errorf("destination fit = %v, want XYZ", dest.At(1))
+			}
+
+			// A direct /Dest must point at a page object, and a string /GoTo
+			// must name the destination the catalog defines.
+			for i, a := range annots {
+				if a.hasDest && a.destPage == nil {
+					t.Errorf("annotation %d has an empty /Dest array", i)
+				}
+				if a.destName != "" && a.destName != "section-two" {
+					t.Errorf("annotation %d /GoTo names %q, want section-two", i, a.destName)
+				}
+			}
+		})
+	}
+}
+
+// TestInlineExternalLinkStillEmitsURI guards the fix from over-reaching: a
+// real external href must keep its /URI action.
+func TestInlineExternalLinkStillEmitsURI(t *testing.T) {
+	const htmlStr = `<html><body>
+		<p>Go <a href="https://example.com/docs">outside</a> the document.</p>
+	</body></html>`
+
+	_, r := htmlRoundtrip(t, htmlStr, document.PageSizeLetter)
+	annots := collectLinkAnnots(t, r)
+	if len(annots) != 1 {
+		t.Fatalf("got %d link annotations, want 1", len(annots))
+	}
+	if annots[0].uri != "https://example.com/docs" {
+		t.Errorf("uri = %q, want https://example.com/docs", annots[0].uri)
+	}
+}

--- a/html/anchor_link_content_test.go
+++ b/html/anchor_link_content_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html_test
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/html"
+)
+
+// fontFaceFS builds an in-memory FS holding the repo's synthetic CJK TTF
+// under the name the test documents reference from @font-face. The fixture
+// covers only CJK codepoints, which is what makes it useful here: a
+// standard PDF-14 face cannot encode them, so a fallback to one is
+// unambiguous rather than a subtle difference in letterforms.
+func fontFaceFS(t *testing.T) fstest.MapFS {
+	t.Helper()
+	ttf, err := os.ReadFile("../font/testdata/synthetic_cjk.ttf")
+	if err != nil {
+		t.Fatalf("read fixture font: %v", err)
+	}
+	return fstest.MapFS{"Test-Regular.ttf": &fstest.MapFile{Data: ttf}}
+}
+
+// renderWithFontFace converts htmlStr with the fixture FS mounted and
+// returns the serialized PDF.
+func renderWithFontFace(t *testing.T, htmlStr string) []byte {
+	t.Helper()
+	doc := document.NewDocument(document.PageSizeLetter)
+	opts := &html.Options{
+		PageWidth:  document.PageSizeLetter.Width,
+		PageHeight: document.PageSizeLetter.Height,
+		BaseFS:     fontFaceFS(t),
+	}
+	if err := doc.AddHTML(htmlStr, opts); err != nil {
+		t.Fatalf("AddHTML: %v", err)
+	}
+	pdf, err := doc.ToBytes()
+	if err != nil {
+		t.Fatalf("ToBytes: %v", err)
+	}
+	return pdf
+}
+
+const fontFaceHead = `<html><head><style>
+	@font-face { font-family: 'TestFace'; src: url('Test-Regular.ttf') format('truetype'); }
+	body { font-family: 'TestFace', Helvetica, sans-serif; }
+</style></head><body>`
+
+// Every rune below is covered by font/testdata/synthetic_cjk.ttf. All
+// rendered text in these documents is CJK so that any standard-14 fallback
+// shows up as a /BaseFont /Helvetica the fixture could never have produced.
+const (
+	cjkBody = "中华人民"
+	cjkLink = "共和国是"
+	cjkDest = "一个历史"
+)
+
+// TestLinkUsesDocumentFace pins that link text is set in the document's
+// declared @font-face, not a standard PDF-14 substitute. The block-level
+// <a> path built its paragraph from resolveFont, which only ever returns
+// one of the 14 standard faces, so a link inside a fully embedded document
+// silently fell back to non-embedded Helvetica.
+func TestLinkUsesDocumentFace(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"block anchor", `<a href="#target" style="display:block">` + cjkLink + `</a>`},
+		{"block external anchor", `<a href="https://example.com/" style="display:block">` + cjkLink + `</a>`},
+		{"inline anchor", `<p>` + cjkBody + `<a href="#target">` + cjkLink + `</a></p>`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pdf := string(renderWithFontFace(t, fontFaceHead+`<p>`+cjkBody+`</p>`+tc.body+
+				`<div id="target">`+cjkDest+`</div></body></html>`))
+
+			// A subset-embedded font is written as /BaseFont /ABCDEF+Name.
+			if !regexp.MustCompile(`/FontFile2`).MatchString(pdf) {
+				t.Fatal("document embeds no font program at all — fixture is wrong")
+			}
+			if strings.Contains(pdf, "/BaseFont /Helvetica") {
+				t.Error("link text fell back to non-embedded Helvetica; " +
+					"it must use the document's embedded face")
+			}
+		})
+	}
+}
+
+// TestAnchorWrappingOnlyAnImage covers an <a> whose entire content is an
+// image — a thumbnail or icon that navigates. Two things must survive: the
+// image itself, and a link annotation over it. The block-level path used to
+// discard the whole subtree when the anchor held no text, and the inline
+// path measured the image into a word that never carried the link target.
+func TestAnchorWrappingOnlyAnImage(t *testing.T) {
+	// A 34x34 flat-colour PNG, inlined so the case needs no asset FS.
+	const png = `data:image/png;base64,` +
+		`iVBORw0KGgoAAAANSUhEUgAAACIAAAAiCAIAAAC1JZyVAAAAKklEQVR4nO3NMQ0AAAgDsAmb/y` +
+		`ALDTxcTfo30z6IRqPRaDQajUaj0WguFlw+pUwg5gZxAAAAAElFTkSuQmCC`
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"block anchor", `<a href="#target" style="display:block"><img src="` + png + `" width="34" height="34" alt=""></a>`},
+		{"inline anchor", `<p><a href="#target"><img src="` + png + `" width="34" height="34" alt=""></a></p>`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			htmlStr := `<html><body>` + tc.body + `<h2 id="target">Target</h2></body></html>`
+			pdf, r := htmlRoundtrip(t, htmlStr, document.PageSizeLetter)
+
+			if !strings.Contains(string(pdf), "/Subtype /Image") {
+				t.Error("the image inside the anchor was dropped from the output")
+			}
+
+			annots := collectLinkAnnots(t, r)
+			assertNoFragmentURI(t, annots)
+			if len(annots) == 0 {
+				t.Fatal("an anchor wrapping an image produced no /Link annotation")
+			}
+			for i, a := range annots {
+				if !a.followable() {
+					t.Errorf("annotation %d navigates nowhere (uri=%q destName=%q hasDest=%v)",
+						i, a.uri, a.destName, a.hasDest)
+				}
+			}
+			if !annots[0].hasDest && annots[0].destName == "" {
+				t.Error("annotation carries no destination")
+			}
+		})
+	}
+}

--- a/html/converter_link.go
+++ b/html/converter_link.go
@@ -11,27 +11,73 @@ import (
 	"golang.org/x/net/html"
 )
 
+// splitLinkTarget classifies an href into an external URI and an internal
+// named destination. A bare fragment ("#id") addresses a destination inside
+// this document, not a resource on the network: emitting it as a PDF /URI
+// action produces a link that resolves to nothing in every viewer, so it
+// must become a destination instead.
+//
+// Both results are empty for an href that navigates nowhere — an absent
+// href, or a lone "#" with no fragment name. Callers render such an <a> as
+// plain text rather than attaching a link annotation with no action.
+func splitLinkTarget(href string) (uri, destName string) {
+	if strings.HasPrefix(href, "#") {
+		return "", href[1:]
+	}
+	return href, ""
+}
+
 // convertLink converts an <a> element into a layout.Link or inline runs.
 func (c *converter) convertLink(n *html.Node, style computedStyle) []layout.Element {
 	href := getAttr(n, "href")
+	uri, destName := splitLinkTarget(href)
+
 	text := collectText(n)
 	if text == "" {
-		return nil
+		// An anchor need not contain text: an image or icon that navigates
+		// is an <a> wrapping only an <img>. Converting the children as
+		// inline runs keeps that content in the document and lets the
+		// paragraph pipeline attach the annotation to it.
+		return c.convertEmptyTextLink(n, style, uri, destName)
 	}
 	text = applyTextTransform(text, style.TextTransform)
 
-	f := resolveFont(style)
+	// Resolve the same font the surrounding text would use, so link text in
+	// a document with an @font-face is set in that face instead of silently
+	// falling back to a non-embedded standard PDF face.
+	stdFont, embFont := c.resolveFontForText(style, text)
 
-	if strings.HasPrefix(href, "#") {
-		destName := href[1:]
-		link := layout.NewInternalLink(text, destName, f, style.FontSize)
-		link.SetColor(style.Color)
-		link.SetUnderline()
-		return []layout.Element{link}
+	var link *layout.Link
+	switch {
+	case destName == "" && uri == "":
+		// Nothing to navigate to — render the text without an annotation.
+		return c.convertInlineContainer(n, style)
+	case destName != "" && embFont != nil:
+		link = layout.NewInternalLinkEmbedded(text, destName, embFont, style.FontSize)
+	case destName != "":
+		link = layout.NewInternalLink(text, destName, stdFont, style.FontSize)
+	case embFont != nil:
+		link = layout.NewLinkEmbedded(text, uri, embFont, style.FontSize)
+	default:
+		link = layout.NewLink(text, uri, stdFont, style.FontSize)
 	}
-
-	link := layout.NewLink(text, href, f, style.FontSize)
 	link.SetColor(style.Color)
 	link.SetUnderline()
 	return []layout.Element{link}
+}
+
+// convertEmptyTextLink handles an <a> whose content carries no text —
+// typically a single <img>. The children are collected as inline runs and
+// tagged with the link target, so the paragraph pipeline both keeps the
+// content and produces an annotation covering it.
+func (c *converter) convertEmptyTextLink(n *html.Node, style computedStyle, uri, destName string) []layout.Element {
+	runs := c.collectRuns(n, style)
+	if len(runs) == 0 {
+		return nil
+	}
+	for i := range runs {
+		runs[i].LinkURI = uri
+		runs[i].LinkDest = destName
+	}
+	return []layout.Element{layout.NewStyledParagraph(runs...)}
 }

--- a/html/converter_paragraph.go
+++ b/html/converter_paragraph.go
@@ -328,14 +328,12 @@ func (c *converter) collectRunsFromNode(child *html.Node, parentStyle computedSt
 		}
 
 		childRuns := c.collectRuns(child, childStyle)
-		// Propagate href from <a> elements to all child runs.
+		// Propagate href from <a> elements to all child runs. A bare
+		// fragment names a destination inside this document, so it must
+		// travel as LinkDest — sent as LinkURI it would be written out as
+		// a /URI action that no viewer can resolve.
 		if child.DataAtom == atom.A {
-			href := getAttr(child, "href")
-			if href != "" {
-				for i := range childRuns {
-					childRuns[i].LinkURI = href
-				}
-			}
+			applyLinkTarget(childRuns, getAttr(child, "href"))
 		}
 		return childRuns
 	}
@@ -401,15 +399,24 @@ func (c *converter) collectListItemRuns(li *html.Node, style computedStyle) []la
 			childStyle := c.computeElementStyle(child, style)
 			childRuns := c.collectRuns(child, childStyle)
 			if child.DataAtom == atom.A {
-				href := getAttr(child, "href")
-				if href != "" {
-					for i := range childRuns {
-						childRuns[i].LinkURI = href
-					}
-				}
+				applyLinkTarget(childRuns, getAttr(child, "href"))
 			}
 			runs = append(runs, childRuns...)
 		}
 	}
 	return runs
+}
+
+// applyLinkTarget marks every run as part of the link named by href,
+// routing a bare fragment to LinkDest and everything else to LinkURI.
+// An href that navigates nowhere leaves the runs untouched.
+func applyLinkTarget(runs []layout.TextRun, href string) {
+	uri, destName := splitLinkTarget(href)
+	if uri == "" && destName == "" {
+		return
+	}
+	for i := range runs {
+		runs[i].LinkURI = uri
+		runs[i].LinkDest = destName
+	}
 }

--- a/layout/element.go
+++ b/layout/element.go
@@ -140,12 +140,17 @@ type TextRun struct {
 	FontSize        float64
 	Color           Color
 	Decoration      TextDecoration
-	DecorationColor *Color      // if non-nil, decoration uses this color instead of text Color
-	DecorationStyle string      // "solid" (default), "dashed", "dotted", "double", "wavy"
-	LetterSpacing   float64     // extra space between characters (points, from CSS letter-spacing)
-	WordSpacing     float64     // extra space between words (points, from CSS word-spacing)
-	BaselineShift   float64     // vertical offset in points (positive = up for super, negative = down for sub)
-	LinkURI         string      // if non-empty, this run is part of a hyperlink
+	DecorationColor *Color  // if non-nil, decoration uses this color instead of text Color
+	DecorationStyle string  // "solid" (default), "dashed", "dotted", "double", "wavy"
+	LetterSpacing   float64 // extra space between characters (points, from CSS letter-spacing)
+	WordSpacing     float64 // extra space between words (points, from CSS word-spacing)
+	BaselineShift   float64 // vertical offset in points (positive = up for super, negative = down for sub)
+	LinkURI         string  // if non-empty, this run is part of a hyperlink
+	// LinkDest is a named destination inside this document (the fragment
+	// of an <a href="#id">, without the '#'). It is mutually exclusive
+	// with LinkURI: a bare fragment is not a URI, and emitting it as a
+	// /URI action produces a link that resolves to nothing in a viewer.
+	LinkDest        string
 	TextShadow      *TextShadow // if non-nil, draws a shadow behind the text
 	BackgroundColor *Color      // if non-nil, a highlight rectangle is drawn behind the text
 	// InlineElement holds a layout element (e.g. ImageElement, SVGElement,
@@ -207,6 +212,14 @@ func (r TextRun) WithDecoration(d TextDecoration) TextRun {
 // Words from this run will produce a clickable annotation in the PDF.
 func (r TextRun) WithLinkURI(uri string) TextRun {
 	r.LinkURI = uri
+	return r
+}
+
+// WithLinkDest returns a copy of the run marked as a link to a named
+// destination within this document. Words from this run produce a
+// clickable annotation that navigates to destName.
+func (r TextRun) WithLinkDest(destName string) TextRun {
+	r.LinkDest = destName
 	return r
 }
 
@@ -326,6 +339,12 @@ type Word struct {
 	// LinkURI is the hyperlink target for this word. If non-empty, the
 	// renderer creates a link annotation covering this word's area.
 	LinkURI string
+
+	// LinkDest is the named destination inside this document that this
+	// word links to. Mutually exclusive with LinkURI; carries the
+	// fragment of an <a href="#id"> so the renderer can emit a /Dest
+	// instead of a /URI action that would navigate nowhere.
+	LinkDest string
 
 	// BackgroundColor, if non-nil, draws a filled highlight rectangle
 	// behind this word before rendering the text.

--- a/layout/link.go
+++ b/layout/link.go
@@ -38,6 +38,13 @@ func NewInternalLink(text, destName string, f *font.Standard, fontSize float64) 
 	return &Link{para: p, destName: destName}
 }
 
+// NewInternalLinkEmbedded creates a link to a named destination within the
+// document, rendered with an embedded font.
+func NewInternalLinkEmbedded(text, destName string, ef *font.EmbeddedFont, fontSize float64) *Link {
+	p := NewParagraphEmbedded(text, ef, fontSize)
+	return &Link{para: p, destName: destName}
+}
+
 // SetColor sets the text color (default is inherited from the paragraph).
 func (l *Link) SetColor(c Color) *Link {
 	for i := range l.para.runs {

--- a/layout/link_dest_span_test.go
+++ b/layout/link_dest_span_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package layout
+
+import (
+	"testing"
+
+	"github.com/carlos7ags/folio/font"
+)
+
+// TestLinkSpansSeparatesTargets pins that linkSpans keys on the whole link
+// target, not just the URI. Adjacent words linking to different places —
+// one internal, one external — must produce two annotations, and an
+// internal target must reach LinkArea.DestName so the writer emits a
+// destination rather than a /URI action.
+func TestLinkSpansSeparatesTargets(t *testing.T) {
+	words := []Word{
+		{Text: "plain", Width: 30, SpaceAfter: 4},
+		{Text: "inside", Width: 40, SpaceAfter: 4, LinkDest: "section-two"},
+		{Text: "outside", Width: 50, SpaceAfter: 4, LinkURI: "https://example.com/"},
+		{Text: "tail", Width: 20},
+	}
+
+	spans := linkSpans(words)
+	if len(spans) != 2 {
+		t.Fatalf("got %d spans, want 2 (one internal, one external): %+v", len(spans), spans)
+	}
+	if spans[0].DestName != "section-two" || spans[0].URI != "" {
+		t.Errorf("internal span = {URI:%q DestName:%q}, want {\"\" \"section-two\"}",
+			spans[0].URI, spans[0].DestName)
+	}
+	if spans[1].URI != "https://example.com/" || spans[1].DestName != "" {
+		t.Errorf("external span = {URI:%q DestName:%q}, want {\"https://example.com/\" \"\"}",
+			spans[1].URI, spans[1].DestName)
+	}
+	if spans[0].W <= 0 || spans[1].W <= 0 {
+		t.Errorf("spans must have positive width: %+v", spans)
+	}
+	// The two spans must not overlap — an overlapping rect would make one
+	// link swallow the other's clickable area.
+	if spans[0].X+spans[0].W > spans[1].X {
+		t.Errorf("spans overlap: %+v", spans)
+	}
+}
+
+// TestLinkSpansMergesContiguousDest keeps words of one internal link in a
+// single annotation instead of one rect per word.
+func TestLinkSpansMergesContiguousDest(t *testing.T) {
+	words := []Word{
+		{Text: "jump", Width: 30, SpaceAfter: 4, LinkDest: "target"},
+		{Text: "here", Width: 30, LinkDest: "target"},
+	}
+	spans := linkSpans(words)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1: %+v", len(spans), spans)
+	}
+	if spans[0].DestName != "target" {
+		t.Errorf("DestName = %q, want target", spans[0].DestName)
+	}
+	if spans[0].W < 64 {
+		t.Errorf("span width = %v, want at least the two words plus the gap (64)", spans[0].W)
+	}
+}
+
+// TestInlineElementCarriesLinkTarget covers an image that is the whole
+// content of a link: the measured word must keep the target so the link
+// area survives into the page.
+func TestInlineElementCarriesLinkTarget(t *testing.T) {
+	img := NewDiv()
+	img.SetWidth(34)
+	img.SetMinHeight(34)
+
+	p := NewStyledParagraph(
+		TextRun{InlineElement: img, LinkDest: "target"},
+		NewRun(" caption", font.Helvetica, 12),
+	)
+	plan := p.PlanLayout(LayoutArea{Width: 300, Height: 500})
+	if len(plan.Blocks) == 0 {
+		t.Fatal("paragraph produced no blocks")
+	}
+
+	var found bool
+	for _, b := range plan.Blocks {
+		for _, l := range b.Links {
+			if l.DestName == "target" {
+				found = true
+			}
+			if l.URI != "" {
+				t.Errorf("inline element link emitted URI %q; an internal target must not become a URI", l.URI)
+			}
+		}
+	}
+	if !found {
+		t.Error("an inline element inside a link produced no link area — the annotation would be missing")
+	}
+}

--- a/layout/paragraph_measure.go
+++ b/layout/paragraph_measure.go
@@ -113,6 +113,12 @@ func measureInlineElement(run TextRun, maxWidth float64, measured []Word, runs [
 		InlineHeight: ih,
 		Width:        iw,
 		SpaceAfter:   inlineSpaceAfter(measured, runs, runIdx),
+		// An inline element can be the entire content of a link (an icon
+		// or thumbnail that navigates). Carry the link target onto the
+		// word so linkSpans covers it with an annotation, exactly as it
+		// does for linked text.
+		LinkURI:  run.LinkURI,
+		LinkDest: run.LinkDest,
 	}
 }
 
@@ -373,6 +379,7 @@ func (p *Paragraph) measureWords(maxWidth float64) ([]Word, float64) {
 				WordSpacing:     run.WordSpacing,
 				BaselineShift:   run.BaselineShift,
 				LinkURI:         run.LinkURI,
+				LinkDest:        run.LinkDest,
 				TextShadow:      run.TextShadow,
 				BackgroundColor: run.BackgroundColor,
 				LineBreak:       nextLineBreak,

--- a/layout/paragraph_split.go
+++ b/layout/paragraph_split.go
@@ -364,6 +364,7 @@ func wordToRun(w Word) TextRun {
 		LetterSpacing:   w.LetterSpacing,
 		WordSpacing:     w.WordSpacing,
 		LinkURI:         w.LinkURI,
+		LinkDest:        w.LinkDest,
 		TextShadow:      w.TextShadow,
 		BackgroundColor: w.BackgroundColor,
 		InlineElement:   w.InlineBlock,
@@ -423,7 +424,8 @@ func (p *Paragraph) cloneWithWords(words []Word) *Paragraph {
 				w.FontSize == cur.FontSize && w.Color == cur.Color &&
 				w.Decoration == cur.Decoration && w.BaselineShift == cur.BaselineShift &&
 				w.LetterSpacing == cur.LetterSpacing && w.WordSpacing == cur.WordSpacing &&
-				w.LinkURI == cur.LinkURI && w.BackgroundColor == cur.BackgroundColor
+				w.LinkURI == cur.LinkURI && w.LinkDest == cur.LinkDest &&
+				w.BackgroundColor == cur.BackgroundColor
 			// A word with LineBreak=true had a forced \n before it.
 			if w.LineBreak {
 				if sameRun {

--- a/layout/paragraph_wrap.go
+++ b/layout/paragraph_wrap.go
@@ -60,17 +60,28 @@ func (p *Paragraph) wrapWords(words []Word, maxWidth float64) [][]Word {
 	return lines
 }
 
+// linkTarget is a word's link destination: either an external URI or a
+// named destination inside the document. Words join the same span only
+// when both components match, so "see A or B" on one line produces two
+// annotations even if one link is internal and the other external.
+type linkTarget struct {
+	uri  string
+	dest string
+}
+
+func (t linkTarget) empty() bool { return t.uri == "" && t.dest == "" }
+
 // linkSpans computes a LinkArea for every contiguous run of words that
-// share the same non-empty LinkURI. Each span's X and W are relative to
-// the line's starting x position. This supports multiple distinct links
+// share the same non-empty link target. Each span's X and W are relative
+// to the line's starting x position. This supports multiple distinct links
 // on the same line (e.g. "Visit GitHub or GitLab").
 func linkSpans(words []Word) []LinkArea {
 	var spans []LinkArea
 	cx := 0.0
 	i := 0
 	for i < len(words) {
-		uri := words[i].LinkURI
-		if uri == "" {
+		target := linkTarget{uri: words[i].LinkURI, dest: words[i].LinkDest}
+		if target.empty() {
 			if i < len(words)-1 {
 				cx += words[i].Width + words[i].SpaceAfter
 			}
@@ -81,7 +92,7 @@ func linkSpans(words []Word) []LinkArea {
 		startX := cx
 		endX := cx + words[i].Width
 		j := i + 1
-		for j < len(words) && words[j].LinkURI == uri {
+		for j < len(words) && (linkTarget{uri: words[j].LinkURI, dest: words[j].LinkDest}) == target {
 			// Extend through the space before this word.
 			endX = cx
 			for k := i; k < j; k++ {
@@ -91,9 +102,10 @@ func linkSpans(words []Word) []LinkArea {
 			j++
 		}
 		spans = append(spans, LinkArea{
-			URI: uri,
-			X:   startX,
-			W:   endX - startX,
+			URI:      target.uri,
+			DestName: target.dest,
+			X:        startX,
+			W:        endX - startX,
 		})
 		// Advance cx past all words in this span.
 		for i < j {

--- a/layout/table.go
+++ b/layout/table.go
@@ -2043,9 +2043,38 @@ func drawCellElementDirect(ctx DrawContext, gc gridCell, cellX, topY, rowHeight 
 		if block.Draw != nil {
 			block.Draw(ctx, bx, by)
 		}
+		recordBlockLinks(ctx, block, bx, by)
 		for _, child := range block.Children {
 			drawBlockRecursive(child, bx, by, ctx)
 		}
+	}
+}
+
+// recordBlockLinks converts a placed block's link areas into page-space
+// annotations. Cells are drawn directly rather than through the plan
+// renderer in render_plans.go, so without this a link inside a table cell
+// is painted as underlined text and nothing else — no clickable region
+// reaches the PDF. bx/by are the block's top-left in PDF coordinates.
+func recordBlockLinks(ctx DrawContext, block PlacedBlock, bx, by float64) {
+	if ctx.Page == nil || len(block.Links) == 0 {
+		return
+	}
+	for _, link := range block.Links {
+		// Use the precise per-line span when the paragraph computed one,
+		// otherwise fall back to the block's full width — the same rule
+		// the plan renderer applies.
+		linkX, linkW := bx, block.Width
+		if link.W > 0 {
+			linkX, linkW = bx+link.X, link.W
+		}
+		ctx.Page.Links = append(ctx.Page.Links, LinkArea{
+			X:        linkX,
+			Y:        by - block.Height,
+			W:        linkW,
+			H:        block.Height,
+			URI:      link.URI,
+			DestName: link.DestName,
+		})
 	}
 }
 
@@ -2056,6 +2085,7 @@ func drawBlockRecursive(block PlacedBlock, baseX, topY float64, ctx DrawContext)
 	if block.Draw != nil {
 		block.Draw(ctx, bx, by)
 	}
+	recordBlockLinks(ctx, block, bx, by)
 	for _, child := range block.Children {
 		drawBlockRecursive(child, bx, by, ctx)
 	}


### PR DESCRIPTION
## Description

An `<a href="#id">` that flows inline — the CSS default, so anywhere inside a
paragraph, heading, list item or table cell — was written out as a PDF `/URI`
action carrying the literal string `#id`. A URI action pointing at a bare
fragment has no scheme and no resource, so no viewer resolves it: the link
looks present (underlined, clickable rect) and does nothing. Only an anchor
forced to `display: block` reached `convertLink`, which checks the leading `#`
and builds an internal link.

The inline handlers in `converter_paragraph.go` assigned the raw href to
`TextRun.LinkURI` because there was no field to carry a destination. This adds
`LinkDest` alongside `LinkURI` on `TextRun` and `Word`, carries it through
measurement, splitting and `linkSpans` into `LinkArea.DestName`, and routes the
href by prefix in both inline handlers. `LinkArea.DestName` and the writer's
named-destination resolution already existed, so the emitted annotation is now
the same `/Dest [pageref /XYZ ...]` the block-level path already produced.

`linkSpans` now keys spans on the whole target rather than the URI alone, so
adjacent internal and external links on one line stay separate annotations.

Three defects in the same `<a>` handling fall out with it:

- **Link text ignored `@font-face`.** `convertLink` built its paragraph from
  `resolveFont`, which only ever returns one of the 14 standard faces, so a link
  in a fully embedded document silently rendered in non-embedded Helvetica. It
  now resolves the same font pair as the surrounding text.
- **An `<a>` wrapping only an image was dropped entirely.** `convertLink` bailed
  when `collectText` returned `""`, discarding the whole subtree — the image
  vanished and no annotation was emitted. Such an anchor now converts its
  children as inline runs tagged with the link target, and
  `measureInlineElement` carries that target onto the measured word.
- **A link in a table cell produced no annotation at all.** Cells are painted by
  the direct-draw path, which never copied `block.Links` onto the page.

An href that navigates nowhere — absent, empty, or a lone `#` — now renders as
plain text instead of an annotation with no action.

## Before / after

Rendered from the same samples with folio at `438802b` (before) and with this
change applied (after), identical A4 page.

**Internal anchors in inline flow.** The page pixels are identical either way —
a dead `/URI (#id)` and a working `/Dest` draw the same underlined text — so the
overlay below is drawn by the tooling from each PDF's *real* `/Link`
annotations. It is not part of the PDF.

![Internal anchors in inline flow](https://raw.githubusercontent.com/kuadrosx/folio/assets/inline-anchor-dest/screenshots/inline-anchor-dest-01-link-actions.png)

**Link text and the document's `@font-face`.** Unretouched page render.

![Link text and @font-face](https://raw.githubusercontent.com/kuadrosx/folio/assets/inline-anchor-dest/screenshots/inline-anchor-dest-02-embedded-font.png)

**An anchor whose only content is an image.** Unretouched page render.

![Anchor wrapping an image](https://raw.githubusercontent.com/kuadrosx/folio/assets/inline-anchor-dest/screenshots/inline-anchor-dest-03-image-anchor.png)

## Related issue

Closes #

## Checklist

- [x] Code is formatted (`gofmt -s -w .`)
- [x] Tests pass (`make test`)
- [x] New functionality includes tests
- [x] No references to external PDF libraries (clean room)

## Notes for the reviewer

- Tests assert on emitted PDF structure: link annotations are parsed out of the
  page tree, every internal anchor must carry a resolvable destination, and no
  `/URI` action may carry a value starting with `#`. A `display:block` anchor is
  kept as a passing control so the boundary stays provable.
- `TestLinkUsesDocumentFace` uses the existing `font/testdata/synthetic_cjk.ttf`
  fixture. It covers only CJK codepoints, which is the point: a standard-14 face
  cannot encode them, so a fallback is unambiguous rather than a subtle
  difference in letterforms.
- `NewInternalLinkEmbedded` is added to `layout` to mirror the existing
  `NewLinkEmbedded`; `LinkDest`/`WithLinkDest` are additive on `TextRun`/`Word`.
  No existing exported signature changes.
