### PR TITLE
layout: fix RTL table cell x for unequal column widths

### DIFF
--- a/layout/table.go
+++ b/layout/table.go
@@ -1856,10 +1856,15 @@ func drawTableRowDirect(ctx DrawContext, tbl *Table, grid []gridRow, rowIndex in
 		var cellX float64
 		if tbl.direction == DirectionRTL {
 			// RTL: column 0 at the right edge, last column at the left.
-			// Start from the right and work leftward past each column.
+			// Start from the right and work leftward past each column
+			// that precedes this one in logical order. Walking the far
+			// end of colWidths instead subtracts the widths of the last
+			// columns, which only lands correctly when every column is
+			// the same width -- otherwise the cell boxes drift out from
+			// under their own text.
 			cellX = x + totalW - gc.spanWidth - sh
 			for c := range gc.col {
-				cellX -= colWidths[len(colWidths)-1-c] + sh
+				cellX -= colWidths[c] + sh
 			}
 		} else {
 			// LTR: column 0 at the left edge (default).


### PR DESCRIPTION
### The bug

In `drawTableRow`, the right-to-left branch walks leftward from the right
edge but subtracts the widths of the **last** columns rather than the ones
preceding this cell:

```go
cellX = x + totalW - gc.spanWidth - sh
for c := range gc.col {
    cellX -= colWidths[len(colWidths)-1-c] + sh   // <- colWidths[c]
}
```

For column `k` the offset should be the sum of `colWidths[0..k-1]`. Walking
the far end of the slice gives the same answer only when every column is the
same width, which is why it has gone unnoticed — the moment widths differ the
cell boxes drift out from under their own text and borders cut through the
content.

### Reproduction

```html
<table dir="rtl" border="1" cellspacing="0" cellpadding="6">
  <tr><th>شرح</th><th>تعداد</th><th>واحد</th><th>مبلغ</th></tr>
  <tr><td>پشتیبانی فنی</td><td>۱۲</td><td>ماه</td><td>۴۲،۰۰۰</td></tr>
</table>
```

The first column is much wider than the rest. Render it and the vertical
rules no longer line up with the cell contents; text in the widest column
overlaps the border. With the fix the borders sit where the content does.

### The fix

One line: subtract `colWidths[c]`.

### A note on test coverage

I did not add a test, because the existing RTL table tests
(`html/rtl_test.go`) assert only that `plan.Consumed > 0` — they never check
geometry, which is why this survived. Happy to add one that asserts cell x
positions if you can point me at the pattern you would prefer for
draw-time geometry.

Found while working on Arabic text rendering; the fix itself is not
Arabic-specific and applies to any RTL table with unequal columns.