### PR TITLE
layout: right-align RTL list items against their marker

### DIFF
--- a/layout/list.go
+++ b/layout/list.go
@@ -745,10 +745,23 @@ func (l *List) planAt(area LayoutArea, baseIndent float64) LayoutPlan {
 					switch {
 					case capturedRTL:
 						// RTL: marker on the right, text indented from the right.
+						// drawTextLine only consults align for justification —
+						// every other alignment has to arrive already applied to
+						// x, the way paragraph layout does it. Passing absX with
+						// AlignRight left every list item stranded against the
+						// left margin with its bullet a column away.
+						textBoxW := capturedMaxW - capturedIndent
 						if len(capturedMarker) > 0 {
-							drawTextLine(ctx, capturedMarker, absX+capturedMaxW-capturedIndent, baselineY, capturedIndent, AlignRight, true)
+							// Right-align the marker inside its gutter so a gap
+							// separates it from the text, as a browser renders it.
+							markerX := absX + capturedMaxW - lineWidth(capturedMarker)
+							drawTextLine(ctx, capturedMarker, markerX, baselineY, capturedIndent, AlignRight, true)
 						}
-						drawTextLine(ctx, capturedWords, absX, baselineY, capturedMaxW-capturedIndent, AlignRight, capturedIsLast)
+						textX := absX + textBoxW - lineWidth(capturedWords)
+						if textX < absX {
+							textX = absX
+						}
+						drawTextLine(ctx, capturedWords, textX, baselineY, textBoxW, AlignRight, capturedIsLast)
 					case capturedInside:
 						// Inside: marker is inline at the content edge; the first
 						// line's text follows it, wrapped lines align under it.


### PR DESCRIPTION
### The bug

`drawTextLine` consults `align` only for justification:

```go
if align == AlignJustify && !isLast && len(words) > 1 { ... }
```

Every other alignment has to arrive already applied to `x` — which is what
paragraph layout does. The right-to-left list branch instead passes `absX`
and relies on `AlignRight` to do the work:

```go
drawTextLine(ctx, capturedWords, absX, baselineY, capturedMaxW-capturedIndent, AlignRight, capturedIsLast)
```

`AlignRight` is a no-op there, so every item is drawn at the container's left
edge while its marker is placed correctly on the right — leaving the bullet
stranded a full column away from its text.

### Reproduction

```html
<ul dir="rtl">
  <li>راه‌اندازی خوشه‌ها</li>
  <li>پایش سرویس‌ها</li>
</ul>
```

The bullets sit at the right margin; the text sits at the left margin, with
the width of the content box between them. A browser renders the text
immediately to the left of each bullet.

### The fix

Compute the start x so the line is right-aligned within the text box, the way
paragraph layout already does, and right-align the marker inside its gutter
so a gap separates it from the text.

### A note on test coverage

Not added, for the same reason as #449: the existing RTL tests assert only
that layout produced positive `Consumed`, never positions. Glad to add a
geometry assertion if you have a preferred pattern for draw-time checks.

Found while working on Arabic text rendering; the fix is not Arabic-specific
and applies to any RTL list.