### PR TITLE
Run CI for Go 1.25, 1.26 and 1.27.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        go: ['1.25', '1.26', '1.27']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Go
+      - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version: ${{ matrix.go }}
           cache: true
 
       - name: Install qpdf


### PR DESCRIPTION
## Description

Run CI against the latest three major Go versions.

In #452 I found that a specific unrelated test was broken on `main`, but only on Go 1.27. There's clearly enough dependence on Go's behaviour that it seems wise to try to catch differences early.