### PR TITLE
html: inherit text-align to child blocks

### DIFF
--- a/html/converter_table.go
+++ b/html/converter_table.go
@@ -70,7 +70,11 @@ func (c *converter) convertTable(n *html.Node, style computedStyle) []layout.Ele
 			if text != "" {
 				f := resolveFont(captionStyle)
 				p := layout.NewParagraph(text, f, captionStyle.FontSize)
-				if captionStyle.TextAlignSet {
+				// The UA default for <caption> is center. A declaration
+				// on the caption itself outranks it, but an alignment
+				// merely inherited from an ancestor does not — so test
+				// the self-only flag, not the inherited one.
+				if captionStyle.TextAlignSelfSet {
 					p.SetAlign(resolveTextAlign(captionStyle))
 				} else {
 					p.SetAlign(layout.AlignCenter)
@@ -400,7 +404,11 @@ func (c *converter) convertTableRowKind(n *html.Node, tbl *layout.Table, parentS
 			// before the equality check (otherwise an RTL document
 			// with `text-align: start` would resolve to AlignLeft and
 			// then get unexpectedly re-aligned to center).
-			if !cellStyle.TextAlignSet && resolveTextAlign(cellStyle) == layout.AlignLeft {
+			//
+			// Self-only flag: the UA default outranks an inherited
+			// alignment, so a <th> under a `text-align: left` ancestor
+			// still centers — only a declaration on the cell keeps left.
+			if !cellStyle.TextAlignSelfSet && resolveTextAlign(cellStyle) == layout.AlignLeft {
 				cellStyle.TextAlign = layout.AlignCenter
 				cellStyle.TextAlignKeyword = ""
 			}

--- a/html/css_props.go
+++ b/html/css_props.go
@@ -94,6 +94,7 @@ var cssProperties = []cssProperty{
 				s.TextAlign = a
 				s.TextAlignKeyword = kw
 				s.TextAlignSet = true
+				s.TextAlignSelfSet = true
 			}
 		},
 	},

--- a/html/style.go
+++ b/html/style.go
@@ -14,7 +14,8 @@ type computedStyle struct {
 	FontStyle            string // "normal", "italic"
 	Color                layout.Color
 	TextAlign            layout.Align
-	TextAlignSet         bool         // true if text-align was explicitly declared
+	TextAlignSet         bool         // true if text-align was declared on this element or inherited from an ancestor that declared it
+	TextAlignSelfSet     bool         // true only if text-align was declared on THIS element; not inherited. Distinguishes an author's own choice from an inherited one for the UA defaults that a direct declaration outranks (<th> centering, <caption> centering).
 	TextAlignKeyword     string       // "start" or "end" when the author used the direction-relative keyword; otherwise "". Resolved at consumer time via resolveTextAlign(style).
 	TextAlignLast        layout.Align // text-align-last override for the last line
 	TextAlignLastSet     bool         // true if text-align-last was explicitly set
@@ -479,6 +480,11 @@ func defaultStyle() computedStyle {
 }
 
 // inherit creates a child style that inherits text properties from the parent.
+//
+// Every inherited property must carry its "was declared" flag alongside its
+// value: consumers guard on the flag, so a value that arrives without it is
+// held but never applied. TextAlignSelfSet is the one deliberate exception —
+// it means "declared on THIS element" and must NOT propagate.
 func (s *computedStyle) inherit() computedStyle {
 	child := computedStyle{
 		FontFamily:           s.FontFamily,
@@ -487,6 +493,7 @@ func (s *computedStyle) inherit() computedStyle {
 		FontStyle:            s.FontStyle,
 		Color:                s.Color,
 		TextAlign:            s.TextAlign,
+		TextAlignSet:         s.TextAlignSet,
 		TextAlignKeyword:     s.TextAlignKeyword,
 		TextAlignLast:        s.TextAlignLast,
 		TextAlignLastSet:     s.TextAlignLastSet,

--- a/html/text_align_inherit_test.go
+++ b/html/text_align_inherit_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Carlos Munoz and the Folio Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package html_test
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/carlos7ags/folio/document"
+	"github.com/carlos7ags/folio/reader"
+)
+
+// textLine is one rendered line of text, reassembled from the individual
+// positioned spans a content stream emits. Kerning splits a single word
+// across several Tj operators, so no one span carries the line's real
+// left edge — only the minimum X over the whole line does.
+type textLine struct {
+	text string
+	x    float64 // leftmost pen position on the line
+	y    float64
+}
+
+// renderedLines groups a page's text spans into lines by baseline and
+// returns them in reading order (top of the page first). Assertions run
+// against the geometry the viewer actually paints rather than against the
+// computed style, so a style that is right but never reaches the
+// paragraph cannot pass.
+func renderedLines(t *testing.T, r *reader.PdfReader) []textLine {
+	t.Helper()
+	page, err := r.Page(0)
+	if err != nil {
+		t.Fatalf("Page(0): %v", err)
+	}
+	spans, err := page.TextSpans()
+	if err != nil {
+		t.Fatalf("TextSpans: %v", err)
+	}
+
+	// Bucket spans by baseline. Exact equality is too strict once a line
+	// carries mixed font sizes, so bucket within half a point.
+	const sameLine = 0.5
+	var lines []textLine
+	for _, s := range spans {
+		if strings.TrimSpace(s.Text) == "" {
+			continue
+		}
+		placed := false
+		for i := range lines {
+			if math.Abs(lines[i].y-s.Y) <= sameLine {
+				lines[i].text += s.Text
+				lines[i].x = math.Min(lines[i].x, s.X)
+				placed = true
+				break
+			}
+		}
+		if !placed {
+			lines = append(lines, textLine{text: s.Text, x: s.X, y: s.Y})
+		}
+	}
+	sort.Slice(lines, func(i, j int) bool { return lines[i].y > lines[j].y })
+	return lines
+}
+
+// TestTextAlignInheritsToChildBlocks locks in that `text-align` declared on
+// a container reaches the block children that inherit it.
+//
+// text-align is an inherited property, so every browser right-aligns all
+// three children of the div below. Folio right-aligned only the heading:
+// computedStyle.inherit() copied the alignment VALUE to the child but not
+// the TextAlignSet flag that converter_paragraph.go guards on, so each
+// paragraph held the right value behind a false flag and kept the default
+// left alignment.
+//
+// The three paragraphs carry identical text so their geometry is directly
+// comparable: an inheriting paragraph must land exactly where the same
+// paragraph lands when it declares the alignment itself.
+func TestTextAlignInheritsToChildBlocks(t *testing.T) {
+	const sample = "Right aligned sample text"
+	src := `<html><body>
+<div style="text-align: right">
+  <h1>Heading</h1>
+  <p>` + sample + `</p>
+  <p>` + sample + `</p>
+</div>
+<p style="text-align: right">` + sample + `</p>
+<p>` + sample + `</p>
+</body></html>`
+
+	_, r := htmlRoundtrip(t, src, document.PageSizeA4)
+	lines := renderedLines(t, r)
+	if len(lines) != 5 {
+		for i, l := range lines {
+			t.Logf("line %d: x=%.2f y=%.2f %q", i, l.x, l.y, l.text)
+		}
+		t.Fatalf("got %d rendered lines, want 5", len(lines))
+	}
+
+	heading := lines[0]
+	inherited1, inherited2 := lines[1], lines[2]
+	declared := lines[3] // passing control: declares text-align itself
+	undeclared := lines[4]
+
+	// Tolerance covers only sub-point rounding in the emitted pen
+	// positions; identical text under identical alignment must land in
+	// the same place.
+	const tol = 0.5
+
+	// The heading already worked before the fix — keep it asserted so a
+	// regression there is caught too.
+	if heading.x < 300 {
+		t.Errorf("heading x = %.2f, want right-aligned (well right of the left margin)", heading.x)
+	}
+
+	// The control proves the alignment is reachable at all: if this fails,
+	// the test is measuring something other than the inheritance bug.
+	if declared.x < 300 {
+		t.Fatalf("control paragraph with its own text-align: right has x = %.2f, want right-aligned", declared.x)
+	}
+
+	for i, got := range []textLine{inherited1, inherited2} {
+		if math.Abs(got.x-declared.x) > tol {
+			t.Errorf("inheriting paragraph %d: x = %.2f, want %.2f (same as the paragraph that declares text-align: right); text-align was not inherited",
+				i+1, got.x, declared.x)
+		}
+	}
+
+	// An element whose ancestors never declared text-align must keep the
+	// default left alignment: inheriting the flag must not turn "default"
+	// into "author declared it".
+	if math.Abs(undeclared.x-declared.x) <= tol {
+		t.Errorf("paragraph outside the aligned container: x = %.2f, want the default left alignment, not %.2f", undeclared.x, declared.x)
+	}
+	if undeclared.x > 300 {
+		t.Errorf("paragraph outside the aligned container: x = %.2f, want left-aligned", undeclared.x)
+	}
+}
+
+// TestTextAlignInheritDoesNotOverrideUADefaults guards the boundary the
+// inheritance fix has to respect: <caption> and <th> default to centered,
+// and a UA default outranks an alignment that was merely INHERITED — only a
+// declaration on the element itself replaces it.
+//
+// Propagating TextAlignSet through inherit() made every descendant of a
+// `text-align: left` container look like it had declared left alignment,
+// which silently left-aligned captions that must stay centered. The self-only
+// TextAlignSelfSet flag keeps the two cases apart; this test fails if they are
+// ever collapsed back together.
+func TestTextAlignInheritDoesNotOverrideUADefaults(t *testing.T) {
+	src := `<html><body>
+<div style="text-align: left">
+<table><caption>Inherited</caption><tr><td>Cell</td></tr></table>
+</div>
+<table><caption>Baseline</caption><tr><td>Cell</td></tr></table>
+<table><caption style="text-align: left">Declared</caption><tr><td>Cell</td></tr></table>
+</body></html>`
+
+	_, r := htmlRoundtrip(t, src, document.PageSizeA4)
+	byText := map[string]textLine{}
+	for _, l := range renderedLines(t, r) {
+		byText[l.text] = l
+	}
+
+	baseline, ok := byText["Baseline"]
+	if !ok {
+		t.Fatalf("caption %q not rendered; got lines %v", "Baseline", byText)
+	}
+	if baseline.x < 200 {
+		t.Fatalf("caption outside any aligned container has x = %.2f, want centered; the control itself is broken", baseline.x)
+	}
+
+	// A caption whose ancestor declared text-align must still centre.
+	inherited, ok := byText["Inherited"]
+	if !ok {
+		t.Fatalf("caption %q not rendered", "Inherited")
+	}
+	if math.Abs(inherited.x-baseline.x) > 0.5 {
+		t.Errorf("caption inside a text-align: left container: x = %.2f, want %.2f (still centered) — an inherited alignment must not displace the UA default",
+			inherited.x, baseline.x)
+	}
+
+	// A caption that declares the alignment itself does override the default.
+	declared, ok := byText["Declared"]
+	if !ok {
+		t.Fatalf("caption %q not rendered", "Declared")
+	}
+	if declared.x > 200 {
+		t.Errorf("caption with its own text-align: left: x = %.2f, want left-aligned", declared.x)
+	}
+}


### PR DESCRIPTION
## Problem

`text-align` is an inherited property, so declaring it once on a container aligns every block inside it. folio applies it to some children and not others:

```html
<div style="text-align: right">
  <h1>Aligned heading</h1>
  <p>First inherited line</p>
  <p>Second inherited line</p>
</div>
```

The heading right-aligns. Both paragraphs render hard left, flush against the left edge of their container. Every browser right-aligns all three.

This is the `text-align` half of #447, reported independently against v0.7.1 — there, a `<p>` inside a `text-align: center` container stays left while its sibling headings centre, and the reporter has to repeat the declaration on the `<p>` to get the expected result. Measured on that issue's own markup, before and after this change:

| line | before | after |
|---|---|---|
| `Title` (h1) | 272.97 centered | 272.97 |
| `Subtitle` (h2) | 264.64 centered | 264.64 |
| **`Address` (p)** | **72.00 — flush left** | **275.63 centered** |
| `Payment Receipt` (h3) | 241.42 centered | 241.42 |

Note this does **not** address the second, unrelated problem in that issue (`justify-content: space-between` not pushing the last flex item right when the first has no intrinsic width), which still reproduces. #447 should stay open for it.

## Root cause

`computedStyle.inherit()` builds a child style from its parent with an explicit struct literal listing each inherited field. It copies `TextAlign`, `TextAlignKeyword`, `TextAlignLast`, `TextAlignLastSet` and `TextAlignLastKeyword` — but not `TextAlignSet`, the flag the consumers guard on:

```go
if style.TextAlignSet {
    p.SetAlign(resolveTextAlign(style))
}
```

So the child holds the correct alignment behind a false flag, the guard never fires, and the paragraph keeps the default left alignment. Heading and paragraph differ only in which converter path they take; the heading path does not consult the flag, which is why one child aligns and its siblings do not.

`TextAlignLastSet` is copied two lines from the omission, so this looks like a missed field in one literal rather than a design decision. It is the only one missing: the other three `*Set` flags on `computedStyle` (`ZIndexSet`, `BookmarkLevelSet`, `BaselineShiftSet`) belong to non-inherited properties, and their values are correctly absent from the literal too.

## Why this is more than a one-line change

Propagating the flag alone regresses `<caption>` and `<th>`, which default to centered. Both guard on `TextAlignSet`, and because `inherit()` dropped it, that flag had until now *meant* "declared on THIS element" — which is what a UA default needs to test, since a direct declaration outranks it but an inherited value does not.

Once the flag inherits, every descendant of a `text-align: left` container looks like it declared left alignment. Measured: a `<caption>` inside such a container moved from centered (x=286.64, matching an unnested caption at 283.30) to the left margin (x=72.00). No existing test caught this.

This PR adds `TextAlignSelfSet`, set beside `TextAlignSet` by the parser and deliberately **not** propagated by `inherit()`, and switches those two table sites to it. That restores their behaviour exactly — the old flag was equivalent to the new one at every element — and leaves `TextAlignSet` free to mean what the paragraph path needs: "an author declared this alignment somewhere up the chain". `inherit()` gains a comment recording why one flag propagates and the other must not.

An element whose ancestors never declared alignment is unaffected: the flag is false at the root, and inheriting false keeps it false, so "default" stays distinct from "author declared it".

## Tests

Both new tests assert **rendered geometry** rather than computed style, so an alignment that is resolved but never reaches the paragraph cannot pass. Text spans are grouped into lines by baseline, since kerning splits a word across several `Tj` operators and no single span carries a line's true left edge.

- `TestTextAlignInheritsToChildBlocks` — three paragraphs with identical text must land at the same pen position whether the alignment is inherited or declared on the paragraph itself. A paragraph outside the container is kept as a control that must stay left, so inheriting the flag cannot quietly turn "default" into "author declared it". Fails on `main` with `x = 72.00, want 388.92`.
- `TestTextAlignInheritDoesNotOverrideUADefaults` — pins the caption/`th` boundary: a caption inside a `text-align: left` container must stay centered, while one that declares the alignment itself must not. It passes on `main` and fails if the two flags are ever collapsed back together, which is what makes it a real guard rather than a restatement of the fix.

`gofmt`, `go vet`, `golangci-lint` (0 issues) and the full `go test ./...` are clean on this branch. No existing test was changed, skipped, or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjoXcExuPNYw6oKw5ZiVKZ
